### PR TITLE
Provide pooler bounded-queuing configuration for all pooler controlled queues

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -180,11 +180,40 @@ default['private_chef']['opscode-erchef']['port'] = 8000
 default['private_chef']['opscode-erchef']['auth_skew'] = '900'
 default['private_chef']['opscode-erchef']['authz_pooler_timeout'] = '0'
 default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
+default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = '20'
+# Pool configuration for postgresql connections
+#
+# db_pool_size - the number of pgsql connections in the pool
+#
+# db_pool_queue_max - the maximum number of pgsql requests to queue up
+# if all connections are busy
+#
+# db_pooler_timeout - the maximum amount of time a request should wait
+# in the queue before timing out.  Request queueing is only effective
+# if db_pooler_timeout > 0
 default['private_chef']['opscode-erchef']['db_pool_size'] = '20'
 default['private_chef']['opscode-erchef']['db_pooler_timeout'] = '0'
 default['private_chef']['opscode-erchef']['sql_db_timeout'] = 5000
-default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = '20'
 default['private_chef']['opscode-erchef']['db_pool_queue_max'] = '20'
+# Pool configuration for depsolver workers
+#
+# depsolver_worker_count - the number of depselector workers.  This is
+# a CPU bound task, thus setting this over the number of CPUs is not
+# advised.
+#
+# depsolver_pool_queue_max - the number of depsolve requets to queue
+# if all workers are busy.
+#
+# depsolver_pooler_timeout - the time in ms to wait before a queued
+# request times out.  Requesting queueing is only effective if
+# db_pooler_timeout > 0
+#
+# depsolver_tiemout - the amount of time to wait in ms before a
+# request to a depsolver worker is abandoned.
+default['private_chef']['opscode-erchef']['depsolver_pooler_timeout'] = '0'
+default['private_chef']['opscode-erchef']['depsolver_pool_queue_max'] = '50'
+default['private_chef']['opscode-erchef']['depsolver_worker_count'] = 5
+default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['couchdb_max_conn'] = '100'
 default['private_chef']['opscode-erchef']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
@@ -199,8 +228,6 @@ default['private_chef']['opscode-erchef']['s3_parallel_ops_fanout'] = 20
 default['private_chef']['opscode-erchef']['authz_timeout'] = 2000
 default['private_chef']['opscode-erchef']['authz_fanout'] = 20
 default['private_chef']['opscode-erchef']['root_metric_key'] = "chefAPI"
-default['private_chef']['opscode-erchef']['depsolver_worker_count'] = 5
-default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['max_request_size'] = 1000000
 default['private_chef']['opscode-erchef']['cleanup_batch_size'] = 0
 default['private_chef']['opscode-erchef']['keygen_cache_size'] = 10
@@ -425,6 +452,9 @@ default['private_chef']['oc_bifrost']['listen'] = '127.0.0.1'
 default['private_chef']['oc_bifrost']['port'] = 9463
 default['private_chef']['oc_bifrost']['superuser_id'] = '5ca1ab1ef005ba111abe11eddecafbad'
 default['private_chef']['oc_bifrost']['db_pool_size'] = '20'
+# The db_pool is only effective for a db_pooler_timeout > 0
+default['private_chef']['oc_bifrost']['db_pooler_timeout'] = '0'
+default['private_chef']['oc_bifrost']['db_pool_queue_max'] = '50'
 default['private_chef']['oc_bifrost']['sql_user'] = "bifrost"
 default['private_chef']['oc_bifrost']['sql_password'] = "challengeaccepted"
 default['private_chef']['oc_bifrost']['sql_ro_user'] = "bifrost_ro"
@@ -439,6 +469,9 @@ default['private_chef']['oc_bifrost']['extended_perf_log'] = true
 ####
 default['private_chef']['oc_chef_authz']['http_init_count'] = 25
 default['private_chef']['oc_chef_authz']['http_max_count'] = 100
+# The queue max is only effective if authz_pooler_timeout (in the
+# opscode-erchef configurables above) is > 0
+default['private_chef']['oc_chef_authz']['http_queue_max'] = 50
 default['private_chef']['oc_chef_authz']['http_cull_interval'] = "{1, min}"
 default['private_chef']['oc_chef_authz']['http_max_age'] = "{70, sec}"
 default['private_chef']['oc_chef_authz']['http_max_connection_duration'] = "{70, sec}"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -96,6 +96,7 @@
           {db_pass, "<%= node['private_chef']['oc_bifrost']['sql_password'] %>" },
           {db_name, "bifrost" },
           {idle_check, 10000},
