### PR TITLE
Move node['postgresql']['sql_user'] and related to node['opscode-erchef']

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -193,6 +193,10 @@ default['private_chef']['opscode-erchef']['auth_skew'] = '900'
 default['private_chef']['opscode-erchef']['authz_pooler_timeout'] = '0'
 default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = '20'
+default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
+default['private_chef']['opscode-erchef']['sql_password'] = "snakepliskin"
+default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
+default['private_chef']['opscode-erchef']['sql_ro_password'] = "shmunzeltazzen"
 # Pool configuration for postgresql connections
 #
 # db_pool_size - the number of pgsql connections in the pool
@@ -416,10 +420,6 @@ default['private_chef']['postgresql']['username'] = "opscode-pgsql"
 default['private_chef']['postgresql']['shell'] = "/bin/sh"
 default['private_chef']['postgresql']['home'] = "/var/opt/opscode/postgresql"
 default['private_chef']['postgresql']['user_path'] = "/opt/opscode/embedded/bin:/opt/opscode/bin:$PATH"
-default['private_chef']['postgresql']['sql_user'] = "opscode_chef"
-default['private_chef']['postgresql']['sql_password'] = "snakepliskin"
-default['private_chef']['postgresql']['sql_ro_user'] = "opscode_chef_ro"
-default['private_chef']['postgresql']['sql_ro_password'] = "shmunzeltazzen"
 default['private_chef']['postgresql']['vip'] = "127.0.0.1"
 default['private_chef']['postgresql']['port'] = 5432
 default['private_chef']['postgresql']['listen_address'] = 'localhost'

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -46,8 +46,8 @@ class OmnibusHelper
 
   def db_connection_uri
     db_protocol = "postgres"
-    db_user     = node['private_chef']['postgresql']['sql_user']
-    db_password = node['private_chef']['postgresql']['sql_password']
+    db_user     = node['private_chef']['opscode-erchef']['sql_user']
+    db_password = node['private_chef']['opscode-erchef']['sql_password']
     db_vip      = vip_for_uri('postgresql')
     db_name     = "opscode_chef"
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -167,6 +167,17 @@ module PrivateChef
           end
         end
       end
+      # Transitional from erchef's sql_user/password etc lived under 'postgresql' and not under opscode-erchef
+      if PrivateChef['postgresql'].has_key? 'sql_password'
+        PrivateChef['opscode_erchef']['sql_password'] ||= PrivateChef['postgresql']['sql_password']
+        PrivateChef['postgresql'].delete 'sql_password'
+        PrivateChef['postgresql'].delete 'sql_user'
+      end
+      if PrivateChef['postgresql'].has_key? 'sql_ro_password'
+        PrivateChef['opscode_erchef']['sql_ro_password'] ||= PrivateChef['postgresql']['sql_ro_password']
+        PrivateChef['postgresql'].delete 'sql_ro_password'
+        PrivateChef['postgresql'].delete 'sql_ro_user'
+      end
 
       me = PrivateChef["servers"][node_name]
       ha_guard = PrivateChef['topology'] == 'ha' && !me['bootstrap']
