### PR TITLE
[perf] Use list:append instead of list:flatten in chef_s3:make_key

### DIFF
--- a/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
@@ -122,8 +122,7 @@ as_string(S) ->
 -spec make_key(OrgId :: object_id(),
                      Checksum :: binary()) -> Key :: string().
 make_key(OrgId, Checksum) ->
-    lists:flatten(["organization-", as_string(OrgId), "/",
-                   "checksum-", as_string(Checksum)]).
+    lists:append(["organization-", as_string(OrgId), "/checksum-", as_string(Checksum)]).
 
 %% @doc Base64-encode an MD5 hex string.
 -spec base64_checksum(Checksum::binary()) -> binary().


### PR DESCRIPTION
This is a minor performance improvement as the list:append function is
faster than list:flatten.  We can substitute list:append for
list:flatten here because we know that we only have one level of
nesting.

For more information see:

http://www.erlang.org/doc/efficiency_guide/listHandling.html#id66880

In local testing with pathelogically large cookbooks, I was able to
get a 10% improvement in request times of the cookbook_versions
endpoint with this change in place.