### PR TITLE
Wrap `make install` with `travis_retry` function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,6 @@ install:
   - eval $(luarocks path)
   - rvm install --binary 2.1.4
   - rvm use 2.1.4
-  - cd $COMPONENT && make install
+  - cd $COMPONENT && travis_retry make install
 script:
   - make travis


### PR DESCRIPTION
According to the documentation:

http://docs.travis-ci.com/user/build-timeouts/

the `travis_retry` function will retry a command 3 times.  This should
help us avoid build failures due to rubygems.org timemouts during the
oc-id tests.