### PR TITLE
Make license endpoint return number of nodes in existing orgs

### DIFF
--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -20,7 +20,7 @@
 {ping, <<"SELECT 'pong' as ping LIMIT 1">>}.
 
 %% Query to count the number of nodes for license checks
-{count_nodes, <<"SELECT COUNT(*) as count FROM nodes">>}.
+{count_nodes, <<"SELECT COUNT(*) FROM nodes INNER JOIN orgs ON nodes.org_id = orgs.id;">>}.
 
 
 {find_node_by_orgid_name,


### PR DESCRIPTION
@stevendanna This fixes https://github.com/chef/chef-server/issues/437.