### PR TITLE
fixed a busted control command - should be script name versus full path

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -38,7 +38,7 @@ then
 elif [[ $type == 'OSC' ]];
 then
     path='chef-server'
-    ctl_cmd='/opt/chef-server/bin/chef-server-ctl'
+    ctl_cmd='chef-server-ctl'
     config_name='chef-server.rb'
 
     if [[ ! -e "/opt/$path/bin/$ctl_cmd" ]];


### PR DESCRIPTION
The control command is constructed from $path and $ctl_cmd vars. For the OSC type $ctl_cmd is an absolute path and this breaks the script.