### PR TITLE
Enabled bounded queuing for erchef and bifrost squerl-based queues

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -203,10 +203,11 @@ default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = '20'
 # db_pooler_timeout - the maximum amount of time a request should wait
 # in the queue before timing out.  Request queueing is only effective
 # if db_pooler_timeout > 0
-default['private_chef']['opscode-erchef']['db_pool_size'] = '20'
-default['private_chef']['opscode-erchef']['db_pooler_timeout'] = '0'
+default['private_chef']['opscode-erchef']['db_pool_size'] = 20
+default['private_chef']['opscode-erchef']['db_pool_queue_max'] = 20
+default['private_chef']['opscode-erchef']['db_pooler_timeout'] = 2000
 default['private_chef']['opscode-erchef']['sql_db_timeout'] = 5000
-default['private_chef']['opscode-erchef']['db_pool_queue_max'] = '20'
+
 # Pool configuration for depsolver workers
 #
 # depsolver_worker_count - the number of depselector workers.  This is
@@ -473,8 +474,8 @@ default['private_chef']['oc_bifrost']['port'] = 9463
 default['private_chef']['oc_bifrost']['superuser_id'] = '5ca1ab1ef005ba111abe11eddecafbad'
 default['private_chef']['oc_bifrost']['db_pool_size'] = '20'
 # The db_pool is only effective for a db_pooler_timeout > 0
-default['private_chef']['oc_bifrost']['db_pooler_timeout'] = '0'
-default['private_chef']['oc_bifrost']['db_pool_queue_max'] = '50'
+default['private_chef']['oc_bifrost']['db_pooler_timeout'] = 2000
+default['private_chef']['oc_bifrost']['db_pool_queue_max'] = 20
 default['private_chef']['oc_bifrost']['sql_user'] = "bifrost"
 default['private_chef']['oc_bifrost']['sql_password'] = "challengeaccepted"
 default['private_chef']['oc_bifrost']['sql_ro_user'] = "bifrost_ro"


### PR DESCRIPTION
Pooler supported bounded queuing of requests when no connections are
available. Without queuing, many users have (at our suggestion) taken
to increasing the db_pool_size to prevent bursts of requests failing
when all database connections are consumed. In some cases, this can
lead to an level of concurrent connections that the backend can't
handle.

The queuing allows the maximum concurrent database connections to
remain capped at a reasonable level while still providing a means for
users to handle bursts of traffic.