### PR TITLE
Explicitly call fetch_org_metadata in chef_wm_object_identifiers

### DIFF
--- a/oc-chef-pedant/spec/api/object_identifier_spec.rb
+++ b/oc-chef-pedant/spec/api/object_identifier_spec.rb
@@ -32,7 +32,7 @@ describe "Private Chef Nodes API endpoint",  :'object-identifiers' do
     context 'for nodes' do
       context 'that exist' do
         include_context 'with temporary testing node'
-        xit "returns a 200 and valid node identifiers" do
+        it "returns a 200 and valid node identifiers" do
           # TODO if we expand the _identifiers behavior beyond nodes, this will
           # get factored up into its own shared context usable across different
           # object types.


### PR DESCRIPTION
For typical requests, organization metadata is populated into the
base_state in malformed_request callback. The object_identifiers
module is an unauthenticated internal-use-only module that does not
export malformed_request. Thus, fetch_org_metadata was never being
called. This was resulting in the reporting add-on getting 404s for
valid node objects. This adds an explicit call to fetch_org_metadata
to avoid this problem.