### PR TITLE
update private-chef-ctl so that it checks for root before proceeding

### DIFF
--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -56,6 +56,12 @@ do
   unset $ruby_env_var
 done
 
+ID=`id -u`
+if [ $ID -ne 0 ]; then
+   echo "This command must be run as root."
+   exit 1
+fi
+
 #{install_dir}/embedded/bin/omnibus-ctl opscode #{install_dir}/embedded/service/omnibus-ctl $@
        EOH
     end


### PR DESCRIPTION
Most private-chef-ctl commands will fail in an unhelpful manner if private-chef-ctl/chef-server-ctl is not run as root.  Add a check for root before invoking omnibus-ctl.

ping @chef/lob 