### PR TITLE
ensure that postgres shared buffers are calculated correctly

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -4,7 +4,7 @@
 # All Rights Reserved
 #
 
-BYTES_IN_GIG = 1048576
+KB_IN_GIG = 1048576
 
 ###
 # Set a project-name for the enterprise-chef-common cookbook
@@ -428,15 +428,17 @@ default['private_chef']['postgresql']['archive_timeout'] = 0 # 0 is disabled.
 #  https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server
 # They generally recomend 25% of avalable memory, and we reserve 15% of shared memory for other uses
 # We limit to 2GB less than shmmax as exessive amounts of shared memory is unhelpful.
+
+# Convert everything to KB to avoid unit confusion
+shmkb = node['private_chef']['postgresql']['shmmax'] / 1024
 quarter_mem = node['memory']['total'].to_i/4
-postgres_max_mem = [0.85*node['private_chef']['postgresql']['shmmax'],
-                    node['private_chef']['postgresql']['shmmax'] - 2*BYTES_IN_GIG].min
+postgres_max_mem = [0.85*shmkb, shmkb - 2*KB_IN_GIG].min
 if(quarter_mem > postgres_max_mem)
   shared_bytes = postgres_max_mem
 else
   shared_bytes = quarter_mem
 end
-default['private_chef']['postgresql']['shared_buffers'] = "#{shared_bytes/1024}MB"
+default['private_chef']['postgresql']['shared_buffers'] = "#{(shared_bytes/1024).to_i}MB"
 
 default['private_chef']['postgresql']['work_mem'] = "8MB"
 default['private_chef']['postgresql']['effective_cache_size'] = "#{(node['memory']['total'].to_i / 2) / (1024)}MB"


### PR DESCRIPTION
cc @mmzyk 
closes #44 

this causes both shmmax and the nodes memory to be handled in kilobytes, rather than shmmax being in bytes and memory in KB.