### PR TITLE
Erlang 17.5 Compatibility

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -30,7 +30,7 @@ override :cacerts, version: '2014.08.20'
 override :rebar, version: "2.0.0"
 override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
-override :erlang, version: "R16B03-1"
+override :erlang, version: "17.5"
 override :ruby, version: "2.1.4"
 
 # creates required build directories

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -30,7 +30,7 @@ override :cacerts, version: '2014.08.20'
 override :rebar, version: "2.0.0"
 override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
-override :erlang, version: "17.5"
+override :erlang, version: "R16B03-1"
 override :ruby, version: "2.1.4"
 
 # creates required build directories

--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang; -*-
 
-{require_otp_vsn, "17.*"}.
+{require_otp_vsn, "R16|17.*"}.
 
 {erl_dep_retries, 10}.
 

--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang; -*-
 
-{require_otp_vsn, "R1[56]B.*"}.
+{require_otp_vsn, "17.*"}.
 
 {erl_dep_retries, 10}.
 
@@ -16,14 +16,14 @@
           {branch, "master"}}},
         {erlware_commons, ".*",
          {git, "git://github.com/erlware/erlware_commons.git",
-          {tag, "v0.6.2"}}},
+          {tag, "v0.11.1"}}},
         {mixer, ".*",
           {git, "git://github.com/opscode/mixer.git", {tag, "0.1.1"}}},
         {mini_s3, ".*",
          {git, "git://github.com/opscode/mini_s3.git",
           {branch, "master"}}},
         {sync, ".*",
-         {git, "https://github.com/rustyio/sync.git", {branch, "master"}}}
+         {git, "https://github.com/rustyio/sync.git", {branch, "master"}}},
         {eper, ".*",
          {git, "git://github.com/massemanet/eper.git", {branch, "master"}}}
        ]}.
@@ -31,7 +31,7 @@
 
 {erl_opts, [debug_info,
             {parse_transform, lager_transform},
-            warnings_as_errors}].
+            warnings_as_errors]}.
 
 {xref_checks,
  [exports_not_used,

--- a/src/bookshelf/rebar.config.lock
+++ b/src/bookshelf/rebar.config.lock
@@ -1,6 +1,6 @@
 %% THIS FILE IS GENERATED. DO NOT EDIT IT MANUALLY %%
 
-{require_otp_vsn,"R1[56]B.*"}.
+{require_otp_vsn,"17.*"}.
 {erl_dep_retries,10}.
 {deps,[{goldrush,".*",
                  {git,"git://github.com/DeadZen/goldrush.git",
@@ -23,9 +23,12 @@
        {iso8601,".*",
                 {git,"git://github.com/opscode/erlang_iso8601.git",
                      "25675e1df8b2bade1fb539cd9a913d61b90468dd"}},
+       {rebar_vsn_plugin,".*",
+                         {git,"https://github.com/erlware/rebar_vsn_plugin.git",
+                              "fd40c960c7912193631d948fe962e1162a8d1334"}},
        {erlware_commons,".*",
                         {git,"git://github.com/erlware/erlware_commons.git",
-                             "e7d175d0dbbcfc9b1b93f69cebfbc73c4b937905"}},
+                             "03f76c6ef2e854a11a62c3a1992f047ab0a0a69e"}},
        {mixer,".*",
               {git,"git://github.com/opscode/mixer.git",
                    "58ded93d5c47675899d8e5e1589270f340ea66c5"}},
@@ -34,19 +37,19 @@
                      "8f3f6a3a30730b193cc340a8885a960586dc98de"}},
        {envy,".*",
              {git,"git://github.com/manderson26/envy.git",
-                  "d62cb227b9000ee866c8bcc724ddf68d87621dea"}},
+                  "e6ba39664a1016ed309ea44269247943de2eb16b"}},
        {mini_s3,".*",
                 {git,"git://github.com/opscode/mini_s3.git",
                      "1cf296868077caefa6791f4996145a369c49091b"}},
