### PR TITLE
pulling in changes from the byop-sqitch-provider branch

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -404,6 +404,7 @@ default['private_chef']['postgresql']['version'] = "9.2"
 # we'll be using these directories to determine what versions we have installed and
 # whether we need to run pg_upgrade.
 default['private_chef']['postgresql']['enable'] = true
+default['private_chef']['postgresql']['external'] = false
 default['private_chef']['postgresql']['ha'] = false
 default['private_chef']['postgresql']['dir'] = "/var/opt/opscode/postgresql/#{node['private_chef']['postgresql']['version']}"
 default['private_chef']['postgresql']['data_dir'] = "/var/opt/opscode/postgresql/#{node['private_chef']['postgresql']['version']}/data"

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -1,0 +1,28 @@
+
+def whyrun_supported?
+  true
+end
+
+use_inline_resources
+
+action :deploy do
+  target = new_resource.target_version ? "--to-target #{new_resource.target_version}" : ""
+  execute "sqitch_deploy_#{new_resource.name}" do
+    command <<-EOM.gsub(/\s+/," ").strip!
+      sqitch --engine pg
+             --db-host #{new_resource.hostname}
+             --db-port #{new_resource.port}
+             --db-user #{new_resource.username}
+             --db-name #{new_resource.database}
+             --top-dir #{new_resource.name}
+             deploy #{target} --verify
+    EOM
+    environment "PERL5LIB" => "",
+                "PGPASSWORD" => new_resource.password
+    # Sqitch Return Codes
+    # 0 - when changes are applied
+    # 1 - when everything is ok but no changes were made
+    # 2(+?) - when an error occurs.
+    returns [0,1]
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -7,22 +7,34 @@ use_inline_resources
 
 action :deploy do
   target = new_resource.target_version ? "--to-target #{new_resource.target_version}" : ""
-  execute "sqitch_deploy_#{new_resource.name}" do
-    command <<-EOM.gsub(/\s+/," ").strip!
-      sqitch --engine pg
-             --db-host #{new_resource.hostname}
-             --db-port #{new_resource.port}
-             --db-user #{new_resource.username}
-             --db-name #{new_resource.database}
-             --top-dir #{new_resource.name}
-             deploy #{target} --verify
-    EOM
-    environment "PERL5LIB" => "",
-                "PGPASSWORD" => new_resource.password
-    # Sqitch Return Codes
-    # 0 - when changes are applied
-    # 1 - when everything is ok but no changes were made
-    # 2(+?) - when an error occurs.
-    returns [0,1]
+
+  # Note: the split behavior below will go away once we modify managed local psql
+  # to use permit password + tcp for postgres user on localhost.
+  if new_resource.password.empty?
+    auth_info = ""
+    run_user = new_resource.username
+  else
+    run_user = Process.uid
+    auth_info = "--db-host #{new_resource.hostname} --db-port #{new_resource.port} --db-user #{new_resource.username}"
+  end
+
+  converge_by "Deploying schema from #{new_resource.name}" do
+    execute "sqitch_deploy_#{new_resource.name}" do
+      command <<-EOM.gsub(/\s+/," ").strip!
+        sqitch --engine pg #{auth_info}
+               --db-name #{new_resource.database}
+               --top-dir #{new_resource.name}
+               deploy #{target} --verify
+      EOM
+      environment "PERL5LIB" => "", # force us to use omnibus perl
+                  "PGPASSWORD" => new_resource.password
+      user run_user
+
+      # Sqitch Return Codes
+      # 0 - when changes are applied
+      # 1 - when everything is ok but no changes were made
+      # 2(+?) - when an error occurs.
+      returns [0,1]
+    end
   end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -21,15 +21,6 @@ private_chef_pg_database 'bifrost' do
   owner bifrost_attrs['sql_user']
 end
 
-# For existing installations, make sure the database owner is set to sql_user
-ruby_block "set bifrost ownership" do
-  block do
-    EcPostgres.with_connection(node, 'bifrost') do |connection|
-      connection.exec("ALTER DATABASE bifrost OWNER TO #{node['private_chef']['oc_bifrost']['sql_user']};")
-    end
-  end
-end
-
 private_chef_pg_user_table_access bifrost_attrs['sql_user'] do
   database 'bifrost'
   schema 'public'
@@ -45,7 +36,7 @@ end
 private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
