### PR TITLE
cache deps and erlang plt files to avoid regen/redownload

### DIFF
--- a/.cache-files
+++ b/.cache-files
@@ -1,7 +1,6 @@
 .luarocks/
 .cpanm/
 .cpan/
-.rvm/
 perl5/
 build/chef/chef-server/src/oc-id/vendor/bundle
 build/chef/chef-server/src/oc_erchef/deps.plt

--- a/.cache-files
+++ b/.cache-files
@@ -1,6 +1,7 @@
 .luarocks/
 .cpanm/
 .cpan/
+.rvm/
 perl5/
 build/chef/chef-server/src/oc-id/vendor/bundle
 build/chef/chef-server/src/oc_erchef/deps.plt

--- a/.cache-files
+++ b/.cache-files
@@ -1,0 +1,8 @@
+.luarocks/
+.cpanm/
+.cpan/
+.rvm/
+perl5/
+build/chef/chef-server/src/oc-id/vendor/bundle
+build/chef/chef-server/src/oc_erchef/deps.plt
+build/chef/chef-server/src/oc_erchef/travis-erlang-17.4.plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,18 +42,18 @@ env:
     - CHEFDK_GECODE_PATH=/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.0.2/lib/dep-selector-libgecode/vendored-gecode
     - LUALIB=~/.luarocks/lib/lua/5.2
   matrix:
-  #- COMPONENT=omnibus
+  - COMPONENT=omnibus
   - COMPONENT=src/oc_erchef
   - COMPONENT=src/oc-id
   - COMPONENT=src/chef-mover
 install:
   - mkdir -p $HOME/.realcache
-  # Some errors expected but not fatal -- thus ||true
+    # Some warning-type errors expected . THis will give a non-zero return
+    # code and stop the build, thus ||true
   - rsync -azr --no-R --stats /home/travis/.realcache/ / || true
-    # TODO - luarocks local install of lpeg is failing, need to look at why.
-  #- luarocks install --local lpeg
-  #- luarocks install --local lua-cjson
-  #- eval $(luarocks path)
+  - luarocks install --local lpeg
+  - luarocks install --local lua-cjson
+  - eval $(luarocks path)
   - rvm install --binary 2.1.4
   - rvm use 2.1.4
   - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ branches:
 cache:
   apt: true
   directories:
-    - src/oc-id/vendor/bundle
-#    - $HOME/.luarocks/rocks
-    - $HOME/.cpanm
-    - $HOME/.cpan
-    - $HOME/perl5
+    - $HOME/.realcache
+
+
 before_cache:
   # Prevent build log from changing cache cand causing repackage
