### PR TITLE
not for merge: PoC - support external postgres instances 

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -390,6 +390,7 @@ default['private_chef']['postgresql']['version'] = "9.2"
 # we'll be using these directories to determine what versions we have installed and
 # whether we need to run pg_upgrade.
 default['private_chef']['postgresql']['enable'] = true
+default['private_chef']['postgresql']['remote'] = false
 default['private_chef']['postgresql']['ha'] = false
 default['private_chef']['postgresql']['dir'] = "/var/opt/opscode/postgresql/#{node['private_chef']['postgresql']['version']}"
 default['private_chef']['postgresql']['data_dir'] = "/var/opt/opscode/postgresql/#{node['private_chef']['postgresql']['version']}/data"
@@ -397,7 +398,10 @@ default['private_chef']['postgresql']['log_directory'] = "/var/log/opscode/postg
 default['private_chef']['postgresql']['log_min_duration_statement'] = -1
 default['private_chef']['postgresql']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['postgresql']['log_rotation']['num_to_keep'] = 10
+# If 'remote' = true, these shoudl be set to the username and password
+# of a superuser on the remote instance who has access over tcp vi pg_hba.conf
 default['private_chef']['postgresql']['username'] = "opscode-pgsql"
+default['private_chef']['postgresql']['password'] = nil
 default['private_chef']['postgresql']['shell'] = "/bin/sh"
 default['private_chef']['postgresql']['home'] = "/var/opt/opscode/postgresql"
 default['private_chef']['postgresql']['user_path'] = "/opt/opscode/embedded/bin:/opt/opscode/bin:$PATH"
@@ -461,6 +465,12 @@ default['private_chef']['oc_bifrost']['db_pool_size'] = '20'
 # The db_pool is only effective for a db_pooler_timeout > 0
 default['private_chef']['oc_bifrost']['db_pooler_timeout'] = '0'
 default['private_chef']['oc_bifrost']['db_pool_queue_max'] = '50'
+## TODO, allow:
+#
+#default['private_chef']['oc_bifrost']['db']['hostname']
+#default['private_chef']['oc_bifrost']['db']['port']
+#default['private_chef']['oc_bifrost']['db']['username']
+#default['private_chef']['oc_bifrost']['db']['password']
 default['private_chef']['oc_bifrost']['sql_user'] = "bifrost"
 default['private_chef']['oc_bifrost']['sql_password'] = "challengeaccepted"
 default['private_chef']['oc_bifrost']['sql_ro_user'] = "bifrost_ro"

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -1,8 +1,8 @@
 class EcPostgres
   def self.with_connection(node, database = 'template1')
     require 'pg'
-    # TODO -
-    #
+    # TODO - this will need to accept params for where to connect once we suppotr splitting out multiple
+    # databases.
     postgres = node['private_chef']['postgresql']
     if postgres['remote']
       # TODO this is a dual user of postgres['username'] - though it makes sense here?

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_database.rb
@@ -13,7 +13,7 @@ action :create do
     result = connection.exec("SELECT datname FROM pg_database WHERE datname='#{new_resource.database}'")
     if result.ntuples == 0
       owner = "WITH OWNER #{new_resource.owner}" if new_resource.owner
-      connection.exec("CREATE DATABASE #{new_resource.database} #{owner} TEMPLATE #{new_resource.template} ENCODING '#{new_resource.encoding}';")
+      connection.exec("CREATE DATABASE \"#{new_resource.database}\" #{owner} TEMPLATE #{new_resource.template} ENCODING '#{new_resource.encoding}';")
     end
   end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_database.rb
@@ -8,35 +8,12 @@ def whyrun_supported?
 end
 
 use_inline_resources
-
 action :create do
-  execute "create_database_#{new_resource.database}" do
-    command createdb_command
-    user node['private_chef']['postgresql']['username']
-    not_if {database_exist?}
-    retries 30
+  EcPostgres.with_connection(node) do |connection|
+    result = connection.exec("SELECT datname FROM pg_database WHERE datname='#{new_resource.database}'")
+    if result.ntuples == 0
+      owner = "WITH OWNER #{new_resource.owner}" if new_resource.owner
+      connection.exec("CREATE DATABASE #{new_resource.database} #{owner} TEMPLATE #{new_resource.template} ENCODING '#{new_resource.encoding}';")
+    end
   end
