### PR TITLE
Make the message you get when entering a bad username a little more vague

### DIFF
--- a/src/oc-id/app/controllers/password_resets_controller.rb
+++ b/src/oc-id/app/controllers/password_resets_controller.rb
@@ -16,7 +16,7 @@ class PasswordResetsController < ApplicationController
         user_not_found
       else
         PasswordResetMailer.password_reset(user).deliver_now
-        flash.now[:notice] = 'Your password reset email has been sent'
+        flash.now[:notice] = password_reset_msg
         @status = :ok
       end
     rescue Net::HTTPServerException => e
@@ -55,7 +55,7 @@ class PasswordResetsController < ApplicationController
         redirect_to signin_path
       rescue Net::HTTPServerException => e
         if e.response.code.to_i == 404
-          flash[:alert] = "User '#{params[:username]}' not found"
+          flash[:notice] = password_reset_msg
           redirect_to action: 'new'
         elsif e.response.code.to_i == 400
           flash.now[:alert] = error_from_json(e)['error']
@@ -70,8 +70,11 @@ class PasswordResetsController < ApplicationController
   private
 
   def user_not_found
-    flash.now[:alert] = "User '#{params[:username]}' not found"
-    @status = :not_found
+    flash.now[:notice] = password_reset_msg
+  end
+
+  def password_reset_msg
+    "If the username you entered exists, you should receive an email shortly"
   end
 
   def escaped_username

--- a/src/oc-id/spec/controllers/password_resets_controller_spec.rb
+++ b/src/oc-id/spec/controllers/password_resets_controller_spec.rb
@@ -37,12 +37,12 @@ describe PasswordResetsController do
         post :create, username: 'jimmy'
       end
 
-      it 'shows a flash message explaining the problem' do
-        expect(flash[:alert]).to match(/not found/)
+      it 'shows a flash message that is informative but not revealing' do
+        expect(flash[:notice]).to match(/entered exists.*email shortly/)
       end
 
-      it 'returns a 404' do
-        expect(response.status).to eql(404)
+      it 'returns a 200 which is a lie but better for security' do
+        expect(response.status).to eql(200)
       end
 
       it 'renders the new template' do
@@ -64,12 +64,12 @@ describe PasswordResetsController do
           post :create, username: 'jimmy'
         end
 
-        it 'shows a flash message explaining the problem' do
-          expect(flash[:alert]).to match(/not found/)
+        it 'shows a flash message that is informative but not revealing' do
+          expect(flash[:notice]).to match(/entered exists.*email shortly/)
         end
 
-        it 'returns a 404' do
-          expect(response.status).to eql(404)
+        it 'returns a 200 which is a lie but better for security' do
+          expect(response.status).to eql(200)
         end
 
         it 'renders the new template' do
@@ -117,7 +117,7 @@ describe PasswordResetsController do
       end
 
       it 'shows a flash message explaining an email was sent' do
-        expect(flash[:notice]).to match(/password reset email has been sent/)
+        expect(flash[:notice]).to match(/entered exists.*email shortly/)
       end
 
       it 'succeeds' do
@@ -217,8 +217,8 @@ describe PasswordResetsController do
               put :update, password: 'haha', signature: signature, expires: expires, username: name
             end
 
-            it 'shows a flash message explaining the problem' do
-              expect(flash[:alert]).to match(/not found/)
+            it 'shows a flash message that is informative but not revealing' do
+              expect(flash[:notice]).to match(/entered exists.*email shortly/)
             end
 
             it 'redirects to new' do


### PR DESCRIPTION
Previously, if you entered a username that didn't exist when trying to reset a password, we'd display a message stating so, in a scary orange box so you knew there was a problem.  We also returned a 404.

Now, it doesn't matter if the username you entered exists or not - everyone gets the same message, so people can't use this as a method of brute forcing usernames.  We return 200 for everything too.

Closes https://github.com/chef/chef-server/issues/197

/cc @chef/chef-visual-interaction 