### PR TITLE
use tcp connections for all possible scenarios when adminstrating local db

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -163,7 +163,9 @@ module PrivateChef
           end
         end
       end
-      # Transitional from erchef's sql_user/password etc lived under 'postgresql' and not under opscode-erchef
+
+      # Transition from erchef's sql_user/password etc living under 'postgresql' in older versions,
+      # to 'opscode_erchef' in newer versions.
       if PrivateChef['postgresql'].has_key? 'sql_password'
         PrivateChef['opscode_erchef']['sql_password'] ||= PrivateChef['postgresql']['sql_password']
         PrivateChef['postgresql'].delete 'sql_password'
@@ -178,15 +180,16 @@ module PrivateChef
       me = PrivateChef["servers"][node_name]
       ha_guard = PrivateChef['topology'] == 'ha' && !me['bootstrap']
 
+      PrivateChef['postgresql']['db_superuser_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['redis_lb']['password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['jobs_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['rabbitmq']['actions_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['drbd']['shared_secret'] ||= generate_hex_if_bootstrap(30, ha_guard)
       PrivateChef['keepalived']['vrrp_instance_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
-      PrivateChef['oc_bifrost']['superuser_id'] ||= generate_hex_if_bootstrap(16, ha_guard)
       PrivateChef['opscode_erchef']['sql_password'] ||= generate_hex_if_bootstrap(30, ha_guard)
       PrivateChef['opscode_erchef']['sql_ro_password'] ||= generate_hex_if_bootstrap(30, ha_guard)
+      PrivateChef['oc_bifrost']['superuser_id'] ||= generate_hex_if_bootstrap(16, ha_guard)
       PrivateChef['oc_bifrost']['sql_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['oc_bifrost']['sql_ro_password'] ||= generate_hex_if_bootstrap(50, ha_guard)
       PrivateChef['oc_id']['secret_key_base'] ||= generate_hex_if_bootstrap(50, ha_guard)
@@ -205,6 +208,9 @@ module PrivateChef
                 'password' => PrivateChef['rabbitmq']['password'],
                 'jobs_password' => PrivateChef['rabbitmq']['jobs_password'],
                 'actions_password' => PrivateChef['rabbitmq']['actions_password'],
+              },
+              'postgresql' => {
+                'db_superuser_password' => PrivateChef['postgresql']['db_superuser_password']
               },
               'opscode-erchef' => {
                 'sql_password' => PrivateChef['opscode_erchef']['sql_password'],

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -7,28 +7,19 @@ use_inline_resources
 
 action :deploy do
   target = new_resource.target_version ? "--to-target #{new_resource.target_version}" : ""
-
-  # Note: the split behavior below will go away once we modify managed local psql
-  # to use permit password + tcp for postgres user on localhost.
-  if node['private_chef']['postgresql']['external']
-    run_user = Process.uid
-    auth_info = "--db-host #{new_resource.hostname} --db-port #{new_resource.port} --db-user #{new_resource.username}"
-  else
-    auth_info = ""
-    run_user = new_resource.username
-  end
-
   converge_by "Deploying schema from #{new_resource.name}" do
     execute "sqitch_deploy_#{new_resource.name}" do
       command <<-EOM.gsub(/\s+/," ").strip!
-        sqitch --engine pg #{auth_info}
+        sqitch --engine pg
                --db-name #{new_resource.database}
+               --db-host #{new_resource.hostname}
+               --db-port #{new_resource.port}
+               --db-user #{new_resource.username}
                --top-dir #{new_resource.name}
                deploy #{target} --verify
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
                   "PGPASSWORD" => new_resource.password
-      user run_user
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
@@ -1,7 +1,7 @@
 # NOTE:
 #
-# Uses the value of node['private_chef']['postgresql']['username'] as
-# the user to run the user-creation psql command
+# Uses the value of node['private_chef']['postgresql']['db_superuser'] and ['db_superuser_password]
+# to make the connection to the postgres server.
 
 def whyrun_supported?
   true

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -123,6 +123,16 @@ if is_data_master?
   execute "/opt/opscode/bin/private-chef-ctl start postgresql" do
     retries 20
   end
+
+  # Update the postgresql superuser  with a password for tcp-based access.
+  private_chef_pg_user node['private_chef']['postgresql']['db_superuser'] do
+    password node['private_chef']['postgresql']['db_superuser_password']
+    # This initial password set must be done over local socket:
+    local_connection true
+    # Don't make superuser into a non-superuser...
+    superuser true
+  end
+
   # Set up a database for the opscode-pgsql user to log into automatically
   private_chef_pg_database "opscode-pgsql"
   include_recipe "private-chef::erchef_database"

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user.rb
@@ -13,3 +13,7 @@ attribute :password,
 attribute :superuser,
 :kind_of => [TrueClass, FalseClass],
 :default => false
+
+attribute :local_connection,
+:kind_of => [TrueClass, FalseClass],
+:default => false


### PR DESCRIPTION
Add a password for the opscode-pgsql superuser when non-external postgres is used, and from that point forward use password auth. 

The goal here is to ensure common connection behavior for all actions that apply to both a remote postgres instance and a local postgres instance, and to make use of other behaviors (connecting via pipe) explicit when needed for a local connection.

This also fixes a bug where the sql_user password for opscode-erchef was regenerated on every reconfigure. This was due to the fact that the password attribute is created under opscode-erchef during the initial run, but for all subsequent runs it can be found under opscode_erchef. 

/cc @chef/lob 