-end
-
-def createdb_command
-  cmd = ["createdb"]
-  cmd << "--template #{new_resource.template}"
-  cmd << "--encoding #{new_resource.encoding}"
-  cmd << "--owner #{new_resource.owner}" if new_resource.owner
-  cmd << new_resource.database
-  cmd.join(" ")
-end
-
-def database_exist?
-  command = <<-EOM.gsub(/\s+/," ").strip!
-    psql --dbname template1
-         --tuples-only
-         --command "SELECT datname FROM pg_database WHERE datname='#{new_resource.database}';"
-    | grep #{new_resource.database}
-  EOM
-
-  s = Mixlib::ShellOut.new(command,
-                           :user => node['private_chef']['postgresql']['username'])
-  s.run_command
-  s.exitstatus == 0
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -1,27 +1,29 @@
 
 def whyrun_supported?
-  false
+  true
 end
 
 use_inline_resources
 
 action :deploy do
-  verify = new_resource.verify ? "--verify" : ""
   target = new_resource.target_version ? "--to-target #{new_resource.target_version}" : ""
-  hostname = new_resource.hostname ? new_resource.hostname : node['private_chef']['postgresql']['vip']
-  port = new_resource.port ? new_resource.port: node['private_chef']['postgresql']['port']
   execute "sqitch_deploy_#{new_resource.name}" do
     command <<-EOM.gsub(/\s+/," ").strip!
       sqitch --engine pg
-             --db-host #{hostname}
-             --db-port #{port}
+             --db-host #{new_resource.hostname}
+             --db-port #{new_resource.port}
              --db-user #{new_resource.username}
              --db-name #{new_resource.database}
              --top-dir #{new_resource.name}
-             deploy #{target} #{verify}
+             deploy #{target} --verify
     EOM
-    environment "PERL5LIB" => "", # force sqitch to use omnibus perl only
-                "SQITCH_PASSWORD" => new_resource.password
+    environment "PERL5LIB" => "",
+                "PGPASSWORD" => new_resource.password
+
+    # Sqitch Return Codes
+    # 0 - when changes are applied
+    # 1 - when everything is ok but no changes were made
+    # 2(+?) - when an error occurs.
     returns [0,1]
   end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -1,0 +1,27 @@
+
+def whyrun_supported?
+  false
+end
+
+use_inline_resources
+
+action :deploy do
+  verify = new_resource.verify ? "--verify" : ""
+  target = new_resource.target_version ? "--to-target #{new_resource.target_version}" : ""
+  hostname = new_resource.hostname ? new_resource.hostname : node['private_chef']['postgresql']['vip']
+  port = new_resource.port ? new_resource.port: node['private_chef']['postgresql']['port']
+  execute "sqitch_deploy_#{new_resource.name}" do
+    command <<-EOM.gsub(/\s+/," ").strip!
+      sqitch --engine pg
+             --db-host #{hostname}
+             --db-port #{port}
+             --db-user #{new_resource.username}
+             --db-name #{new_resource.database}
+             --top-dir #{new_resource.name}
+             deploy #{target} #{verify}
+    EOM
+    environment "PERL5LIB" => "", # force sqitch to use omnibus perl only
+                "SQITCH_PASSWORD" => new_resource.password
+    returns [0,1]
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
@@ -66,6 +66,7 @@ def functions_access
 end
 
 def run_sql(connection, sql, *params)
+  # TODO - don't really want to see every query in my output...
   converge_by sql do
     connection.exec(sql, *params)
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -3,12 +3,15 @@
 
 # Extract the attribute hash here so we're not quite so verbose
 bifrost_attrs = node['private_chef']['oc_bifrost']
+postgres_attrs = node['private_chef']['postgresql']
 
 # create users
 private_chef_pg_user bifrost_attrs['sql_user'] do
   password bifrost_attrs['sql_password']
   superuser false
 end
+
+
 
 private_chef_pg_user bifrost_attrs['sql_ro_user'] do
   password bifrost_attrs['sql_ro_password']
@@ -17,6 +20,14 @@ end
 
 private_chef_pg_database 'bifrost' do
   owner bifrost_attrs['sql_user']
+end
+
+private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
+  hostname postgres_attrs['vip']
+  port     postgres_attrs['port']
+  username bifrost_attrs['sql_user']
+  password bifrost_attrs['sql_password']
+  database "bifrost"
 end
 
 private_chef_pg_user_table_access bifrost_attrs['sql_user'] do