@@ -175,11 +186,11 @@ module PrivateChef
       PrivateChef['rabbitmq']['password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['jobs_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['actions_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
-      PrivateChef['postgresql']['sql_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
-      PrivateChef['postgresql']['sql_ro_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['drbd']['shared_secret'] ||= generate_hex_if_bootstrap(30, ha_guard)
       PrivateChef['keepalived']['vrrp_instance_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['oc_bifrost']['superuser_id'] ||= generate_hex_if_bootstrap(16, ha_guard)
+      PrivateChef['opscode_erchef']['sql_password'] ||= generate_hex_if_bootstrap(30, ha_guard)
+      PrivateChef['opscode_erchef']['sql_ro_password'] ||= generate_hex_if_bootstrap(30, ha_guard)
       PrivateChef['oc_bifrost']['sql_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['oc_bifrost']['sql_ro_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['oc_id']['secret_key_base'] ||= generate_hex_if_bootstrap(50, ha_guard)
@@ -199,9 +210,9 @@ module PrivateChef
                 'jobs_password' => PrivateChef['rabbitmq']['jobs_password'],
                 'actions_password' => PrivateChef['rabbitmq']['actions_password'],
               },
-              'postgresql' => {
-                'sql_password' => PrivateChef['postgresql']['sql_password'],
-                'sql_ro_password' => PrivateChef['postgresql']['sql_ro_password']
+              'opscode-erchef' => {
+                'sql_password' => PrivateChef['opscode_erchef']['sql_password'],
+                'sql_ro_password' => PrivateChef['opscode_erchef']['sql_ro_password']
               },
               'oc_id' => {
                 'sql_password' => PrivateChef['oc_id']['sql_password'],

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -1,18 +1,19 @@
 
 postgres = node['private_chef']['postgresql']
+erchef = node['private_chef']['opscode-erchef']
 
-private_chef_pg_user postgres['sql_user'] do
-  password postgres['sql_password']
+private_chef_pg_user erchef['sql_user'] do
+  password erchef['sql_password']
   superuser false
 end
 
-private_chef_pg_user postgres['sql_ro_user'] do
-  password postgres['sql_ro_password']
+private_chef_pg_user erchef['sql_ro_user'] do
+  password erchef['sql_ro_password']
   superuser false
 end
 
 private_chef_pg_database "opscode_chef" do
-  owner postgres['sql_user']
+  owner erchef['sql_user']
   notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema/baseline]", :immediately
 end
 
@@ -20,13 +21,13 @@ end
 ruby_block "set opscode_chef ownership" do
   block do
     EcPostgres.with_connection(node, 'opscode_chef') do |connection|
-      connection.exec("ALTER DATABASE opscode_chef OWNER TO #{node['private_chef']['postgresql']['sql_user']};")
+      connection.exec("ALTER DATABASE opscode_chef OWNER TO #{erchef['sql_user']};")
     end
   end
 end
 
 # Note that the sqitch migrations below only trigger when we create the database.
-# At this tiem, we're using partybus to apply upgrade-related sqitch migrations,
+# At this time, we're using partybus to apply upgrade-related sqitch migrations,
 # so that we can also apply any necessary data migrations (not yet managed through sqitch)
 # at that time.
 private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/baseline" do
@@ -49,20 +50,21 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
 end
 
 
-private_chef_pg_user_table_access postgres['sql_user'] do
+private_chef_pg_user_table_access erchef['sql_user'] do
   database 'opscode_chef'
   schema 'public'
   access_profile :write
+  only_if { is_data_master? }
 end
 
-private_chef_pg_user_table_access postgres['sql_ro_user'] do
+private_chef_pg_user_table_access erchef['sql_ro_user'] do
   database 'opscode_chef'
   schema 'public'
   access_profile :read
+  only_if { is_data_master? }
 end
 
 # Cleanup old enterprise-chef-server-schema
-# TODO don't we have a cleanup mechanism this can live in?
 directory "/opt/opscode/embedded/service/enterprise-chef-server-schema" do
   recursive true
   action :delete

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bootstrap-config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bootstrap-config.rb.erb
@@ -2,8 +2,8 @@ output_directory: '/tmp/opscode-platform-test'
 
 db_driver: "postgres"
 db_host: '<%= node['private_chef']['postgresql']['vip'] %>'
-db_user: '<%= node['private_chef']['postgresql']['sql_user'] %>'
-db_password: '<%= node['private_chef']['postgresql']['sql_password'] %>'
+db_user: '<%= node['private_chef']['opscode-erchef']['sql_user'] %>'
+db_password: '<%= node['private_chef']['opscode-erchef']['sql_password'] %>'
 
 bifrost_host: '<%= node['private_chef']['oc_bifrost']['vip'] %>'
 bifrost_port: '<%= node['private_chef']['oc_bifrost']['port'] %>'

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -186,8 +186,8 @@
            %% Database connection parameters
            {db_host, "<%= node['private_chef']['postgresql']['vip'] %>"},
            {db_port, 5432},
-           {db_user, "<%= node['private_chef']['postgresql']['sql_user'] %>"},
-           {db_pass, "<%= node['private_chef']['postgresql']['sql_password'] %>"},
+           {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
+           {db_pass, "<%= node['private_chef']['opscode-erchef']['sql_password'] %>"},
            {db_name, "opscode_chef" },
            {idle_check, 10000},
            {pooler_timeout, <%= @db_pooler_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -99,8 +99,8 @@
            %% Database connection parameters
            {db_host, "<%= node['private_chef']['postgresql']['vip'] %>"},
            {db_port, 5432},
-           {db_user, "<%= node['private_chef']['postgresql']['sql_user'] %>"},
-           {db_pass, "<%= node['private_chef']['postgresql']['sql_password'] %>"},
+           {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
+           {db_pass, "<%= node['private_chef']['opscode-erchef']['sql_password'] %>"},
            {db_name, "opscode_chef" },
            {idle_check, 10000},
            {db_timeout, <%= node['private_chef']['opscode-chef-mover']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
+++ b/omnibus/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
@@ -369,6 +369,8 @@ EOF
     end
 
     running_config = JSON.parse(File.read("/etc/chef-server/chef-server-running.json"))
+    # Note that the location of sql_user/sql_password has changed to 'opscode-erchef'
+    # but for this upgrade we would still expect it to be in 'postgresql'
     sql_host = running_config['chef_server']['postgresql']['vip']
     sql_port = running_config['chef_server']['postgresql']['port']
     sql_user = running_config['chef_server']['postgresql']['sql_user']


### PR DESCRIPTION
This updates omnibus to expect and set sql user and password for the erchef database as part of the erchef attributes and not postgresql. This follows the model used by oc-id and bifrost.