### PR TITLE
Update sqerl to latest version to address increased transaction rate

### DIFF
--- a/src/oc_erchef/rebar.config.lock
+++ b/src/oc_erchef/rebar.config.lock
@@ -38,7 +38,7 @@
                     "7bb8ab83c6f60475e6ef8867d3d5afa0b1dd4013"}},
        {sqerl,".*",
               {git,"https://github.com/opscode/sqerl",
-                   "cd8f9588699f872dfdf80f6316c9ef8286ad501b"}},
+                   "770a4bc7515fbbbc0ca276fe85e80f09ee951fdc"}},
        {meck,".*",
              {git,"https://github.com/eproxus/meck",
                   "69664df5d0e01a0ae27efb62831d6eea45cc1cd4"}},
@@ -138,4 +138,3 @@
            {d,'CHEF_WM_DARKLAUNCH',xdarklaunch_req},
            {parse_transform,lager_transform},
            debug_info]}.
-


### PR DESCRIPTION
Recent changes to sqerl resulted in users seeing double their previous
transaction rate.  This was caused by a `SET statement_time` command
being sent before every query.  The newest version of sqerl only sends
the command on startup.

ChangeLog-Entry: Eliminate unnecessary postgresql transactions caused
by new version of sqerl.