### PR TITLE
[dvm] fix for dep loading to work again in the new location

### DIFF
--- a/dev/TODO.md
+++ b/dev/TODO.md
@@ -1,4 +1,4 @@
-
+- [ ] bug: dvm gem mount gets undone after halt/up
 - [ ] populate command to load test users and orgs
 - [ ] use runsv 'down' file to cleanly disable loaded services even
       across chef-server-ctl reconfigure

--- a/dev/dvm/lib/dvm/project/erlang.rb
+++ b/dev/dvm/lib/dvm/project/erlang.rb
@@ -107,7 +107,7 @@ EOM
       #
       # TODO this can also be wrapped and handled in the base...
       # TODO this makes an assumption that this is NOT anything bundled in our chef-server env.
-      if ! project_dir_exists_on_host?(name)
+      if ! project_dir_exists_on_host?(path)
         git = project['git']
         if git
           if git['uri']

--- a/dev/dvm/lib/dvm/project/erlang.rb
+++ b/dev/dvm/lib/dvm/project/erlang.rb
@@ -106,7 +106,8 @@ EOM
       # typically sync, builder, eunit , mixer and common_test
       #
       # TODO this can also be wrapped and handled in the base...
-      if ! project_dir_exists_on_host?
+      # TODO this makes an assumption that this is NOT anything bundled in our chef-server env.
+      if ! project_dir_exists_on_host?(name)
         git = project['git']
         if git
           if git['uri']

--- a/dev/dvm/lib/dvm/project/erlang_dep.rb
+++ b/dev/dvm/lib/dvm/project/erlang_dep.rb
@@ -2,6 +2,8 @@ module DVM
   class ErlangDep < Dep
     # TODO the path names suck
     attr_reader :ref, :url, :dep_path, :real_path, :parent, :libname, :libpath
+    # Needed for now to make tools mixin behave:
+    attr_reader :path
     def initialize(name, base_dir, data, parent_inst)
       super(name)
       @deps = nil
@@ -9,6 +11,7 @@ module DVM
       @ref  = data["ref"]
       @name = name
       @real_path = File.join("/host", name)
+      @path = @real_path
       @dep_path = File.join(base_dir, name)
       @parent = parent_inst
       @available = nil
@@ -47,7 +50,7 @@ module DVM
     def load(opts)
       load_info
       # Again, muich of this can be offloaded to a base class that hooks into child class via callbacks.
-      if ! project_dir_exists_on_host?
+      if !project_dir_exists_on_host?(name)
         # Some things to consider:
         # do we want to match the revision/branch from rebar?
         # do we want to auto-create a new branch from it if we did the clone ourselves or detect master or

--- a/dev/dvm/lib/dvm/project/omnibus_dep.rb
+++ b/dev/dvm/lib/dvm/project/omnibus_dep.rb
@@ -1,10 +1,13 @@
 module DVM
   class OmnibusDep < Dep
     attr_reader :source_path, :dest_path, :reconfigure_on_load
+    # Needed for now to make tools mixin behave:
+    attr_reader :path
     def initialize(base_dir, name, config)
       super(name)
       @source_path = File.join("#{base_dir}/files", config['source_path'])
       @dest_path = config['dest_path']
+      @path = @source_path
       @reconfigure_on_load = config['reconfigure_on_load']
       @available = true
     end

--- a/dev/dvm/lib/dvm/project/project.rb
+++ b/dev/dvm/lib/dvm/project/project.rb
@@ -63,7 +63,7 @@ module DVM
       raise DVM::DVMArgumentError, "Load the project before loading deps." unless loaded?
       dep = ensure_dep(name)
       raise DVM::DVMArgumentError, "#{name} is not loaded." unless dep.loaded?
-      deps.unload
+      deps[name].unload
     end
 
     def ensure_dep(name)

--- a/dev/dvm/lib/dvm/tools.rb
+++ b/dev/dvm/lib/dvm/tools.rb
@@ -29,7 +29,7 @@ module DVM
       "/mnt/host-do-not-use"
     end
 
-    def host_project_dir
+    def host_project_dir(path)
       File.join(host_raw_dir, path)
     end
 
@@ -37,8 +37,8 @@ module DVM
       run_command("git clone '#{uri}' '#{name}'", "Cloning #{name} to host.", cwd: host_raw_dir)
     end
 
-    def project_dir_exists_on_host?
-      File.directory? host_project_dir
+    def project_dir_exists_on_host?(name)
+      File.directory? host_project_dir(name)
     end
 
     def checkout(name, ref)


### PR DESCRIPTION
Ths unbreaks (to an extent) project dep loading, like 'dvm load oc_erchef sqerl' and 'dvm unload omnibus private-chef-cookbooks'

