### PR TITLE
use relx tooling to not start all apps. sync versions on chef-server version

### DIFF
--- a/src/bookshelf/rel/reltool.config
+++ b/src/bookshelf/rel/reltool.config
@@ -1,7 +1,7 @@
 {sys,[{lib_dirs,["../deps","apps"]},
       {erts,[{mod_cond,derived},{app_file,strip}]},
       {app_file,strip},
-      {rel,"bookshelf","1.1.6",
+      {rel,"bookshelf","12.1.0",
            [kernel,stdlib,sasl,crypto,public_key,ssl,inets,erlsom,mochiweb,
             webmachine,xmerl,ibrowse,lager,mini_s3,bookshelf,opscoderl_wm]},
       {rel,"start_clean",[],[kernel,stdlib]},

--- a/src/bookshelf/relx.config
+++ b/src/bookshelf/relx.config
@@ -1,4 +1,15 @@
-{release,{bookshelf,"1.1.7"},[bookshelf, syntax_tools, compiler]}.
+%% -*- mode: erlang -*-
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+{release,{bookshelf,"12.1.0"},
+ [bookshelf,
+  {sync, load},
+  {eunit, load},
+  {mixer, load},
+  syntax_tools,
+  compiler,
+  eper
+  ]}.
 {extended_start_script,true}.
 {overlay,[{template,"rel/files/vm.args","vm.args"},
           {template,"rel/files/app.config","sys.config"}]}.

--- a/src/bookshelf/src/bookshelf.app.src
+++ b/src/bookshelf/src/bookshelf.app.src
@@ -19,7 +19,7 @@
 {application, bookshelf,
  [{description  , "Bookshelf Rest Interface: Amazon S3 Compatible"
    "Object Store Rest API"},
-  {vsn, "1.1.6"},
+  {vsn, "12.1.0"},
   {mod, {bksw_app, []}},
   {registered, [bksw_sup]},
   {applications , [
@@ -37,10 +37,6 @@
                     lager,
                     opscoderl_wm,
                     iso8601,
-                    eper,
                     runtime_tools,
-                    tools,
-                    sync,
-                    eunit,
-                    mixer
+                    tools
                   ]}]}.

--- a/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
@@ -1,7 +1,7 @@
 %%-*- mode: erlang -*-
 {application, bifrost,
  [{description, "Bifrost: Opscode Authorization API"},
-  {vsn, "0.0.1"},
+  {vsn, "12.1.0"},
   {modules, []},
   {registered, []},
   {mod, {bifrost_app, []}},
@@ -11,15 +11,11 @@
                   lager,
                   sasl,
                   stats_hero,
-                  eper,
                   ej,
                   jiffy,
-                  mixer,
                   envy,
                   sqerl,
                   opscoderl_wm,
                   runtime_tools,
-                  tools,
-                  sync,
-                  eunit
+                  tools
                  ]}]}.

--- a/src/oc_bifrost/rel/reltool.config
+++ b/src/oc_bifrost/rel/reltool.config
@@ -1,5 +1,5 @@
 {sys,[{lib_dirs,["../deps","../apps"]},
-      {rel,"oc_bifrost","1.4.7",
+      {rel,"oc_bifrost","12.1.0",
            [kernel,stdlib,sasl,crypto,eper,jiffy,ej,lager,epgsql,sqerl,
             webmachine,bifrost]},
       {rel,"start_clean",[],[kernel,stdlib]},

--- a/src/oc_bifrost/relx.config
+++ b/src/oc_bifrost/relx.config
@@ -1,4 +1,15 @@
-{release,{oc_bifrost,"1.4.7"},[bifrost, syntax_tools, compiler]}.
+%% -*- mode: erlang -*-
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+{release,{oc_bifrost,"12.1.0"},
+     [bifrost,
+      {sync, load},
+      {eunit, load},
+      {mixer, load},
+      syntax_tools,
+      compiler,
+      eper
+     ]}.
 {extended_start_script,true}.
 {overlay,[{template,"rel/files/vm.args","vm.args"},
           {template,"rel/files/sys.config","sys.config"}]}.

--- a/src/oc_erchef/rel/reltool.config
+++ b/src/oc_erchef/rel/reltool.config
@@ -1,5 +1,5 @@
 {sys,[{lib_dirs,["../deps","../apps"]},
-      {rel,"oc_erchef","1.8.3",
+      {rel,"oc_erchef","12.1.0",
            [kernel,stdlib,sasl,crypto,mochiweb,webmachine,ejson,oauth,ibrowse,
             couchbeam,lager,epgsql,sqerl,rabbit_common,amqp_client,gen_bunny,
             chef_index,darklaunch,oc_chef_wm,opscoderl_wm,opscoderl_httpc,

--- a/src/oc_erchef/relx.config
+++ b/src/oc_erchef/relx.config
@@ -1,7 +1,16 @@
 %% -*- mode: erlang -*-
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-{release,{oc_erchef,"1.8.3"},[oc_erchef, syntax_tools, compiler]}.
+{release,{oc_erchef,"12.1.0"},
+ [oc_erchef,
+  {sync, load},
+  {eunit, load},
+  {mixer, load},
+  syntax_tools,
+  compiler,
+  eper
+ ]}.
+
 {extended_start_script,true}.
 {overlay_vars,"rel/reltool.config"}.
 {overlay,[{mkdir,"log/sasl"},

--- a/src/oc_erchef/src/oc_erchef.app.src
+++ b/src/oc_erchef/src/oc_erchef.app.src
@@ -4,7 +4,7 @@
 {application, oc_erchef,
  [
   {description, ""},
-  {vsn, "1"},
+  {vsn, "12.1.0"},
   {registered, []},
   {applications, [
                   kernel,
@@ -15,14 +15,10 @@
                   depsolver,
                   oc_chef_authz,
                   oc_chef_wm,
-
-                  %% TODO: The following deps should be pulled in by the above
-                  %% apps, but they aren't. Isn't that sad? We should fix it!
                   bear,
                   chef_authn,
                   ej,
                   envy,
-                  eper,
                   erlware_commons,
                   et,
                   folsom_graphite,
@@ -37,14 +33,9 @@
                   runtime_tools,
                   tools,
                   uuid,
-                  webtool,
-                  %% These are effectively dev-only, but need to be present as apps pulled into the
-                  %% development environment by relx.  mixer is not startable, and sync is only started when
-                  %% DEVVM=1 environment variable is present.
-                  sync,
-                  mixer,
-                  eunit
+                  webtool
                  ]},
   {mod, { oc_erchef_app, []}},
   {env, []}
  ]}.
+


### PR DESCRIPTION
use relx tooling to not start dev apps in normal runs 
make our erlang project  versions the same as the chef-server version. 

ping @chef/lob 