@@ -30,11 +41,4 @@ private_chef_pg_user_table_access bifrost_attrs['sql_ro_user'] do
   schema 'public'
   access_profile :read
 end
-
-private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
-  username bifrost_attrs['sql_user']
-  password bifrost_attrs['sql_password']
-  database "bifrost"
-end
-
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -31,42 +31,10 @@ private_chef_pg_user_table_access bifrost_attrs['sql_ro_user'] do
   access_profile :read
 end
 
-execute "bifrost_schema" do
-  # The version of the schema to be deployed will the the maximum
-  # available in the oc_bifrost repository.  This will be the same
-  # version needed by the code that is deployed here.  If we ever
-  # split bifrost's code and schema into separate repositories,
-  # we'll need to deploy to a specific schema tag
-  command <<-EOM.gsub(/\s+/," ").strip!
-    sqitch --engine pg
-           --db-name bifrost
-           --top-dir /opt/opscode/embedded/service/oc_bifrost/db
-           deploy --verify
-  EOM
-  user node['private_chef']['postgresql']['username']
-  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
-  # installation
-  environment "PERL5LIB" => ""
-  # If sqitch is deploying the first time, it'll return 0 on
-  # success.  If it's running a second time and ends up deploying
-  # nothing (since we've already deployed all changesets), it'll
-  # return 1.  Both scenarios should be considered successful.
-  returns [0,1]
+private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
+  username bifrost_attrs['sql_user']
+  password bifrost_attrs['sql_password']
+  database "bifrost"
 end
 
-# Permissions for the database users got set in the schema... though
-# that means that the role names should be hard-coded in this
-# cookbook.
-execute "add_permissions_bifrost" do
-  command <<-EOM.gsub(/\s+/," ").strip!
-      psql --dbname bifrost
-           --single-transaction
-           --set ON_ERROR_STOP=1
-           --set database_name=bifrost
-           --file sql/permissions.sql
-    EOM
-  cwd "/opt/opscode/embedded/service/oc_bifrost/db"
-  user node['private_chef']['postgresql']['username']
-  # This can run each time, since the commands in the SQL file are all
-  # idempotent anyway
-end
+

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -245,6 +245,16 @@ include_recipe "private-chef::plugins"
       end
 
       case service
+      when  "postgresql"
+        # Data master check is to only attempt this from one place.
+        if is_data_master? and node['private_chef']['postgresql']['remote']
+          # We still need users created!
+          #private_chef_pg_database "opscode-pgsql"
+          include_recipe "private-chef::erchef_database"
+          include_recipe "private-chef::bifrost_database"
+          include_recipe "private-chef::oc_id_database"
+        end
+
       when "opscode-expander"
         runit_service "opscode-expander-reindexer" do
           action :disable
@@ -258,6 +268,7 @@ include_recipe "private-chef::plugins"
   end
 end
 
+# If an external database is provided, we still need to ensure our users are set up.
 
 
 include_recipe "private-chef::actions" if darklaunch_values["actions"]

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -1,66 +1,42 @@
+postgres = node['private_chef']['postgresql']
+
+private_chef_pg_user postgres['sql_user'] do
+  password postgres['sql_password']
+  superuser false
+end
+private_chef_pg_user postgres['sql_ro_user'] do
+  password postgres['sql_ro_password']
+  superuser false
+end
+
 private_chef_pg_database "opscode_chef" do
-#  owner node['private_chef']['postgresql']['username'] # Do we really want this?
-  notifies :run, "execute[chef-server-schema]", :immediately
+  owner postgres['sql_user']
+end
+# TODO these originally were only run on notify - is this still required
+# to get a sqitch schema in place from EC11? We already use sqitch in
+# 11.2 and 11.3, which I think are the only ones we support upgrading from.
+private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/baseline" do
+  username  postgres['sql_user']
+  password  postgres['sql_password']
+  database  "opscode_chef"
 end
 
