### PR TITLE
bookshelf-receiver and keepalived scaffold

### DIFF
--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -109,6 +109,10 @@ projects:
         source_path: private-chef-cookbooks/chef-ha-drbd
         dest_path: /opt/opscode/embedded/cookbooks/chef-ha-drbd
         reconfigure_on_load: true
+      ha-native-cookbooks:
+        source_path: private-chef-cookbooks/chef-ha-native
+        dest_path: /opt/opscode/embedded/cookbooks/chef-ha-native
+        reconfigure_on_load: true
 
   oc-chef-pedant:
     type: ruby

--- a/omnibus/Makefile
+++ b/omnibus/Makefile
@@ -4,7 +4,7 @@
 #
 # e.g., 'make -f build_node.mk $TARGET'
 
-DEV_PLATFORM ?= ubuntu-1004
+DEV_PLATFORM ?= ubuntu-1204
 DEV_PROJECT=opscode-omnibus
 
 .DEFAULT_GOAL=dev

--- a/omnibus/config/software/chef-ha-plugin-config.rb
+++ b/omnibus/config/software/chef-ha-plugin-config.rb
@@ -26,6 +26,11 @@ plugin "chef-ha-drbd" do
   enabled_by_default false
   cookbook_path "/opt/opscode/embedded/cookbooks"
 end