+       {sync,".*",
+             {git,"https://github.com/rustyio/sync.git",
+                  "ae7dbd4e6e2c08d77d96fc4c2bc2b6a3b266492b"}},
        {eper,".*",
              {git,"git://github.com/massemanet/eper.git",
                   "80e7cd6446d26d2423f2acd37253826bb3152964"}},
        {rebar_lock_deps_plugin,".*",
                                {git,"git://github.com/seth/rebar_lock_deps_plugin.git",
                                     "7a5835029c42b8138325405237ea7e8516a84800"}},
-       {sync,".*",
-             {git,"https://github.com/rustyio/sync.git",
-                  "ae7dbd4e6e2c08d77d96fc4c2bc2b6a3b266492b"}},
        {edown,".*",
               {git,"git://github.com/seth/edown.git",
                    "30a9f7867d615af45783235faa52742d11a9348e"}}]}.

--- a/src/bookshelf/rebar.config.lock
+++ b/src/bookshelf/rebar.config.lock
@@ -1,6 +1,6 @@
 %% THIS FILE IS GENERATED. DO NOT EDIT IT MANUALLY %%
 
-{require_otp_vsn,"17.*"}.
+{require_otp_vsn,"R16|17.*"}.
 {erl_dep_retries,10}.
 {deps,[{goldrush,".*",
                  {git,"git://github.com/DeadZen/goldrush.git",

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -718,7 +718,7 @@ update_object(#context{reqid = ReqId}, ActorId, Fun, Object) ->
 -spec create_name_id_dict(#context{},
                           Index :: node | role | client | environment | binary(),
                           OrgId :: object_id()) ->
-                                 dict() | {error, term()}.
+                                 dict:dict() | {error, term()}.
 create_name_id_dict(#context{reqid=ReqId}, Index, OrgId) ->
     case ?SH_TIME(ReqId, chef_sql, create_name_id_dict, (OrgId, Index)) of
         {ok, D} ->

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -26,6 +26,10 @@
 
 -module(chef_db).
 
+-ifdef(namespaced_types).
+-type dict() :: dict:dict().
+-endif.
+
 -export([
          %% Context record manipulation
          make_context/2,
@@ -718,7 +722,7 @@ update_object(#context{reqid = ReqId}, ActorId, Fun, Object) ->
 -spec create_name_id_dict(#context{},
                           Index :: node | role | client | environment | binary(),
                           OrgId :: object_id()) ->
-                                 dict:dict() | {error, term()}.
+                                 dict() | {error, term()}.
 create_name_id_dict(#context{reqid=ReqId}, Index, OrgId) ->
     case ?SH_TIME(ReqId, chef_sql, create_name_id_dict, (OrgId, Index)) of
         {ok, D} ->

--- a/src/oc_erchef/apps/chef_db/src/chef_sql.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_sql.erl
@@ -102,6 +102,7 @@
 
         ]).
 
+-define(namespaced_types, true).
 -include_lib("sqerl/include/sqerl.hrl").
 -include("../../include/chef_types.hrl").
 
@@ -1421,7 +1422,7 @@ finalize_versions({Cookbook, Versions}) ->
 %%
 %% The key of the dict is a `{CookbookName, Version}' tuple, which
 %% corresponds to the data that Depsolver gives.
--spec create_cookbook_version_dict(OrgId :: object_id()) -> {ok, dict()} |
+-spec create_cookbook_version_dict(OrgId :: object_id()) -> {ok, dict:dict()} |
                                                             {error, term()}.
 create_cookbook_version_dict(OrgId) ->
     case sqerl:select(fetch_all_cookbook_version_ids_by_orgid, [OrgId]) of
@@ -1444,7 +1445,7 @@ create_cookbook_version_dict(OrgId) ->
 %% @doc Returns just the IDs of cookbook versions that are in
 %% environment-filtered set of cookbook versions.  Ordering is not
 %% important (and so not guaranteed).
--spec extract_ids_using_filtered_results(MappingDict :: dict(),
+-spec extract_ids_using_filtered_results(MappingDict :: dict:dict(),
                                          FilteredCookbookVersions :: [{CookbookName :: binary(),
                                                                        [BestVersion :: binary()]}]) ->
                                                 [Id :: integer()].
@@ -1547,7 +1548,7 @@ safe_split(N, L) ->
 %% data bag.
 -spec create_name_id_dict(OrgId :: object_id(),
                           Index :: node | role | client | environment | binary()) ->
-                                 {ok, dict()} | {error, term()}.
+                                 {ok, dict:dict()} | {error, term()}.
 create_name_id_dict(OrgId, Index) ->
     Query = dict_query_for_index(Index),
     Args = dict_query_args_for_index(OrgId, Index),
@@ -1607,7 +1608,7 @@ dict_key_value_for_index(Index) when Index =:= node;
                   Args :: list(),
                   {Key :: <<_:32,_:_*40>>, %% <<"name">> | <<"item_name">>
                    Value :: <<_:16>>}) %% <<"id">>
-                 -> {ok, dict()} | {error, term()}.
+                 -> {ok, dict:dict()} | {error, term()}.
 create_dict(Query, Args, {Key, Value}) ->
     case proplist_results(Query, Args) of
         Results when is_list(Results) ->
@@ -1641,7 +1642,7 @@ proplist_results(Query, Args) ->
 %% This spec brought to you by -Wunderspecs
 -spec proplists_to_dict(ResultSetProplist :: [[tuple()]],
                         Key :: <<_:32,_:_*40>>, %% <<"name">> | <<"item_name">>
-                        Value :: <<_:16>>) -> dict(). %% <<"id">>
+                        Value :: <<_:16>>) -> dict:dict(). %% <<"id">>
 proplists_to_dict(ResultSetProplist, Key, Value) ->
     lists:foldl(fun(Row, Dict) ->
                         K = proplists:get_value(Key, Row),

--- a/src/oc_erchef/apps/chef_db/src/chef_sql.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_sql.erl
@@ -24,7 +24,6 @@
 %% @author Ho-Sheng
 %% @author Marc Paradise <marc@chef.io>
 
-
 -module(chef_sql).
 
 -include("../../include/chef_db.hrl").
@@ -33,6 +32,9 @@
 -compile(export_all).
 -endif.
 
+-ifdef(namespaced_types).
+-type dict() :: dict:dict().
+-endif.
 
 -export([
          create_name_id_dict/2,
@@ -102,7 +104,6 @@
 
         ]).
 
--define(namespaced_types, true).
 -include_lib("sqerl/include/sqerl.hrl").
 -include("../../include/chef_types.hrl").
 
@@ -1422,7 +1423,7 @@ finalize_versions({Cookbook, Versions}) ->
 %%
 %% The key of the dict is a `{CookbookName, Version}' tuple, which
 %% corresponds to the data that Depsolver gives.
--spec create_cookbook_version_dict(OrgId :: object_id()) -> {ok, dict:dict()} |
+-spec create_cookbook_version_dict(OrgId :: object_id()) -> {ok, dict()} |
                                                             {error, term()}.
 create_cookbook_version_dict(OrgId) ->
     case sqerl:select(fetch_all_cookbook_version_ids_by_orgid, [OrgId]) of
@@ -1445,7 +1446,7 @@ create_cookbook_version_dict(OrgId) ->
 %% @doc Returns just the IDs of cookbook versions that are in
 %% environment-filtered set of cookbook versions.  Ordering is not
 %% important (and so not guaranteed).
--spec extract_ids_using_filtered_results(MappingDict :: dict:dict(),
+-spec extract_ids_using_filtered_results(MappingDict :: dict(),
                                          FilteredCookbookVersions :: [{CookbookName :: binary(),
                                                                        [BestVersion :: binary()]}]) ->
                                                 [Id :: integer()].
@@ -1548,7 +1549,7 @@ safe_split(N, L) ->
 %% data bag.
 -spec create_name_id_dict(OrgId :: object_id(),
                           Index :: node | role | client | environment | binary()) ->
-                                 {ok, dict:dict()} | {error, term()}.
+                                 {ok, dict()} | {error, term()}.
 create_name_id_dict(OrgId, Index) ->
     Query = dict_query_for_index(Index),
     Args = dict_query_args_for_index(OrgId, Index),
@@ -1608,7 +1609,7 @@ dict_key_value_for_index(Index) when Index =:= node;
                   Args :: list(),
                   {Key :: <<_:32,_:_*40>>, %% <<"name">> | <<"item_name">>
                    Value :: <<_:16>>}) %% <<"id">>
-                 -> {ok, dict:dict()} | {error, term()}.
+                 -> {ok, dict()} | {error, term()}.
 create_dict(Query, Args, {Key, Value}) ->
     case proplist_results(Query, Args) of
         Results when is_list(Results) ->
@@ -1642,7 +1643,7 @@ proplist_results(Query, Args) ->
 %% This spec brought to you by -Wunderspecs
 -spec proplists_to_dict(ResultSetProplist :: [[tuple()]],
                         Key :: <<_:32,_:_*40>>, %% <<"name">> | <<"item_name">>
-                        Value :: <<_:16>>) -> dict:dict(). %% <<"id">>
+                        Value :: <<_:16>>) -> dict(). %% <<"id">>
 proplists_to_dict(ResultSetProplist, Key, Value) ->
     lists:foldl(fun(Row, Dict) ->
                         K = proplists:get_value(Key, Row),

--- a/src/oc_erchef/apps/depsolver/src/depsolver.erl
+++ b/src/oc_erchef/apps/depsolver/src/depsolver.erl
@@ -95,7 +95,7 @@
 %%============================================================================
 %% type
 %%============================================================================
--type dep_graph() :: gb_tree().
+-type dep_graph() :: gb_trees:tree().
 -opaque t() :: {?MODULE, dep_graph()}.
 -type pkg() :: {pkg_name(), vsn()}.
 -type pkg_name() :: binary() | atom().

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.erl
@@ -42,6 +42,7 @@
 
 -include("../../include/oc_chef_authz.hrl").
 -include("oc_chef_authz_db.hrl").
+-define(namespaced_types, true).
 -include_lib("sqerl/include/sqerl.hrl").
 
 %% TODO Fix:

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.erl
@@ -42,7 +42,6 @@
 
 -include("../../include/oc_chef_authz.hrl").
 -include("oc_chef_authz_db.hrl").
--define(namespaced_types, true).
 -include_lib("sqerl/include/sqerl.hrl").
 
 %% TODO Fix:

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -170,7 +170,7 @@ decompress_and_decode(Object) ->
                     BatchSize :: non_neg_integer(),
                     OrgInfo :: org_info(),
                     Index :: index(),
-                    NameIdDict :: dict()) -> ok.
+                    NameIdDict :: dict:dict()) -> ok.
 batch_reindex(Ctx, Ids, BatchSize, OrgInfo, Index, NameIdDict) when is_list(Ids) ->
     DoBatch = fun(Batch, _Acc) ->
                       ok = index_a_batch(Ctx, Batch, OrgInfo, Index, NameIdDict),
@@ -184,7 +184,7 @@ batch_reindex(Ctx, Ids, BatchSize, OrgInfo, Index, NameIdDict) when is_list(Ids)
                     BatchOfIds :: [object_id()],
                     OrgInfo :: org_info(),
                     Index :: index(),
-                    NameIdDict :: dict()) -> ok.
+                    NameIdDict :: dict:dict()) -> ok.
 index_a_batch(Ctx, BatchOfIds, {OrgId, OrgName}, Index, NameIdDict) ->
     SerializedObjects = chef_db:bulk_get(Ctx, OrgName, chef_object_type(Index), BatchOfIds),
     ok = send_to_index_queue(OrgId, Index, SerializedObjects, NameIdDict),
@@ -200,7 +200,7 @@ chef_object_type(Index)                       -> Index.
 -spec send_to_index_queue(OrgId :: object_id(),
                           Index :: index(),
                           SerializedObjects :: [binary()] | [ej:json_object()],
-                          NameIdDict :: dict()) -> ok.
+                          NameIdDict :: dict:dict()) -> ok.
 send_to_index_queue(_, _, [], _) ->
     ok;
 send_to_index_queue(OrgId, Index, [SO|Rest], NameIdDict) ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -19,6 +19,10 @@
 -module(chef_reindex).
 -compile([warnings_as_errors]).
 
+-ifdef(namespaced_types).
+-type dict() :: dict:dict().
+-endif.
+
 -include("../../include/chef_types.hrl").
 -include_lib("ej/include/ej.hrl").
 
@@ -170,7 +174,7 @@ decompress_and_decode(Object) ->
                     BatchSize :: non_neg_integer(),
                     OrgInfo :: org_info(),
                     Index :: index(),
-                    NameIdDict :: dict:dict()) -> ok.
+                    NameIdDict :: dict()) -> ok.
 batch_reindex(Ctx, Ids, BatchSize, OrgInfo, Index, NameIdDict) when is_list(Ids) ->
     DoBatch = fun(Batch, _Acc) ->
                       ok = index_a_batch(Ctx, Batch, OrgInfo, Index, NameIdDict),
@@ -184,7 +188,7 @@ batch_reindex(Ctx, Ids, BatchSize, OrgInfo, Index, NameIdDict) when is_list(Ids)
                     BatchOfIds :: [object_id()],
                     OrgInfo :: org_info(),
                     Index :: index(),
-                    NameIdDict :: dict:dict()) -> ok.
+                    NameIdDict :: dict()) -> ok.
 index_a_batch(Ctx, BatchOfIds, {OrgId, OrgName}, Index, NameIdDict) ->
     SerializedObjects = chef_db:bulk_get(Ctx, OrgName, chef_object_type(Index), BatchOfIds),
     ok = send_to_index_queue(OrgId, Index, SerializedObjects, NameIdDict),
