### PR TITLE
Fix chef-server-ctl install bugs

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 4ca326c4ea5dadbd32c700ff3c31cb8b63a9977b
+  revision: 2d2399de502240f914cf297ccaf651eeff76bc06
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/opscode/omnibus.git
-  revision: ab0417987c624eb10299c99f4321c234adb7f9ef
+  revision: 4b019f031c32a0d92c389d3949103e643884d864
   specs:
     omnibus (4.0.0)
       chef-sugar (~> 3.0)
@@ -31,7 +31,7 @@ GEM
     libyajl2 (1.2.0)
     mime-types (1.25.1)
     mixlib-cli (1.5.0)
-    mixlib-config (2.1.0)
+    mixlib-config (2.2.1)
     mixlib-log (1.6.0)
     mixlib-shellout (1.6.1)
     mixlib-versioning (1.0.0)

--- a/omnibus/files/private-chef-ctl-commands/cleanup.rb
+++ b/omnibus/files/private-chef-ctl-commands/cleanup.rb
@@ -4,13 +4,11 @@
 add_command_under_category "cleanup", "general", "Perform post-upgrade removal of now-obsolete data, configuration files, logs, etc.  Add the '--no-op' flag to see what *would* be removed.", 2 do
   use_why_run_mode = ARGV.include?("--no-op")
 
-  # Our cleanup process is really just a special chef run
-  command = ["chef-client -z",
-             "--config #{base_path}/embedded/cookbooks/solo.rb",
-             "--json-attributes #{base_path}/embedded/cookbooks/post_upgrade_cleanup.json",
-             "--log_level fatal"] # yes, that's an underscore in log_level
-  command << "--why-run" if use_why_run_mode
+  attributes_path = "#{base_path}/embedded/cookbooks/post_upgrade_cleanup.json"
 
-  status = run_command(command.join(" "))
+  chef_args = "-l fatal"
+  chef_args << " --why-run" if use_why_run_mode
+
+  status = run_chef(attributes_path, chef_args)
   exit!(status.success? ? 0 : 1)
 end

--- a/omnibus/files/private-chef-ctl-commands/install.rb
+++ b/omnibus/files/private-chef-ctl-commands/install.rb
@@ -4,7 +4,6 @@
 KNOWN_ADDONS = %w(
   chef-ha
   chef-sync
-  opscode-analytics
   opscode-manage
   opscode-push-jobs-server
   opscode-reporting

--- a/omnibus/files/private-chef-ctl-commands/install.rb
+++ b/omnibus/files/private-chef-ctl-commands/install.rb
@@ -17,12 +17,6 @@ add_command_under_category "install", "general", "Install addon package by name,
     install_path = ARGV[ARGV.index(path_arg) + 1]
   end
 
-  attributes_path = "#{base_path}/embedded/cookbooks/install_params.json"
-  command = ["chef-client -z",
-    "--config #{base_path}/embedded/cookbooks/solo.rb",
-    "--json-attributes #{attributes_path}",
-    "--log_level fatal"]
-
   if package.nil?
     STDERR.puts "You must supply an addon name. Valid names include: #{KNOWN_ADDONS.join(', ')}."
     exit 1
@@ -31,6 +25,7 @@ add_command_under_category "install", "general", "Install addon package by name,
     exit 1
   end
 
+  attributes_path = "#{base_path}/embedded/cookbooks/install_params.json"
   json_src = { "run_list" => ["recipe[private-chef::add_ons_wrapper]"],
     "private_chef" => { "addons"=> {
         "install" => true,
@@ -41,6 +36,8 @@ add_command_under_category "install", "general", "Install addon package by name,
     file.write json_src.to_json
   end
 
-  status = run_command(command.join(" "))
+  chef_args = "-l fatal"
+
+  status = run_chef(attributes_path, chef_args)
   exit!(status.success? ? 0 : 1)
 end


### PR DESCRIPTION
This PR fixes 2 bugs in chef-server-ctl install:

- Stale node state was not being removed before
  the install command, leading to multiple packages
  to be installed in some cases.

- The opscode-analytics add-on should not be installed
  on the same machine as your chef-server