### PR TITLE
[OC-11648] EC11: Undefined Behavior with Full Log or Data Disk

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/cluster.sh.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/cluster.sh.erb
@@ -63,7 +63,9 @@ function transition
       fi
 
       ;;
-    backup)
+    # If we see a reason for a FAULT, we should try to relinquish control gracefully, like a BACKUP.
+    # Worst case, the FAULT state will keep us out of the mix.
+    backup|fault)
 <%- keepalive_services.reverse.each do |service| -%>
       log_me "Stopping service <%= service %>"
       /opt/opscode/bin/private-chef-ctl graceful-kill <%= service %> || error_exit "Cannot kill <%= service %>"
@@ -89,9 +91,6 @@ function transition
           fi
       fi
 
-      ;;
-    fault)
-      # Um... we are on the way elsewhere
       ;;
     *)
   esac

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/keepalived.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/keepalived.conf.erb
@@ -15,6 +15,15 @@ vrrp_sync_group <%= @vrrp_sync_group %> {
   }
 }
 
+#Enter FAULT status if any condition is false
+# TODO: We should check the log area and /var/opt/opscode. If close to full, FAULT
+vrrp_script chk_df {
+       script "[ `df -h | perl -lane 'print substr($F[-2], 0, -1) if m|/$|'` -lt 80 ]"
+       interval 10
+       fall 2   # Two intervals to die
+       rise 2   # Two intervals to live
+}
+
 vrrp_instance <%= @vrrp_sync_instance %> {
     state <%= @vrrp_instance_state %>
     preempt_delay <%= @vrrp_instance_preempt_delay %>
@@ -37,6 +46,10 @@ vrrp_instance <%= @vrrp_sync_instance %> {
     }
 <% end %>
     advert_int <%= @vrrp_instance_advert_int %>
+    track_script {
+      chk_df
+   }
+
 		notify_backup "/var/opt/opscode/keepalived/bin/cluster.sh backup"
 		notify_master "/var/opt/opscode/keepalived/bin/cluster.sh master"
 		notify_fault  "/var/opt/opscode/keepalived/bin/cluster.sh fault"


### PR DESCRIPTION
From @sean-horn in chef/opscode-omnibus#297:

> I would appreciate review on this. I have tested it against a working EC11.1.3 HA install with no issues through keepalived shutdown failovers, recoveries of disk space so that the cluster member comes out of FAULT state and enters BACKUP. Also, if both backend cluster members enter FAULT state, things look good(no member has either the DRBD volume or the backend_VIP) and either one can recover and resume MASTER status.

I plan to parameterize the obvious settings and allow for multiple vrrp_scripts.