@@ -200,7 +204,7 @@ chef_object_type(Index)                       -> Index.
 -spec send_to_index_queue(OrgId :: object_id(),
                           Index :: index(),
                           SerializedObjects :: [binary()] | [ej:json_object()],
-                          NameIdDict :: dict:dict()) -> ok.
+                          NameIdDict :: dict()) -> ok.
 send_to_index_queue(_, _, [], _) ->
     ok;
 send_to_index_queue(OrgId, Index, [SO|Rest], NameIdDict) ->

--- a/src/oc_erchef/include/chef_regex.hrl
+++ b/src/oc_erchef/include/chef_regex.hrl
@@ -35,7 +35,7 @@
                       policy_file_name |
                       policy_identifier.
 
--type re_regex() :: {re_pattern, integer(), integer(), binary()}.
+-type re_regex() :: re:mp(). %%{re_pattern, integer(), integer(), binary()}.
 %% FIXME: This type is not yet correct
 %% I'd like to use binary() but dialyzer wants this more specific type
 -type re_msg() :: <<_:64,_:_*8>>.

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -94,4 +94,6 @@
             {d, 'CHEF_WM_DARKLAUNCH', xdarklaunch_req},
             {parse_transform, lager_transform},
             warnings_as_errors,
-            debug_info]}.
+            debug_info,
+            {platform_define, "^[0-9]+", namespaced_types}
+           ]}.

--- a/src/oc_erchef/rebar.config.lock
+++ b/src/oc_erchef/rebar.config.lock
@@ -128,5 +128,6 @@
            {d,'CHEF_DB_DARKLAUNCH',xdarklaunch_req},
            {d,'CHEF_WM_DARKLAUNCH',xdarklaunch_req},
            {parse_transform,lager_transform},
-           warnings_as_errors,debug_info]}.
-
+           warnings_as_errors,
+           debug_info,
+           {platform_define,"^[0-9]+",namespaced_types}]}.


### PR DESCRIPTION
This PR allows all projects to build in erlang 17.5 except for `chef-mover`.

`chef-mover` needs some attention to get that done, which it should be receiving shortly.

Since that's the case, these changes were all made to be compatible with R16B03-1 as well, and omnibus continues to build it that way.