### PR TITLE
ACL Restrictions - Prevent admins group removal from grant ACE

### DIFF
--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -1277,7 +1277,9 @@ describe "ACL API", :acl do
                     :payload => {"grant" => {
                         "actors" => [platform.non_admin_user.name,
                           platform.admin_user.name, "pivotal"],
-                        "groups" => []
+                        # Per ACL policy, non-superusers can't remove the admins
+                        # group from the grant ACL.
+                        "groups" => ["admins"]
                       }}).should look_like({
                       :status => 200
                     })
@@ -1315,7 +1317,9 @@ describe "ACL API", :acl do
                     :payload => {"grant" => {
                         "actors" => [platform.non_admin_client.name,
                           platform.admin_user.name, "pivotal"],
-                        "groups" => []
+                        # Per ACL policy, non-superusers can't remove the admins
+                        # group from the grant ACL.
+                        "groups" => ["admins"]
                       }}).should look_like({
                       :status => 200
                     })

--- a/oc-chef-pedant/spec/api/account/account_group_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_group_spec.rb
@@ -477,7 +477,9 @@ describe "opscode-account groups", :groups do
             put(api_url("groups/#{test_group}/_acl/#{permission}"), platform.admin_user,
               :payload => {permission => {
                   "actors" => [platform.admin_user.name],
-                  "groups" => []
+                  # Leave admins in the groups, as per ACL policy
+                  # it can't be removed from the grant ACL except by the superuser
+                  "groups" => ["admins"]
                 }}).should look_like({
                 :status => 200
               })

--- a/oc-chef-pedant/spec/api/groups_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/groups_acl_spec.rb
@@ -4,7 +4,7 @@ require 'pedant/acl'
 describe "Groups ACL", :acl do
   include Pedant::ACL
 
-  describe "returns Forbidden when trying to remove the admin group from any grant ACE" do
+  describe "returns expected response when trying to remove the admin group from any grant ACE" do
     # For now testing with groups, but potentially also want to test with other objects
     %w(admins clients users).each do |test_group|
       context "for #{test_group}" do
@@ -47,11 +47,18 @@ describe "Groups ACL", :acl do
               :payload => payload).should look_like({:status => 200})
         end
 
-        it "returns Fordidden trying to remove grant ace from #{test_group} group" do
+        it "returns Fordidden trying to remove grant ace from #{test_group} group using non-superuser" do
           response = put(write_acl_url, platform.admin_user,
                          :payload => request_body)
           response.should look_like({:status => 403})
         end
+
+        it "returns OK trying to remove grant ace from #{test_group} group user superuser" do
+          response = put(write_acl_url, superuser,
+                         :payload => request_body)
+          response.should look_like({:status => 200})
+        end
+
 
       end
     end

--- a/oc-chef-pedant/spec/api/groups_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/groups_acl_spec.rb
@@ -47,7 +47,7 @@ describe "Groups ACL", :acl do
               :payload => payload).should look_like({:status => 200})
         end
 
-        it "returns Fordidden trying to remove grant ace from #{test_group} group", :pending => true do
+        it "returns Fordidden trying to remove grant ace from #{test_group} group" do
           response = put(write_acl_url, platform.admin_user,
                          :payload => request_body)
           response.should look_like({:status => 403})

--- a/oc-chef-pedant/spec/api/groups_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/groups_acl_spec.rb
@@ -55,5 +55,62 @@ describe "Groups ACL", :acl do
 
       end
     end
