### PR TITLE
Implemented X-Ops-Server-API-Version Response Header

### DIFF
--- a/src/oc_erchef/README.md
+++ b/src/oc_erchef/README.md
@@ -87,19 +87,24 @@ The following should be installed on the development system and in your path.
 
 ```
 make
-make bundle # this installs dep_selector
 ```
 
 #### Running Tests
 
 ##### Running Integration Tests
 
-`rebar skip_deps=true ct`
+`make ct`
 
 You can see the output of test results by open the itest index files in your browser for the `oc_chef_authz`, `chef_db`, and `oc_chef_wm` apps:
 
 `<path_to_repo>/apps/<app_to_view>/itest/ct_logs/index.html`
 
+You can run individual ct tests by running:
+
+`make ct_<full_file_name_minus_suite>`
+
+For example, if you want to run the tests in `oc_chef_wm_server_api_version_SUITE.erl`, just run `make ct_oc_chef_wm_server_api_version`.
+
 ##### Running Unit Tests
 
-`rebar skip_deps=true eunit`
+`make test`

--- a/src/oc_erchef/custom.mk
+++ b/src/oc_erchef/custom.mk
@@ -36,7 +36,7 @@ ct_%: clean_ct
 		SUITE=$$(echo "$$FIND_RESULT" | perl -wlne 'print $$1 if /\/([^\/]+)_SUITE\.erl/') && \
 		APP=$$(echo "$$FIND_RESULT" | perl -wlne 'print $$1 if /\.\/apps\/([^\/]+)\/.*\/[^\/]+_SUITE\.erl/') && \
 		SKIP_APPS=$$(echo "$(APPS)" | sed "s/$$APP//" | sed -E "s/[ ]+/,/g") && \
-		echo "suite=$$SUITE skip_apps=$$SKIP_APPS"; \
+		echo "suites=$$SUITE skip_apps=$$SKIP_APPS"; \
 	fi) && COMMAND="time $(REBAR) ct $$EXTRAS skip_deps=true" && echo $$COMMAND && eval $$COMMAND;
 
 clean_ct:

--- a/src/oc_erchef/include/oc_chef_wm.hrl
+++ b/src/oc_erchef/include/oc_chef_wm.hrl
@@ -119,7 +119,7 @@
           %% We will not allow it to be
           %% undefined by default, because in error conditions where it does not get set we will
           %% still attempt to capture it to log in finish_request.
-          server_api_version  = -1 :: integer(),
+          server_api_version  = -1 :: integer() | 'bad_value_requested',
 
           %% OTP information for the Erchef server in {ReleaseName, OtpVersion} form.
           otp_info :: {string(), string()},


### PR DESCRIPTION
Ping @chef/lob 

Related: https://github.com/chef/chef-rfc/pull/123

[Build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/505/downstreambuildview/)

##### Response Header

In the response header, `X-Ops-Server-API-Version` will return json of the format:

```
{
  "min_version":"<non-negative integer>",
  "max_version":"<non-negative integer>",
  "request_version":"<integer>",
  "response_version":"<integer>"
}
```

Where:
+ `min_version` is the minimum API version the server supports.
+ `max_version` is the maximum API version the server supports.
+ `request_version` is an integer representing the desired API version from the client passed via X-Ops-Server-API-Version
defaulting to 0 if X-Ops-Server-API-Version was not sent by the client. If X-Ops-Server-API-Version sent by the client contained
an invalid value (not an integer), then -1 is returned in `request_version`.
+ `response_version` is an integer representing the API version used by the server to process the request.
It either matches what the client requested in X-Ops-Server-API-Version or is -1 if a 406 occurred (which happens
when X-Ops-Server-API-Version sent by the client was invalid or not in the supported range of the server).