### PR TITLE
Update the bulk fetch cookbook query to return less data

### DIFF
--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -361,13 +361,10 @@
 %% Used in implementation of environemnts/ENVNAME/cookbook_versions endpoint.
 %%
 %% Depends on the cbv type existing in the schema
-{bulk_fetch_cookbook_versions,
+{bulk_fetch_minimal_cookbook_versions,
  <<"WITH inputs AS ( select * from unnest($2::cbv[]) )
-  SELECT v.id,  v.major, v.minor, v.patch, v.frozen, v.meta_attributes,
-         v.meta_deps, v.meta_long_desc, v.metadata, v.serialized_object,
-         v.last_updated_by, v.created_at, v.updated_at, c.authz_id, c.org_id, c.name,
-         (SELECT ARRAY(SELECT checksum FROM cookbook_version_checksums cvc
-                       WHERE org_id = $1 AND cvc.cookbook_version_id = v.id)) checksums
+  SELECT v.frozen, v.meta_deps, v.metadata, v.serialized_object,
+         c.authz_id, c.org_id, c.name
     FROM inputs,
          cookbooks as c,
          cookbook_versions as v

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -65,7 +65,7 @@
          fetch_cookbook_version/3,
          fetch_cookbook_versions/2,
          fetch_cookbook_versions/3,
-         bulk_fetch_cookbook_versions/3,
+         bulk_fetch_minimal_cookbook_versions/3,
          fetch_latest_cookbook_version/3,
          fetch_latest_cookbook_versions/2,
          fetch_latest_cookbook_versions/3,
@@ -405,19 +405,19 @@ cookbook_exists(#context{reqid=ReqId} = DbContext, OrgName, CookbookName) ->
 
 %% @doc Given a list of cookbook names and versions, return a list of #chef_cookbook_version
 %% objects.  This is used by the depsolver endpoint.
--spec bulk_fetch_cookbook_versions(DbContext :: #context{}, OrgName :: binary(), [versioned_cookbook()]) -> [#chef_cookbook_version{}] | {error, any()}.
-bulk_fetch_cookbook_versions(#context{}, _OrgName, []) ->
+-spec bulk_fetch_minimal_cookbook_versions(DbContext :: #context{}, OrgName :: binary(), [versioned_cookbook()]) -> [#chef_cookbook_version{}] | {error, any()}.
+bulk_fetch_minimal_cookbook_versions(#context{}, _OrgName, []) ->
     %% Avoid database calls in the case of an empty run_list
     [];
-bulk_fetch_cookbook_versions(#context{reqid = ReqID} = Ctx, OrgName, VersionedCookbooks) ->
+bulk_fetch_minimal_cookbook_versions(#context{reqid = ReqID} = Ctx, OrgName, VersionedCookbooks) ->
     case fetch_org_id(Ctx, OrgName) of
         not_found ->
             not_found;
         OrgId ->
-            stats_hero:ctime(ReqID, {chef_sql, bulk_fetch_cookbook_versions},
+            stats_hero:ctime(ReqID, {chef_sql, bulk_fetch_minimal_cookbook_versions},
                              fun() ->
-                                     chef_sql:bulk_fetch_cookbook_versions(OrgId,
-                                                                           VersionedCookbooks)
+                                     chef_sql:bulk_fetch_minimal_cookbook_versions(OrgId,
+                                                                                   VersionedCookbooks)
                              end)
     end.
 

--- a/src/oc_erchef/apps/chef_db/src/chef_sql.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_sql.erl
@@ -62,7 +62,7 @@
 
          %% cookbook version ops
          cookbook_exists/2,
-         bulk_fetch_cookbook_versions/2,
+         bulk_fetch_minimal_cookbook_versions/2,
          fetch_cookbook_version/2,
          fetch_cookbook_versions/1,
          fetch_cookbook_versions/2,
@@ -494,11 +494,11 @@ fetch_environment_filtered_recipes(OrgId, Environment) ->
     end.
 
 %% cookbook version ops
--spec bulk_fetch_cookbook_versions(OrgId::object_id(), [versioned_cookbook()]) ->
+-spec bulk_fetch_minimal_cookbook_versions(OrgId::object_id(), [versioned_cookbook()]) ->
                                           [#chef_cookbook_version{}].
-bulk_fetch_cookbook_versions(OrgId, CookbookVersions) ->
+bulk_fetch_minimal_cookbook_versions(OrgId, CookbookVersions) ->
     QueryParam = cookbook_versions_array_to_binary(CookbookVersions),
-    case sqerl:select(bulk_fetch_cookbook_versions, [OrgId, QueryParam], ?ALL(chef_cookbook_version)) of
+    case sqerl:select(bulk_fetch_minimal_cookbook_versions, [OrgId, QueryParam], ?ALL(chef_cookbook_version)) of
         {ok, none} ->
             [];
         {ok, Results} ->
@@ -522,7 +522,7 @@ cookbook_versions_array_to_binary([], Acc, EndBin, _Sep) ->
 
 
 %% @doc Tranform a versioned_cookbook() into a binary that can be used
-%% in the bulk_fetch_cookbook_version sql query.  A
+%% in the bulk_fetch_minimal_cookbook_version sql query.  A
 %% versioned_cookbook() looks like:
 %%   {binary(), {integer(), integer(), integer()}}
 %%

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -248,7 +248,7 @@ handle_depsolver_results(ok, {error, {unreachable_package, Unreachable}}, Req, S
 handle_depsolver_results(ok, {ok, Cookbooks}, Req, #base_state{chef_db_context = DbContext,
                                                                organization_name = OrgName} = State) ->
     %% TODO - helper function to deal with the call and match on a chef_cookbook version
-    CookbookRecords = chef_db:bulk_fetch_cookbook_versions(DbContext, OrgName, Cookbooks),
+    CookbookRecords = chef_db:bulk_fetch_minimal_cookbook_versions(DbContext, OrgName, Cookbooks),
     assemble_response(Req, State, CookbookRecords).
 
 %% @doc Utility function to remove some of the verbosity


### PR DESCRIPTION
The only use of bulk_fetch_cookbook_verions is in
chef_wm_depsolvers. All cookbooks it returns pass through
chef_cookbook_version:minimal_cookbook_ejson, which only returns a
subset of the cookbook record. This change removes any data not used
in minimal_cookbook_ejson from the initial query to avoid doing extra
work in the database.

To wit, this change removes:

- checksums (and the subquery required to get them)
- id
- major
- minor
- patch
- meta_attributes
- meta_long_desc

from the return of the bulk fetch query.

To make the change clear, the query has been renamed to
bulk_fetch_minimal_cookbook_versions.