-  username bifrost_attrs['sql_user']
-  password bifrost_attrs['sql_password']
+  # TODO: will become db_superuser , db_superuser_password
+  username postgres_attrs['username']
   database "bifrost"
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -3,8 +3,10 @@
 
 # Extract the attribute hash here so we're not quite so verbose
 bifrost_attrs = node['private_chef']['oc_bifrost']
+postgres_attrs = node['private_chef']['postgresql']
 
 # create users
+
 private_chef_pg_user bifrost_attrs['sql_user'] do
   password bifrost_attrs['sql_password']
   superuser false
@@ -19,6 +21,15 @@ private_chef_pg_database 'bifrost' do
   owner bifrost_attrs['sql_user']
 end
 
+# For existing installations, make sure the database owner is set to sql_user
+ruby_block "set bifrost ownership" do
+  block do
+    EcPostgres.with_connection(node, 'bifrost') do |connection|
+      connection.exec("ALTER DATABASE bifrost OWNER TO #{node['private_chef']['oc_bifrost']['sql_user']};")
+    end
+  end
+end
+
 private_chef_pg_user_table_access bifrost_attrs['sql_user'] do
   database 'bifrost'
   schema 'public'
@@ -31,42 +42,10 @@ private_chef_pg_user_table_access bifrost_attrs['sql_ro_user'] do
   access_profile :read
 end
 
-execute "bifrost_schema" do
-  # The version of the schema to be deployed will the the maximum
-  # available in the oc_bifrost repository.  This will be the same
-  # version needed by the code that is deployed here.  If we ever
-  # split bifrost's code and schema into separate repositories,
-  # we'll need to deploy to a specific schema tag
-  command <<-EOM.gsub(/\s+/," ").strip!
-    sqitch --engine pg
-           --db-name bifrost
-           --top-dir /opt/opscode/embedded/service/oc_bifrost/db
-           deploy --verify
-  EOM
-  user node['private_chef']['postgresql']['username']
-  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
-  # installation
-  environment "PERL5LIB" => ""
-  # If sqitch is deploying the first time, it'll return 0 on
-  # success.  If it's running a second time and ends up deploying
-  # nothing (since we've already deployed all changesets), it'll
-  # return 1.  Both scenarios should be considered successful.
-  returns [0,1]
-end
-
-# Permissions for the database users got set in the schema... though
-# that means that the role names should be hard-coded in this
-# cookbook.
-execute "add_permissions_bifrost" do
-  command <<-EOM.gsub(/\s+/," ").strip!
-      psql --dbname bifrost
-           --single-transaction
-           --set ON_ERROR_STOP=1
-           --set database_name=bifrost
-           --file sql/permissions.sql
-    EOM
-  cwd "/opt/opscode/embedded/service/oc_bifrost/db"
-  user node['private_chef']['postgresql']['username']
-  # This can run each time, since the commands in the SQL file are all
-  # idempotent anyway
+private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
+  hostname postgres_attrs['vip']
+  port     postgres_attrs['port']
+  username bifrost_attrs['sql_user']
+  password bifrost_attrs['sql_password']
+  database "bifrost"
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -1,50 +1,20 @@
-private_chef_pg_user node['private_chef']['postgresql']['sql_user'] do
-  password node['private_chef']['postgresql']['sql_password']
+
+postgres = node['private_chef']['postgresql']
+
+private_chef_pg_user postgres['sql_user'] do
+  password postgres['sql_password']
   superuser false
 end
 
-private_chef_pg_user node['private_chef']['postgresql']['sql_ro_user'] do
-  password node['private_chef']['postgresql']['sql_ro_password']
+private_chef_pg_user postgres['sql_ro_user'] do
+  password postgres['sql_ro_password']
   superuser false
 end
 
 private_chef_pg_database "opscode_chef" do
-  owner node['private_chef']['postgresql']['sql_user']
-  notifies :run, "execute[chef-server-schema]", :immediately
+  owner postgres['sql_user']
+  notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema/baseline]", :immediately
 end
