### PR TITLE
Require authentication for redis.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -170,6 +170,7 @@ module PrivateChef
       me = PrivateChef["servers"][node_name]
       ha_guard = PrivateChef['topology'] == 'ha' && !me['bootstrap']
 
+      PrivateChef['redis_lb']['password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['jobs_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['actions_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
@@ -189,6 +190,9 @@ module PrivateChef
         File.open("/etc/opscode/private-chef-secrets.json", "w") do |f|
           f.puts(
             Chef::JSONCompat.to_json_pretty({
+              'redis_lb' => {
+                'password' => PrivateChef['redis_lb']['password']
+              },
               'rabbitmq' => {
                 'password' => PrivateChef['rabbitmq']['password'],
                 'jobs_password' => PrivateChef['rabbitmq']['jobs_password'],

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -138,6 +138,7 @@ nginx_vars = nginx_vars.merge({ :helper => NginxErb.new(node) })
 lbconf = node['private_chef']['lb'].to_hash.merge(nginx_vars).merge({
   :redis_host => node['private_chef']['redis_lb']['vip'],
   :redis_port => node['private_chef']['redis_lb']['port'],
+  :redis_password => node['private_chef']['redis_lb']['password'],
   :omnihelper => OmnibusHelper.new(node)
 })
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
@@ -107,7 +107,9 @@ ruby_block "set_lb_redis_values" do
   only_if { is_data_master? }
   block do
     require "redis"
-    redis = Redis.new(:host => redis_data.vip, :port => redis_data.port)
+    redis = Redis.new(:host => redis_data.vip,
+                      :port => redis_data.port,
+                      :password => redis_data.password)
     xdl = node['private_chef']['lb']['xdl_defaults']
     banned_ips = PrivateChef['banned_ips']
     maint_mode_ips = PrivateChef['maint_mode_whitelist_ips']

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
@@ -46,7 +46,6 @@ end
 local function connect_redis()
    local red = redis:new()
    red:set_timeout(<%=@redis_connection_timeout%>)
-   red:set_timeout(1000)
    local ok, err = red:connect("<%= @omnihelper.vip_for_uri('redis_lb') %>", <%=@redis_port%>)
 
    if not ok then

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
@@ -36,15 +36,33 @@ local function array_to_hash(t)
   return h
 end
 
+local function auth_not_required(err)
+  -- conservatively try to determine if auth is not required.
+  -- if auth isn't required, we can safely ignore an error from
+  -- the AUTH command
+  return err == "ERR Client sent AUTH, but no password is set"
+end
+
 local function connect_redis()
-  local red = redis:new()
-  local results
-  red:set_timeout(<%=@redis_connection_timeout%>)
-  local ok, err = red:connect("<%= @omnihelper.vip_for_uri('redis_lb') %>", <%=@redis_port%>)
-  if not ok then
-    ngx.log(ngx.ERR, "failed to connect redis: ", err)
-  end
-  return ok, red
+   local red = redis:new()
+   red:set_timeout(<%=@redis_connection_timeout%>)
+   red:set_timeout(1000)
+   local ok, err = red:connect("<%= @omnihelper.vip_for_uri('redis_lb') %>", <%=@redis_port%>)
+
+   if not ok then
+      ngx.log(ngx.ERR, "failed to connect redis: ", err)
+   end
+
+   local ok, err = red:auth("<%= @redis_password %>")
+   if not ok then
+      if auth_not_required(err) then
+         ok = true
+      else
+         ngx.log(ngx.ERR, "failed to authenticate to redis: ", err)
+      end
+   end
+
+   return ok, red
 end
 
 local function close_redis(red)

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -152,7 +152,8 @@
           % If dry_run is true, eredis host and port will be ignored.
           {eredis_host, "127.0.0.1"},
           {eredis_port, 16379},
-	   {solr_url, "<%= node['private_chef']['opscode-solr4']['url'] %>"}
+          {eredis_password, "<%= node['private_chef']['redis_lb']['password'] %>"},
+          {solr_url, "<%= node['private_chef']['opscode-solr4']['url'] %>"}
          ]},
  {chef_reindex, [
           {solr_service, [{root_url, "<%= node['private_chef']['opscode-solr4']['url'] %>"},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/redis_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/redis_lb.conf.erb
@@ -6,6 +6,8 @@ port <%= @port %>
 bind <%= @bind %> <%= @listen == @bind ? "" : @listen %>
 <% end %>
 
+requirepass "<%= @password %>"
+
 tcp-keepalive <%= @keepalive %>
 timeout <%= @timeout %>
 loglevel <%= @loglevel %>

--- a/src/chef-mover/src/mover_eredis_sup.erl
+++ b/src/chef-mover/src/mover_eredis_sup.erl
@@ -10,7 +10,7 @@
 
 %% Supervisor callbacks
 -export([init/1,
-         eredis_start_link/2
+         eredis_start_link/3
         ]).
 
 -define(SERVER, ?MODULE).
@@ -21,9 +21,10 @@ start_link() ->
 init([]) ->
     Host = envy:get(mover, eredis_host, string),
     Port = envy:get(mover, eredis_port, integer),
-    StartUp = {?MODULE, eredis_start_link, [Host, Port]},
+    Password = envy:get(mover, eredis_password, "", string),
+    StartUp = {?MODULE, eredis_start_link, [Host, Port, Password]},
     Child = [{eredis, StartUp, permanent, brutal_kill, worker, [eredis]}],
     {ok, {{one_for_one, 60, 10}, Child}}.
 
-eredis_start_link(Host, Port) ->
-    gen_server:start_link({local, mover_eredis_client}, eredis_client, [Host, Port, 0, "", 100, 2000], []).
+eredis_start_link(Host, Port, Password) ->
+    gen_server:start_link({local, mover_eredis_client}, eredis_client, [Host, Port, 0, Password, 100, 2000], []).

--- a/src/chef-mover/test/mover_eredis_sup_test.erl
+++ b/src/chef-mover/test/mover_eredis_sup_test.erl
@@ -12,5 +12,4 @@
 %% the start_link path from being followed.
 start_link_should_start_client() ->
     process_flag(trap_exit, true),
-    ?assertMatch({error, {connection_error, {connection_error,_}}}, mover_eredis_sup:eredis_start_link("host", 1234)).
-
+    ?assertMatch({error, {connection_error, {connection_error,_}}}, mover_eredis_sup:eredis_start_link("host", 1234, "")).


### PR DESCRIPTION
In standalone mode, redis only listens on 127.0.0.1, meaning that only
local users can connect to the service. However, in HA or Tiered
configurations, redis listens on the backend VIP. In environments
where the VIP may be accessible by untrusted users, the lack of
authentication means that untrusted users have access to redis.

Our previous recommendation was that users should use iptables or
other firewalling to ensure that only trusted users could access the
VIP.

NB: Redis still sends and recieves data in the clear.