### PR TITLE
Avoid Unintended Updates for RHEL

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_remote.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_remote.rb
@@ -5,6 +5,10 @@
 # All Rights Reserved
 #
 
+# Only "enabled false" on yum repos, because
+# the default contents of "/etc/apt/apt.conf.d/50unattended-upgrades" 
+# on an Ubuntu system would prevent chef-stable packages from being auto upgraded.
+
 case node['platform_family']
 when 'debian'
 
@@ -35,6 +39,7 @@ when 'rhel'
     sslverify true
     sslcacert '/etc/pki/tls/certs/ca-bundle.crt'
     gpgcheck true
+    enabled false
     action :create
   end
 
@@ -47,5 +52,9 @@ end
 node['private_chef']['addons']['packages'].each do |pkg|
   package pkg do
     notifies :create, "ruby_block[addon_install_notification_#{pkg}]", :immediate
+    case node['platform_family']
+    when 'rhel'
+      options "--enablerepo=chef-stable"
+    end
   end
 end


### PR DESCRIPTION
ChangeLog-Entry: Several customers on RHEL installs have had unintended Chef Server updates
    with the current enabled=1 setting for the chef-stable repo. We should disable
    the repo by default so RHEL OS updates don't pull in the chef-stable contents as well.