### PR TITLE
Migration to decompress node data

### DIFF
--- a/src/chef-mover/src/mover_uncompress_serialized_objects_callback.erl
+++ b/src/chef-mover/src/mover_uncompress_serialized_objects_callback.erl
@@ -1,0 +1,67 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Jason Reed <jreed@chef.io>
+%% @copyright 2015 Chef, Inc.
+-module(mover_uncompress_serialized_objects_callback).
+
+-export([
+	 migration_init/0,
+	 migration_type/0,
+	 supervisor/0,
+	 migration_start_worker_args/2,
+	 error_halts_migration/0,
+	 reconfigure_object/2,
+	 migration_action/2,
+	 next_object/0
+	]).
+
+-record(node_record, {
+        'id',
+        'serialized_object'
+       }).
+
+-include("mover.hrl").
+
+migration_init() ->
+    mover_transient_migration_queue:initialize_queue(?MODULE,
+                                                     all_unconverted_nodes()),
+    ok.
+
+migration_start_worker_args(Object, AcctInfo) ->
+    [Object, AcctInfo].
+
+migration_action(Row, AcctInfo) ->
+    Id = Row#node_record.id,
+    SerializedObject = Row#node_record.serialized_object,
+    NewObject = chef_db_compression:decompress(SerializedObject),
+    {ok, _Num} = sqerl:execute(node_update_sql(), [Id, NewObject]),
+    ok.
+
+next_object() ->
+    mover_transient_migration_queue:next(?MODULE).
+
+migration_type() ->
+    <<"uncompress_serialized_objects">>.
+
+supervisor() ->
+    mover_transient_worker_sup.
+
+error_halts_migration() ->
+    true.
+
+reconfigure_object(_ObjectId, _AcctInfo) ->
+    no_op.
+
+all_unconverted_nodes() ->
+    {ok, Rows} = sqerl:execute(all_unconverted_nodes_sql(), []),
+    XF = sqerl_transformers:rows_as_records(node_record, record_info(fields, node_record)),
+    {ok, Data} = XF(Rows),
+    Data.
+
+all_unconverted_nodes_sql() ->
+    <<"SELECT id, serialized_object FROM nodes">>.
+
+node_update_sql() ->
+    <<"UPDATE nodes
+          SET serialized_object = $2
+        WHERE id = $1">>.


### PR DESCRIPTION
:construction: WIP, don't merge yet.

@marcparadise does this look plausible as a starting point for decompressing unnecessarily compressed data in postgres in chef-server? I tested it locally via

``` shell
$ dvm load chef-mover --force && dvm start chef-mover
erlang> mover_manager:migrate(all, 1, mover_uncompress_serialized_objects_callback).
```

and it seems to work fine, and work idempotently at that, since `chef_db_compression:uncompress` checks for the gzip magic number and does nothing if it's not present. Moreover because of that the frontend works fine without any further changes, independently of whether the underlying database items are compressed or not. e.g. I can run this migration, and chef-manage still happily lists node attributes. The questions I want to resolve before expecting substantive review are:
1. Is it important to hunt down all the other database columns that are compressed just like `serialized_object` in table `node`? There aren't that many of them, are there?
2. Is this compression noted in some schema file (formal or informal) that I should change? Or does the schema only say `bytea` and leave it at that?
3. Should I be batching this change org-by-org? I probably should, yeah? I could use some more information about how that ought to be done maximally idiomatically inside `chef-mover`

For the sake of not being redundant, the node `SELECT` might itself want to check for gzip magic number via a `WHERE NOT (get_byte(serialized_object, 0) = 31 AND get_byte(serialized_object, 1) = 139)` in case the migration gets interrupted, but as noted above, I think this is only a matter of performance, not correctness.

Also, it's worth noting that although I am putting up this PR first, it seems to me that the logically prior thing to do is to disable, in `chef_db_compression` itself, any compression of data going forward. I don't know of any downsides to having a database in a mixed state where old rows are gzipped and new rows aren't.
