### PR TITLE
Bypasses a memory leak in Erlang's ssl_session_cache

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -236,6 +236,7 @@ default['private_chef']['opscode-erchef']['keygen_cache_workers'] = :auto
 default['private_chef']['opscode-erchef']['keygen_timeout'] = 1000
 default['private_chef']['opscode-erchef']['keygen_key_size'] = 2048
 default['private_chef']['opscode-erchef']['strict_search_result_acls'] = false
+default['private_chef']['opscode-erchef']['ssl_session_caching']['enabled'] = false
 
 ###
 # Legacy path (required for cookbok migration)

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -227,6 +227,11 @@
                      {start_mfa, {chef_depsolver_worker, start_link, []}}]]},
            {metrics_module, folsom_metrics}
           ]}
+<% if !node['private_chef']['opscode-erchef']['ssl_session_caching']['enabled'] -%>
+,  {ssl, [
+      {session_cb, noop_session_cache}
+  ]}
+<% end -%>
 <% if node['private_chef']['folsom_graphite']['enabled'] -%>
 , {folsom_graphite, [
                      {graphite_host, "<%= @helper.normalize_host(node['private_chef']['folsom_graphite']['host']) %>"},

--- a/src/chef-mover/test/mover_eredis_sup_test.erl
+++ b/src/chef-mover/test/mover_eredis_sup_test.erl
@@ -12,5 +12,5 @@
 %% the start_link path from being followed.
 start_link_should_start_client() ->
     process_flag(trap_exit, true),
-    ?assertEqual({error, {connection_error, {connection_error,nxdomain}}}, mover_eredis_sup:eredis_start_link(host, port)).
-            
+    ?assertMatch({error, {connection_error, {connection_error,_}}}, mover_eredis_sup:eredis_start_link("host", 1234)).
+

--- a/src/oc_erchef/rebar.config.lock
+++ b/src/oc_erchef/rebar.config.lock
@@ -98,7 +98,7 @@
                               "fd40c960c7912193631d948fe962e1162a8d1334"}},
        {erlware_commons,".*",
                         {git,"https://github.com/erlware/erlware_commons.git",
-                             "ef0d252b11c863f9c228af2fe93a4e42fba2f7f3"}},
+                             "2e23e43079686ddb68bfca772d37f78dfe4dd95e"}},
        {darklaunch,".*",
                    {git,"https://github.com/opscode/opscode-darklaunch-erlang",
                         "05881cb04e9393ab42b6fac3b22803130ef2701c"}},
@@ -128,6 +128,6 @@
            {d,'CHEF_DB_DARKLAUNCH',xdarklaunch_req},
            {d,'CHEF_WM_DARKLAUNCH',xdarklaunch_req},
            {parse_transform,lager_transform},
-           warnings_as_errors,
-           debug_info,
+           warnings_as_errors,debug_info,
            {platform_define,"^[0-9]+",namespaced_types}]}.
+

--- a/src/oc_erchef/src/noop_session_cache.erl
+++ b/src/oc_erchef/src/noop_session_cache.erl
@@ -1,0 +1,58 @@
+-module(noop_session_cache).
+
+%% This module exists to stop session reuse from happening
+
+-behaviour(ssl_session_cache_api).
+
+-export([init/1, terminate/1, lookup/2, update/3, delete/2, foldl/3,
+         select_session/2]).
+
+%%--------------------------------------------------------------------
+%% Description: Return table reference. Called by ssl_manager process.
+%%--------------------------------------------------------------------
+init(_Options) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Description: Handles cache table at termination of ssl manager.
+%%--------------------------------------------------------------------
+terminate(_Cache) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Description: Looks up a cach entry. Should be callable from any
+%% process.
+%%--------------------------------------------------------------------
+lookup(_Cache, _Key) ->
+    undefined.
+
+%%--------------------------------------------------------------------
+%% Description: Caches a new session or updates a already cached one.
+%% Will only be called from the ssl_manager process.
+%%--------------------------------------------------------------------
+update(_Cache, _Key, _Session) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Description: Deletes a cache entry.
+%% Will only be called from the ssl_manager process.
+%%--------------------------------------------------------------------
+delete(_Cache, _Key) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Description: Calls Fun(Elem, AccIn) on successive elements of the
+%% cache, starting with AccIn == Acc0. Fun/2 must return a new
+%% accumulator which is passed to the next call. The function returns
+%% the final value of the accumulator. Acc0 is returned if the cache
+%% is empty.Should be callable from any process
+%%--------------------------------------------------------------------
+foldl(_Fun, _Acc0, _Cache) ->
+    [].
+
+%%--------------------------------------------------------------------
+%% Description: Selects a session that could be reused. Should be callable
+%% from any process.
+%%--------------------------------------------------------------------
+select_session(_Cache, _PartialKey) ->
+    [].


### PR DESCRIPTION
For a particular load scenario, Erlang's ssl_session_cache would use up
too much memory and then the CPU would start churning, hoping to GC all
that memory, but it was never able to catch up. By replacing
ssl_manager's callback module (originally ssl_session_cache) to our
noop_session_cache, we essentially do nothing, and therefore leak no
memory.

Reproducing this error, often got CPU usage up to at least 300% in the
short term, and over 700% in 30 minutes or less. With this fix, I have
yet to see CPU usage go over 200%.

P.S. This is terrible branch name for what this actually did.

ping @chef/lob and everybody!