### PR TITLE
Rename ORGNAME_global_admins groups to ORGNAME_read_access_group

### DIFF
--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -9,8 +9,8 @@ describe "ACL API", :acl do
     let(:username) { platform.admin_user.name }
     let(:request_url) { "#{platform.server}/users/#{username}/_acl" }
 
-    let(:global_admins) { platform.test_org.name + "_global_admins"}
-    let(:read_groups) { [global_admins] }
+    let(:read_access_group) { platform.test_org.name + "_read_access_group"}
+    let(:read_groups) { [read_access_group] }
 
     context "GET /users/<user>/_acl"  do
 

--- a/oc-chef-pedant/spec/api/account/account_association_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_association_spec.rb
@@ -215,7 +215,6 @@ describe "opscode-account user association", :association do
             result.should look_like({ :status => 200 })
             json = JSON.parse(result)
             org = json.find {|o| o["organization"]["name"] == platform.test_org.name }["organization"]
-            expect(org.nil?).to be(false)
             expect(org["name"]).to eq(platform.test_org.name)
             expect(org["full_name"]).to eq(platform.test_org.name)
             expect(org["guid"].nil?).to be(false)

--- a/omnibus/files/private-chef-upgrades/001/26_global_admins_rename.rb
+++ b/omnibus/files/private-chef-upgrades/001/26_global_admins_rename.rb
@@ -1,24 +1,15 @@
 define_upgrade do
   if Partybus.config.bootstrap_server
     must_be_data_master
-
-    # We require the schema to at least contain the tag
-    # "policyfile-api-tables"; That tag comes _before_ "@cbv-type", which we
-    # upgraded to in 022_cbv_type_addition. Therefore we don't need to run any
-    # sqitch migration here.
-
     # Make sure API is down
     stop_services(["nginx", "opscode-erchef"])
-
     start_services(["oc_bifrost", "postgresql"])
-
     force_restart_service("opscode-chef-mover")
-
-    log "Creating default permissions for policyfile endpoints..."
+    log "Renaming internal groups"
 
     run_command("/opt/opscode/embedded/bin/escript " +
                 "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +
-                "mover_policies_containers_creation_callback " +
+                "mover_global_admins_rename_callback " +
                 "normal " +
                 "mover_transient_queue_batch_migrator")
 