-# Though Sqitch runs are idempotent, we need to have them run only
-# when the database is first created (thus the chained notifications).
-# This is only for EC11; subsequent versions can run them
-# idempotently, like normal.  This is just to allow fresh EC11
-# installs to use Sqitch; upgraded installations have a Partybus
-# upgrade to run.  The end result should be that whether or not you
-# are installing or upgrading EC11, at the end of the day, you'll have
-# Sqitch metadata info in your database.
-execute "chef-server-schema" do
-  command "sqitch --db-name opscode_chef deploy --verify"
-  # OSC schema is a dependency of the EC schema, and managed by it
-  cwd "/opt/opscode/embedded/service/opscode-erchef/schema/baseline"
-  user node['private_chef']['postgresql']['username']
-  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
-  # installation
-  environment "PERL5LIB" => ""
-  returns [0,1]
-  action :nothing
-  notifies :run, "execute[enterprise-chef-server-schema]", :immediately
-end
-
-execute "enterprise-chef-server-schema" do
-  command "sqitch --db-name opscode_chef deploy --verify"
-  cwd "/opt/opscode/embedded/service/opscode-erchef/schema"
-  user node['private_chef']['postgresql']['username']
-  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
-  # installation
-  environment "PERL5LIB" => ""
-  returns [0,1]
-  action :nothing
+private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
+  username postgres['sql_user']
+  password postgres['sql_password']
+  database "opscode_chef"
 end
 
 
-# Create Database Users
-
-private_chef_pg_user node['private_chef']['postgresql']['sql_user'] do
-  password node['private_chef']['postgresql']['sql_password']
-  superuser false
-end
-
-private_chef_pg_user_table_access node['private_chef']['postgresql']['sql_user'] do
-  database 'opscode_chef'
-  schema 'public'
-  access_profile :write
-end
-
-private_chef_pg_user node['private_chef']['postgresql']['sql_ro_user'] do
-  password node['private_chef']['postgresql']['sql_ro_password']
-  superuser false
-end
-
-private_chef_pg_user_table_access node['private_chef']['postgresql']['sql_ro_user'] do
+# TODO ... sqitch this.
+private_chef_pg_user_table_access postgres['sql_ro_user'] do
   database 'opscode_chef'
   schema 'public'
   access_profile :read
 end
 
 # Cleanup old enterprise-chef-server-schema
+# TODO don't we have a cleanup mechanism this can live in?
 directory "/opt/opscode/embedded/service/enterprise-chef-server-schema" do
   recursive true
   action :delete

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -16,14 +16,18 @@ end
 # to get a sqitch schema in place from EC11? We already use sqitch in
 # 11.2 and 11.3, which I think are the only ones we support upgrading from.
 private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/baseline" do
+  hostname  postgres['vip']
+  port      postgres['port']
   username  postgres['sql_user']
   password  postgres['sql_password']
   database  "opscode_chef"
 end
 
 private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
-  username postgres['sql_user']
-  password postgres['sql_password']
+  hostname  postgres['vip']
+  port      postgres['port']
+  username  postgres['sql_user']
+  password  postgres['sql_password']
   database "opscode_chef"
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
@@ -1,0 +1,11 @@
+actions :deploy
+default_action :deploy
+
+attribute :name,           kind_of: String, required: true, name_attribute: true
+attribute :database,       kind_of: String, required: true
+attribute :username,       kind_of: String, required: true
+attribute :password,       kind_of: String, required: true
+attribute :hostname,       kind_of: String
+attribute :port,           kind_of: Integer
+attribute :target_version, kind_of: String
+attribute :verify,         kind_of: [TrueClass, FalseClass], default: true

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
@@ -3,9 +3,8 @@ default_action :deploy
 
 attribute :name,           kind_of: String, required: true, name_attribute: true
 attribute :database,       kind_of: String, required: true
-attribute :username,       kind_of: String, required: true
-attribute :password,       kind_of: String, required: true
-attribute :hostname,       kind_of: String
-attribute :port,           kind_of: Integer
+attribute :username,       kind_of: String
+attribute :password,       kind_of: String, required: false, default: ""
 attribute :target_version, kind_of: String
-attribute :verify,         kind_of: [TrueClass, FalseClass], default: true
+attribute :hostname,       kind_of: String, required: true
+attribute :port,           kind_of: Integer, required: true


### PR DESCRIPTION
ping @chef/lob to take a look  and offer feedback. 

This is a preliminary PoC to demonstrate allowing chef server to use a remote postgres instance that it can connect to/run migrations against purposes of creating schemas and users, but does not attempt to otherwise own it. 

This PR needs some splitting up and cleanup, and there are more tasks/questions/tests  that I'll write up separately , but overall we don't have far to go from this point. 

Local pedant passes with --all using a remote host. I'm going to ship it off to CI to make sure I didn't break the default configuration. 