+
+   describe "returns success when trying to remove the admin group from the read ACE (a non-grant ACE)" do
+    # This test exists to ensure the non-grant case works, as there was a bug in the code
+    # where the code checking for the grant case was causing the non-grant case to fail
+
+    # For now testing with groups, but potentially also want to test with other objects
+    %w(admins clients users).each do |test_group|
+      context "for #{test_group}" do
+        let(:admin_username) { platform.admin_user.name }
+        let(:acl_url) { "#{platform.server}/groups/#{test_group}/_acl" }
+        let(:read_acl_url) { api_url("groups/#{test_group}/_acl") }
+        let(:write_acl_url) { api_url("groups/#{test_group}/_acl/read") }
+
+        let(:actors) { ["pivotal"] }
+        let(:groups) { [] }
+
+        # Both the actors and groups keys must be present when doing a PUT
+        # or else the server rejects the request
+        let(:request_body) {{
+          "read" => {
+            "actors" => actors,
+            "groups" => groups
+          }
+        }}
+
+        # Since we're playing with permissions, let's make sure we restore them
+        # If these tests pass, this shouldn't be needed, but if they fail we
+        # might be in a bad state, and then the restore is needed
+        before :each do
+          original_state = get(read_acl_url, superuser)
+          # If we can't get the original state, die, because then we can't restore it
+          original_state.should look_like({:status => 200})
+          # The response is returned as a string that is valid JSON (in this case at least)
+          # Parsing it turns it into a usable hash
+          state_hash = JSON.parse original_state
+          # We're only changing the read ACE, so pull that out to be able to use it
+          # for the restore
+          @original_perms = state_hash['read']
+        end
+
+        after :each do
+          payload = {"read" => @original_perms}
+          # If the original permissions don't restore, die, as we have an issue
+          put(write_acl_url, superuser,
+              :payload => payload).should look_like({:status => 200})
+        end
+
+        it "returns success trying to remove read ace from #{test_group} group" do
+          response = put(write_acl_url, platform.admin_user,
+                         :payload => request_body)
+          response.should look_like({:status => 200})
+        end
+
+      end
+    end
   end
+ end
+
 end

--- a/oc-chef-pedant/spec/api/groups_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/groups_acl_spec.rb
@@ -1,0 +1,59 @@
+require 'pedant/rspec/common'
+require 'pedant/acl'
+
+describe "Groups ACL", :acl do
+  include Pedant::ACL
+
+  describe "returns Forbidden when trying to remove the admin group from any grant ACE" do
+    # For now testing with groups, but potentially also want to test with other objects
+    %w(admins clients users).each do |test_group|
+      context "for #{test_group}" do
+        let(:admin_username) { platform.admin_user.name }
+        let(:acl_url) { "#{platform.server}/groups/#{test_group}/_acl" }
+        let(:read_acl_url) { api_url("groups/#{test_group}/_acl") }
+        let(:write_acl_url) { api_url("groups/#{test_group}/_acl/grant") }
+
+        let(:actors) { ["pivotal"] }
+        let(:groups) { [] }
+
+        # Both the actors and groups keys must be present when doing a PUT
+        # or else the server rejects the request
+        let(:request_body) {{
+          "grant" => {
+            "actors" => actors,
+            "groups" => groups
+          }
+        }}
+
+        # Since we're playing with permissions, let's make sure we restore them
+        # If these tests pass, this shouldn't be needed, but if they fail we
+        # might be in a bad state, and then the restore is needed
+        before :each do
+          original_state = get(read_acl_url, superuser)
+          # If we can't get the original state, die, because then we can't restore it
+          original_state.should look_like({:status => 200})
+          # The response is returned as a string that is valid JSON (in this case at least)
+          # Parsing it turns it into a usable hash
+          state_hash = JSON.parse original_state
+          # We're only changing the grant ACE, so pull that out to be able to use it
+          # for the restore
+          @original_grant_perms = state_hash['grant']
+        end
+
+        after :each do
+          payload = {"grant" => @original_grant_perms}
+          # If the original permissions don't restore, die, as we have an issue
+          put(write_acl_url, superuser,
+              :payload => payload).should look_like({:status => 200})
+        end
+
+        it "returns Fordidden trying to remove grant ace from #{test_group} group", :pending => true do
+          response = put(write_acl_url, platform.admin_user,
+                         :payload => request_body)
+          response.should look_like({:status => 403})
+        end
+
+      end
+    end
+  end
+end

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl_constraints.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl_constraints.erl
@@ -1,0 +1,94 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Mark  Mzyk <mm@chef.io>
+%% Copyright 2015 Chef Software, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(oc_chef_authz_acl_constraints).
+
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
+
+-export([check_acl_constraints/4]).
+
+check_acl_constraints(AuthzId, Type, AclPerm, Ace) ->
+  check_acl_constraints(AuthzId, Type, AclPerm, Ace, acl_checks()).
+
+check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks) ->
+  case lists:filtermap(fun(Check) -> Check(AuthzId, Type, AclPerm, Ace) end, AclChecks) of
+    [] ->
+      ok;
+    Failures ->
+      Failures
+  end.
+
+acl_checks() ->
+  [
+    fun check_admins_group_removal_from_grant_ace/4
+  ].
+
+check_admins_group_removal_from_grant_ace(AuthzId, Type, AclPerm, NewAce) ->
+  %% It is necessary to pull the current ace and compare to the new ace.
+  %% This is because there are some groups that don't have the admin
+  %% group by default, such as billing-admins. This will have the effect
+  %% that if a group doesn't have the admin group, but then it is later added,
+  %% the admin group will never be able to be removed.
+  case AclPerm of
+    <<"grant">> ->
+      NewGroups = extract_acl_groups(AclPerm, NewAce),
+      CurrentAce = oc_chef_authz_acl:fetch(Type, AuthzId),
+      CurrentGroups = extract_acl_groups(AclPerm, CurrentAce),
+      case check_admins_group_removal(CurrentGroups, NewGroups) of
+        not_removed ->
+          false;
+        removed ->
+          {true, attempted_admin_group_removal_grant_ace}
+      end;
+    _Other ->
+      ok
+  end.
+
+check_admins_group_removal(CurrentGroups, NewGroups) ->
+  %% Check if the CurrentGroups contains the admin group. If it doesn't, there
+  %% is nothing to do. If it does, then check if the admin group is present in
+  %% the new group.
+  case contains_admins_group(CurrentGroups) of
+    false ->
+      not_removed;
+    true ->
+      case contains_admins_group(NewGroups) of
+        true ->
+          not_removed;
+        false ->
+          removed
+      end
+  end.
+
+contains_admins_group(Groups) ->
+  case lists:filter(fun(X) -> X =:= <<"admins">> end, Groups) of
+    [] ->
+        false;
+    _NonEmpty ->
+        true
+    end.
+
+extract_acl_groups(AclPerm, Ace) ->
+      ActorsAndGroups = ej:get({AclPerm}, Ace),
+      ej:get({<<"groups">>}, ActorsAndGroups).
+
+

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl_constraints.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl_constraints.erl
@@ -60,7 +60,9 @@ check_admins_group_removal_from_grant_ace(AuthzId, Type, AclPerm, NewAce) ->
           {true, attempted_admin_group_removal_grant_ace}
       end;
     _Other ->
