### PR TITLE
[omnibus] Move reindex-opc-organization into omnibus

### DIFF
--- a/oc-chef-pedant/spec/api/reindex_spec.rb
+++ b/oc-chef-pedant/spec/api/reindex_spec.rb
@@ -17,7 +17,7 @@ describe "Server-side reindexing" do
 
   context "reindexing OPC", :omnibus => true do
     it_should_behave_like "Reindexing" do
-      let(:executable){"/opt/opscode/embedded/service/opscode-erchef/bin/reindex-opc-organization"}
+      let(:executable){"/opt/opscode/bin/reindex-opc-organization"}
       let(:reindex_args){[platform.test_org.name]}
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -46,6 +46,12 @@ template erchef_config do
   notifies :restart, 'runit_service[opscode-erchef]' unless backend_secondary?
 end
 
+template "/opt/opscode/bin/reindex-opc-organization" do
+  source "reindex-opc-organization.erb"
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
+  mode "755"
+end
 # Erchef still ultimately uses disk_log [1] for request logging, and if
 # you change the log file sizing in the configuration **without also
 # issuing a call to disk_log:change_size/2, Erchef won't start.

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/reindex-opc-organization.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/reindex-opc-organization.erb
@@ -1,8 +1,8 @@
 #!/usr/bin/env escript
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
-%% ex: ts=4 sw=4 et
+%% ex: ts=4 sw=4 et ft=erlang
 
-%% Copyright (c) 2013 Opscode, Inc.
+%% Copyright (c) 2013-2015 Chef Software, Inc.
 %% All Rights Reserved
 
 %% TODO: The cookie used by erchef should be part of config
@@ -106,8 +106,9 @@ perform(complete, Context, OrgInfo) ->
 
 make_context(OrgName, IntLB) ->
     ReqId = base64:encode(crypto:hash(md5, (term_to_binary(make_ref())))),
-    % TODO api versioning to be handled when we move this into an omnibus template
-    rpc:call(?ERCHEF, chef_db, make_context, [0, ReqId, find_dl_headers(OrgName, IntLB)]).
+    rpc:call(?ERCHEF, chef_db, make_context, [ <%= node['private_chef']['server-api-version'] %>,
+                                               ReqId, find_dl_headers(OrgName, IntLB)]).
+
 
 %% @doc Verify that the given `OrgName' actually corresponds to a real
 %% organization.  Returns the organization's ID if so; 'not_found' otherwise.

--- a/omnibus/files/private-chef-ctl-commands/reindex.rb
+++ b/omnibus/files/private-chef-ctl-commands/reindex.rb
@@ -8,6 +8,6 @@ add_command_under_category "reindex", "general", "Reindex all server data for a 
   # Always perform a complete reindexing; if you want more granular options,
   # use the reindex-opc-server escript directly
   Dir.chdir(File.join(base_path, "embedded", "service", "opscode-erchef", "bin")) do
-    exec("./reindex-opc-organization complete #{organization}")
+    exec("/opt/opscode/bin/reindex-opc-organization complete #{organization}")
   end
 end

--- a/src/oc_erchef/rel/reltool.config
+++ b/src/oc_erchef/rel/reltool.config
@@ -39,8 +39,6 @@
           {copy,"files/nodetool","{{erts_vsn}}/bin/nodetool"},
           {copy,"files/oc_erchef","bin/oc_erchef"},
           {copy,"../schema/*","schema"},
-          {copy,"files/reindex-opc-organization",
-                "bin/reindex-opc-organization"},
           {template,"files/app.config","etc/app.config"},
           {copy,"files/vm.args","etc/vm.args"}]}.
 

--- a/src/oc_erchef/relx.config
+++ b/src/oc_erchef/relx.config
@@ -17,7 +17,5 @@
           {mkdir,"lib/patches"},
           {mkdir,"etc/keys"},
           {copy,"schema","."},
-          {copy,"rel/files/reindex-opc-organization",
-                "bin/reindex-opc-organization"},
           {template,"rel/files/vm.args","vm.args"},
           {template,"rel/files/app.config","sys.config"}]}.


### PR DESCRIPTION
In order to ensure that  reindex-opc-organization has a valid
server API version and to help clean up rel/,make
reindex-opc-organization into an omnibus template.

ping @chef/lob 