### PR TITLE
Mp/dvm/coverage support

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -85,37 +85,34 @@ available.
 
 Ruby project dependency loading support coming soon.
 
-### Code Coverage
+### Coverage Analysis
 
-If you want to run code coverage reports, here's what you need to do .
+Erlang has built-in support for code coverage analaysis which will
+evaluate how often each line of code in erlang modules is hit.  To enable this
+for a full project, use:
 
-#### Get Ready!
-in your oc_erchef window run `sync:pause().`. If you don't, your coverage enabled modules will be replaced by sync, and your coverage reports won't generate.
+    dvm cover PROJECT enable
 
-If you only want coverage for a single module, compile a coverage friendly beam like this `cover:compile_beam(Module).`
+To enable it for a specific module, use:
 
-If you're looking to cover all of our modules, use this
+    dvm cover PROJECT enable MODULE_NAME
 
-```erlang
-Dirs = file:wildcard("/host/oc_erchef/apps/*/ebin") .
-[cover:compile_beam_dir(Dir) || Dir <- Dirs].
-```
+To reset coverage stats for one or all modules:
 
-#### You're now "covered"
-Test chef server however you'd like. A good way would be running pedant as described above, but if you want to test a specific scenario, now's your chance.
+    dvm cover PROJECT reset [MODULE_NAME]
 
-#### Generate a report
-Once you're done running whatever tests you want to do, you'll need to generate coverage reports.
+To write coverage results to file (chef-server/testdata/coverage) use:
 
-For each module you want to generate a report for `cover:analyze_to_file(Module, "/root/filename").`
+    dvm cover PROJECT report [MODULE_NAME]
 
-If you want a list comprehension for generaitng coverage reports for all modules, I've got you covered! (see what I did there?! _covered_!)
+And finally to disable coverage and re-enable automatic code sync:
 
-```erlang
-[cover:analyze_to_file(Mod, filename:join("/root", atom_to_list(Mod)) || Mod <- cover:modules()].
-```
+    dvm cover PROJECT disable
 
-## Not so quick start
+Note that enabling cover will disable automatic compile and load of changed
+modules, and disabling it will turn that back on.
+
+## Not So Quick Start
 
 TODO: details of components, terminology, etc. explore more dvm
 commands?
@@ -144,7 +141,6 @@ common activities:
 * open a console to a running erlang app
 * etop a running erlang app
 * access the DB for a project
-* coming soon: enable coverage for an erlang project
 
 And a few other things.  You can just use `dvm` by itself and a list of
 commands will be generated. You may also want to take a look in

--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -1,11 +1,15 @@
-- [x] MOTD with some useful instructions and available commands
+
 - [ ] populate command to load test users and orgs
+- [ ] use runsv 'down' file to cleanly disable loaded services even
+      across chef-server-ctl reconfigure
 - [ ] simple merge of vm settings in config.yml and default.yml files so that
       packages and vm config can be overridden.
 - [ ] Once that's done, update config.yml  with basic skeleton to show what can be done,
       then add to .gitignore
-- [ ] verify `bookshelf` works as-is
-- [ ] add 'sync' erlang dependency to bookshelf, oc_bifrost and chef-mover
+- [ ] we're all in one place - can we use and include a ../concrete.mk
+      to simplify keeping things up to date?
+- [ ] add 'sync' erlang dependency to chef-mover
+- [ ] mover to relx and concrete
 - [ ] option to auto-modify /etc/hosts to add the vm name
       Also ensure DNS for named host resolves to external IP and
       everything works with this.
@@ -18,11 +22,12 @@
 - [ ] not really any support for ruby project deps, something that we
       will want if we expand this to support the things that layer atop chef
       server (manage, etc)
-- [ ] why doesn't NFS file share work, at least with linux host?
+- [ ] why doesn't NFS file share work for intensive IO (git pulls,
+      builds), at least with linux host?
 - [ ] dvm run oc-chef-pedant appears to run as if '--all' were specified
       by default, instead of '--smoke' (this may be a change in behavior
       of pedant itself due to other recent changes)
-- [ ] modify auto clone/load of erlang deps so that it won't clutter up
+- [ ] modify auto clone/load of erlang project deps so that it won't clutter up
       the chef-server dir on the host.
 - [ ] add oc_id supprt
 - [ ] add indexer support (is this worth it?)
@@ -30,13 +35,15 @@
       gemfile.lock
 - [ ] can ruby services (oc-id) support hot-loading of changes as erlang
       projects can? If not, can we fake it?
