### PR TITLE
[omnibus] add internal attribute for sever api version in use

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -80,6 +80,15 @@ default['private_chef']['couchdb']['port'] = 5984
 default['private_chef']['opscode-solr']['data_dir'] = "/var/opt/opscode/opscode-solr/data"
 
 ####
+# Server API Version - is not used in server configuration, but rather in the configuration
+# of components that need to know how to talk to the erchef server.
+#
+# This is set to the current minimally supported version.
+####
+default['private_chef']['server-api-version'] = 0
+
+
+####
 # RabbitMQ
 ####
 default['private_chef']['rabbitmq']['enable'] = true

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -181,7 +181,7 @@ search_acls?               <%= node['private_chef']['opscode-erchef']['strict_se
 old_runlists_and_search true
 
 # Default server api version for all requests that don't specify it.
-server_api_version      0
+server_api_version         <%= node['private_chef']['server-api-version'] %>
 
 <%- if @log_http_requests %>
 


### PR DESCRIPTION
Just like it says on the label.  This is currently used for pedant config, and will also be used once we move the reindex script into a template, since it needs to be version-aware.

ping @chef/lob 