### PR TITLE
Generate 2048 bit dhparam on first reconfigure

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -350,8 +350,13 @@ default['private_chef']['nginx']['proxy_connect_timeout'] = 1
 # "SSLv3" to the below line.
 default['private_chef']['nginx']['ssl_protocols'] = "TLSv1 TLSv1.1 TLSv1.2"
 default['private_chef']['nginx']['ssl_ciphers'] = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA"
+#
+# The SSL Certificate and DH Param will be automatically generated if
+# these are nil.  Otherwise we expect these attributes to point at the
+# on-disk location of a user-provided certificate and dhparam
 default['private_chef']['nginx']['ssl_certificate'] = nil
 default['private_chef']['nginx']['ssl_certificate_key'] = nil
+default['private_chef']['nginx']['ssl_dhparam'] = nil
 default['private_chef']['nginx']['ssl_country_name'] = "US"
 default['private_chef']['nginx']['ssl_state_name'] = "WA"
 default['private_chef']['nginx']['ssl_locality_name'] = "Seattle"

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -93,8 +93,24 @@ unless File.exists?(ssl_keyfile) && File.exists?(ssl_crtfile) && File.exists?(ss
   end
 end
 
+
+ssl_dhparam = File.join(nginx_ca_dir, "dhparams.pem")
+# We do the File.exist check at compile-time to prevent expensive
+# dhapram generation.
+if ! File.exists?(ssl_dhparam)
+  file ssl_dhparam do
+    content `/opt/opscode/embedded/bin/openssl dhparam 2048 2>/dev/null`
+    mode "0644"
+    owner "root"
+    group "root"
+    action :create_if_missing
+  end
+end
+
+
 node.default['private_chef']['nginx']['ssl_certificate'] ||= ssl_crtfile
 node.default['private_chef']['nginx']['ssl_certificate_key'] ||= ssl_keyfile
+node.default['private_chef']['nginx']['ssl_dhparam'] ||= ssl_dhparam
 
 remote_directory nginx_html_dir do
   source "html"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -7,6 +7,7 @@
       ssl on;
       ssl_certificate <%= @ssl_certificate %>;
       ssl_certificate_key <%= @ssl_certificate_key %>;
+      ssl_dhparam <%= @ssl_dhparam %>;
 
       ssl_session_timeout 5m;
 


### PR DESCRIPTION
We were previously using the default nginx/openssl values for dhparam.
This means that we were using a 1024 bit prime for Diffie-Hellman.
This is problematic because:

- it is smaller than our certificate size which means users of
  non-elliptic DHE were getting, in some sense, weaker security than
  those using less advanced ciphers, and

- recent research shows that 1024 bit primes are vulnerable to
  pre-computation attacks by nation-state level actors.