### PR TITLE
Include missing dependencies in mover build

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -22,8 +22,8 @@ package_name    "chef-server-core"
 replace         "private-chef"
 conflict        "private-chef"
 install_dir     "/opt/opscode"
-# last released version is 12.0.8
-build_version   "12.1.0"
+# last released version is 12.1.0
+build_version   "12.1.1"
 build_iteration 1
 
 override :cacerts, version: '2014.08.20'

--- a/src/chef-mover/jenkins/build.sh
+++ b/src/chef-mover/jenkins/build.sh
@@ -15,15 +15,13 @@ then
     VERSION=$(git describe --tags --exact-match --match='[0-9]*.[0-9]*.[0-9]*')
     PACKAGE=${PROJ_NAME}-${VERSION}.tar.gz
 else
-    REL_VERSION=`cat rel/reltool.config|grep '{rel,.*"mover"'|cut -d ',' -f 3|sed 's/"//g'`
+    REL_VERSION=`cat relx.config|grep '{release,' |cut -d ',' -f 3|sed 's/"//g'|sed 's/}//g'`
     GIT_SHA=`git rev-parse --short HEAD`
     VERSION=${REL_VERSION}-${GIT_SHA}
     PACKAGE=${PROJ_NAME}-${VERSION}.tar.gz
 fi
 
-
-cd rel
+cd _rel
 tar zcf $PACKAGE $PROJ_NAME/
 s3cmd put $PACKAGE s3://opscode-ci/artifacts/ubuntu-10.04/x86_64/chef-mover/$PACKAGE
 s3cmd put $PACKAGE s3://opscode-ci/artifacts/ubuntu-12.04/x86_64/chef-mover/$PACKAGE
-

