### PR TITLE
erlang 17.4 travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_cache:
   - rm -f $HOME/.cpanm/build.log
 language: erlang
 otp_release:
-  - R16B03-1
+  - 17.4
 addons:
   postgresql: "9.3"
   apt:

--- a/src/oc_erchef/concrete.mk
+++ b/src/oc_erchef/concrete.mk
@@ -104,7 +104,7 @@ ifeq ($(TRAVIS),true)
 ## reported by erlang:system_info(otp_release)
 ## s3cmd put --acl-public --guess-mime-type <FILENAME> s3://concrete-plts
 
-BASE_PLT := travis-erlang-$(ERLANG_VERSION).plt
+BASE_PLT := travis-erlang-$(TRAVIS_OTP_RELEASE).plt
 BASE_PLT_URL := http://s3.amazonaws.com/concrete-plts/$(BASE_PLT)
 else
 BASE_PLT := ~/.concrete_dialyzer_plt_$(BASE_PLT_ID)_$(ERLANG_VERSION).plt


### PR DESCRIPTION
1. Use TRAVIS_OTP_VERSION to grab the correct plt file (pulled in via `concrete update` 
2. Now that the 17.4 PLT has been uploaded, change the project back to using 17.4