### PR TITLE
[oc_erchef] dialyzer cleanup to remove undefined types and functions

### DIFF
--- a/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
@@ -42,7 +42,10 @@
 
 -record(state, {port, os_pid}).
 
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl"). %% TODO: remove
+-endif.
+-include("../../include/chef_types.hrl").
 
 %%%===================================================================
 %%% API
@@ -68,7 +71,7 @@ start_link() ->
                          Cookbooks :: [Name::binary() |
                                              {Name::binary(), Version::binary()}],
                          Timeout :: integer()) ->
-                                {ok, [ chef_depsolver:versioned_cookbook()]} | {error, term()}.
+                                {ok, [ versioned_cookbook()]} | {error, term()}.
 solve_dependencies(AllVersions, EnvConstraints, Cookbooks, Timeout) ->
     case pooler:take_member(chef_depsolver, pooler_timeout()) of
         error_no_members ->

--- a/src/oc_erchef/apps/chef_objects/src/chef_role.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_role.erl
@@ -178,7 +178,7 @@ parse_binary_json(Bin, Action) ->
 set_default_values(Role) ->
     chef_object_base:set_default_values(Role, ?DEFAULT_FIELD_VALUES).
 
--spec validate(ej:ejson_object()) -> {ok, ej:ejson_object()}.
+-spec validate(jiffy:json_value()) -> {ok, jiffy:json_value()}.
 validate(Role) ->
     case chef_object_base:strictly_valid(?VALIDATION_CONSTRAINTS, ?VALID_KEYS, Role) of
         ok ->

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.erl
@@ -53,11 +53,10 @@
 -ifdef(TEST).
 -compile([export_all]).
 -include_lib("eunit/include/eunit.hrl").
-
 -endif.
 
--include("../../include/oc_chef_authz.hrl").
 -include("../../include/server_api_version.hrl").
+-include("../../include/oc_chef_authz.hrl").
 -include("oc_chef_authz_db.hrl").
 
 -export_type([oc_chef_authz_context/0]).

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -178,7 +178,7 @@ set_json_body(Req, EjsonData) ->
 %% in an error message envelope, which is then encoded to JSON and set as the body of the
 %% request.  This updated request is returned.
 -spec with_error_body(Req :: wm_req(),
-                      ErrorData :: ej:json_object() | ej:json_string()) ->
+                      ErrorData :: jiffy:json_value()) ->
                              ReqWithErrorJSON :: wm_req().
 with_error_body(Req, ErrorData) ->
     ErrorPayload = error_message_envelope(ErrorData),

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -677,7 +677,7 @@ object_creation_hook(Object, _State) ->
 %% See oc_chef_authz:add_client_to_clients_group/4 for more
 %% information on the `RequestorId` argument
 -spec client_cleanup(#chef_client{},
-                     AuthContext :: chef_authz:chef_authz_context(),
+                     AuthContext :: oc_chef_authz:oc_chef_authz_context(),
                      OrgId :: object_id(),
                      RequestorId :: superuser) -> #chef_client{} |
                                                                 {error, term()}.
@@ -1289,7 +1289,7 @@ route_args(ObjectRec,_State) ->
     {TypeName, [{name, chef_object:name(ObjectRec)}]}.
 
 -spec default_malformed_request_message(
-        term(), wm_req(), chef_wm:base_state()) -> none().
+        term(), wm_req(), #base_state{}) -> none().
 default_malformed_request_message(Any, _Req, _State) ->
     error({unexpected_malformed_request_message, Any}).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_license.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_license.erl
@@ -62,6 +62,6 @@ license_body(State) ->
 node_count(#base_state{chef_db_context = DbContext}) ->
     chef_db:count_nodes(DbContext).
 
--spec malformed_request_message(any(), wm_req(), oc_chef_wm_base:base_state()) -> no_return().
+-spec malformed_request_message(any(), wm_req(), #base_state{}) -> no_return().
 malformed_request_message(Any, Req, State) ->
     oc_chef_wm_base:default_malformed_request_message(Any, Req, State).

--- a/src/oc_erchef/include/oc_chef_wm.hrl
+++ b/src/oc_erchef/include/oc_chef_wm.hrl
@@ -172,7 +172,7 @@
           chef_db_context :: chef_db:db_context(),
 
           %% Opaque db connection context record as returned by chef_authz:make_context.
-          chef_authz_context :: chef_authz:chef_authz_context(),
+          chef_authz_context :: oc_chef_authz:oc_chef_authz_context(),
 
           %% AuthzId for the actor making the request.
           requestor_id :: object_id(),


### PR DESCRIPTION
Some final dialyzer cleanup to remove the last of the errors. 

This is dependent on mp/use_callbacks_for_policyfiles 


ping @chef/lob 

