### PR TITLE
[dvm] do not autoload components

### DIFF
--- a/dev/cookbooks/dev/recipes/dvm.rb
+++ b/dev/cookbooks/dev/recipes/dvm.rb
@@ -33,19 +33,9 @@ mount "dvm" do
   options "bind"
 end
 
-# Finally, load in our base projects
-#
-execute "load oc-chef-pedant"  do
-  command "dvm load oc-chef-pedant"
+# Let's make sure this remounts on reboot:
+bash "dvm mount to fstab" do
+   user "root"
+   code lazy { "echo /vagrant/dvm #{DVMHelper.dvm_path} none bind >> /etc/fstab" }
+   not_if "grep -q dvm /etc/fstab"
 end
-execute "load omnibus upgrades" do
-  command "dvm load omnibus upgrades"
-end
-
-# Note that dvm knows that ocokbook changes require a reconfigure.
-# This will be our only reconfigure during provisioning, so that
-# we avoid doing it multiple times.
-execute "load omnibus private-chef-cookbooks"  do
-  command "dvm load omnibus private-chef-cookbooks"
-end
-

--- a/dev/cookbooks/provisioning/recipes/chef-server.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-server.rb
@@ -40,6 +40,7 @@ template "/etc/opscode/chef-server.rb" do
   owner "root"
   group "root"
   action :create
+  notifies :run, 'bash[reconfigure-chef-server]'
 end
 
 template "/etc/hosts" do
@@ -50,3 +51,9 @@ template "/etc/hosts" do
   variables({"fqdns" => ["api.chef-server.dev",  "manage.chef-server.dev" ]})
 end
 
+
+bash "reconfigure-chef-server" do
+  user 'root'
+  code "chef-server-ctl reconfigure"
+  action :nothing
+end


### PR DESCRIPTION
- autoloading omnibus from local source (and cookbooks in particular)
  has been causing trouble for people starting using installer pacakges
  that don't match their local chef-server repository.  This change
  moves reconfigure to time of provisioning, and removes the automatic
  loading of chef-pedant, party bus upgrades, and cookbooks.
- this also adds a new entry to fstab so that the dvm gem mount will
  persist between restarts.

ping @chef/lob 
