### PR TITLE
Allow file specificity to be null

### DIFF
--- a/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
@@ -275,7 +275,7 @@ file_list_spec() ->
     {array_map, {[{<<"name">>, string},
                   {<<"path">>, string},
                   {<<"checksum">>, string},
-                  {<<"specificity">>, string}
+                  {<<"specificity">>, {any_of, {string, null}}}
                  ]}}.
 
 -define(COOKBOOK_SEGMENTS, [<<"attributes">>,

--- a/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
@@ -275,7 +275,7 @@ file_list_spec() ->
     {array_map, {[{<<"name">>, string},
                   {<<"path">>, string},
                   {<<"checksum">>, string},
-                  {<<"specificity">>, {any_of, {string, null}}}
+                  {<<"specificity">>, {any_of, {[string, null], <<"specificity must be a string or null">>}}}
                  ]}}.
 
 -define(COOKBOOK_SEGMENTS, [<<"attributes">>,

--- a/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
@@ -70,6 +70,18 @@ valid_resources_test() ->
                   ]}]),
     ?assertEqual({ok, CB}, chef_cookbook_version:validate_cookbook(CB, NameVer)).
 
+null_specificity_test() ->
+    CB0 = basic_cookbook(<<"php">>, <<"1.2.3">>),
+    NameVer = {<<"php">>, <<"1.2.3">>},
+    CB = ej:set({<<"resources">>}, CB0,
+                [{[
+                   {<<"name">>, <<"a1">>},
+                   {<<"path">>, <<"c/b/a1">>},
+                   {<<"checksum">>, <<"abababababababababababababababab">>},
+                   {<<"specificity">>, null}
+                  ]}]),
+    ?assertEqual({ok, CB}, chef_cookbook_version:validate_cookbook(CB, NameVer)).
+
 top_level_key_validation_test() ->
     Name = <<"test_name">>,
     Version = <<"1.2.3">>,


### PR DESCRIPTION
This happens when you put templates or cookbook files directly in the base folder (added in Chef 12.0.0). I have no idea if this patch is correct, just trying to reconstruct based on reading the existing source and ej. Feel free to chuck it and write a better patch.
