### PR TITLE
chef-server-ctl backup and restore

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -44,6 +44,7 @@ dependency "openresty"
 dependency "redis-gem" # gem for interacting with redis
 dependency "openresty-lpeg"  # lua-based routing
 dependency "runit"
+dependency "chef_backup-gem" # chef-server-ctl backup
 
 # the backend
 dependency "postgresql92"

--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -1,0 +1,26 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name 'chef_backup-gem'
+default_version '0.0.1.dev.3'
+
+dependency 'ruby'
+dependency 'rubygems'
+dependency 'rsync'
+
+build do
+  gem "install chef_backup -n #{install_dir}/embedded/bin --no-rdoc --no-ri -v #{version}"
+end

--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 name 'chef_backup-gem'
-default_version '0.0.1.dev.3'
+default_version '0.0.1.dev.4'
 
 dependency 'ruby'
 dependency 'rubygems'

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -82,6 +82,7 @@ module PrivateChef
   enabled_plugins []
 
   backup Mash.new
+  backup['strategy'] = 'tar'
 
   # - legacy config mashes -
   # these config values are here so that if any config has been previously

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -81,6 +81,8 @@ module PrivateChef
   disabled_plugins []
   enabled_plugins []
 
+  backup Mash.new
+
   # - legacy config mashes -
   # these config values are here so that if any config has been previously
   # set for these projects in an older version of private-chef/chef-server.rb
@@ -277,6 +279,7 @@ module PrivateChef
         "disabled_plugins",
         "enabled_plugins",
         "license",
+        "backup",
 
         # keys for cleanup and back-compat
         "couchdb",

--- a/omnibus/files/private-chef-ctl-commands/backup.rb
+++ b/omnibus/files/private-chef-ctl-commands/backup.rb
@@ -1,0 +1,76 @@
+require 'chef_backup'
+require 'chef/mixin/deep_merge'
+require 'optparse'
+require 'ostruct'
+
+add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
+  unless running_config
+    puts '[ERROR] cannot backup if you haven\'t completed a reconfigure'
+    exit 1
+  end
+
+  options = OpenStruct.new
+  options.agree_to_go_offline = false
+
+  OptionParser.new do |opts|
+    opts.banner = 'Usage: chef-server-ctl backup [options]'
+
+    opts.on('-y', '--yes', 'Agree to go offline during tar based backups') do
+      options.agree_to_go_offline = true
+    end
+
+    opts.on('-h', '--help', 'Show this message') do
+      puts opts
+      exit
+    end
+  end.parse!(ARGV)
+
+  Chef::Mixin::DeepMerge.deep_merge!(stringify_keys(options.to_h), running_config['private_chef']['backup'])
+
+  status = ChefBackup::Runner.new(running_config).backup
+  exit(status ? 0 : 1)
+end
+
+add_command_under_category 'restore', 'general', 'Restore the Chef Server from backup', 2 do
+  options = OpenStruct.new
+  options.agree_to_cleanse = nil
+  options.restore_dir = nil
+
+  OptionParser.new do |opts|
+    opts.banner = 'Usage: chef-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]'
+
+    opts.on('-d', '--staging-dir [directory]', String, 'The path to an empty directory for use in restoration.  Ensure it has enough available space for all expanded data in the backup archive') do |staging_directory|
+      options.restore_dir = File.expand_path(staging_directory)
+    end
+
+    opts.on('-c', '--cleanse', 'Agree to cleansing all existing state during a restore.  THIS WILL COMPLETELY REMOVING EXISTING CHEF DATA') do
+      options.agree_to_cleanse = 'yes'
+    end
+
+    opts.on('-h', '--help', 'Show this message') do
+      puts opts
+      exit
+    end
+  end.parse!(ARGV)
+
+  unless ARGV.length >= 3
+    puts 'ERROR: Invalid command'
+    puts 'USAGE: chef-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]'
+    exit 1
+  end
+
+  config = stringify_keys(options.to_h)
+  config['restore_param'] = normalize_arg(ARGV[3])
+
+  status = ChefBackup::Runner.new(config).restore
+  exit(status ? 0 : 1)
+end
+
+def stringify_keys(hash)
+  hash.keys.each { |k| hash[k.to_s] = hash.delete(k) }
+  hash
+end
+
+def normalize_arg(arg)
+  arg =~ /^snap-\h{8}$/ ? arg : File.expand_path(arg)
+end


### PR DESCRIPTION
From @ryancragun in opscode-omnibus#739:

> Holy smokes Batman, the time has finally come to put initial support for offline tar based backup and restores into `chef-server-ctl`.  Not a whole lot has changed from the [initial proposal](https://gist.github.com/ryancragun/2c9c76920153482d4d03) save for a bit of config syntax.  The interface to the [chef_backup gem](https://github.com/ryancragun/chef_backup) should be pretty solid going forward so when we add new backup and restore strategies we'll just need to bump the gem version.  The existing 'tar' strategy will backup everything in the configuration directories of the Chef Server and any installed add-ons.  It also slurps up the variable state of the Chef Server and the upgrade configuration.  By default it will also do a full pg_dump, but that can easily be disabled via config option if you don't want it.

> [CI BUILD](http://wilson.ci.chef.co/job/chef-server-12-build/893/)

> ### chef-server-ctl backup
> #### Usage
```shell
chef-server-ctl backup
```

> #### Configuration
```ruby
# /etc/opscode/chef-server.rb

> # the only supported strategy right now is 'tar'
backup['strategy'] = 'tar'
# defaults to /var/opt/chef-backups
backup['export_dir'] = '/directory/to/ship/tarballs/to'
# defaults to a unique directory in /tmp
backup['tmp_dir'] = '/temporary/directory/to/use/during/backup'
# defaults to true in 'tar' strategy
backup['always_dump_db'] = true
# defaults to 'offline' in 'tar' strategy.  This determines whether or not services are shut down during backup.  'online' should only be used if you don't care about consistency.
backup['mode'] = 'offline' 
# defaults to STDOUT
backup['logfile'] = '/path/to/log.txt'
```

> ### chef-server-ctl restore
```shell
chef-server-ctl restore backup.tgz [options]
```
> #### options
  * --staging-dir:  The path to an empty directory for holding files during restoration
  * --cleanse:  Agree to cleanse the existing state in the Chef Server