--- a/src/chef-mover/src/mover_global_admins_rename_callback.erl
+++ b/src/chef-mover/src/mover_global_admins_rename_callback.erl
@@ -1,0 +1,97 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Steven Danna <steve@chef.io>
+%% @copyright 2015 Chef Software, Inc.
+%%
+%% The global_admins_rename callback renames ORGNAME_global_admins to
+%% ORGNAME_read_access_group.
+%%
+%% The ORGNAME_global_admins group has a single purpose: providing
+%% READ access to other user objects in ORGNAME. The rename in this
+%% migrations makes the groups purpose more clear.
+%%
+-module(mover_global_admins_rename_callback).
+
+-export([
+         migration_init/0,
+         migration_complete/0,
+         migration_type/0,
+         supervisor/0,
+         migration_start_worker_args/2,
+         migration_action/2,
+         next_object/0,
+         error_halts_migration/0,
+         reconfigure_object/2,
+         needs_account_dets/0
+        ]).
+
+-include("mover.hrl").
+-record(group, {name,
+                id,
+                authz_id}).
+
+migration_init() ->
+    mover_transient_migration_queue:initialize_queue(?MODULE, all_global_admin_groups()).
+
+migration_action(Group, _) ->
+    rename_group(Group, new_groupname(Group)).
+
+migration_complete() ->
+    ok.
+
+-spec all_global_admin_groups() -> [#group{}].
+all_global_admin_groups() ->
+    {ok, Groups} = sqerl:select(all_global_admin_groups_query(), [], rows_as_records, [group, record_info(fields, group)]),
+    Groups.
+
+-spec all_global_admin_groups_query() -> binary().
+all_global_admin_groups_query() ->
+    %%
+    %% Selects all global admin groups by maching both on the global
+    %% org_id and the name.
+    %%
+    <<"SELECT name, id, authz_id "
+      "FROM groups "
+      "WHERE org_id = '00000000000000000000000000000000'"
+      "  AND name LIKE '%_global_admins'">>.
+
+-spec new_groupname(#group{}) -> binary().
+new_groupname(#group{name = GroupName}) ->
+    re:replace(GroupName, "global_admins$", "read_access_group", [{return, binary}]).
+
+-spec rename_group(#group{}, binary()) -> ok | {error, any()}.
+rename_group(#group{id = GroupId} = Group, NewGroupName) ->
+    case sqerl:execute(<<"UPDATE groups SET name = $1 WHERE id = $2">>, [NewGroupName, GroupId]) of
+        {ok, 0} ->
+            lager:warn("Group ~p not found, may have been deleted since the start of the migration", [Group#group.name]),
+            ok;
+        {ok, 1} ->
+            ok;
+        Error ->
+            {error, Error}
+    end.
+
+%%
+%% Generic mover callback functions for
+%% a transient queue migration
+%%
+needs_account_dets() ->
+    false.
+
+migration_start_worker_args(Object, AcctInfo) ->
+    [Object, AcctInfo].
+
+next_object() ->
+    mover_transient_migration_queue:next(?MODULE).
+
+migration_type() ->
+    <<"global_admins_rename">>.
+
+supervisor() ->
+    mover_transient_worker_sup.
+
+error_halts_migration() ->
+    false.
+
+reconfigure_object(_ObjectId, _AcctInfo) ->
+    ok.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
@@ -68,9 +68,9 @@
 -define(DEFAULT_EC_EXPANDED_ORG,
         [{create_containers, ?CONTAINERS},
          {create_groups, ?GROUPS},
-         {create_org_global_admins},
+         {create_org_read_access_group},
          {add_to_groups, user, [creator], [admins, users]},
-         {add_to_groups, group, [admins, users], [global_admins]},
+         {add_to_groups, group, [admins, users], [read_access_group]},
 
          %% ACLs are expanded, then applied
          {acls,
@@ -168,15 +168,15 @@ process_policy_step({add_to_groups, ActorType, Members, Groups},
         {_, GroupId} <- GroupIds,
         {Type,MemberId} <- MemberIds],
     {Cache, []};
-process_policy_step({create_org_global_admins},
+process_policy_step({create_org_read_access_group},
                     #oc_chef_organization{name=OrgName, server_api_version = ApiVersion},
                     #chef_requestor{authz_id=RequestorId}, Cache) ->
-    GlobalGroupName = oc_chef_authz_db:make_global_admin_group_name(OrgName),
+    ReadAccessGroupName = oc_chef_authz_db:make_read_access_group_name(OrgName),
     %% TODO: Fix this to be the global groups org id.
     GlobalOrgId = ?GLOBAL_PLACEHOLDER_ORG_ID,
-    case create_helper(ApiVersion, GlobalOrgId, RequestorId, group, GlobalGroupName) of
+    case create_helper(ApiVersion, GlobalOrgId, RequestorId, group, ReadAccessGroupName) of
         AuthzId when is_binary(AuthzId) ->
-            {add_cache(Cache, {group, global_admins}, group, AuthzId), []};
+            {add_cache(Cache, {group, read_access_group}, group, AuthzId), []};
         Error ->
             {error, Error}
     end;

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
@@ -274,7 +274,7 @@ create_type_helper(client) ->
 
 
 %%
-%% We at mininimum need to clean up the org and the global_admins group
+%% We at mininimum need to clean up the org and the read_access group
 %% We will orphan some org-local information (groups, containers, validator client, and default environment)
 %% But that's no worse than any org deletion right now, and is sufficient to allow retry of org creation.
 %%
@@ -285,7 +285,7 @@ cleanup_org({_Error, _Body,
                 requestor_id = RequestorId,
                 organization_name = OrgName,
                 resource_state = #organization_state{oc_chef_organization = Organization}}} = Result) ->
-    oc_chef_wm_named_organization:delete_global_admins(DbContext, AuthzContext, OrgName, RequestorId),
+    oc_chef_wm_named_organization:delete_read_access_group(DbContext, AuthzContext, OrgName, RequestorId),
     oc_chef_wm_base:delete_object(DbContext, Organization, RequestorId),
     Result.
 

--- a/src/oc_erchef/doc/API/groups.md
+++ b/src/oc_erchef/doc/API/groups.md
@@ -18,7 +18,7 @@ Tasks Remaining
 -------
 
 This is derived from reading the opscode-account code. A complete specification should incorporate
-more sources. 
+more sources.
 
 TODO: Read tests in detail, verify that these are correct, and identify missing tests. In the end
 tests should define this spec exactly
@@ -36,7 +36,7 @@ groups, but there are some special system groups that all organizations must hav
 Some special services (reporting and pushy) use other special groups as a form of access
 control. (TODO document more)
 
-There also is a global group 'ORGNAME_global_admins'. This may be deprecated in future versions, and
+There also is a global group 'ORGNAME_read_access_group'. This may be deprecated in future versions, and
 is for internal use only.
 
 (TODO: Explain exactly what this group does)
@@ -73,7 +73,7 @@ The groups resource has two methods, GET and POST
 
 #### GET
 
-The GET method returns the list of groups for an org. It does not list the ORGNAME_global_admins
+The GET method returns the list of groups for an org. It does not list the ORGNAME_read_access_group
 group. This method takes no parameters
 
 ##### Request
@@ -133,7 +133,7 @@ With a request body of the form
 }
 ```
 
-All other fields are ignored. Specifically, we ignore actor and group fields. 
+All other fields are ignored. Specifically, we ignore actor and group fields.
 
 'groupname' can also be used to set the name, but 'id' wins if both are set. The 'name' field is ignored.
 
@@ -146,7 +146,7 @@ TODO BUG new ruby-sql groups api actually appears to accept and set actors
 
 ##### Response
 
-The response body will be 
+The response body will be
 
 ```{ "uri" : "API_URL/organizations/ORGNAME/groups/NAME" }```
 
@@ -159,17 +159,17 @@ Unlike containers the 'Location' header is not set. This is probably a bug.
 | 201 | Ok |
 | 400 | Bad Request if validation fails |
 | 401 | Unauthorized (TODO check that this is tested) |
-| 403 | Forbidden. The requestor does not have permission. The requestor must have CREATE 
+| 403 | Forbidden. The requestor does not have permission. The requestor must have CREATE
 permissions in the 'groups' container and be a member of the organization. |
 | 409 | Conflict: "Container already exists." |
 
 ### Resource /groups/NAME
 
-This operates on individual groups. 
+This operates on individual groups.
 
 #### GET
 
-The GET method retrieves a group. It takes no parameters. 
+The GET method retrieves a group. It takes no parameters.
 
 #####  Request
 
@@ -224,11 +224,11 @@ of being flattened as it is returned by GET.
 }
 `
 
-The request body may have the following fields: 
+The request body may have the following fields:
 
 * 'groupname': If the groupname differers from the NAME provided, this
 is a rename operation.
-* 'orgname': may be omitted.  
+* 'orgname': may be omitted.
 * 'actors'; which has subfields
 ** 'clients'
 ** 'users'
@@ -295,7 +295,3 @@ s.match("/groups", :method=>"get").to(:controller=>'groups', :action=>'index')
 s.match("/groups/:id", :method=>"get").to(:controller=>'groups', :action=>'show')
 s.match("/groups/:id", :method=>"put").to(:controller=>'groups', :action=>'update')
 s.match("/groups/:id", :method=>"delete").to(:controller=>'groups', :action=>'destroy')
-
-
-
-


### PR DESCRIPTION
The ORGNAME_global_admins group has one purpose inside the Chef
Server. To provide READ access to users who join an organization.  Its
name, however, implies great power. This change renames the group to
something more appropriate by:

- changing the organization creation code to create a
  ORGNAME_read_access_group rather than a global_admins group,

- providing a migration for existing global_admins groups,

- changing oc_chef_authz to transparently handle either group