### PR TITLE
Allow users to read other user objects when both users share an org

### DIFF
--- a/oc-chef-pedant/spec/api/account/account_association_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_association_spec.rb
@@ -172,16 +172,26 @@ describe "opscode-account user association", :association do
       end
     end
   end
+
   context "/users/USER/organizations endpoint" do
     let(:test_username) { "test-user-#{Time.now.to_i}-#{Process.pid}" }
+    let(:test_orgname2) { "test-org-#{Time.now.to_i}-#{Process.pid}" }
     let(:test_user) { platform.create_user(test_username) }
+    let(:test_org2) { platform.create_org(test_orgname2)}
+    let(:test_user2) { platform.create_user(test_username + "-2") }
     let(:user_org_url) { "#{users_url}/#{test_username}/organizations" }
     before do
+      platform.create_org(test_orgname2)
       platform.associate_user_with_org(platform.test_org.name, test_user)
+      platform.associate_user_with_org(platform.test_org.name, test_user2)
+      platform.associate_user_with_org(test_orgname2, test_user2)
     end
     after do
-      delete(api_url("users/#{test_username}"), platform.superuser)
-      delete("#{platform.server}/users/#{test_username}", platform.superuser)
+      [test_username, "#{test_username}-2"].each do |u|
+        delete(api_url("users/#{u}"), platform.superuser)
+        delete("#{platform.server}/users/#{u}", platform.superuser)
+      end
+      delete("#{platform.server}/organizations/#{test_orgname2}", platform.superuser)
     end
 
     context "invoking" do
@@ -193,21 +203,41 @@ describe "opscode-account user association", :association do
       end
 
       context "GET" do
-        it "returns a proper list of orgs for the user" do
-          result = get(user_org_url, test_user)
-          result.should look_like({ :status => 200 })
-          # we need to split out our field checks here, because
-          # we don't know the value of guid, so we can't include it in
-          # a body check.  however pedant will fail on an unaccounted-for field
-          # in the body response
-          json = JSON.parse(result)
-          json.length.should == 1
-          org = json[0]["organization"]
-          expect(org.nil?).to be(false)
-          expect(org["name"]).to eq(platform.test_org.name)
-          expect(org["full_name"]).to eq(platform.test_org.name)
-          expect(org["guid"].nil?).to be(false)
-          expect(org["guid"].empty?).to be(false)
+        context "when the requesting user is the targetuser" do
+          it "returns all organizations the user is a member of" do
+            result = get(user_org_url, test_user)
+            result.should look_like({:status => 200})
+            expect(JSON.parse(result).length == 2)
+          end
+
+          it "returns a proper list of orgs for the user" do
+            result = get(user_org_url, test_user)
+            result.should look_like({ :status => 200 })
+            json = JSON.parse(result)
+            org = json.find {|o| o["organization"]["name"] == platform.test_org.name }["organization"]
+            expect(org.nil?).to be(false)
+            expect(org["name"]).to eq(platform.test_org.name)
+            expect(org["full_name"]).to eq(platform.test_org.name)
+            expect(org["guid"].nil?).to be(false)
+            expect(org["guid"].empty?).to be(false)
+          end
+        end
+
+        context "when the requesting user is the superuser" do
+          it "returns all organizations the user is a member of" do
+            result = get(user_org_url, platform.superuser)
+            result.should look_like({:status => 200})
+            expect(JSON.parse(result).length == 2)
+          end
+        end
+
+        context "when the requesting user shares 1 organization with the target user" do
+          it "only returns the shared organization" do
+            result = get(user_org_url, platform.superuser)
+            result.should look_like({:status => 200})
+            expect(JSON.parse(result).length).to eq(1)
+            expect(JSON.parse(result)[0]["organization"]["name"]).to eq(platform.test_org.name)
+          end
         end
       end
     end

--- a/oc-chef-pedant/spec/api/account/account_association_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_association_spec.rb
@@ -222,8 +222,8 @@ describe "opscode-account user association", :association do
       it "an admin org user succeeds" do
         get(user_org_url, platform.admin_user).should look_like({:status => 200})
       end
-      it "another org member fails" do
-        get(user_org_url, platform.non_admin_user).should look_like({:status => 403})
+      it "another org member succeeds" do
+        get(user_org_url, platform.non_admin_user).should look_like({:status => 200})
       end
       it "some other user fails" do
         get(user_org_url, platform.bad_user).should look_like({:status => 403})