-      ok
+      %% Needs to return false here, which means all is okay, so this can
+      %% work when called within lists:filtermap
+      false
   end.
 
 check_admins_group_removal(CurrentGroups, NewGroups) ->

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_constraints_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_constraints_tests.erl
@@ -1,0 +1,104 @@
+%% @author Mark Mzyk <mm@chef.io>
+%%
+%% Copyright 2015 Chef Software, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(oc_chef_authz_acl_constraints_tests).
+
+-compile([export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Test generators that setup and run the tests
+oc_chef_authz_acl_constraints_test_() ->
+  [
+    { "Reports that admins group is found", contains_admins_group_true() },
+    { "Reports that admins group is not found", contains_admins_group_false() },
+    { "Check admins group removal returns admins group was not removed", check_admins_group_removal_not_removed() },
+    { "Check admins group removal returns admins group was removed", check_admins_group_removal_removed() },
+    { "Check that the acl constraints reports no failures when there should be none", check_acl_constraints_no_failures() },
+    { "Check that the acl constraints reports failures when they are present", check_acl_constraints_failures() }
+  ].
+
+
+%% contains_admins_group tests
+contains_admins_group_true() ->
+  [
+    ?_assertEqual(true, oc_chef_authz_acl_constraints:contains_admins_group([<<"admins">>])),
+    ?_assertEqual(true, oc_chef_authz_acl_constraints:contains_admins_group([<<"admins">>, <<"another_group">>]))
+  ].
+
+contains_admins_group_false() ->
+  [
+    ?_assertEqual(false, oc_chef_authz_acl_constraints:contains_admins_group([])),
+    ?_assertEqual(false, oc_chef_authz_acl_constraints:contains_admins_group([<<"another_group">>]))
+  ].
+
+
+%% check_admins_group_removal tests
+check_admins_group_removal_not_removed() ->
+  %% Not a true unit test, since it calls through to contains_admins_group,
+  %% but meck can't currently mock intra module calls.
+  [
+    %% CurrentGroup doesn't contain the admins group
+    ?_assertEqual(not_removed, oc_chef_authz_acl_constraints:check_admins_group_removal([], [])),
+    %% CurrentGroup doesn't contain the admins group, NewGroup does
+    ?_assertEqual(not_removed, oc_chef_authz_acl_constraints:check_admins_group_removal([], [<<"admins">>])),
+    %% CurrentGroup contains admins group, NewGroup also contains admins group
+    ?_assertEqual(not_removed, oc_chef_authz_acl_constraints:check_admins_group_removal([<<"admins">>], [<<"admins">>]))
+  ].
+
+check_admins_group_removal_removed() ->
+  %% Not a true unit test, since it calls through to contains_admins_group,
+  %% but meck can't currently mock intra module calls.
+  [
+    %% CurrentGroup contains the admins group, NewGroup does not
+    ?_assertEqual(removed, oc_chef_authz_acl_constraints:check_admins_group_removal([<<"admins">>], []))
+  ].
+
+%% check_acl_constraints tests
+check_acl_constraints_no_failures() ->
+  %% All dummy values, but based on real values.
+  %% Key to the test is AclChecks, which give the return value
+  %% check_acl_constraints operates on
+  AuthzId = <<"10000000000000000000000000000000">>,
+  Type = group,
+  AclPerm = <<"grant">>,
+  Ace = {[{<<"grant">>,{[{<<"actors">>,[<<"pivotal">>]},{<<"groups">>,[]}]}}]},
+  AclChecks = [ fun(_AuthzId, _Type, _AclPerm, _Ace) -> false end ],
+  [
+    ?_assertEqual(ok, oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks))
+  ].
+
+check_acl_constraints_failures() ->
+  %% All dummy values, but based on real values.
+  %% Key to the test is AclChecks, which give the return value
+  %% check_acl_constraints operates on
+  AuthzId = <<"10000000000000000000000000000000">>,
+  Type = group,
+  AclPerm = <<"grant">>,
+  Ace = {[{<<"grant">>,{[{<<"actors">>,[<<"pivotal">>]},{<<"groups">>,[]}]}}]},
+  AclChecks = [ fun(_AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_message_here} end ],
+  Test1 = ?_assertEqual([failure_message_here], oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks)),
+  AclChecks2 = [
+                fun(_AuthzId, _Type, _AclPerm, _Ace) -> false end,
+                fun(_AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_one} end,
+                fun(_AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_two} end
+               ],
+  Test2 = ?_assertEqual([failure_one, failure_two], oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks2)),
+  [ Test1, Test2 ].
+

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_constraints_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_constraints_tests.erl
@@ -31,7 +31,8 @@ oc_chef_authz_acl_constraints_test_() ->
     { "Check admins group removal returns admins group was not removed", check_admins_group_removal_not_removed() },
     { "Check admins group removal returns admins group was removed", check_admins_group_removal_removed() },
     { "Check that the acl constraints reports no failures when there should be none", check_acl_constraints_no_failures() },