-- [x] clone and load project deps (erlang)
-- [x] refactor the crap out of projects.rb...
-- [x] verify `oc_bifrost` works as-is
 - [ ] re-add support for compiling dependencies after linking them in,
       instead of relying on the hot loading - hot loading doesn't work
       if the service isn't started (and it won't work for projects that
       don't have sync...)
-- [ ] mover to relx
-- [ ] bookshelf, bifrost: don't run unit on devrel, and add proper usage
+- [x] bookshelf, bifrost: don't run unit on devrel, and add proper usage
       of relx devmode for clean symlinks
+- [x] verify `bookshelf` works as-is
+- [x] clone and load project deps (erlang)
+- [x] refactor the crap out of projects.rb...
+- [x] verify `oc_bifrost` works as-is
+- [x] add 'sync' erlang dependency to bookshelf, oc_bifrost
+- [x] MOTD with some useful instructions and available commands

--- a/dev/cookbooks/dev/recipes/user-env.rb
+++ b/dev/cookbooks/dev/recipes/user-env.rb
@@ -50,6 +50,10 @@ end
   end
 end
 
+directory "/vagrant/testdata/cover" do
+  action :create
+  recursive true
+end
 directory "/vagrant/testdata/keys" do
   action :create
   recursive true

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -7,8 +7,8 @@ vm:
     - deps/
     - _rel/
     - chef-mover/rel/mover/
-    - opscode-dev-vm/
-    - chef-docs/ # Huge if you have it checked out!
+      # - opscode-dev-vm/
+      # - chef-docs/ # Huge if you have it checked out!
     - ebin/
     - .eunit/
     - .kitchen/
@@ -20,8 +20,13 @@ vm:
     - "*.vmdk"
     - "*.plt"
     - "*.beam"
-    - relx
+    - logs/
+    - /dev/
+    - .concrete/
+    - relx # we don't want to pull in a mac relx to our linux vm
     - rspec.failures
+  cover:
+    base_output_path: /vagrant/testdata/cover
 
 projects:
   oc_erchef:
@@ -39,9 +44,6 @@ projects:
   oc_bifrost:
     type: erlang
     database: opscode_bifrost
-    build:
-      # higher concurrency appears to cause eunit failures...
-      max_concurrency: 1
     service:
       rel-type: relx
       name:  oc_bifrost
@@ -55,19 +57,13 @@ projects:
       name:  opscode-chef-mover
       cookie: mover
       node: mover@127.0.0.1
-    build:
-      # higher concurrency appears to cause eunit failures...
-      max_concurrency: 1
   bookshelf:
     type: erlang
     service:
       rel-type: relx
-      name:  bookhself
+      name: bookshelf
       cookie: bookshelf
       node: bookshelf@127.0.0.1
-    build:
-      # higher concurrency appears to cause eunit failures...
-      max_concurrency: 1
   omnibus:
     path: "omnibus"
     name: opscode-omnibus

--- a/dev/dvm/lib/dvm/application.rb
+++ b/dev/dvm/lib/dvm/application.rb
@@ -95,11 +95,28 @@ module DVM
       end
 
     end
+
+    # TODO this could be split into subcommands ...
+    option :with_deps, type: :boolean,
+                       aliases: ['-d'],
+                       default: false,
+                       desc: "when enabling coverage for all modules, also include deps"
+    option :raw_output,  type: :boolean,
+                         aliases: ['-r'],
+                         default: false,
+                         desc: "generate raw coverage reports. HTML is the default. Use with 'report'"
+    desc "cover <project> <start|stop|report|reset> [modulename] [-r -d]", "manage runtime code coverage"
+    def cover(project_name, action, modulename = "all")
+      ensure_project(project_name)
+      @projects[project_name].cover(action, modulename, options)
+    end
+
     desc "update <project> <pause|resume>",  "if the  project supports it, pause or resume sync updates in the running instance"
     def update(project_name, action)
       ensure_project(project_name)
       @projects[project_name].update(action)
     end
+
     desc "runit <project> [run-args]", "Run the project"
     def runit(project_name, *args)
       ensure_project(project_name)

--- a/dev/dvm/lib/dvm/project/erlang.rb
+++ b/dev/dvm/lib/dvm/project/erlang.rb
@@ -2,7 +2,7 @@ require_relative "erlang_dep"
 
 module DVM
   class ErlangProject < Project