--- a/oc-chef-pedant/spec/api/user_spec.rb
+++ b/oc-chef-pedant/spec/api/user_spec.rb
@@ -612,6 +612,13 @@ describe "users", :users do
               :body_exact => user_body
             })
         end
+
+        it "can get the admin user since they share an organization", :authorization do
+          req_url = "#{platform.server}/users/#{platform.admin_user.name}"
+          get(req_url, platform.non_admin_user).should look_like({
+              :status => 200
+           })
+        end
       end
 
       context "default client" do

--- a/omnibus/files/private-chef-upgrades/001/025_user_read_access.rb
+++ b/omnibus/files/private-chef-upgrades/001/025_user_read_access.rb
@@ -1,0 +1,19 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+    # Make sure API is down
+    stop_services(["nginx", "opscode-erchef"])
+
+    start_services(["oc_bifrost", "postgresql"])
+    force_restart_service("opscode-chef-mover")
+    log "Granting READ permission for users within the same org using internal group membership"
+
+    run_command("/opt/opscode/embedded/bin/escript " +
+                "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +
+                "mover_global_admins_user_addition_callback " +
+                "normal " +
+                "mover_transient_queue_batch_migrator")
+
+    stop_services(["opscode-chef-mover"])
+  end
+end

--- a/src/chef-mover/src/mover_global_admins_user_addition_callback.erl
+++ b/src/chef-mover/src/mover_global_admins_user_addition_callback.erl
@@ -1,0 +1,106 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Steven Danna <steve@chef.io>
+%% @copyright 2015 Chef Software, Inc.
+%%
+%% The global_admins_user_addition addition callback adds the user
+%% group from a given organization into the ORGNAME_global_admins
+%% group for that organization.
+%%
+%% The ORGNAME_global_admins group has a signle purpose: providing
+%% READ access to other user objects in ORGNAME.  Thus, the only
+%% change that this migration produces is that users that share an org
+%% can now see each others user objects.
+%%
+%% This change is necessary to facilitate the use of chef-vault.
+%%
+-module(mover_global_admins_user_addition_callback).
+
+-export([
+         migration_init/0,
+         migration_complete/0,
+         migration_type/0,
+         supervisor/0,
+         migration_start_worker_args/2,
+         migration_action/2,
+         next_object/0,
+         error_halts_migration/0,
+         reconfigure_object/2,
+         needs_account_dets/0
+        ]).
+
+-include("mover.hrl").
+
+-record(org, {name, id, authz_id}).
+-record(group, {name, id, authz_id}).
+
+migration_init() ->
+    mv_oc_chef_authz_http:create_pool(),
+    mover_transient_migration_queue:initialize_queue(?MODULE, all_orgs()).
+
+migration_action(#org{name = OrgName} = Org, _) ->
+    GAGroup = global_admin_group(Org),
+    UserGroup = user_group(Org),
+    case add_group_to_group(UserGroup, GAGroup) of
+        ok ->
+            ok;
+        {error, Error} ->
+            lager:warn("Organization ~p failed during group addition.", [OrgName]),
+            Error
+    end.
+
+migration_complete() ->
+    mv_oc_chef_authz_http:delete_pool().
+
+global_admin_query() ->
+    <<"SELECT name, id, authz_id FROM groups WHERE name = $1">>.
+
+users_group_query() ->
+    <<"SELECT name, id, authz_id FROM groups WHERE name = 'users' AND org_id = $1">>.
+
+all_orgs_query() ->
+    <<"SELECT name, id, authz_id FROM orgs">>.
+
+all_orgs() ->
+    %% TODO: Will this be Bad(TM) in Hosted?
+    {ok, Orgs} = sqerl:select(all_orgs_query(), [], rows_as_records, [org, record_info(fields, org)]),
+    Orgs.
+
+global_admin_group(Org) ->
+    {ok, [Group]} = sqerl:select(global_admin_query(), [ga_groupname(Org)], rows_as_records, [group, record_info(fields, group)]),
+    Group.
+
+ga_groupname(#org{name = OrgName}) ->
+    iolist_to_binary([OrgName, <<"_global_admins">>]).
+
+user_group(#org{id = OrgId}) ->
+    {ok, [Group]} = sqerl:select(users_group_query(), [OrgId], rows_as_records, [group, record_info(fields, group)]),
+    Group.
+
+add_group_to_group(#group{authz_id = IdToAdd}, #group{authz_id = TargetId}) ->
+    mv_oc_chef_authz:add_to_group(TargetId, group, IdToAdd, superuser).
+
+%%
+%% Generic mover callback functions for
+%% a transient queue migration
+%%
+needs_account_dets() ->
+    false.
+
+migration_start_worker_args(Object, AcctInfo) ->
+    [Object, AcctInfo].
+
+next_object() ->
+    mover_transient_migration_queue:next(?MODULE).
+
+migration_type() ->
+    <<"global_admins_user_addition">>.
+
+supervisor() ->
+    mover_transient_worker_sup.
+
+error_halts_migration() ->
+    false.
+
+reconfigure_object(_ObjectId, _AcctInfo) ->
+    ok.

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -545,6 +545,14 @@
   WHERE id = $13">>
 }.
 
+{list_common_orgs_for_users,
+ <<"SELECT o.name as name, o.full_name as full_name, o.id as guid"
+   "  FROM (SELECT * FROM org_user_associations WHERE user_id = $1) AS a,"
+   "       (SELECT * FROM org_user_associations WHERE user_id = $2) AS b,"
+   "       orgs o"
+   " WHERE a.org_id = o.id"
+   "   AND a.org_id = b.org_id">>
+}.
 
 {update_user_by_id,
 <<"UPDATE users

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -47,6 +47,7 @@
          mark_checksums_as_uploaded/3,
 
          %% user ops
+         list_common_orgs/3,
          node_record_to_authz_id/2,
 
          %% role_record_to_authz_id/2,
@@ -561,6 +562,10 @@ count_nodes(#context{reqid = ReqId} = _Ctx) ->
         {error, Error} ->
             {error, Error}
     end.
+
+-spec list_common_orgs(object_id(), object_id(), #context{}) -> [list()].
+list_common_orgs(User1Id, User2Id, #context{reqid=ReqId}) ->
+    ?SH_TIME(ReqId, chef_sql, list_common_orgs_for_users, (User1Id, User2Id)).
 
 -spec is_user_in_org(#context{}, binary(), binary()) -> boolean() | {error, _}.
 is_user_in_org(#context{reqid = ReqId}, UserName, OrgName) ->

--- a/src/oc_erchef/apps/chef_db/src/chef_sql.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_sql.erl
@@ -91,6 +91,7 @@
          fetch_org_metadata/1,
 
          %% user-org ops
+         list_common_orgs_for_users/2,
          is_user_in_org/2,
 
          %% key ops
@@ -170,6 +171,21 @@ is_user_in_org(UserName, OrgName) ->
             false;
         {ok, N} when is_integer(N) ->
             true;
+        {error, Error} ->
+            {error, Error}
+    end.
+
+%%
+%% list_common_orgs: List the common organizations between two users
+%%
+%%
+-spec list_common_orgs_for_users(binary(), binary()) -> [list()].
+list_common_orgs_for_users(User1Id, User2Id) ->
+    case sqerl:select(list_common_orgs_for_users, [User1Id, User2Id], rows) of
+        {ok, none} ->
+            [];
+        {ok, L} when is_list(L) ->
+            L;
         {error, Error} ->
             {error, Error}
     end.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
@@ -70,7 +70,7 @@
          {create_groups, ?GROUPS},
          {create_org_global_admins},
          {add_to_groups, user, [creator], [admins, users]},
-         {add_to_groups, group, [admins], [global_admins]},
+         {add_to_groups, group, [admins, users], [global_admins]},
 
          %% ACLs are expanded, then applied
          {acls,


### PR DESCRIPTION
This changes the creation policy for newly created organizations and
provides a migration for existing organizations to ensure that the
users group is added to the ORGNAME_global_admins group.

The ORGNAME_global_admins group has one purposes inside the Chef
Server: to provide READ access to users that are associated with
ORGNAME. Previously only admins were granted this READ access.
However, users of chef-vault would like ordinary users to be able to
encrypt items for other users, thus promping this change in behavior.

The following API requests that would have previously failed, will now
succeed if two users are members of the same organization:

- GET /users/USERNAME
- GET /users/USERNAME/organizations
- GET /users/USERNAME/keys
- GET /users/USERNAME/keys/KEYNAME