-    { "Check that the acl constraints reports failures when they are present", check_acl_constraints_failures() }
+    { "Check that the acl constraints reports failures when they are present", check_acl_constraints_failures() },
+    { "Check that removal of grant ace passes if not grant ace", check_acl_constraints_not_grant_ace() }
   ].
 
 
@@ -101,4 +102,23 @@ check_acl_constraints_failures() ->
                ],
   Test2 = ?_assertEqual([failure_one, failure_two], oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks2)),
   [ Test1, Test2 ].
+
+check_acl_constraints_not_grant_ace() ->
+  %% Not a true unit test, as this is more of an integration
+  %% test within this module, but this tests catches an observed
+  %% failure that bubbled up in pedant.
+
+  %% The opposite tests that checks if this works with the grant ace
+  %% can't be run as an eunit test because it relies on calling out
+  %% to another module
+
+  %% All dummy values, but based on real values.
+  AuthzId = <<"10000000000000000000000000000000">>,
+  Type = organization,
+  AclPerm = <<"create">>,
+  Ace = {[{<<"create">>,{[{<<"actors">>,[<<"pivotal">>]},{<<"groups">>,[]}]}}]},
+  [
+    ?_assertEqual(ok, oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, oc_chef_authz_acl_constraints:acl_checks()))
+  ].
+
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_malformed.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_malformed.erl
@@ -63,6 +63,13 @@ malformed_request_message({bad_headers, Bad}, _Req, _State) ->
                             <<"bad header(s) ">>,
                             bin_str_join(Bad, <<", ">>)]),
     {[{<<"error">>, [Msg]}]};