-
-# Though Sqitch runs are idempotent, we need to have them run only
-# when the database is first created (thus the chained notifications).
-# This is only for EC11; subsequent versions can run them
-# idempotently, like normal.  This is just to allow fresh EC11
-# installs to use Sqitch; upgraded installations have a Partybus
-# upgrade to run.  The end result should be that whether or not you
-# are installing or upgrading EC11, at the end of the day, you'll have
-# Sqitch metadata info in your database.
-execute "chef-server-schema" do
-  command "sqitch --db-name opscode_chef deploy --verify"
-  # OSC schema is a dependency of the EC schema, and managed by it
-  cwd "/opt/opscode/embedded/service/opscode-erchef/schema/baseline"
-  user node['private_chef']['postgresql']['username']
-  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
-  # installation
-  environment "PERL5LIB" => ""
-  returns [0,1]
-  action :nothing
-  notifies :run, "execute[enterprise-chef-server-schema]", :immediately
-end
-
-execute "enterprise-chef-server-schema" do
-  command "sqitch --db-name opscode_chef deploy --verify"
-  cwd "/opt/opscode/embedded/service/opscode-erchef/schema"
-  user node['private_chef']['postgresql']['username']
-  # Clear PERL5LIB to ensure sqitch only uses omnibus's perl
-  # installation
-  environment "PERL5LIB" => ""
-  returns [0,1]
-  action :nothing
-end
-
 
 # For existing installations, make sure the database owner is set to sql_user
 ruby_block "set opscode_chef ownership" do
@@ -55,20 +25,39 @@ ruby_block "set opscode_chef ownership" do
   end
 end
 
-private_chef_pg_user_table_access node['private_chef']['postgresql']['sql_user'] do
-  database 'opscode_chef'
-  schema 'public'
-  access_profile :write
+# Note that the sqitch migrations below only trigger when we create the database.
+# At this tiem, we're using partybus to apply upgrade-related sqitch migrations,
+# so that we can also apply any necessary data migrations (not yet managed through sqitch)
+# at that time.
+private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/baseline" do
+  hostname  postgres['vip']
+  port      postgres['port']
+  username  postgres['sql_user']
+  password  postgres['sql_password']
+  database  "opscode_chef"
+  action :nothing
+  notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema]", :immediately
+end
+
+private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
+  hostname  postgres['vip']
+  port      postgres['port']
+  username  postgres['sql_user']
+  password  postgres['sql_password']
+  database "opscode_chef"
+  action :nothing
 end
 
 
-private_chef_pg_user_table_access node['private_chef']['postgresql']['sql_ro_user'] do
+# TODO ... sqitch this.
+private_chef_pg_user_table_access postgres['sql_ro_user'] do
   database 'opscode_chef'
   schema 'public'
   access_profile :read
 end
 
 # Cleanup old enterprise-chef-server-schema
+# TODO don't we have a cleanup mechanism this can live in?
 directory "/opt/opscode/embedded/service/enterprise-chef-server-schema" do
   recursive true
   action :delete

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -32,8 +32,8 @@ end
 private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/baseline" do
   hostname  postgres['vip']
   port      postgres['port']
-  username  postgres['sql_user']
-  password  postgres['sql_password']
+  # TODO: will become db_superuser , db_superuser_password
+  username  postgres['username']
   database  "opscode_chef"
   action :nothing
   notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema]", :immediately
@@ -42,14 +42,19 @@ end
 private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
   hostname  postgres['vip']
   port      postgres['port']
-  username  postgres['sql_user']
-  password  postgres['sql_password']
+  # TODO: will become db_superuser , db_superuser_password
+  username  postgres['username']
   database "opscode_chef"
   action :nothing
 end
 
 
-# TODO ... sqitch this.
+private_chef_pg_user_table_access postgres['sql_user'] do
+  database 'opscode_chef'
+  schema 'public'
+  access_profile :write
+end
+
 private_chef_pg_user_table_access postgres['sql_ro_user'] do
   database 'opscode_chef'
   schema 'public'

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
@@ -1,0 +1,10 @@
+actions :deploy
+default_action :deploy
+
+attribute :name,           kind_of: String, required: true, name_attribute: true
+attribute :database,       kind_of: String, required: true
+attribute :username,       kind_of: String
+attribute :password,       kind_of: String, required: false, default: ""
+attribute :target_version, kind_of: String
+attribute :hostname,       kind_of: String, required: true
+attribute :port,           kind_of: Integer, required: true


### PR DESCRIPTION
This PR is mainly changing db updates from using execute blocks calling sqitch to start using a new private_chef_pg_sqitch provider which can update both local and external Postgres instances.

I pulled @andy-dufour's changes in from byop-sqitch-provider branch  because the commit history is pretty badly broken on that branch, making it difficult to merge or even squash.   

This supersedes https://github.com/chef/chef-server/pull/385 which has been closed. 