+
+plugin "chef-ha-native" do
+  enabled_by_default false
+  cookbook_path "/opt/opscode/embedded/cookbooks"
+end
 EOF
     end
   end

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/attributes/default.rb
@@ -1,0 +1,11 @@
+#######
+# Bookshelf Receiver
+#######
+default['private_chef']['bookshelf-receiver']['enable'] = true
+default['private_chef']['bookshelf-sender']['ha'] = true
+default['private_chef']['bookshelf-receiver']['dir'] = "/var/opt/opscode/bookshelf-receiver"
+default['private_chef']['bookshelf-receiver']['log_directory'] = "/var/log/opscode/bookshelf-receiver"
+default['private_chef']['bookshelf-receiver']['log_rotation']['file_maxbytes'] = 104857600
+default['private_chef']['bookshelf-receiver']['log_rotation']['num_to_keep'] = 10
+default['private_chef']['bookshelf-receiver']['listen'] = '0.0.0.0'
+default['private_chef']['bookshelf-receiver']['port'] = 11873

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/metadata.rb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/metadata.rb
@@ -1,0 +1,13 @@
+name "chef-ha-native"
+maintainer        "Chef Software, Inc."
+maintainer_email  "cookbooks@chef.io"
+license           "Apache 2.0"
+description       "Sets up UNRELEASED per-service replication for Chef Server"
+long_description  "Sets up UNRELEASED per-service replication for Chef Server"
+version           "0.1.0"
+
+%w{ ubuntu debian redhat centos oracle scientific fedora amazon }.each do |os|
+  supports os
+end
+
+depends "enterprise"

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/recipes/bookshelf-receiver.rb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/recipes/bookshelf-receiver.rb
@@ -1,0 +1,46 @@
+# Copyright 2014 Chef Software Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License.  You
+# may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.  See the License for the specific language governing
+# permissions and limitations under the License.
+
+bookshelf_receiver_dir = node['private_chef']['bookshelf-receiver']['dir']
+bookshelf_receiver_etc_dir = ::File.join(bookshelf_receiver_dir, 'etc')
+bookshelf_receiver_log_dir = node['private_chef']['bookshelf-receiver']['log_directory']
+
+[
+  bookshelf_receiver_dir,
+  bookshelf_receiver_etc_dir,
+  bookshelf_receiver_log_dir
+].each do |dir|
+  directory dir do
+    owner OmnibusHelper.new(node).ownership['owner']
+    group OmnibusHelper.new(node).ownership['group']
+    mode node['private_chef']['service_dir_perms']
+    recursive true
+  end
+end
+
+rsyncd_config = ::File.join(bookshelf_receiver_etc_dir, "rsyncd.conf")
+template rsyncd_config do
+  source "rsyncd.conf.erb"
+  owner "root"
+  owner "root"
+  variables(node['private_chef']['bookshelf-receiver'])
+end
+
+directory "#{node['runit']['sv_dir']}/bookshelf-receiver"
+
+file "#{node['runit']['sv_dir']}/bookshelf-receiver/down" do
+  action :create
+end
+
+component_runit_service "bookshelf-receiver"

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe "chef-ha-native::enable"

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/recipes/enable.rb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/recipes/enable.rb
@@ -1,0 +1,59 @@
+#
+# Author:: Steven Danna (<steve@chef.io>)
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if ENV["IM_A_CHEF_DEVELOPER_AND_KNOW_THE_CONSEQUENCES"].nil?
+  Chef::Log.error <<EOF
+
+You have tried to enable an unreleased feature of Chef Server.  Thank
+you for your interest, but this feature is not yet ready for
+prime-time!  In fact, it might not even be close to working!
+
+If you are interested in testing this feature in development, please
+set the environment variable IM_A_CHEF_DEVELOPER_AND_KNOW_THE_CONSEQUENCES.
+EOF
+  exit!(1)
+else
+  Chef::Log.warn <<EOF
+
+
+You have enabled an unreleased feature of Chef Server. Please be aware
+that this feature is not yet ready for release.  It might not even be
+close to working!
+
+By enabling this feature, you agree to the following oath:
+
+On my honor, I will not use this feature in production. I swear to
+fix the bugs I find and be suspicious of the ones I don't. I will
+leave the code better than when I found it.
+EOF
+end
+
+directory "#{node['private_chef']['keepalived']['dir']}/bin" do
+  recursive true
+end
+
+# TODO We should name this file, but for now this lets us hook into an
+# unmodified cluster.sh for testing
+template "#{node['private_chef']['keepalived']['dir']}/bin/ha_backend_storage" do
+  source "ha_backend_storage_native.erb"
+  owner "root"
+  group "root"
+  mode "0755"
+end
+
+include_recipe "chef-ha-native::bookshelf-receiver"

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/ha_backend_storage_native.erb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/ha_backend_storage_native.erb
@@ -1,0 +1,123 @@
+#!/bin/bash
+# vim: sw=2 sts=2 et ts=8:
+LOGNAME=/var/log/opscode/keepalived/cluster.log
+
+function log_me
+{
+  echo $1
+  echo "$(date -R): ${1}" >> $LOGNAME
+}
+
+function error_exit
+{
+  log_me "$1"
+  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+# 10 * SVWAIT
+try=300
+
+ACTION="$1"
+
+transition_postgresql_master() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+transition_bookshelf_master() {
+    log_me "Stopping receiver, starting bookshelf"
+    chef-server-ctl stop bookshelf-receiver
+    chef-server-ctl start bookshelf
+}
+
+transition_rabbitmq_master() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+transition_solr_master() {
+    log_me "Rebuilding solr index..."
+    # Postgresql, Rabbit, Expander, and Solr must all but up for
+    # reindexing
+    #
+    # Postgresql should already be transitioned to master
+    #
+    chef-server-ctl start rabbitmq
+    chef-server-ctl start opscode-expander
+    chef-server-ctl start opscode-erchef
+    chef-server-ctl start opscode-solr4
+    # TODO: We need a status command to tell us when we are ready to
+    # reindex, otherwise we need to sleep
+    chef-server-ctl reindex --all-orgs --wait
+}
+
+transition_redis_master() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+transition_postgresql_backup() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+transition_bookshelf_backup() {
+    log_me "Stopping bookshelf, starting receiver"
+    chef-server-ctl stop bookshelf
+    chef-server-ctl start bookshelf-receiver
+}
+
+transition_rabbitmq_backup() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+transition_solr_backup() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+transition_redis_backup() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+postgresql_status() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+bookshelf_status() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+rabbit_status() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+solr_status() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+redis_status() {
+    log_me "I have no idea how to do that.  Good luck, Chief."
+}
+
+case $ACTION in
+    attach)
+        transition_postgresql_master
+        transition_bookshelf_master
+        transition_rabbitmq_master
+        transition_solr_master
+        transition_redis_master
+        log_me "Backend storage services transitioned to master"
+        ;;
+    detach)
+        transition_postgresql_backup
+        transition_bookshelf_backup
+        transition_rabbitmq_backup
+        transition_solr_backup
+        transition_redis_backup
+        log_me "Backend storage services transitioned to backup"
+        ;;
+    status)
+        postgresql_status
+        bookshelf_status
+        rabbitmq_status
+        solr_status
+        redis_status
+        ;;
+esac

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/rsyncd.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/rsyncd.conf.erb
@@ -1,0 +1,11 @@
+pid file = <%= @dir -%>/rsync.pid
+port = <%= @port -%>
+address = <%= @listen -%>
+
+[bookshelf]
+use chroot = no
+uid = <%= node['private_chef']['user']['username'] %>
+read only = no
+write only = yes
+path = <%= node['private_chef']['bookshelf']['data_dir'] %>
+auth user = <%= node['private_chef']['user']['username'] %>

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/sv-bookshelf-receiver-log-run.erb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/sv-bookshelf-receiver-log-run.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec chpst -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> \
+  svlogd -tt <%= @options[:log_directory] %>

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/sv-bookshelf-receiver-run.erb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/sv-bookshelf-receiver-run.erb
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+
+exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> rsync --daemon --no-detach --config <%= node['private_chef']['bookshelf-receiver']['dir'] %>/etc/rsyncd.conf --log-file /dev/stdout

