### PR TITLE
level up travis build caching and use system gecode for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 # luarocks is added to the apt package whitelist:
 #   https://github.com/travis-ci/travis-ci/issues/3716
 #
+sudo: false
 branches:
   only:
     - master
@@ -14,26 +15,34 @@ cache:
     - $HOME/.cpanm
     - $HOME/.cpan
     - $HOME/perl5
-sudo: false
+before_cache:
+  # Prevent build log from changing cache cand causing repackage
+  - rm -f $HOME/.cpanm/work/*/build.log
+  - rm -f $HOME/.cpanm/build.log
 language: erlang
 otp_release:
   - R16B03-1
 addons:
   postgresql: "9.3"
   apt:
+    sources:
+      - chef-stable-precise
     packages:
       - cpanminus
       - perl
 #      - lua5.1
       - libdbd-pg-perl
       - build-essential
+      - chefdk
 env:
   global:
     - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
     - USE_OMNIBUS_FILES=0
+    - CHEFDK_GECODE_PATH=/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.0.2/lib/dep-selector-libgecode/vendored-gecode
+
 #    - LUALIB=~/.luarocks/lib/lua/5.2
   matrix:
-  - COMPONENT=omnibus
+    # - COMPONENT=omnibus
   - COMPONENT=src/oc_erchef
   - COMPONENT=src/oc-id
   - COMPONENT=src/chef-mover
@@ -44,6 +53,9 @@ install:
 #  - eval $(luarocks path)
   - rvm install --binary 2.1.4
   - rvm use 2.1.4
+  - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+  - cpanm --notest --quiet App::Sqitch
   - cd $COMPONENT && travis_retry make install
+
 script:
-  - make travis
+  - USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis

--- a/src/oc_erchef/custom.mk
+++ b/src/oc_erchef/custom.mk
@@ -55,9 +55,8 @@ bundle:
 
 install:
 	@./rebar get-deps -C rebar.config.lock
-	@cpanm --notest --quiet App::Sqitch
 
 travis: all
-	PATH=~/perl5/bin:$(PATH) $(REBARC) skip_deps=true ct
+	 PATH=~/perl5/bin:$(PATH) $(REBARC) skip_deps=true ct
 
 DEVVM_DIR = $(DEVVM_ROOT)/_rel/oc_erchef


### PR DESCRIPTION
* install sqitch to cache 
* install chef-dk 
* modify travis build to use chefk embedded libgecode instead of building with each run
* remove a couple of files that were causing our cache to get repackaged on every build 

ping @chef/lob 