+          {pooler_timeout, <%= @db_pooler_timeout %>},
           {db_timeout, <%= node['private_chef']['oc_bifrost']['sql_db_timeout'] %>},
           {prepared_statements, {bifrost_db, statements, []} },
           {column_transforms, []}
@@ -110,6 +111,7 @@
            {pools, [[{name, sqerl},
                      {max_count, <%= @db_pool_size %> },
                      {init_count, <%= @db_pool_size %> },
+                     {queue_max, <%= @db_pool_queue_max %>},
                      {start_mfa, {sqerl_client, start_link, []}}]]}
            %%,{metrics_module, folsom_metrics}
           ]},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -127,6 +127,7 @@
                                  {timeout, <%= node['private_chef']['opscode-erchef']['authz_timeout'] %>},
                                  {init_count, <%= node['private_chef']['oc_chef_authz']['http_init_count'] %>},
                                  {max_count, <%= node['private_chef']['oc_chef_authz']['http_max_count'] %>},
+                                 {queue_max, <%= node['private_chef']['oc_chef_authz']['http_queue_max'] %>},
                                  {cull_interval, <%= node['private_chef']['oc_chef_authz']['http_cull_interval'] %>},
                                  {max_age, <%= node['private_chef']['oc_chef_authz']['http_max_age'] %>},
                                  {max_connection_duration, <%= node['private_chef']['oc_chef_authz']['http_max_connection_duration'] %>},
@@ -166,7 +167,8 @@
                   {s3_url_expiry_window_size, <%= @helper.s3_url_caching(node['private_chef']['opscode-erchef']['s3_url_expiry_window_size']) %>},
                   {s3_parallel_ops_timeout, <%= node['private_chef']['opscode-erchef']['s3_parallel_ops_timeout'] %>},
                   {s3_parallel_ops_fanout, <%= node['private_chef']['opscode-erchef']['s3_parallel_ops_fanout'] %>},
-                  {depsolver_timeout, <%= @depsolver_timeout %>}
+                  {depsolver_timeout, <%= @depsolver_timeout %>},
+                  {depsolver_pooler_timeout, <%= @depsolver_pooler_timeout %>}
                  ]},
   {stats_hero, [
                %% Set sender pool size to DB max_connections to avoid contention
@@ -221,6 +223,7 @@
                     [{name, chef_depsolver},
                      {max_count, <%= @depsolver_worker_count %>},
                      {init_count, <%= @depsolver_worker_count %>},
+                     {queue_max, <%= @depsolver_pool_queue_max %>},
                      {start_mfa, {chef_depsolver_worker, start_link, []}}]]},
            {metrics_module, folsom_metrics}
           ]}

--- a/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
@@ -70,7 +70,7 @@ start_link() ->
                          Timeout :: integer()) ->
                                 {ok, [ chef_depsolver:versioned_cookbook()]} | {error, term()}.
 solve_dependencies(AllVersions, EnvConstraints, Cookbooks, Timeout) ->
-    case pooler:take_member(chef_depsolver) of
+    case pooler:take_member(chef_depsolver, pooler_timeout()) of
         error_no_members ->
             {error, no_depsolver_workers};
         Pid ->
@@ -86,6 +86,9 @@ solve_dependencies(AllVersions, EnvConstraints, Cookbooks, Timeout) ->
                     Result
             end
     end.
+
+pooler_timeout() ->
+    envy:get(chef_objects, depsolver_pooler_timeout, 0, non_neg_integer).
 
 %%%===================================================================
 %%% gen_server callbacks


### PR DESCRIPTION
Previously, the only connection pooler with user-controllable queuing settings was
the sqerl pool in oc_erchef.  Now the queueing can be added to the following pools:

- sqerl in oc_erchef,
- depsolvers in oc_erchef,
- oc_chef_authz in oc_erchef,
- sqerl in oc_bifrost

By default, queueing is diabled because the relevant pooler_timeouts
are set to 0.  The queue max for sqerl is left at 20, while all others
are set to 50 which is the existing default in pooler.

As mentioned queueing is only used when a timeout > 0 is given.  This
also requires that pooler:take_member/2 is used rather than
pooler:take_member/1.  Thus, one callsite of pooler:take_member/1 has
been converted.