-    attr_reader :rebar_config_path, :project_dir, :relpath, :libpath, :relname
+    attr_reader :rebar_config_path, :project_dir, :relpath, :libpath, :relname, :node
     def initialize(project_name, config)
       super
       # TODO use .lock if available, else use .config
@@ -12,6 +12,7 @@ module DVM
       @relpath = "#{@project_dir}/#{reldir}/#{relname}"
       @service_dir = "/var/opt/opscode/embedded/service/#{service['name']}"
       @libpath =  File.join(@relpath, "lib")
+      @node = service['node']
     end
 
     def parse_deps
@@ -27,14 +28,16 @@ module DVM
     end
 
     def is_running?
-      `ps waux | grep "host/#{name}.*/run_erl"`.split("\n").length > 2 ||
-      `ps waux | grep "host/#{name}.*/beam.smp"`.split("\n").length > 2
+      `ps waux | grep "host/.*#{name}.*/run_erl"`.split("\n").length > 2 ||
+      `ps waux | grep "host/.*#{name}.*/beam.smp"`.split("\n").length > 2
     end
 
     def start(args, background)
       raise DVMArgumentError, "#{name} appears to be already running. Try 'dvm console oc_erchef', or 'dvm stop oc_erchef'" if is_running?
+      # Ensure that our packaged installation isn't running, thereby preventing spewage of startup errors.
+      disable_service
       if background
-        run_command("bin/#{relname} start -env DEVVM=1", "Starting #{name}", cwd: relpath, env: { "DEVVM" => "1" } )
+        run_command("bin/#{relname} start", "Starting #{name}", cwd: relpath, env: { "DEVVM" => "1" } )
       else
         exec "cd #{relpath} && bin/#{relname} console"
       end
@@ -45,12 +48,12 @@ module DVM
 "#{name} does not seem to be running from a loaded instance.
 If you want to stop the global instance, use chef-server-ctl stop #{service['name']}'"
 EOM
-      run_command("bin/#{name} stop", "Stoopping #{name}", :cwd => relpath)
+      run_command("bin/#{name} stop", "Stopping #{name}", :cwd => relpath)
     end
 
     def console
       raise "#{name} does not seem to be running from a loaded instance. Use `dvm start #{name}` to start it" unless is_running?
-      exec "#{erl_command} -remsh #{service["node"]}"
+      exec "#{erl_command_base} -remsh #{service["node"]}"
     end
 
     def loaded?
@@ -60,14 +63,6 @@ EOM
       # Filter out everything that fits this criteria - if any files remain
       # then a proper devrel has not been performed.
       #
-      # Addendum:
-      # looks like some concrete projects don't properly link system libraries
-      # into the lib dir, so we'll to verify if one of these is true:
-      # - verify as we are here, which assumes a proprly linked lib dir
-      # - verify that everything in 'deps' is linked to in lib dir,
-      #   which matches the naive approach taken by concrete projects
-      #   TODO - maybe just another config item sthat specifies expected concrete behavior?
-
       begin
         files = Dir.entries(libpath)
         if files.length < 4
@@ -86,14 +81,7 @@ EOM
           (File.symlink?(fullpath) and (File.file?(fullpath) or File.directory?(fullpath)))
 
       end
-      # Some relx projects do not properly link system libraries -
-      # so we have to make sure that *some* of our
       @loaded = files.length == 0
-      return true if @loaded
-
-      # Now our alternative check, based on naive dep linking:
-
-
       @loaded
 
     end
@@ -113,6 +101,10 @@ EOM
     end
 
     def do_load(options)
+      # TODO: Can we just link in our dev-time dependencies post-build,
+      # so that we don't have to declare them as apps in app.src? These are
+      # typically sync, builder, eunit , mixer and common_test
+      #
       # TODO this can also be wrapped and handled in the base...
       if ! project_dir_exists_on_host?
         git = project['git']
@@ -129,78 +121,115 @@ EOM
       end
 
       raise DVMArgumentError, "Project already loaded. Use --force to proceed." if loaded? and not options[:force]
-      run_command("chef-server-ctl stop #{service['name']}", "Stopping #{service['name']}", cwd: project_dir)
+      run_command("chef-server-ctl stop  #{service['name']}", "Stopping #{service['name']}")
       do_build unless options[:no_build]
-
+      disable_service
       link
