### PR TITLE
Notify user during dhparam creation

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -98,6 +98,7 @@ ssl_dhparam = File.join(nginx_ca_dir, "dhparams.pem")
 # We do the File.exist check at compile-time to prevent expensive
 # dhapram generation.
 if ! File.exists?(ssl_dhparam)
+  Chef::Log.info("Creating 2048 bit dhparam because it does not exist.  This may take some time.")
   file ssl_dhparam do
     content `/opt/opscode/embedded/bin/openssl dhparam 2048 2>/dev/null`
     mode "0644"


### PR DESCRIPTION
Creating a 2048 bit dhparam can take a long time depending on the
state of the machine. This might confuse the user and cause them to
interrupt the process.