+  # Look and see what we have:
   - rm -f $HOME/.cpanm/work/*/build.log
   - rm -f $HOME/.cpanm/build.log
+  - $HOME/build/chef/chef-server/cache-push.sh
 language: erlang
 otp_release:
   - 17.4
@@ -30,7 +30,8 @@ addons:
     packages:
       - cpanminus
       - perl
-#      - lua5.1
+      - lua5.1
+      - luarocks
       - libdbd-pg-perl
       - build-essential
       - chefdk
@@ -39,23 +40,28 @@ env:
     - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
     - USE_OMNIBUS_FILES=0
     - CHEFDK_GECODE_PATH=/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.0.2/lib/dep-selector-libgecode/vendored-gecode
-
-#    - LUALIB=~/.luarocks/lib/lua/5.2
+    - LUALIB=~/.luarocks/lib/lua/5.2
   matrix:
-    # - COMPONENT=omnibus
+  #- COMPONENT=omnibus
   - COMPONENT=src/oc_erchef
   - COMPONENT=src/oc-id
   - COMPONENT=src/chef-mover
 install:
-#  - sudo apt-get install luarocks
-#  - luarocks install --local lpeg
-#  - luarocks install --local lua-cjson
-#  - eval $(luarocks path)
+  - mkdir -p $HOME/.realcache
+  # Some errors expected but not fatal -- thus ||true
+  - rsync -azr --no-R --stats /home/travis/.realcache/ / || true
+    # TODO - luarocks local install of lpeg is failing, need to look at why.
+  #- luarocks install --local lpeg
+  #- luarocks install --local lua-cjson
+  #- eval $(luarocks path)
   - rvm install --binary 2.1.4
   - rvm use 2.1.4
-  - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+  - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib
+  - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
   - cpanm --notest --quiet App::Sqitch
-  - cd $COMPONENT && travis_retry make install
+  - cd $COMPONENT
+  - travis_retry make install
 
 script:
   - USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,18 +46,21 @@ install:
     # Some warning-type errors expected . THis will give a non-zero return
     # code and stop the build, thus ||true
   - rsync -azr --no-R --stats /home/travis/.realcache/ / || true
+    # Omnibus
   - luarocks install --local lpeg
   - luarocks install --local lua-cjson
   - eval $(luarocks path)
+    # OC-ID
   - rvm install --binary 2.1.4
   - rvm use 2.1.4
+    # oc_erchef
   - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib
   - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
   - cpanm --notest --quiet App::Sqitch
 
 script:
-  - cd $HOME/build/chef-server/src/oc_erchef && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
-  - cd $HOME/build/chef-server/src/oc-id && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
-  - cd $HOME/build/chef-server/src/chef-mover && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
-  - cd $HOME/build/chef-server/omnibus && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef/chef-server/src/oc_erchef && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef/chef-server/src/oc-id && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef/chef-server/src/chef-mover && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef/chef-server/omnibus && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,6 @@ env:
     - USE_OMNIBUS_FILES=0
     - CHEFDK_GECODE_PATH=/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.0.2/lib/dep-selector-libgecode/vendored-gecode
     - LUALIB=~/.luarocks/lib/lua/5.2
-  matrix:
-  - COMPONENT=omnibus
-  - COMPONENT=src/oc_erchef
-  - COMPONENT=src/oc-id
-  - COMPONENT=src/chef-mover
 install:
   - mkdir -p $HOME/.realcache
     # Some warning-type errors expected . THis will give a non-zero return
@@ -59,9 +54,10 @@ install:
   - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib
   - eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
   - cpanm --notest --quiet App::Sqitch
-  - cd $COMPONENT
-  - travis_retry make install
 
 script:
-  - USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef-server/src/oc_erchef && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef-server/src/oc-id && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef-server/src/chef-mover && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
+  - cd $HOME/build/chef-server/omnibus && travis_retry make install && USE_SYSTEM_GECODE=1 LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib LD_LIBRARY_PATH=$CHEFDK_GECODE_PATH/lib CPLUS_INCLUDE_PATH=$CHEFDK_GECODE_PATH/include make travis
 

--- a/cache-push.sh
+++ b/cache-push.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+while read f; do
+  rsync -azrR --delete --stats $HOME/$f $HOME/.realcache
+done < $HOME/build/chef/chef-server/.cache-files

--- a/cache-push.sh
+++ b/cache-push.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+regex=".*transferred: 0"
 while read f; do
-  rsync -azrR --delete --stats $HOME/$f $HOME/.realcache
+  results=`rsync -azrR --delete --stats $HOME/$f $HOME/.realcache | grep "files transferred: 0"`
+  if [ "$results" == "" ]
+  then
+    echo "Update to cache due to change in $HOME/$f"
+    touch $HOME/.realcache # Ensure timestamp is updated so cacher knows we've changed.
+  fi
 done < $HOME/build/chef/chef-server/.cache-files

--- a/src/oc_erchef/concrete.mk
+++ b/src/oc_erchef/concrete.mk
@@ -166,7 +166,7 @@ dialyzer: $(BASE_PLT) $(DEPS_PLT)
 	@$(DIALYZER) $(DIALYZER_OPTS) --plts $(BASE_PLT) $(DEPS_PLT) $(DIALYZER_SRC)
 
 $(DEPS_PLT):
-	@$(DIALYZER) --build_plt $(DIALYZER_DEPS) --output_plt $(DEPS_PLT)
+	@$(DIALYZER) --build_plt $(DIALYZER_DEPS) --plts $(BASE_PLT) --output_plt $(DEPS_PLT)
 endif
 
 $(BASE_PLT):


### PR DESCRIPTION
the cache mechanism used by container builds re-extracts a complete bz2-compressed tarball of the cache for each named item, resulting in a linearly increasing constant time operation for each line item that we add to the cache.  

This works around that by pulling cache content out of a single travis-cache item, .realcache/, using rsync to preserve dates/times/etc.   After the build it then uses rysnc to push changed things into .realcache/. 

Testing has shown that this does also prevent mtime updates to .realcache unless something has changed - so travis doesn't reupload the cache unnecessarily. 