-      # Make runsv forget about us so that chef-server-ctl reconfigure doesn't restart.
-      # Link may be missing if we're force-reloading
-      #if (File.exists? "/opt/opscode/service/#{service['name']}")
-        #FileUtils.rm("/opt/opscode/service/#{service['name']}")
-      #end
       say(HighLine.color("Success! Your project is loaded.", :green))
       say("Start it now:")
       say(HighLine.color("    dvm start #{name} [--background]", :green))
     end
 
+    # TODO these can probably live in Tools so they're useful outside of erlang projects.
+    def disable_service
+      svname = service['name']
+      # Don't worry about stopping things until after our build succeeds...
+      FileUtils.touch("/opt/opscode/sv/#{svname}/down")
+      run_command("sv x #{service['name']}", "Stopping #{name}")
+    end
+
+    def enable_service
+      svname = service['name']
+      FileUtils.rm("/opt/opscode/sv/#{svname}/down")
+      run_command("sv s #{svname}", "Enabling packaged #{name}")
+      # TODO sv s should be starting it (it thinks it is) but is not.  Take a look at why
+      # this extra step is needed
+      run_command("chef-server-ctl start #{svname}", "Starting packaged #{name}")
+
+    end
     def unload
-      name = service['name']
       if File.exists?("#{relpath}/sys.config")
         FileUtils.rm("#{relpath}/sys.config")
       else
         FileUtils.rm("#{relpath}/etc/sys.config")
       end
       FileUtils.rm("#{relpath}/log")
-      run_command("chef-server-ctl start #{name}", "Restarting packaged version of #{name} via chef-server-ctl", cwd: project_dir)
+      enable_service
     end
 
     def do_build
-      say("Cleaning deps...")
-      FileUtils.rm_rf(["#{project_dir}/deps"])
-      run_command("make clean relclean", "Cleaning up everything else",     cwd: project_dir)
-      run_command("rebar get-deps -C rebar.config.lock",       "Getting all deps, please hold.", cwd: project_dir)
-
-      concurrency = project_setting("build.max_concurrency") || 4
-      # TODO erm, this env should be in from config, it's specific to oc_erchef...
-      run_command("make devrel -j #{concurrency}",    "Building... ", cwd: project_dir, env: { "USE_SYSTEM_GECODE" => "1"})
+      # TODO currently we only load projects that are maintained by Chef and live in chef-server/src.
+      # If this changes, we'll need to support specification of alternative build commands.
+      # TODO2: add build.env since only erchef needs use_system_gecode...
+      run_command("make -j 4 devvm", "Building...", cwd: project_dir, env: { "USE_SYSTEM_GECODE" => "1"})
     end
 
