### PR TITLE
use jiffy via chef_json instead of ejson everywhere

### DIFF
--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
@@ -31,7 +31,7 @@
 
 update_part(Part, AceRecord, Type, AuthzId, OrgId) ->
     Ids = names_to_ids(ej:get({Part}, AceRecord), OrgId),
-    Data = ejson:encode(Ids),
+    Data = chef_json:encode(Ids),
     Path = acl_path(Type, AuthzId, Part),
     SuperuserId = envy:get(oc_chef_authz, authz_superuser_id, binary),
     Result = oc_chef_authz_http:request(Path, put, ?DEFAULT_HEADERS, Data, SuperuserId),

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_containers_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_containers_SUITE.erl
@@ -79,7 +79,7 @@ list_when_created_containers(_) ->
     [ http_create_container(Container) || Container <- Containers ],
     {ok, ResponseCode, _, ResponseBody} = http_list_containers(),
     ?assertEqual("200", ResponseCode),
-    Ejson = ejson:decode(ResponseBody),
+    Ejson = chef_json:decode(ResponseBody),
     {ContainerList} = Ejson,
     [ ?assertEqual(true, proplists:is_defined(list_to_binary(Container), ContainerList))
       || Container <- Containers ].
@@ -103,14 +103,14 @@ delete_container(_) ->
 fetch_non_existant_container(_) ->
     Result = {ok, _, _, ResponseBody} = http_fetch_container("bar"),
     ?assertMatch({ok, "404", _, ResponseBody} , Result),
-    ?assertEqual([<<"Cannot load container bar">>], ej:get({"error"}, ejson:decode(ResponseBody))),
+    ?assertEqual([<<"Cannot load container bar">>], ej:get({"error"}, chef_json:decode(ResponseBody))),
     ok.
 
 fetch_existant_container(_) ->
     http_create_container("foo"),
     {ok, ResponseCode, _, ResponseBody} = http_fetch_container("foo"),
     ?assertMatch("200", ResponseCode),
-    Ejson = ejson:decode(ResponseBody),
+    Ejson = chef_json:decode(ResponseBody),
     ?assertEqual(<<"foo">>, ej:get({"containername"}, Ejson)),
     ?assertEqual(<<"foo">>, ej:get({"containerpath"}, Ejson)).
 
@@ -139,7 +139,7 @@ http_create_container(Name) ->
                      [{"x-ops-userid", "test-client"},
                       {"accept", "application/json"},
                       {"content-type", "application/json"}
-                     ],post, ejson:encode({[{<<"containername">>, list_to_binary(Name)}]})
+                     ],post, chef_json:encode({[{<<"containername">>, list_to_binary(Name)}]})
                     ).
 
 http_delete_container(Name) ->
@@ -153,4 +153,4 @@ http_update_container(Name, Ejson) ->
                      [{"x-ops-userid", "test-client"},
                       {"accept", "application/json"},
                       {"content-type", "application/json"}
-                     ], put, ejson:encode(Ejson)).
+                     ], put, chef_json:encode(Ejson)).

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_cookbook_artifact_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_cookbook_artifact_SUITE.erl
@@ -357,7 +357,7 @@ http_request(Method, RouteSuffix, JsonOrNull) ->
                       {"accept", "application/json"},
                       {"content-type", "application/json"}],
                      Method, body(JsonOrNull)),
-    {RespCode, ejson:decode(RespBody)}.
+    {RespCode, chef_json:decode(RespBody)}.
 
 url_for(RouteSuffix) ->
     OrgNameStr = erlang:binary_to_list(?ORG_NAME),
@@ -365,7 +365,7 @@ url_for(RouteSuffix) ->
       ++ "/cookbook_artifacts" ++ RouteSuffix.
 
 body(null) -> <<>>;
-body(Json) -> ejson:encode(Json).
+body(Json) -> chef_json:encode(Json).
 
 -define(COOKBOOK_ARTIFACT_VERSION_CANONICAL_EXAMPLE, <<"
     {
@@ -443,7 +443,7 @@ body(Json) -> ejson:encode(Json).
     }">>).
 
 canonical_example() ->
-    ejson:decode(?COOKBOOK_ARTIFACT_VERSION_CANONICAL_EXAMPLE).
+    chef_json:decode(?COOKBOOK_ARTIFACT_VERSION_CANONICAL_EXAMPLE).
 canonical_example(Name, Identifier) ->
     Renamed = ej:set({<<"name">>}, canonical_example(),
                      erlang:list_to_binary(Name)),

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
@@ -304,7 +304,7 @@ list_when_created_policies(_) ->
     [ ?assertMatch({ok, "201", _, _}, http_create_modified_policy(Policy)) || Policy <- Policies ],
     {ok, ResponseCode, _, ResponseBody} = http_list_policies(),
     ?assertEqual("200", ResponseCode),
-    Ejson = ejson:decode(ResponseBody),
+    Ejson = chef_json:decode(ResponseBody),
     ?assertEqual( [<<"bar">>, <<"foo">>],
                   Ejson).
 
@@ -344,7 +344,7 @@ delete_policy(_) ->
 fetch_non_existant_policy(_) ->
     Result = {ok, _, _, ResponseBody} = http_fetch_policy("bar"),
     ?assertMatch({ok, "404", _, ResponseBody} , Result),
-    ?assertEqual([<<"Cannot load policy bar in policy group group_name">>], ej:get({"error"}, ejson:decode(ResponseBody))),
+    ?assertEqual([<<"Cannot load policy bar in policy group group_name">>], ej:get({"error"}, chef_json:decode(ResponseBody))),
     ok.
 
 fetch_existant_policy(_) ->
@@ -352,7 +352,7 @@ fetch_existant_policy(_) ->
     {ok, ResponseCode, _, ResponseBody} = http_fetch_policy("foo"),
     ?assertEqual("200", ResponseCode),
 	ExpectedJson = canonical_example_policy_json("foo"),
-	?assertEqual(ExpectedJson, ejson:decode(ResponseBody)).
+	?assertEqual(ExpectedJson, chef_json:decode(ResponseBody)).
 
 put_when_non_existant_policy_should_create(_) ->
 	Name = "foo",
@@ -419,7 +419,7 @@ http_create_modified_policy(Name, RevisionID) ->
 
 http_create_policy(Name, Json) ->
     UrlEncodedName = ibrowse_lib:url_encode(Name),
-    http_request(put, "/policy_groups/group_name/policies/" ++ UrlEncodedName, ejson:encode(Json)).
+    http_request(put, "/policy_groups/group_name/policies/" ++ UrlEncodedName, chef_json:encode(Json)).
 
 http_delete_policy(Name) ->
     UrlEncodedName = ibrowse_lib:url_encode(Name),
@@ -427,7 +427,7 @@ http_delete_policy(Name) ->
 
 http_update_policy(Name, Ejson) ->
     UrlEncodedName = ibrowse_lib:url_encode(Name),
-    http_request(put, "/policy_groups/group_name/policies/" ++ UrlEncodedName, ejson:encode(Ejson)).
+    http_request(put, "/policy_groups/group_name/policies/" ++ UrlEncodedName, chef_json:encode(Ejson)).
 
 http_request(Method, RouteSuffix, Body) ->
     OrgStr = erlang:binary_to_list(?ORG_NAME),
@@ -439,14 +439,14 @@ http_request(Method, RouteSuffix, Body) ->
                      ], Method, Body).
 
 canonical_example_policy_json(Name) ->