+
+%% acl_constraint_violation messages
+malformed_request_message(attempted_admin_group_removal_grant_ace, _Req, _State) ->
+  {[{<<"error">>, [<<"Admin group cannot be removed from the Grant ACE">>]}]};
+
+%% End acl_constraint_violation messages
+
 malformed_request_message({error, invalid_json}, _Req, _State) ->
     %% in theory, there might be some sort of slightly useful error detail from
     %% chef_json/jiffy, but thus far nothing specific enough to beat out this. Also, would

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
@@ -1,7 +1,8 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Douglas Triggs <doug@chef.io>
-%% Copyright 2014 Chef Software, Inc. All Rights Reserved.
+%% @author Mark Mzyk <mm@chef.io>
+%% Copyright 2014-2015 Chef Software, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -69,13 +70,26 @@ validate_request('PUT', Req, #base_state{chef_db_context = DbContext,
     Body = wrq:req_body(Req),
     Ace = chef_json:decode_body(Body),
     Part = list_to_binary(wrq:path_info(acl_permission, Req)),
-    case chef_object_base:strictly_valid(acl_spec(Part), [Part], Ace) of
-        ok ->
-            oc_chef_wm_acl:validate_authz_id(Req, State,
-                                             AclState#acl_state{acl_data = Ace},
-                                             Type, OrgId, DbContext);
-        Other ->
-            throw(Other)
+    %% Make sure we have valid json before trying other checks
+    %% Throws if invalid json is found
+    check_json_validity(Part, Ace),
+    %% validate_authz_id will populate the ACL AuthzId, which is needed
+    %% for checking the ACL constraints; we need to run validate_authz_id
+    %% anyway, so go ahead and do so
+    {Req1, State1 = #base_state{resource_state = #acl_state{
+          authz_id = AuthzId}}} =
+                                  oc_chef_wm_acl:validate_authz_id(Req, State,
+                                                                   AclState#acl_state{acl_data = Ace},
+                                                                    Type, OrgId,  DbContext),
+
+    %% Check if we're violating any constraints around modifying ACLs
+    %% i.e. deleting default groups, etc.
+    case oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, Part, Ace) of
+      ok ->
+        {Req1, State1};
+      [ Violation | _T ] ->
+        %% Received one or more failures. Report back the first one.
+        throw({acl_constraint_violation, Violation})
     end.
 
 auth_info(Req, State) ->
