### PR TITLE
Reindex from a hidden node.

### DIFF
--- a/src/oc_erchef/rel/files/reindex-opc-organization
+++ b/src/oc_erchef/rel/files/reindex-opc-organization
@@ -120,7 +120,14 @@ get_org_id(Context, OrgName) ->
 init_network() ->
     net_kernel:start([?SELF, longnames]),
     erlang:set_cookie(node(), ?ERCHEF_COOKIE),
-    pong = net_adm:ping(?ERCHEF).
+    %% A hidden node is "invisible", and thus won't alter the behavior of the node / cluster
+    %% it is connecting to (by simple virtue of establishing the connection, that is).  Kind
+    %% of a handy quality for maintenance / support scripts to have, eh?
+    %%
+    %% See http://learnyousomeerlang.com/distribunomicon#hidden-nodes, won't you?
+    %%
+    %% Captain Picard has the Prime Directive; we have hidden nodes.
+    true = net_kernel:hidden_connect(?ERCHEF).
 
 find_dl_headers(OrgNameBin, IntLB) when is_binary(OrgNameBin) ->
     find_dl_headers(binary_to_list(OrgNameBin), IntLB);


### PR DESCRIPTION
From @christophermaier in chef/oc_erchef#19:

> Not super-essential now, since Erchef isn't a distributed application,
but who knows what the future might bring?  This seems like a good bit
of hygiene for maintenance / support script, though, which really
shouldn't be considered an active participant in the node / cluster to
which it is connecting.

> Erlang campfire ghost story: "THE CALL WAS COMING FROM INSIDE THE
CLUSTER!" :)