-    def enable_cover(modules = nil)
-      say "Disabling sync to prevent conflicts in loaded beam files."
-      update("pause")
-        run_command("#{erl_command} -eval \"rpc:call('#{node}', sync, go, []).\" -s erlang halt", "Resuming sync on #{node}")
-        run_command("#{erl_command} -eval \"rpc:call('#{node}', sync, go, []).\" -s erlang halt", "Resuming sync on #{node}")
-      say "Cover-compiling app beams."
-      # Run these guys next - need to do it by hand via eval!
-      eval_cmd = <<-EOM
-F = fun() ->
-  Dirs = file:wildcard("/host/#{project_name}/apps/*/ebin\") ++ ["/host/#{project_name}/ebin"]
-  [cover:compile_beam_dir(Dir) || Dir <- Dirs]
-end,
-spawn(#{node}, F).
-EOM
-      run_command("#{erl_command} -eval \"#{eval_cmd}\" -s erlang halt", "Cover-compiling modules on the erlang node.")
+    def cover(action, modulename, options)
+      runargs, message = case action
+                         when 'enable'
+                           cover_enable_args(modulename, options)
+                         when 'report'
+                           cover_report_args(modulename, options)
+                         when 'reset'
+                           [ [modulename], "Resetting coverage stats for #{modulename}"]
+                         when 'disable'
+                           [ [], "Disabling coverage for all modules and re-enabling automatic code loading" ]
+                         else
+                           raise DVMArgumentError, "Valid cover commands are enable, disable, reset, and report."
+                         end
+       erl_rpc("user_default", "cov_#{action}", runargs, message)
     end
-    def dump_cover(modules = nil)
-      # TODO
+
+    def cover_enable_args(modulename, options)
+      msg = "Important: automatic code loading will be disabled until 'dvm cover #{name} stop' is invoked\n"
+      msg << "Enabling coverage for #{modulename}"
+      msg = "Enabling coverage for #{modulename}"
+      runargs = ["\\\"#{@project_dir}\\\""]
+      runargs << modulename
+      runargs << options[:with_deps]
+      [runargs, msg]
     end
+
+    def cover_report_args(modulename, options)
+       msg = "Generating coverage report for #{modulename}"
+       out_path = File.join(config['vm']['cover']['base_output_path'], name)
+       FileUtils.mkdir_p(out_path)
+       runargs = ["\\\"#{out_path}\\\""]
+       runargs << modulename
+       runargs << options[:raw_output]
+       [runargs, msg]
+    end
+
     def update(args)
       # No running check in case we're trying to attach to the global instance
-      node = service['node']
       if args == "pause"
         pause_msg = "Pausing sync on #{node}. This will take effect after any running scans have been completed. \nUse 'dvm update oc_erchef resume' to re-enable automatic updates."
-        run_command("#{erl_command} -eval \"rpc:call('#{node}', sync, pause, []).\" -s erlang halt", pause_msg)
+        erl_rpc("user_default", "sync_action", ["pause"], pause_msg)
       elsif args == "resume"
-        run_command("#{erl_command} -eval \"rpc:call('#{node}', sync, go, []).\" -s erlang halt", "Resuming sync on #{node}")
+        erl_rpc("user_default", "sync_action", ["go"], "Resuming sync")
+      else
+        # TODO for those that don't have sync, support using user_defaults:um(mod) for explicit reloading.
+        raise DVMArgumentError, "Supported update options are 'pause' and 'resume'"
       end
     end
 
     def etop
-      exec "#{erl_command} -s etop -s erlang halt -output text -sort reductions -lines 25 -node #{service['node']}"
+      exec "#{erl_command_base("dvmetop")} -s etop -s erlang halt -output text -sort reductions -lines 25 -node #{service['node']}"
     end
 
-    def erl_command
-      "erl -hidden -name dvm@127.0.0.1 -setcookie #{service["cookie"]}"
+    def erl_rpc(mod, fun, args, message = nil)
+      if message.nil?
+        message = "[#{node}]: Invoking #{mod}:#{fun}(#{args.join(", ")})"
+      else
+        message = "[#{node}]: #{message}"
+      end
+      command = "#{erl_command_base} -noshell -eval \"rpc:call('#{node}', #{mod}, #{fun}, [#{args.join(",")}])\""
+      # puts ">> " command
+      # exec command
+      run_command("#{command} -s erlang halt", message)
+    end
+    def erl_command_base(myname = "dvm")
+      "erl -hidden -name #{myname}@127.0.0.1 -setcookie #{service["cookie"]}"
     end
 
   end

--- a/dev/dvm/lib/dvm/project/project.rb
+++ b/dev/dvm/lib/dvm/project/project.rb
@@ -25,6 +25,10 @@ module DVM
       project['database']
     end
 
+    def cover(action, modulename, options)
+      raise DVM::DVMArgumentError, "Only Erlang projects support coverage at this time."
+    end
+
     def deps
       parse_deps
       @deps

--- a/dev/sync
+++ b/dev/sync
@@ -25,7 +25,9 @@ while true do
   # TODO how to safely stop any interrupt from passing through to child process
   # before we intercept?
   begin
-    @screen.set_status("Syncing...")
+    # Removing this - having it regularly flickering up and calling attention
+    # to itself has proven annoying...
+    #@screen.set_status("Syncing...")
     r = do_sync
     # Prevent scrolling and resizing from doing ugly things...
     @screen.clear

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -23,7 +23,7 @@
           %% and the rotation time to "", or instead specify a 2-tuple that only
           %% consists of {Logfile, Level}.
           {handlers, [
-              {lager_console_backend, error},
+              {lager_console_backend, [info, {lager_default_formatter, [ "[", severity, "] ", message, "\n"]}]},
               {lager_file_backend, [
                                     {file, "<%= File.join(@log_directory, 'error.log') %>"},
                                     {level, error},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -1,4 +1,5 @@
 %% -*- mode: erlang -*-
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*- %% ex: ts=4 sw=4 ft=erlang et
 %%
 %% oc_bifrost sys.config file
 %%
@@ -25,7 +26,7 @@
           %% and the rotation time to "", or instead specify a 2-tuple that only
           %% consists of {Logfile, Level}.
           {handlers, [
-              {lager_console_backend, error},
+              {lager_console_backend, [info, {lager_default_formatter, [ "[", severity, "] ", message, "\n"]}]},
               {lager_file_backend, [
                                     {file, "<%= File.join(@log_directory, 'error.log') %>"},
                                     {level, error},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -12,7 +12,7 @@
         ]},
  {lager, [
           {handlers, [
-              {lager_console_backend, [info, {lager_default_formatter, ["[", severity, "] ", message, "\n"]}]},
+              {lager_console_backend, [info, {lager_default_formatter, [ "[", severity, "] ", message, "\n"]}]},
               {lager_file_backend, [
                                     {file, "<%= File.join(@log_directory, 'erchef.log') %>"},
                                     {level, info},

--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -22,15 +22,16 @@
         {mini_s3, ".*",
          {git, "git://github.com/opscode/mini_s3.git",
           {branch, "master"}}},
+        {sync, ".*",
+         {git, "https://github.com/rustyio/sync.git", {branch, "master"}}}
         {eper, ".*",
          {git, "git://github.com/massemanet/eper.git", {branch, "master"}}}
        ]}.
 
 
-{erl_opts,
- [debug_info,
-  {parse_transform, lager_transform},
-  warnings_as_errors]}.
+{erl_opts, [debug_info,
+            {parse_transform, lager_transform},
+            warnings_as_errors}].
 
 {xref_checks,
  [exports_not_used,

--- a/src/bookshelf/rebar.config.lock
+++ b/src/bookshelf/rebar.config.lock
@@ -44,6 +44,9 @@
        {rebar_lock_deps_plugin,".*",
                                {git,"git://github.com/seth/rebar_lock_deps_plugin.git",
                                     "7a5835029c42b8138325405237ea7e8516a84800"}},
+       {sync,".*",
+             {git,"https://github.com/rustyio/sync.git",
+                  "ae7dbd4e6e2c08d77d96fc4c2bc2b6a3b266492b"}},
        {edown,".*",
               {git,"git://github.com/seth/edown.git",
                    "30a9f7867d615af45783235faa52742d11a9348e"}}]}.

--- a/src/bookshelf/relx.config
+++ b/src/bookshelf/relx.config
@@ -1,4 +1,4 @@
-{release,{bookshelf,"1.1.7"},[bookshelf]}.
+{release,{bookshelf,"1.1.7"},[bookshelf, syntax_tools, compiler]}.
 {extended_start_script,true}.
 {overlay,[{template,"rel/files/vm.args","vm.args"},
           {template,"rel/files/app.config","sys.config"}]}.

--- a/src/bookshelf/src/bksw_app.erl
+++ b/src/bookshelf/src/bksw_app.erl
@@ -26,6 +26,11 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
+    case os:getenv("DEVVM") of
+        "1" ->
+            application:start(sync);
+        _ -> ok
+    end,
     bksw_sup:start_link().
 
 stop(_State) ->

--- a/src/bookshelf/src/bookshelf.app.src
+++ b/src/bookshelf/src/bookshelf.app.src
@@ -37,5 +37,10 @@
                     lager,
                     opscoderl_wm,
                     iso8601,
-                    eper
+                    eper,
+                    runtime_tools,
+                    tools,
+                    sync,
+                    eunit,
+                    mixer
                   ]}]}.

--- a/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
@@ -17,5 +17,9 @@
                   mixer,
                   envy,
                   sqerl,
-                  opscoderl_wm
+                  opscoderl_wm,
+                  runtime_tools,
+                  tools,
+                  sync,
+                  eunit
                  ]}]}.

--- a/src/oc_bifrost/apps/bifrost/src/bifrost_app.erl
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost_app.erl
@@ -4,6 +4,11 @@
 -export([start/2,stop/1]).
 
 start(_Type, _StartArgs) ->
+    case os:getenv("DEVVM") of
+        "1" ->
+            application:start(sync);
+        _ -> ok
+    end,
     bifrost_sup:start_link().
 
 stop(_State) ->

--- a/src/oc_bifrost/rebar.config
+++ b/src/oc_bifrost/rebar.config
@@ -26,7 +26,9 @@
   {stats_hero, ".*",
    {git, "git://github.com/chef/stats_hero.git", {branch, "master"}}},
   {opscoderl_wm, ".*",
-   {git, "git://github.com/chef/opscoderl_wm.git", {branch, "master"}}}
+   {git, "git://github.com/chef/opscoderl_wm.git", {branch, "master"}}},
+  {sync, ".*",
+   {git, "https://github.com/rustyio/sync.git", {branch, "master"}}}
  ]}.
 
 {use_lock_deps, true}.

--- a/src/oc_bifrost/rebar.config.lock
+++ b/src/oc_bifrost/rebar.config.lock
@@ -50,6 +50,9 @@
        {opscoderl_wm,".*",
                      {git,"git://github.com/chef/opscoderl_wm.git",
                           "64db62e070da58cf7bb0caebde7a3f11c2e3cbbb"}},
+       {sync,".*",
+             {git,"https://github.com/rustyio/sync.git",
+                  "ae7dbd4e6e2c08d77d96fc4c2bc2b6a3b266492b"}},
        {rebar_lock_deps_plugin,".*",
                                {git,"git://github.com/seth/rebar_lock_deps_plugin.git",
                                     "7a5835029c42b8138325405237ea7e8516a84800"}}]}.

