### PR TITLE
Add features for full-installation reindex to chef-server-ctl reindex

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/reindex.rb
+++ b/omnibus/files/private-chef-ctl-commands/reindex.rb
@@ -1,13 +1,143 @@
-# Copyright (c) 2013 Opscode, Inc.
-# All Rights Reserved
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'optparse'
+require 'chef/config'
+require 'chef/rest'
+require 'chef/org'
+require 'redis'
+
+def all_orgs
+  Chef::Config.from_file("/etc/opscode/pivotal.rb")
+  Chef::Org.list.keys
+end
+
+def expander_queue_size
+  output = `/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl list_queues -p /chef | awk '{sum += $2} END {print sum}'`
+  status = $?
+  if !status.success?
+    $stderr.puts "Failed to get queue size!"
+    exit 1
+  else
+    output.to_i
+  end
+end
+
+def wait_for_empty_queue
+  loop do
+    size = expander_queue_size
+    if size == 0
+      break
+    else
+      puts "\t#{size} objects remaining in queue"
+      sleep 1
+    end
+  end
+end
+
+def enqueue_data_for_org(org)
+  status = Dir.chdir(File.join(base_path, "embedded", "service", "opscode-erchef", "bin")) do
+    run_command("./reindex-opc-organization complete #{org} >/dev/null")
+  end
+  if !status.success?
+    $stderr.puts "Failed to enqueue data for #{org}!"
+  end
+end
+
+def redis
+  @redis ||= begin
+                 vip = running_config["private_chef"]["redis_lb"]["vip"]
+                 port = running_config["private_chef"]["redis_lb"]["port"]
+                 password = running_config["private_chef"]["redis_lb"]["password"]
+                 Redis.new(port: port, ip: vip, password: password)
+             end
+end
+
+def disable_api
+  puts "- Disabling the Chef API."
+  redis.hset("dl_default", "503_mode", true)
+end
+
+def enable_api
+  puts "- Re-enabling the Chef API"
+  redis.hdel("dl_default", "503_mode")
+end
+
+def do_reindex(orgs_to_reindex, options)
+  disable_api if options[:disable_api]
+
+  puts "- Enqueueing data for indexing."
+  orgs_to_reindex.each do |org|
+    enqueue_data_for_org(org)
+  end
+
+  if options[:wait]
+    puts "- Waiting for reindexing to complete"
+    wait_for_empty_queue
+  end
+ensure
+  enable_api if options[:disable_api]
+end
 
 add_command_under_category "reindex", "general", "Reindex all server data for a given organization", 2 do
   reindex_args = ARGV[3..-1] # Chop off first 3 args, keep the rest... that is, everything after "private-chef-ctl reindex"
-  organization = reindex_args[0]
+  options = {}
 
-  # Always perform a complete reindexing; if you want more granular options,
-  # use the reindex-opc-server escript directly
-  Dir.chdir(File.join(base_path, "embedded", "service", "opscode-erchef", "bin")) do
-    exec("./reindex-opc-organization complete #{organization}")
+  OptionParser.new do |opts|
+    opts.on("-w", "--wait", "Wait for reindex queue to clear before exiting") do |w|
+      options[:wait] = w
+    end
+
+    opts.on("-d", "--disable-api", "Disable writes during reindexing") do |n|
+      options[:disable_api] = n
+    end
+
+    opts.on("-a", "--all-orgs", "Reindex all organizations. Overrides any organizations provided as arguments.") do |a|
+      options[:all_orgs] = a
+    end
+
+    opts.on("-t", "--with-timing", "Print reindex timing information") do |a|
+      options[:with_timing] = a
+    end
+  end.parse!(reindex_args)
+
+  if options[:with_timing]
+    start_time = Time.now
+  end
+
+  orgs_to_reindex = if options[:all_orgs]
+                      puts "Reindexing all organizations"
+                      all_orgs
+                    else
+                      puts "Reindexing orgs: #{reindex_args.compact}"
+                      reindex_args.compact
+                    end
+
+  if orgs_to_reindex.length == 0 && options[:all_orgs]
+    puts "No organizations to reindex"
+    exit 0
+  elsif orgs_to_reindex.length == 0
+    $stderr.puts "Please specify an organization to reindex or use the --all-orgs flag"
+    exit 1
+  end
+
+  do_reindex(orgs_to_reindex, options)
+
+  if options[:with_timing]
+    puts "#{Time.now - start_time} seconds to reindex."
+    exit 0
   end
 end


### PR DESCRIPTION
This adds the following features to `chef-server-ctl reindex`:

- an --all-orgs flag to reindex all organizations on the server,

- a --wait flag to wait for the reindex queue to empty before
  returning,

- a --disable-api flag to put the API into 503 mode at the start of an
  index, and

- a --with-timings flag to report the total time, useful for testing.