### PR TITLE
travis: build on erlang R16B03-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_cache:
   - rm -f $HOME/.cpanm/build.log
 language: erlang
 otp_release:
-  - 17.4
+  - R16B03-1
 addons:
   postgresql: "9.3"
   apt:


### PR DESCRIPTION
travis is currently failing due to timeouts when building the plt for
Erlang 17.4. Since we're not currently shipping Erlang 17 with Chef
Server, let's roll travis back to R16 for now.