### PR TITLE
Adding users list action

### DIFF
--- a/src/oc-id/app/controllers/v1/users_controller.rb
+++ b/src/oc-id/app/controllers/v1/users_controller.rb
@@ -1,6 +1,6 @@
 module V1
   class UsersController < ApplicationController
-    doorkeeper_for :all, except: [ :show, :all_users ]
+    doorkeeper_for :all, except: [ :show ]
 
     respond_to :json
 

--- a/src/oc-id/app/controllers/v1/users_controller.rb
+++ b/src/oc-id/app/controllers/v1/users_controller.rb
@@ -1,6 +1,6 @@
 module V1
   class UsersController < ApplicationController
-    doorkeeper_for :all, except: :show
+    doorkeeper_for :all, except: [ :show, :all_users ]
 
     respond_to :json
 
@@ -24,6 +24,15 @@ module V1
       @user = User.find(doorkeeper_token.resource_owner_id)
 
       respond_with @user.organizations
+    end
+
+    def all_users
+      app = Doorkeeper::Application.find_by_uid(params[:app_id])
+      head :unauthorized and return unless app
+
+      @users = User.all
+
+      respond_with @users
     end
   end
 end

--- a/src/oc-id/app/models/user.rb
+++ b/src/oc-id/app/models/user.rb
@@ -68,6 +68,8 @@ class User
   end
 
   class << self
+    include ChefResource
+
     def find(username)
       begin
         new(username: username).get unless username.nil?
@@ -101,6 +103,10 @@ class User
       else
         nil
       end
+    end
+
+    def all
+      chef.get("users?verbose=true")
     end
   end
 end

--- a/src/oc-id/config/routes.rb
+++ b/src/oc-id/config/routes.rb
@@ -24,6 +24,7 @@ OcId::Application.routes.draw do
       resources :users, only: :show
 
       get 'me', to: 'users#me'
+      get 'all_users', to: 'users#all_users'
       get 'me/organizations', to: 'users#organizations'
       get 'status', to: 'health#show'
     end

--- a/src/oc-id/spec/controllers/v1/users_controller_spec.rb
+++ b/src/oc-id/spec/controllers/v1/users_controller_spec.rb
@@ -60,7 +60,12 @@ describe V1::UsersController do
       }
     end
 
+    let(:token) { double acceptable?: true }
+
     before do
+      # Stubs doorkeeper authentication
+      allow(controller).to receive(:doorkeeper_token).and_return(token)
+
       allow(User).to receive(:all).and_return(sample_users)
     end
 

--- a/src/oc-id/spec/controllers/v1/users_controller_spec.rb
+++ b/src/oc-id/spec/controllers/v1/users_controller_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe V1::UsersController do
   describe 'GET#show' do
-
     let(:app) { double('oauth_applications', id: '1') }
 
     let(:user) { FactoryGirl.build(:user) }
@@ -38,6 +37,67 @@ describe V1::UsersController do
 
           expect(response.body).to include(user.username, user.first_name, user.last_name)
         end
+      end
+    end
+  end
+
+  describe 'GET#all' do
+    let(:app) { double('oauth_applications', id: '1') }
+
+    let(:user) { FactoryGirl.build(:user) }
+
+    let(:json) do
+      { format: 'json', app_id: app.id}
+    end
+
+    let(:sample_users) do
+      {
+        "some_user"=> {
+          "email"=> user.email,
+          "first_name" => user.first_name,
+          "last_name" => user.last_name
+        }
+      }
+    end
+
+    before do
+      allow(User).to receive(:all).and_return(sample_users)
+    end
+
+    it 'searches for the app' do
+      expect(Doorkeeper::Application).to receive(:find_by_uid).with(app.id.to_s)
+      get :all_users, json
+    end
+
+    context 'when the app is valid' do
+      before do
+        allow(Doorkeeper::Application).to receive(:find_by_uid).with(app.id.to_s).and_return(app)
+      end
+
+      it 'finds all users' do
+        expect(User).to receive(:all).and_return(sample_users)
+        get :all_users, json
+      end
+
+      it 'returns all users' do
+        get :all_users, json
+        expect(response.body).to include("some_user", user.email, user.first_name, user.last_name)
+      end
+    end
+
+    context 'when the app is not valid' do
+      before do
+        allow(Doorkeeper::Application).to receive(:find_by_uid).with(app.id.to_s).and_return(nil)
+      end
+
+      it 'does not find all users' do
+        expect(User).to_not receive(:all)
+        get :all_users, json
+      end
+
+      it 'does not return all users' do
+        get :all_users, json
+        expect(response.body).to_not include("some_user", user.email, user.first_name, user.last_name)
       end
     end
   end

--- a/src/oc-id/spec/controllers/v1/users_controller_spec.rb
+++ b/src/oc-id/spec/controllers/v1/users_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe V1::UsersController do
+  describe 'GET#show' do
+
+    let(:app) { double('oauth_applications', id: '1') }
+
+    let(:user) { FactoryGirl.build(:user) }
+
+    let(:json) do
+      { format: 'json', id: user.id, app_id: app.id}
+    end
+
+    it 'searches for the application' do
+      expect(Doorkeeper::Application).to receive(:find_by_uid).with(app.id.to_s)
+      get :show, json
+    end
+
+    context 'when the app_id is valid' do
+      before do
+        allow(Doorkeeper::Application).to receive(:find_by_uid).with(app.id).and_return(app)
+      end
+
+      it 'searches for the user' do
+        expect(User).to receive(:find).with(user.username)
+        get :show, json
+      end
+
+      context 'when the user is valid' do
+        before do
+          allow(User).to receive(:find).and_return(user)
+        end
+
+        it 'returns the public user' do
+          json = { format: 'json', id: user.id, app_id: app.id}
+
+          get :show, json
+
+          expect(response.body).to include(user.username, user.first_name, user.last_name)
+        end
+      end
+    end
+  end
+end

--- a/src/oc-id/spec/models/user_spec.rb
+++ b/src/oc-id/spec/models/user_spec.rb
@@ -83,4 +83,17 @@ describe User do
       end
     end
   end
+
+  context 'when retrieving all users on a Chef Server' do
+    let(:chef) { double('chef') }
+
+    before do
+      allow_any_instance_of(ChefResource).to receive(:chef).and_return(chef)
+    end
+
+    it 'requests all users with verbose=true' do
+      expect(chef).to receive(:get).with('users?verbose=true')
+      User.all
+    end
+  end
 end


### PR DESCRIPTION
Supermarket makes heavy use of oc-id.  It would be very useful to be able to retrieve a full list of Chef Server users and their information from oc-id.  This will help us keep our user data in Supermarket in sync with the user data in Chef Server.  Therefore, here is a pull request which adds this.  I also added in some additional specs around the users#show method as I figured out how it worked.
