### PR TITLE
omnibus: build chef last

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -37,7 +37,6 @@ override :ruby, version: "2.1.4"
 dependency "preparation"
 
 # global
-dependency "chef" # for embedded chef-client -z runs
 dependency "private-chef-scripts" # assorted scripts used by installed instance
 dependency "private-chef-ctl" # additional project-specific private-chef-ctl subcommands
 dependency "ctl-man" # install man page
@@ -92,6 +91,7 @@ dependency "oc-chef-pedant"
 dependency "private-chef-upgrades"
 dependency "private-chef-cookbooks"
 dependency "chef-ha-plugin-config"
+dependency "chef" # for embedded chef-client -z runs (built from master - build last)
 
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']


### PR DESCRIPTION
We build chef from git master, so it changes frequently. To avoid
dirtying the omnibus git cache on each new build / nightly, this
commit puts chef and the end of the build. This should speed up
rebuilds significantly.

/cc @chef/lob 

TODO:
* [x] passing [ci](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/542/downstreambuildview/)
* [x] verification that chef actually builds last