--- a/src/oc_bifrost/relx.config
+++ b/src/oc_bifrost/relx.config
@@ -1,4 +1,4 @@
-{release,{oc_bifrost,"1.4.7"},[bifrost]}.
+{release,{oc_bifrost,"1.4.7"},[bifrost, syntax_tools, compiler]}.
 {extended_start_script,true}.
 {overlay,[{template,"rel/files/vm.args","vm.args"},
           {template,"rel/files/sys.config","sys.config"}]}.

--- a/src/oc_erchef/devvm.mk
+++ b/src/oc_erchef/devvm.mk
@@ -1,30 +1,25 @@
-## Copied from opscode-dev-vm/devvm.mk
-## For use with relx erlang projects
+# Very simple make sequence that cleans, compiles and builds a release
+# and does a --dev-mode relx.  In dvm, ct/eunit/dialyzer are expected to be run
+# on the host.  dvm only wants to load the project.
 
-SHELL := /bin/bash
+devvm_distclean:
+	@rm -rf deps $(DEPS_PLT) #distclean
 
-## DEV VM Targets
-DEVVM_PROJ ?= $(notdir $(CURDIR))
-DEVVM_ROOT ?= /srv/piab/mounts/$(notdir $(CURDIR))
-DEVVM_DIR ?= $(DEVVM_ROOT)/_rel/$(PROJ)
+devvm_relclean: devvm_distclean
+	@rm -rf $(RELX_OUTPUT_DIR) # relclean
 
