### PR TITLE
Adds link to oc-id blog post

### DIFF
--- a/src/oc-id/README.md
+++ b/src/oc-id/README.md
@@ -5,6 +5,7 @@ oc-id
 
 Chef identity: An [OAuth 2](http://oauth.net/2/) provider for Chef.
 
+For an introduction to oc-id and how it works, please see this blog post [oc-id on Chef Server: An Introduction](https://www.chef.io/blog/2015/06/09/oc-id-on-chef-server-an-introduction/)
 
 ## System Requirements
 


### PR DESCRIPTION
This adds in a link to the recently published oc-id blog posts, which gives some context to what oc-id is and how it works.