### PR TITLE
Remove nested directories from log rotation template

### DIFF
--- a/omnibus/CHANGELOG.md
+++ b/omnibus/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Remove install message from postinst package script
 * Update chef-server-ctl key commands to use chef-client's Chef::Key object.
 * New gather-log script gathers a lot more debugging information.
+* Remove nested directories from log rotation template
 
 ## 12.0.8 (2015-04-20)
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/logrotate.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/logrotate.erb
@@ -1,4 +1,4 @@
-<%= @log_directory %>/*.log <%= @log_directory %>/*/*.log {
+<%= @log_directory %>/*.log {
   rotate <%= @log_rotation['num_to_keep'] %>
   size <%= @log_rotation['file_maxbytes'] %>
   create 644 <%= @owner || 'opscode' %> <%= @group || 'opscode' %>


### PR DESCRIPTION
nginx, redis_lb, and opscode-solr4 are the current services that use the
logrotate.erb template for their corresponding logrotate entries.  None
of those services actually have nested log directories which results in
an error that prevent logrotate from running correctly:

error: stat of /var/log/opscode/nginx/*/*.log failed: No such file or
directory

Removing unnecessary nested directory directive resolves this problem