### PR TITLE
silence oc_id warning about config.serve_static_assets

### DIFF
--- a/src/oc-id/config/environments/production.rb
+++ b/src/oc-id/config/environments/production.rb
@@ -20,7 +20,7 @@ OcId::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = true
+  config.serve_static_files = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
Silence this warning in Rails:

2015-07-13_22:31:57.76063 DEPRECATION WARNING: The configuration option `config.serve_static_assets` has been renamed to `config.serve_static_files` to clarify its role (it merely enables serving everything in the `public` folder and is unrelated to the asset pipeline). The `serve_static_assets` alias will be removed in Rails 5.0. Please migrate your configuration files accordingly. (called from block in <top (required)> at /opt/opscode/embedded/service/oc_id/config/environments/production.rb:23)