--- a/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/sv-bookshelf-receiver-run.erb
+++ b/omnibus/files/private-chef-cookbooks/chef-ha-native/templates/default/sv-bookshelf-receiver-run.erb
@@ -1,4 +1,11 @@
 #!/bin/sh
 exec 2>&1
 
-exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> rsync --daemon --no-detach --config <%= node['private_chef']['bookshelf-receiver']['dir'] %>/etc/rsyncd.conf --log-file /dev/stdout
+# Don't allow bookshelf-receiver to come up if bookshelf is still
+# running
+if chef-server-ctl wait bookshelf -d -t10
+then
+    exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> rsync --daemon --no-detach --config <%= node['private_chef']['bookshelf-receiver']['dir'] %>/etc/rsyncd.conf --log-file /dev/stdout
+else
+    exit 1
+fi

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/plugins.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/plugins.rb
@@ -14,6 +14,6 @@ plugins.each do |plugin|
   next if !plugin.parent_plugin.nil?
   chef_run plugin.run_list do
     cookbook_path plugin.cookbook_path
-    included_attrs ["private_chef"]
+    included_attrs ["private_chef", "runit"]
   end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-bookshelf-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-bookshelf-run.erb
@@ -1,4 +1,11 @@
 #!/bin/sh
 exec 2>&1
 
-exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> env HOME=<%= node['private_chef']['bookshelf']['dir'] %> /opt/opscode/embedded/service/bookshelf/bin/bookshelf foreground
+# Don't allow bookshelf to come up if bookshelf-receiver is still
+# running
+if chef-server-ctl wait bookshelf-receiver -d -t10
+then
+    exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> env HOME=<%= node['private_chef']['bookshelf']['dir'] %> /opt/opscode/embedded/service/bookshelf/bin/bookshelf foreground
+else
+    exit 1
+fi

--- a/omnibus/files/private-chef-ctl-commands/wait.rb
+++ b/omnibus/files/private-chef-ctl-commands/wait.rb
@@ -1,0 +1,71 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'optparse'
+
+def check_services(service_names)
+  statuses = service_names.map do |svc|
+    check_service(svc)
+  end
+  return statuses
+end
+
+def check_service(service_name)
+  status = run_command("#{base_path}/init/#{service_name} status >/dev/null 2>&1")
+  status.success?
+end
+
+add_command_under_category "wait", "service-management", "Wait for a given service to be up", 2 do
+  wait_args = ARGV[3..-1]
+  options = {}
+
+  OptionParser.new do |opts|
+    opts.on("-t SECONDS", "--timeout SECONDS", "Timeout after SECONDS seconds.") do |t|
+      options[:timeout] = t.to_i
+    end
+
+    opts.on("-d", "--down", "Wait until the services are down rather than up") do |d|
+      options[:down] = d
+    end
+  end.parse!(wait_args)
+
+  service_names = wait_args
+  start_msg = "Waiting for service#{ service_names.length > 1 ? "s" : ""}: #{service_names.join(" ")} to be "
+  if options[:down]
+    start_msg << "down"
+  else
+    start_msg << "up"
+  end
+
+  begin
+    Timeout::timeout(options[:timeout]) do
+      loop do
+        status = check_services(service_names)
+        if options[:down]
+          break if status.none?
+        else
+          break if status.all?
+        end
+        sleep 0.25
+      end
+    end
+  rescue Timeout::Error
+    $stderr.puts "Timed out after #{options[:timeout]} seconds"
+    exit 1
+  end
+
+  exit 0
+end


### PR DESCRIPTION
This pull request adds:

- configuration for the bookshelf-receiver rsyncd instance
- scaffolding for performing a failover without using DRBD.  Right now this scaffolding mostly does not actually work, but is there for future development.