--- a/src/chef-mover/rel/sys.config
+++ b/src/chef-mover/rel/sys.config
@@ -2,6 +2,7 @@
 %% ex: ts=4 sw=4 ft=erlang et
 
 [
+ {kernel, [{start_pg2, true}]},
  %% SASL config
  {sasl, [
          {sasl_error_logger, {file, "log/sasl-error.log"}},
@@ -10,89 +11,147 @@
          {error_logger_mf_maxbytes, 10485760},   % 10 MB max file size
          {error_logger_mf_maxfiles, 5}           % 5 files max
         ]},
+ %% Lager Config
+ {lager, [
+            %% https://github.com/basho/lager/blob/master/README.org
+          {handlers, [
+                      {lager_console_backend,
+                       [error,
+                        {lager_default_formatter,
+                         [time, " [", severity, "] ",
+                          {error_type, [error_type, " "], ""},
+                          {org_name, [org_name, " (", org_id, "): "], ""}, message, "\n"]}]},
 
- {fast_log, [
-             {loggers, [[{name, mover_manager_log},
-                         {file, "log/mover_manager.log"},
-                         {files, 5},
-                         {file_size, 50}],
-                        [{name, mover_worker_log},
-                         {file, "log/mover_worker.log"},
-                         {files, 5},
-                         {file_size, 50}],
-                        [{name, node_errors},
-                         {file, "log/node_errors.log"},
-                         {files, 5},
-                         {file_size, 50}]
-                       ]}
+                      {lager_file_backend, [
+                                            [{"log/error.log", error, 10485760, "$D0", 5},
+                                             {lager_default_formatter,
+                                              [date, " ", time, " [", severity, "] ",
+                                               {org_name, [org_name, " (", org_id, "): "], "no_org (no_id):"},
+                                               {error_type, [error_type, " "], ""},
+                                               message, "\n"]}],
+
+                                            [{"log/console.log", info, 10485760, "$D0", 5},
+                                             {lager_default_formatter,
+                                              [date, " ", time, " [", severity, "] ",
+                                               {org_name, [org_name, " (", org_id, "): "], "no_org (no_id):"},
+                                               {error_type, [error_type, " "], ""},
+                                               message, "\n"]}]
+                                           ]}
+                     ]},
+          {crash_log, "log/crash.log"},
+          {crash_log_msg_size, 65536},
+          {crash_log_size, 10485760},
+          {crash_log_date, "$D0"},
+          {crash_log_count, 5},
+          {error_logger_redirect, true},
+          {error_logger_hwm, 1000 }
+         ]},
+  {oc_chef_authz, [
+                {authz_service, [{root_url, "http://localhost/dontcare"},
+                                 {timeout, 0},
+                                 {init_count, 25},
+                                 {max_count, 50},
+                                 {cull_interval, {1,min}},
+                                 {max_age, {70, sec}},
+                                 {max_connection_duration, {70,sec}},
+                                 {ibrowse_options, [{connect_timeout, 5000}]}]},
+
+                {authz_superuser_id, <<"12345">>},
+                {authz_root_url, "http://localhost/dontcare" }
+               ]},
+  {chef_db, [
+             {bulk_fetch_batch_size, 5},
+             {cache_defaults, [{max_size, 10000 },
+                               {ttl, 3600 }]},
+             {couchdb_host, {{couchdb_server}} },
+             {couchdb_port, {{couchdb_port}} }
             ]},
 
- {mover, [
-          {redis_host, "{{redis_host}}" },
-          {redis_port, {{redis_port}} },
-          {redis_db, {{redis_db}} },
-          {redis_conns, {{redis_conns}} },
-
-          {dry_run, {{dry_run}} },
-          {preload_org_count, {{preload_org_count}} },
-
-          {nginx_control_urls, ["http://nginx_host1/a",
-                                "http://nginx_host2/a"]},
-
-          {darklaunch_urls, ["http://darklaunch1",
-                             "http://darklaunch2"] }
-         ]},
-
- {stats_hero, [
-               {udp_socket_pool_size, {{udp_socket_pool_size}} },
-               {estatsd_host, "{{estatsd_server}}" },
-               {estatsd_port, {{estatsd_port}} }
-              ]},
-
- {chef_common, [
-                {solr_url, "{{solr_url}}" },
-                {couchdb_host, "{{couchdb_server}}"},
-                {couchdb_port, {{couchdb_port}} },
-                {dark_launch_sql_users, {{sql_users}} },
-                {cache_defaults, [{max_size, {{max_cache_size}} },
-                                  {ttl, {{cache_ttl}} }]},
-                {rabbitmq_host, "{{rabbitmq_host}}"},
+  {chef_index, [
+                {rabbitmq_host, "{{rabbitmq_host}}" },
                 {rabbitmq_port, {{rabbitmq_port}} },
                 {rabbitmq_user, <<"{{rabbitmq_user}}">>},
                 {rabbitmq_password, <<"{{rabbitmq_password}}">>},
                 {rabbitmq_vhost, <<"{{rabbitmq_vhost}}">>},
-                {rabbitmq_exchange, <<"{{rabbitmq_exchange}}">>},
-
-                {authz_root_url, "{{authz_root_url}}" },
-                {keyring, [{default, "{{keyring_default}}"}]},
-                {keyring_dir, "{{keyring_dir}}"}
+                {rabbitmq_exchange, <<"">>},
+                {solr_url, "{{solr_url}}" }
                ]},
+
+  {chef_objects, [
+                  {certificate_root_url, "http://localhost/dontcare/certificates"},
+                  {s3_access_key_id, "bleh"},
+                  {s3_secret_key_id, "blag"},
+                  {s3_url, "http://localhost/dontcare"},
+                  {s3_platform_bucket_name, "bucket"},
+                  {s3_url_ttl, 28800},
+                  {s3_parallel_ops_timeout, 5000},
+                  {s3_parallel_ops_fanout, 20}
+                 ]},
+
  {sqerl, [
-          %% The database system you are using (e.g., mysql, pgsql)
-          {db_type, {{db_type}} },
-
           %% Database connection parameters
-          {db_host, "{{db_host}}" },
+          {db_host, "{{db_host}}"},
           {db_port, {{db_port}} },
-          {db_user, "{{db_user}}" },
-          {db_pass, "{{db_pass}}" },
-          {db_name, "{{db_name}}" },
-
-          {prepared_statements, {chef_sql, statements, [ {{db_type}} ]} },
-          %% what's this?
-          {column_transforms, undefined}
+          {db_user, "{{db_user}}"},
+          {db_pass, "{{db_pass}}"},
+          {db_name,   "{{db_name}}"},
+          {db_timeout, {{db_timeout}} },
+          {idle_check, 10000},
+          {prepared_statements, {oc_chef_sql, statements, [pgsql]}},
+          {column_transforms,
+           [{<<"created_at">>,
+             {sqerl_transformers, convert_YMDHMS_tuple_to_datetime}},
+            {<<"updated_at">>,
+             {sqerl_transformers, convert_YMDHMS_tuple_to_datetime}}]}
          ]},
 
  {pooler, [
-           {pools, [[{name, "sqerl"},
+           {pools, [[{name, sqerl},
                      {max_count, {{db_pool_size}} },
                      {init_count, {{db_pool_size}} },
                      {start_mfa, {sqerl_client, start_link, []}}]]},
            {metrics_module, folsom_metrics}
           ]},
 
- {darklaunch, [
-               {config, "{{darklaunch_config}}" },
-               {reload_time, {{darklaunch_reload_time}} }
-              ]}
+ {ibrowse, [
+            {default_max_sessions, {{ibrowse_max_sessions}} },
+            {default_max_pipeline_size, {{ibrowse_max_pipeline_size}} }
+           ]},
+
+ {moser, [
+           {moser_dets_dir, "/tmp/moser"},
+           {couch_path, "/tmp/couch"},
+           {purge_chunksize, 10},
+           {purge_throttle, 0},
+           {purge_backup, false},
+           {purge_auth, false},
+           {purge_backup_dir, ""}
+           ]},
+
+ {folsom_graphite,[ {application, "moser"}]},
+
+ {stats_hero, [
+               %% Set sender pool size to DB max_connections to avoid contention
+               {udp_socket_pool_size, {{udp_socket_pool_size}} },
+               {estatsd_host, "{{estatsd_host}}"},
+               {estatsd_port, {{estatsd_port}} }
+               ]},
+ {mover, [
+          {eredis_host, "{{redis_host}}"},
+          {eredis_port, {{redis_port}} },
+          {dry_run, {{dry_run}} },
+          {sleep_time, 0},
+          {solr_url, "{{solr_url}}" }
+         ]},
+ {chef_reindex, [
+          {solr_service, [{root_url, "{{solr_url}}" },
+                          {timeout, {{solr_timeout}} },
+                          {init_count, {{solr_http_init_count}} },
+                          {max_count, {{solr_http_max_count}} },
+                          {cull_interval, {{solr_http_cull_interval}} },
+                          {max_age, {{solr_http_max_age}} },
+                          {max_connection_duration, {{solr_http_max_connection_duration}} },
+                          {ibrowse_options,[{connect_timeout, 10000}] }]
+          }
+         ]}
 ].

--- a/src/chef-mover/rel/vars.config
+++ b/src/chef-mover/rel/vars.config
@@ -10,7 +10,18 @@
 {estatsd_port, 5665}.
 {udp_socket_pool_size, 5}.
 {bulk_fetch_batch_size, 5}.
+
+%% Solr
 {solr_url, "http://localhost:8983/solr"}.
+{solr_timeout, 30000}.
+{solr_http_init_count, 25}.
+{solr_http_max_count, 100}.
+{solr_http_cull_interval, {1, min}}.
+{solr_http_max_age, {70, sec}}.
+{solr_http_max_connection_duration, {70,sec}}.
+
+{ibrowse_max_sessions, 256}.
+{ibrowse_max_pipeline_size, 1}.
 
 %% AMQP Connection info
 {rabbitmq_host, "127.0.0.1"}.
@@ -58,15 +69,20 @@
 %%                    "http://darklaunch2"]}.
 {preload_org_count, 15}.
 
-%% db_type, db_port, db_user, db_pass, and db_name are all set in
-%% db_vars.config as an overlay
 {db_type, mysql}.
-{db_host, "localhost"}.
-{db_pool_size, 5}.
 {db_host, "localhost"}.
 {db_port, 3306}.
 {db_user, "dev"}.
 {db_pass, "opensesame"}.
 {db_name, "opscode_chef"}.
 {db_pool_size, 5}.
+{db_timeout, 5000}.
 
+%% Moser config
+{moser_data, ""}.
+{moser_couch_data, ""}.
+{purge_chunksize, 0}.
+{purge_throttle, 0}.
+{purge_backup, 0}.
+{purge_auth, 0}.
+{purge_backup_dir, ""}.

--- a/src/chef-mover/relx.config
+++ b/src/chef-mover/relx.config
@@ -1,6 +1,27 @@
-{release,{mover,"12.1.0"},[
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+
+{release,{mover,"12.1.1"},[
         mover,
         moser,
+        jiffy,
+        eredis,
+        {darklaunch, load},
+        bear,
+        folsom,
+        chef_authn,
+        erlware_commons,
+        mini_s3,
+        mnesia,
+        oauth,
+        opscoderl_folsom,
+        opscoderl_wm,
+        quickrand,
+        ssh,
+        uuid,
+        debugger,
+        hipe,
+        runtime_tools,
         {decouch, load},
         {chef_db, load},
         {chef_objects, load},

--- a/src/chef-mover/src/mover.app.src
+++ b/src/chef-mover/src/mover.app.src
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 {application, mover,
  [{description, ""},
-  {vsn, "0.1"},
+  {vsn, "12.1.1"},
   {applications, [kernel,
                   stdlib,
                   sasl,
@@ -13,6 +13,8 @@
                   lager,
                   bcrypt,
                   chef_reindex,
+                  bear,
+                  folsom,
                   stats_hero]},
   {mod, {mover_app, []}}
  ]}.

--- a/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
@@ -1,7 +1,7 @@
 %%-*- mode: erlang -*-
 {application, bifrost,
  [{description, "Bifrost: Opscode Authorization API"},
-  {vsn, "12.1.0"},
+  {vsn, "12.1.1"},
   {modules, []},
   {registered, []},
   {mod, {bifrost_app, []}},

--- a/src/oc_bifrost/jenkins/build.sh
+++ b/src/oc_bifrost/jenkins/build.sh
@@ -6,10 +6,9 @@
 
 PROJ_NAME=oc_bifrost
 
-export PATH=$PATH:/usr/local/bin
+export PATH=/opt/erlang/bin:$PATH:/usr/local/bin
 jenkins/builder_info.rb
 source machine_info
-ARTIFACT_BASE=opscode-ci/artifacts/$os/$machine/$PROJ_NAME
 
 make distclean rel || exit 1
 
@@ -18,15 +17,17 @@ if git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --exact-match
 then
     VERSION=$(git describe --tags --exact-match --match='[0-9]*.[0-9]*.[0-9]*')
     PACKAGE=${PROJ_NAME_}${VERSION}.tar.gz
-    cd rel
-    tar zcvf $PACKAGE $PROJ_NAME/
-    s3cmd put --progress $PACKAGE s3://$ARTIFACT_BASE/$PACKAGE
 else
-    REL_VERSION=`cat rel/reltool.config|grep '{rel,.*"oc_bifrost"'|cut -d ',' -f 3|sed 's/"//g'`
+    REL_VERSION=`cat relx.config|grep '{release,' |cut -d ',' -f 3|sed 's/"//g'|sed 's/}//g'`
     GIT_SHA=`git rev-parse --short HEAD`
     VERSION=${REL_VERSION}-${GIT_SHA}
     PACKAGE=${PROJ_NAME_}${VERSION}.tar.gz
-    cd rel
-    tar zcvf $PACKAGE $PROJ_NAME/
-    s3cmd put --progress $PACKAGE s3://$ARTIFACT_BASE/$PACKAGE
 fi
+
+cd _rel
+
+# Yep, hard-coding platform and version. We're building ubuntu only, 10.04 only,
+# but need to distribute to both.
+tar zcf $PACKAGE $PROJ_NAME/
+s3cmd put $PACKAGE s3://opscode-ci/artifacts/ubuntu-10.04/x86_64/$PROJ_NAME/$PACKAGE
+s3cmd put $PACKAGE s3://opscode-ci/artifacts/ubuntu-12.04/x86_64/$PROJ_NAME/$PACKAGE

--- a/src/oc_bifrost/rel/reltool.config
+++ b/src/oc_bifrost/rel/reltool.config
@@ -1,5 +1,5 @@
 {sys,[{lib_dirs,["../deps","../apps"]},
-      {rel,"oc_bifrost","12.1.0",
+      {rel,"oc_bifrost","12.1.1",
            [kernel,stdlib,sasl,crypto,eper,jiffy,ej,lager,epgsql,sqerl,
             webmachine,bifrost]},
       {rel,"start_clean",[],[kernel,stdlib]},
@@ -22,4 +22,3 @@
           {copy,"files/nodetool","{{erts_vsn}}/bin/nodetool"},
           {copy,"files/oc_bifrost","bin/oc_bifrost"},
           {copy,"files/vm.args","etc/vm.args"}]}.
-

--- a/src/oc_erchef/jenkins/build.sh
+++ b/src/oc_erchef/jenkins/build.sh
@@ -14,15 +14,14 @@ if git describe --tags --match='[0-9]*.[0-9]*.[0-9]*' --exact-match
 then
     VERSION=$(git describe --tags --exact-match --match='[0-9]*.[0-9]*.[0-9]*')
     PACKAGE=${PROJ_NAME}-${VERSION}.tar.gz
-    cd _rel
 else
-    REL_VERSION=`cat rel/reltool.config|grep '{rel,.*"oc_erchef"'|cut -d ',' -f 3|sed 's/"//g'`
+    REL_VERSION=`cat relx.config|grep '{release,' |cut -d ',' -f 3|sed 's/"//g'|sed 's/}//g'`
     GIT_SHA=`git rev-parse --short HEAD`
     VERSION=${REL_VERSION}-${GIT_SHA}
     PACKAGE=${PROJ_NAME}-${VERSION}.tar.gz
-    cd _rel
 fi
 
+cd _rel
 # Yep, hard-coding platform and version. We're building ubuntu only, 10.04 only,
 # but need to distribute to both.
 tar zcf $PACKAGE $PROJ_NAME/

--- a/src/oc_erchef/rel/reltool.config
+++ b/src/oc_erchef/rel/reltool.config
@@ -1,5 +1,5 @@
 {sys,[{lib_dirs,["../deps","../apps"]},
-      {rel,"oc_erchef","12.1.0",
+      {rel,"oc_erchef","12.1.1",
            [kernel,stdlib,sasl,crypto,mochiweb,webmachine,ibrowse,
             lager,epgsql,sqerl,rabbit_common,amqp_client,gen_bunny,
             chef_index,darklaunch,oc_chef_wm,opscoderl_wm,opscoderl_httpc,

--- a/src/oc_erchef/relx.config
+++ b/src/oc_erchef/relx.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-{release,{oc_erchef,"12.1.0"},
+{release,{oc_erchef,"12.1.1"},
  [oc_erchef,
   {sync, load},
   {eunit, load},

--- a/src/oc_erchef/src/oc_erchef.app.src
+++ b/src/oc_erchef/src/oc_erchef.app.src
@@ -4,7 +4,7 @@
 {application, oc_erchef,
  [
   {description, ""},
-  {vsn, "12.1.0"},
+  {vsn, "12.1.1"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
I think we're including too many dependencies now, which is better than
not enough, but armed with a good test environment, we should be able to
pull out the dependencies we don't actually need.