### PR TITLE
Add ssd as core maintainer, knife-opc and knife-ec-backup lieutenant

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,6 +32,7 @@ The core chef REST API server, packaging/installation,  and its primary dependen
 ### Maintainers
 
 * [Oliver Ferrigni](http://github.com/oferrigni)
+* [Steven Danna](https://github.com/stevendanna)
 
 # Supporting Components
 
@@ -41,6 +42,8 @@ The core chef REST API server, packaging/installation,  and its primary dependen
 
 ### Lieutenants
 
+* [Steven Danna](https://github.com/stevendanna)
+
 ### Maintainers
 
 ## Knife OPC
@@ -48,5 +51,7 @@ The core chef REST API server, packaging/installation,  and its primary dependen
 [knife-opc](http://github.com/opscode/knife-opc) provides  administrative command-line control to the Chef Server from the console
 
 ### Lieutenants
+
+* [Steven Danna](https://github.com/stevendanna)
 
 ### Maintainers


### PR DESCRIPTION
I'm the primary author of knife-opc and did much of the v2 cleanup of
the knife-ec-backup code.  With respect to core Chef Server, I added
myself as a maintainer since it bothered me that the maintainer list
was empty.