### PR TITLE
add secondary postgres vm option

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -1,16 +1,34 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby
 
+
 require "yaml"
+CS_VM_ADDRESS="192.168.33.100"
+DB_VM_ADDRESS="192.168.33.150"
+DB_SUPERUSER="bofh"
+DB_SUPERPASS="i1uvd3v0ps"
+
 
 Vagrant.configure("2") do |config|
-  provisioning, installer, installer_path, attributes = prepare()
+  attributes = load_settings
   # Use the official Ubuntu 14.04 box
   # Vagrant will auto resolve the url to download from Atlas
   config.vm.box = "ubuntu/trusty64"
-  config.vm.hostname = "api.chef-server.dev"
-  config.vm.network "private_network", ip: "192.168.33.100"
+  if attributes['vm']['postgresql']['start']
+    config.vm.define("database") do |c|
+      define_db_server(c, attributes)
+    end
+  end
+  config.vm.define("chef-server", primary: true) do |c|
+    define_chef_server(c, attributes)
+  end
+end
 
+
+def define_chef_server(config, attributes)
+  provisioning, installer, installer_path = prepare()
+  config.vm.hostname = "api.chef-server.dev"
+  config.vm.network "private_network", ip: CS_VM_ADDRESS
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id,
                   "--name", "chef-server",
@@ -20,7 +38,6 @@ Vagrant.configure("2") do |config|
                   "--usbehci", "off",
                   "--nictype1", "virtio",
                   "--nictype2", "virtio"
-                  # ^ TODO if platform is mac don't?
     ]
   end
 
@@ -31,8 +48,17 @@ Vagrant.configure("2") do |config|
       "omnibus-autoload" => attributes["vm"]["omnibus-autoload"]
     }.merge attributes["vm"]["node-attributes"]
 
-    # Note that we can't exclude .git from top-level projects, and by extension from anything,
-    # otherwise rebar commands begin to fail.
+    if attributes["vm"]["postgresql"]["start"] and attributes["vm"]["postgresql"]["use-external"]
+      # TODO make this stuff common - we have these values in 2-3 places now...
+      pg = { "postgresql['external']" => true,
+             "postgresql['vip']" => "\"#{DB_VM_ADDRESS}\"",
+             "postgresql['port']" => 5432,
+             "postgresql['db_superuser']" => "\"#{DB_SUPERUSER}\"",
+             "postgresql['db_superuser_password']" => "\"#{DB_SUPERPASS}\"", }
+      # TODO merge with other options nicely.
+      json["provisioning"] = {}
+      json["provisioning"]["chef-server-config"] = pg
+    end
     config.vm.synced_folder File.absolute_path(File.join(Dir.pwd, "../")), "/host",
       type: "rsync",
       rsync__args: ["--verbose", "--archive", "--delete", "-z", "--no-owner", "--no-group" ],
@@ -55,7 +81,29 @@ Vagrant.configure("2") do |config|
       chef.json = json || {}
     end
   end
+
 end
+
+def define_db_server(config, attributes)
+  config.vm.hostname = "database.chef-server.dev"
+  config.vm.network "private_network", ip: DB_VM_ADDRESS
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id,
+                  "--name", "database",
+                  "--memory", 1024,
+                  "--cpus", 2,
+                  "--usb", "off",
+                  "--usbehci", "off",
+                  "--nictype1", "virtio",
+                  "--nictype2", "virtio"
+    ]
+  end
+
+  # Using shell here to ave the trouble of downloading
+  # chef-client for the node.  May reconsider...
+  config.vm.provision "shell", inline: configure_postgres
+end
+
 
 ##############
 # Internals
@@ -65,14 +113,18 @@ end
 ##############
 
 
-def prepare
-  action = ARGV.shift
+def load_settings
   attributes = YAML.load_file("defaults.yml")
   begin
     custom_attributes = YAML.load_file("config.yml")
     attributes = simple_deep_merge(attributes, custom_attributes)
   rescue
   end
+  attributes
+end
+
+def prepare
+  action = ARGV[0]
   if action =~ /^(provision|up|reload)$/
     installer = prompt_installer
     raise "Please set INSTALLER to the path of a .deb package for Chef Server 12+." if installer.nil?
@@ -80,7 +132,7 @@ def prepare
     installer_path = File.dirname(File.expand_path(installer))
     provisioning = true
   end
-  [provisioning, installer, installer_path, attributes]
+  [provisioning, installer, installer_path]
 end
 
 def prompt_installer
@@ -113,7 +165,7 @@ def prompt_installer
 
   loop do
     print "Select an image, or set the INSTALLER variable and run again: [1 - #{files.length}]: "
-    selection = gets.chomp.to_i
+    selection = $stdin.gets.chomp.to_i
     break if selection > 0 and selection <= files.length
   end
 
@@ -158,6 +210,8 @@ def host_timezone_osx
   end
 end
 
+
+
 # this is here in order to avoid having to download a chef provisioner -
 # we already have a chef-client install included with the server package, and since
 # we're going to run in solo mode, it will run for VM provisioning without
@@ -175,6 +229,26 @@ else
   sudo dpkg -i /installers/#{server_installer_name}
 fi
 SCRIPT