-    BaseJson = ejson:decode(?POLICY_FILE_CANONICAL_EXAMPLE),
+    BaseJson = chef_json:decode(?POLICY_FILE_CANONICAL_EXAMPLE),
     ej:set({<<"name">>}, BaseJson, iolist_to_binary(Name)).
 
 canonical_example_policy_json(Name, RevisionID) ->
-    BaseJson = ejson:decode(?POLICY_FILE_CANONICAL_EXAMPLE),
+    BaseJson = chef_json:decode(?POLICY_FILE_CANONICAL_EXAMPLE),
     WithNewName = ej:set({<<"name">>}, BaseJson, iolist_to_binary(Name)),
     ej:set({<<"revision_id">>}, WithNewName, iolist_to_binary(RevisionID)).
 
 minimal_example_policy_json(Name) ->
-    BaseJson = ejson:decode(?POLICY_FILE_MINIMAL_EXAMPLE),
+    BaseJson = chef_json:decode(?POLICY_FILE_MINIMAL_EXAMPLE),
     ej:set({<<"name">>}, BaseJson, list_to_binary(Name)).

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_sanboxes_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_sanboxes_SUITE.erl
@@ -117,8 +117,8 @@ http_request(Method, RouteSuffix, Json) ->
                      [{"x-ops-userid", "test-client"},
                       {"accept", "application/json"},
                       {"content-type", "application/json"}],
-                     Method, ejson:encode(Json)),
-    {RespCode, ejson:decode(RespBody)}.
+                     Method, chef_json:encode(Json)),
+    {RespCode, chef_json:decode(RespBody)}.
 
 url_for(RouteSuffix) ->
     OrgNameStr = erlang:binary_to_list(?ORG_NAME),

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_principal.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_principal.erl
@@ -118,12 +118,12 @@ auth_info(Req, State) ->
 to_json(Req, #base_state{server_api_version = ?API_v0, resource_state = Principal,
                          chef_db_context = DbContext, organization_name = OrgName} = State) ->
     EJson = assemble_principal_ejson(Principal, OrgName, DbContext),
-    Json = ejson:encode(EJson),
+    Json = chef_json:encode(EJson),
     {Json, Req, State};
 to_json(Req, #base_state{resource_state = Principals,
                          chef_db_context = DbContext, organization_name = OrgName} = State) ->
     EJ = [ assemble_principal_ejson(Principal, OrgName, DbContext) || Principal <- Principals ],
-    Json = ejson:encode({[{ <<"principals">>, EJ}]} ),
+    Json = chef_json:encode({[{ <<"principals">>, EJ}]} ),
     {Json, Req, State}.
 
 assemble_principal_ejson(#principal_state{name = Name,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authenticate_user.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authenticate_user.erl
@@ -49,7 +49,7 @@ validate_request('POST', Req, #base_state{resource_state = UserState} = State) -
       Body  when Body == undefined orelse Body == <<>> ->
           throw({error, missing_body});
       Body ->
-          UserData = ejson:decode(Body),
+          UserData = chef_json:decode(Body),
           % This change on hold until our front-end components expect it
           % chef_user:validate_user_name(UserData),
           case ej:valid(valid_user_data(), UserData) of

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_system_recovery.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_system_recovery.erl
@@ -50,7 +50,7 @@ validate_request('POST', Req, #base_state{resource_state = UserState} = State) -
       Body  when Body == undefined orelse Body == <<>> ->
           throw({error, missing_body});
       Body ->
-          UserData = ejson:decode(Body),
+          UserData = chef_json:decode(Body),
           case ej:valid(valid_user_data(), UserData) of
               ok ->
                   UserState1 = UserState#user_state{user_data = UserData},


### PR DESCRIPTION
From @marcparadise in chef/oc_erchef#116:

> Let's just use chef_json so we don't need to pull in ejson anymore. ejson has an old version of mochiweb pinned which is causing minor trouble in upstream projects (chef-mover).

> Running through tests now, locally it all looks good.

> This won't be completable until we remove couchbeam - our fork depends on a fork of ejson.