@@ -109,6 +123,14 @@ from_json(Req, #base_state{organization_guid = OrgId,
 
 %% Internal functions
 
+check_json_validity(Part, Ace) ->
+  case chef_object_base:strictly_valid(acl_spec(Part), [Part], Ace) of
+    ok ->
+      ok;
+    Other ->
+      throw(Other)
+  end.
+
 acl_spec(Part) ->
     {[
       {Part,
@@ -131,7 +153,6 @@ update_from_json(#acl_state{type = Type, authz_id = AuthzId, acl_data = Data},
         throw:bad_group ->
             bad_group
     end.
-
 
 malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -536,6 +536,7 @@ http_method_to_authz_perm('PUT') ->
     update.
 
 %% Tells whether this user is the superuser.
+-spec is_superuser(Req :: #wm_reqdata{} | binary()) -> boolean().
 is_superuser(Req = #wm_reqdata{}) ->
     UserName = get_username_from_request(Req),
     is_superuser(UserName);
@@ -544,11 +545,13 @@ is_superuser(UserName) ->
     lists:member(UserName, Superusers).
 
 %% Get the username from the request (and tell whether it is a superuser)
+-spec get_user(Req :: #wm_reqdata{}, #base_state{}) -> {binary(), boolean()}.
 get_user(Req, #base_state{superuser_bypasses_checks = SuperuserBypassesChecks}) ->
     UserName = get_username_from_request(Req),
     BypassesChecks = SuperuserBypassesChecks andalso is_superuser(UserName),
     {UserName, BypassesChecks}.
 
+-spec get_username_from_request(Req :: #wm_reqdata{}) -> binary().
 get_username_from_request(Req) ->
     list_to_binary(wrq:get_req_header("x-ops-userid", Req)).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -536,15 +536,21 @@ http_method_to_authz_perm('PUT') ->
     update.
 
 %% Tells whether this user is the superuser.
+is_superuser(Req = #wm_reqdata{}) ->
+    UserName = get_username_from_request(Req),
+    is_superuser(UserName);
 is_superuser(UserName) ->
     Superusers = envy:get(oc_chef_wm, superusers, [], list),
     lists:member(UserName, Superusers).
 
 %% Get the username from the request (and tell whether it is a superuser)
 get_user(Req, #base_state{superuser_bypasses_checks = SuperuserBypassesChecks}) ->
-    UserName = list_to_binary(wrq:get_req_header("x-ops-userid", Req)),
+    UserName = get_username_from_request(Req),
     BypassesChecks = SuperuserBypassesChecks andalso is_superuser(UserName),
     {UserName, BypassesChecks}.
+
+get_username_from_request(Req) ->
+    list_to_binary(wrq:get_req_header("x-ops-userid", Req)).
 
 -spec set_authz_id(object_id(), resource_state(), chef_wm:container_name())
                   -> resource_state().

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -854,6 +854,10 @@ malformed_request(Req, #base_state{resource_mod=Mod,
             lager:info("json too large (~p)", [Msg]),
             Req3 = wrq:set_resp_body(chef_json:encode({[{<<"error">>, Msg}]}), Req),
             {{halt, 413}, Req3, State1#base_state{log_msg = too_big}};
+        throw:{acl_constraint_violation, Violation} ->
+            Msg = chef_wm_malformed:malformed_request_message(Violation, Req, State),
+            Req3 = wrq:set_resp_body(chef_json:encode(Msg), Req),
+            {{halt, 403}, Req3, State1#base_state{log_msg = Msg}};
         throw:Why ->
             Msg =  chef_wm_malformed:malformed_request_message(Why, Req, State),
             NewReq = wrq:set_resp_body(chef_json:encode(Msg), Req),

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
@@ -245,10 +245,9 @@ to_json(Req, #base_state{ resource_args = org_list,
 superuser_or_self(UserId, UserId, _Req) ->
     true;
 superuser_or_self(_UserId, _RequestorID, Req) ->
-    % The is_superuser function only knows how to deal with usernames.  Thus, we pull the
-    % username from request rather than using the RequestorID:
-    UserName = list_to_binary(wrq:get_req_header("x-ops-userid", Req)),
-    oc_chef_wm_base:is_superuser(UserName).
+    %% The is_superuser function only knows how to deal with usernames and how to
+    %% pull them from request objects, so we use that instead of the RequestorID
+    oc_chef_wm_base:is_superuser(Req).
 
 orgs_to_ej(Orgs) ->
     [{[{<<"organization">>,


### PR DESCRIPTION
Add in stubb for performing acl integrity checks

This commit changes nothing about how the current code operates. However, it does add a new module and call to that module that gives a hook for performing acl integrity checks, such as if we are removing the admin group from the grant ace, which is something we desire not to be possible.

This branch is branched from https://github.com/chef/chef-server/pull/240.

The desire at this point is that both of these branches could be merged to master and would essential be no-ops as the desired functionality is built on top of these changes.