+end
+
+# Quick and dirty postgres configuration that avoids having to download
+# a chef installer when we bring a box up.
+def configure_postgres
+<<BASH
+echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+wget --quiet https://www.postgresql.org/media/keys/ACCC4CF8.asc
+apt-key add ACCC4CF8.asc
+apt-get update
+apt-get install postgresql-9.2 -y
+echo "host    all             bofh            #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
+echo "host    oc_id           oc_id           #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
+echo "host    bifrost         bifrost         #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
+echo "host    opscode_chef    opscode_chef    #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
+echo "listen_addresses='*'" >> /etc/postgresql/9.2/main/postgresql.conf
+service postgresql restart
+export PATH=/usr/lib/postgresql/9.2/bin:$PATH
+sudo -u postgres psql -c "CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v0ps';"
+BASH
 end
 
 def base_path

--- a/dev/config.yml.example
+++ b/dev/config.yml.example
@@ -22,14 +22,26 @@ vm:
   # *before* the first reconfigure:
   omnibus-autoload: [private-chef-cookbooks]
 
+  postgresql:
+    # enable a separate postgres vm but do not use it unless
+    # use-external is set.
+    #  start: true
+
+    # When this is set true, and start is true,
+    # the chef-server node will be configured to use
+    # this vm as an external postgresql server from the start.
+    #  use-external: true
+
   # These will map directly to entries in the generated chef-server.rb
   node-attributes:
     provisioning:
-      # uncomment to enable default configuration of remote postgres node.
-      # This assumes that the postgres server is the host of this VM,
-      # and that you've configured a local superuser with user/pass below
+      # uncomment to enable configuration of an external postgres node
+      # using your host as the server. Note that if you have postgresql: use-vm-for-external
+      # set, that will override any customization ehre.
+      # This assumes that that you've configured a local superuser with user/pass below
       # and tcp-based access.
       #chef-server-config:
+      #  postgresql['external']: true
       #  postgresql['vip']:  "\"192.168.33.1\""
       #  postgresql['port']: 5432
       #  postgresql['db_superuser']: "\"bob\""

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -1,11 +1,27 @@
 # Anything in this file can be overridden in config.yml.
 #
 vm:
+  # Override this in config.yml if you want to bring up the
+  # postgres box, and if you want to automatically configure chef-server
+  # to use it as an externally managed postgres instance.
+  postgresql:
+    # enable a separate postgres vm but do not use it unless
+    # use-vm-for-external is set.
+    start: false
+    # When this is set true, and start is true,
+    # the chef-server node will be configured to use
+    # this vm as an external postgresql server from the start.
+    use-external: true
+
+  # All settings below apply only to the chef-server vm
   cpus: 4
   memory: 4096
   packages: [ ntp, curl, wget, htop, uuid-dev, tmux, vim, iotop ]
   omnibus-autoload: [] # see config.yml for details and to add components
+
   # TODO whitelist as well?
+  # Note that we can't exclude .git from top-level projects, and by extension from anything,
+  # otherwise rebar commands begin to fail.
   sync-exclude:
     - pkg/
     - deps/

--- a/dev/sync
+++ b/dev/sync
@@ -51,6 +51,8 @@ while true do
         suspend
       when ?h
         halt
+      when ?d
+        nuke
       else
         @screen.clear
         @screen.say_at 1, 1, banner
@@ -72,7 +74,7 @@ BEGIN {
     @all_stats = { walltime: 0.0,  transferred: 0, created: 0, deleted: 0, bytes: 0, time: 0.0}
     # Determine our ssh args up front, so we won't need to do this on every sync.
     ssh_info = {}
-    `vagrant ssh-config`.split("\n").each do |line|
+    `vagrant ssh-config chef-server`.split("\n").each do |line|
       k, v = line.split(" ")
       ssh_info[k.strip] = v.strip
     end
@@ -128,6 +130,16 @@ BEGIN {
     @screen.say_at 6, 5, "The VM will remain running, though sync is now terminated."
     @screen.say_at 7, 5, "To resume syncing, just run:"
     @screen.say_at 8, 8, "#{@screen.color(:magenta)}./sync#{@screen.endcolor}."
+    exit 0
+  end
+
+  def nuke
+    @screen.set_status "Destroying the VM(s), please wait..."
+    `vagrant destroy -f`
+    @screen.clear_status
+    @screen.say_at 6, 5, "VM destroyed."
+    @screen.say_at 7, 5, "To start the VM fresh and resume syncing, just run: "
+    @screen.say_at 8, 8, "#{@screen.color(:magenta)}vagrant up#{@screen.endcolor} && #{@screen.color(:magenta)}./sync#{@screen.endcolor}."
     exit 0
   end
 
@@ -244,6 +256,7 @@ BEGIN {
         (q) terminate and leave the VM running
         (h) terminate and halt the VM
         (s) terminate and suspend
+        (d) destroy the V
         Any other key to continue syncing
 EOM
   end


### PR DESCRIPTION
This PR allows you to also start up and configure a postgres VM for use as an external postgres instance with chef server. 

To start the vm, copy over config.yml.example to config.yml and uncomment the entry "vm: postgresql: start: true" 

To start the vm and use it as an external instance (will not work pending additional changes in flight) also uncomment the entrry: "vm: postgresql: use-external: true" 
