### PR TITLE
Changed runit command for oc_id to use unicorn by default

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
@@ -6,4 +6,4 @@ export RAILS_ENV=production
 export PATH=/opt/opscode/embedded/bin:$PATH
 export LD_LIBRARY_PATH=/opt/opscode/embedded/lib
 cd $DIR
-exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /opt/opscode/embedded/bin/bundle exec rails server -p <%= node['private_chef']['oc_id']['port'] %>
+exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /opt/opscode/embedded/bin/bundle exec unicorn -l <%= "#{node['private_chef']['oc_id']['vip']}:#{node['private_chef']['oc_id']['port']}" %> -c /opt/opscode/embedded/service/oc_id/config/unicorn.rb


### PR DESCRIPTION
We were installing unicorn but not using it, this change leaves the same default port but changes the rack server to unicorn.  There was already a unicorn config in place which is now used, but wasn't modified.