### PR TITLE
Add ability to specify top level node attributes in Chef Search

### DIFF
--- a/src/opscode-expander/lib/opscode/expander/flattener.rb
+++ b/src/opscode-expander/lib/opscode/expander/flattener.rb
@@ -29,6 +29,7 @@ module Opscode
 
         @item.each do |key, value|
           flatten_each([key.to_s], value)
+          flatten_each(['toplevel-' + key.to_s], value)
         end
 
         @flattened_item.each_value { |values| values.uniq! }


### PR DESCRIPTION
A more comprehensive fix for https://github.com/chef/chef-server/issues/303

This allows users to search any top level attribute they are interested in as opposed to only the Chef specific top level attributes.

This would be helpful to users but it will have a greater impact on the server than PR https://github.com/chef/chef-server/pull/331.

The flattened object will be double its usual size which will impact memory, network and disk usage. This might be enough reason to avoid implementing but I'll leave that up for discussion.