-bummer:
-	@/bin/echo Bummer! If you\'re stuck reading this error message, it\'s not the end of the world!
-	@/bin/echo You\'ll need to Ctrl-C twice to get out of this stuck rake command \(densoneold\)
-	@/bin/echo Then \'rake ssh\' into the box and cd $(DEVVM_ROOT)
-	@/bin/echo Then \'make devvm\' will get you running
+devvm_clean: devvm_relclean
+	@$(REBARC) -j 4  clean #clean
 
-devvm_stop:
-	private-chef-ctl stop $(DEVVM_PROJ)
+devvm_deps: devvm_clean
+	@$(REBARC) -j 4 get-deps # get-deps
 
-devvm_link:
-	rm -f $(DEVVM_DIR)/sys.config
-	ln -s  /var/opt/opscode/$(DEVVM_PROJ)/sys.config $(DEVVM_DIR)/sys.config
+devvm_compile: devvm_deps
+	@$(REBARC) -j 4 compile # compile
 
-devvm: devvm_stop devrel devvm_link
+devvm_relx:
+	curl -Lo relx $(RELX_URL) || wget $(RELX_URL)
+	chmod a+x relx
 
-compile_fast:
-	$(REBARC) compile skip_deps=true
-
-update: compile_fast
-	@cd _rel/$(PROJ);bin/$(PROJ) restart
+devvm: devvm_compile bundle  devvm_relx
+	@$(RELX) --dev-mode -c $(RELX_CONFIG) -o $(RELX_OUTPUT_DIR) $(RELX_OPTS) # devrel


### PR DESCRIPTION
I still need to test behavior of oc_bifrost and bookshelf with sync enabled at dev-time, so this isn't ready for merge.    I would welcome feedback on enabling coverage support and usage of it though. 

This also includes some enhancements to rpc calls into the erlang node, so that it will wait for the call to complete before returning. 

ping @chef/lob /redundant-cc @joedevivo 