### PR TITLE
Removed all ../../includes from -include directives

### DIFF
--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_clients.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_clients.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 %%%======================================================================
 %%% CLIENTS

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_cookbook_deps.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_cookbook_deps.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 
 test_all() ->

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_cookbook_recipes.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_cookbook_recipes.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 test_all() ->
     [ test_one(Description, Specs) || {Description, Specs} <- cbv_specs() ].

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_cookbook_versions.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_cookbook_versions.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 %%%======================================================================
 %%% COOKBOOKS

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_data_bag.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_data_bag.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 %%%======================================================================
 %%% DATA BAGS

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_data_bag_item.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_data_bag_item.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 %%%======================================================================
 %%% DATA BAG ITEMS

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_environment_cookbooks.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_environment_cookbooks.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 test_all() ->
     [ environment_cookbooks_test(Description,

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_latest_cookbooks.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_latest_cookbooks.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 test_all() ->
     [ test_latest_cookbooks(Desc, Specs, NumVersions, Expected)

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_nodes.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_nodes.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 %%%======================================================================
 %%% NODES

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_sandboxes.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_sandboxes.erl
@@ -3,8 +3,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 %%%======================================================================
 %%% SANDBOXES AND CHECKSUMS

--- a/src/oc_erchef/apps/chef_db/itest/chef_sql_users.erl
+++ b/src/oc_erchef/apps/chef_db/itest/chef_sql_users.erl
@@ -24,8 +24,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 -define(PUBLIC_KEY, <<"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwxOFcrbsV7bEbqzOvW5u"
 		      "W5lyB23qsenlUdIGyRttqzGEaki01s7X+PpYy4BLfmVVmA6A6FCbL38CzzTUFX1a"

--- a/src/oc_erchef/apps/chef_db/itest/itest_cookbook_util.erl
+++ b/src/oc_erchef/apps/chef_db/itest/itest_cookbook_util.erl
@@ -24,8 +24,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 %%------------------------------------------------------------------------------
 %% Cookbook-related Helper Functions

--- a/src/oc_erchef/apps/chef_db/itest/itest_util.erl
+++ b/src/oc_erchef/apps/chef_db/itest/itest_util.erl
@@ -24,8 +24,8 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
 
 create_record(Record) ->
     chef_test_suite_helper:create_record(Record).

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -91,10 +91,10 @@
          list_all_policy_revisions_by_orgid/2,
          find_all_policy_revisions_by_group_and_name/2]).
 
--include("../../include/chef_db.hrl").
--include("../../include/chef_types.hrl").
--include("../../include/oc_chef_types.hrl").
--include("../../include/chef_osc_defaults.hrl").
+-include("chef_db.hrl").
+-include("chef_types.hrl").
+-include("oc_chef_types.hrl").
+-include("chef_osc_defaults.hrl").
 -include_lib("stats_hero/include/stats_hero.hrl").
 
 -record(context, {server_api_version,

--- a/src/oc_erchef/apps/chef_db/src/chef_sql.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_sql.erl
@@ -26,7 +26,7 @@
 
 -module(chef_sql).
 
--include("../../include/chef_db.hrl").
+-include("chef_db.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -112,7 +112,7 @@
         ]).
 
 -include_lib("sqerl/include/sqerl.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -type delete_query() :: atom().
 

--- a/src/oc_erchef/apps/chef_db/test/chef_db_tests.erl
+++ b/src/oc_erchef/apps/chef_db/test/chef_db_tests.erl
@@ -20,7 +20,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -define(REQ_ID, <<"req-id-123">>).
 

--- a/src/oc_erchef/apps/chef_db/test/chef_sql_tests.erl
+++ b/src/oc_erchef/apps/chef_db/test/chef_sql_tests.erl
@@ -18,5 +18,5 @@
 -module(chef_sql_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 

--- a/src/oc_erchef/apps/chef_index/src/chef_index_queue.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_queue.erl
@@ -28,7 +28,7 @@
 -compile([export_all]).
 -endif.
 
--include("../../include/chef_index.hrl").
+-include("chef_index.hrl").
 
 -type uuid_binary() :: <<_:288>> | <<_:256>>. %% with|without hypens are both allowed
 -type chef_db_name() :: binary().

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -34,7 +34,7 @@
          solr_commit/0
         ]).
 
--include("../../include/chef_solr.hrl").
+-include("chef_solr.hrl").
 
 -spec make_query_from_params(binary()|string(),
                              string() | binary() | undefined,

--- a/src/oc_erchef/apps/chef_index/test/chef_index_sup_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_sup_tests.erl
@@ -18,7 +18,7 @@
 -module(chef_index_sup_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_solr.hrl").
+-include("chef_solr.hrl").
 
      
 server_for_vhost_test() ->

--- a/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
@@ -18,7 +18,7 @@
 -module(chef_solr_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_solr.hrl").
+-include("chef_solr.hrl").
 
 %expect_params(Params) ->
     %meck:expect(wrq, get_qs_value, fun(Key, req_mock) ->

--- a/src/oc_erchef/apps/chef_objects/src/chef_client.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_client.erl
@@ -21,8 +21,8 @@
 -module(chef_client).
 
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
--include("../../include/chef_osc_defaults.hrl").
+-include("chef_types.hrl").
+-include("chef_osc_defaults.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 -export([
@@ -359,4 +359,3 @@ default_field_values(_) ->
 
 set_api_version(ObjectRec, Version) ->
     ObjectRec#chef_client{server_api_version = Version}.
-

--- a/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
@@ -21,7 +21,7 @@
 
 -module(chef_cookbook_version).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 

--- a/src/oc_erchef/apps/chef_objects/src/chef_data_bag.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_data_bag.erl
@@ -21,7 +21,7 @@
 
 -module(chef_data_bag).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 -export([
          authz_id/1,

--- a/src/oc_erchef/apps/chef_objects/src/chef_data_bag_item.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_data_bag_item.erl
@@ -23,7 +23,7 @@
 -module(chef_data_bag_item).
 
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -behaviour(chef_object).
 -export([

--- a/src/oc_erchef/apps/chef_objects/src/chef_db_compression.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_db_compression.erl
@@ -26,7 +26,7 @@
          decompress/1,
          decompress_and_decode/1]).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -type chef_compressable() :: 'chef_data_bag_item'
                           | 'chef_environment'

--- a/src/oc_erchef/apps/chef_objects/src/chef_depsolver.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_depsolver.erl
@@ -35,8 +35,8 @@
 -compile(export_all).
 -endif.
 
--include("../../include/chef_types.hrl").
--include("../../include/chef_regex.hrl").
+-include("chef_types.hrl").
+-include("chef_regex.hrl").
 
  %% @doc the input into the depsolver is a single run_list
 -define(VALIDATION_CONSTRAINTS,

--- a/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
@@ -45,7 +45,7 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl"). %% TODO: remove
 -endif.
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 %%%===================================================================
 %%% API

--- a/src/oc_erchef/apps/chef_objects/src/chef_environment.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_environment.erl
@@ -24,7 +24,7 @@
 
 -include_lib("mixer/include/mixer.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -export([
          authz_id/1,

--- a/src/oc_erchef/apps/chef_objects/src/chef_json.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_json.erl
@@ -27,7 +27,7 @@
          encode/1
         ]).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -spec decode(binary() | iolist()) -> jiffy:json_value().
 decode(Bin) ->

--- a/src/oc_erchef/apps/chef_objects/src/chef_json_validator.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_json_validator.erl
@@ -32,7 +32,7 @@
 -compile(export_all).
 -endif.
 
--include("../../include/chef_regex.hrl").
+-include("chef_regex.hrl").
 
 %% @doc `ej:valid/2` spec for attribute hashes.  This can be used for,
 %% e.g., a node's default, override, normal, and automatic attributes,

--- a/src/oc_erchef/apps/chef_objects/src/chef_key.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_key.erl
@@ -22,7 +22,7 @@
 -module(chef_key).
 
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -behaviour(chef_object).
 

--- a/src/oc_erchef/apps/chef_objects/src/chef_key_base.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_key_base.erl
@@ -21,7 +21,7 @@
 
 -module(chef_key_base).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -export([maybe_generate_key_pair/1,
          maybe_generate_key_pair/2,

--- a/src/oc_erchef/apps/chef_objects/src/chef_node.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_node.erl
@@ -21,7 +21,7 @@
 
 -module(chef_node).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 -export([

--- a/src/oc_erchef/apps/chef_objects/src/chef_object.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_object.erl
@@ -21,7 +21,7 @@
 
 -module(chef_object).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 -include_lib("ej/include/ej.hrl").
 
 -type object_rec() :: tuple().

--- a/src/oc_erchef/apps/chef_objects/src/chef_object_base.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_object_base.erl
@@ -25,7 +25,7 @@
 %% "Chef Objects", such as nodes, roles, etc.
 -module(chef_object_base).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 -include_lib("ej/include/ej.hrl").
 
 -export([

--- a/src/oc_erchef/apps/chef_objects/src/chef_regex.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_regex.erl
@@ -34,7 +34,7 @@
 -compile(export_all).
 -endif.
 
--include("../../include/chef_regex.hrl").
+-include("chef_regex.hrl").
 
 %% Regular Expression Macros
 %% (Just to help DRY things up and make the usage patterns a little more clear)

--- a/src/oc_erchef/apps/chef_objects/src/chef_role.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_role.erl
@@ -24,7 +24,7 @@
 
 
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -export([
          authz_id/1,

--- a/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
@@ -25,7 +25,7 @@
 
 -module(chef_s3).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -export([
          check_checksums/2,

--- a/src/oc_erchef/apps/chef_objects/src/chef_s3_ops.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_s3_ops.erl
@@ -22,7 +22,7 @@
 
 -module(chef_s3_ops).
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -export([
          delete/2,

--- a/src/oc_erchef/apps/chef_objects/src/chef_sandbox.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_sandbox.erl
@@ -35,7 +35,7 @@
 -compile(export_all).
 -endif.
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -define(VALIDATION_CONSTRAINTS,
         {[

--- a/src/oc_erchef/apps/chef_objects/src/chef_user.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_user.erl
@@ -22,7 +22,7 @@
 
 -include_lib("mixer/include/mixer.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -export([assemble_user_ejson/2,
          authz_id/1,

--- a/src/oc_erchef/apps/chef_objects/test/chef_client_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_client_tests.erl
@@ -21,8 +21,8 @@
 
 
 -module(chef_client_tests).
--include("../../include/chef_types.hrl").
--include("../../include/chef_osc_defaults.hrl").
+-include("chef_types.hrl").
+-include("chef_osc_defaults.hrl").
 -include_lib("ej/include/ej.hrl").
 -include_lib("eunit/include/eunit.hrl").
 

--- a/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
@@ -23,7 +23,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -define(MAX_GOOD_VERSION, "9223372036854775807").
 -define(MAX_GOOD_VERSION_INT, list_to_integer(?MAX_GOOD_VERSION)).

--- a/src/oc_erchef/apps/chef_objects/test/chef_data_bag_item_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_data_bag_item_tests.erl
@@ -7,7 +7,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 validate_data_bag_item_test_() ->
     [

--- a/src/oc_erchef/apps/chef_objects/test/chef_data_bag_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_data_bag_tests.erl
@@ -7,7 +7,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 validate_data_bag_test_() ->
     [

--- a/src/oc_erchef/apps/chef_objects/test/chef_depsolver_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_depsolver_tests.erl
@@ -24,8 +24,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_osc_defaults.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_osc_defaults.hrl").
+-include("chef_types.hrl").
 -compile([export_all]).
 
 -define(NEEDED_APPS, [ pooler ]).

--- a/src/oc_erchef/apps/chef_objects/test/chef_environment_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_environment_tests.erl
@@ -22,7 +22,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 new_record_test() ->
     OrgId = <<"12345678123456781234567812345678">>,

--- a/src/oc_erchef/apps/chef_objects/test/chef_key_base_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_key_base_tests.erl
@@ -23,7 +23,7 @@
 -module(chef_key_base_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 public_key_data() ->
     {ok, Bin} = file:read_file("../test/spki_public.pem"),

--- a/src/oc_erchef/apps/chef_objects/test/chef_key_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_key_tests.erl
@@ -21,7 +21,7 @@
 -module(chef_key_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -define(KEY_NAME, <<"test_key">>).
 -define(DEFAULT_EXPIRATION, <<"2099-10-24T22:49:08Z">>).

--- a/src/oc_erchef/apps/chef_objects/test/chef_node_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_node_tests.erl
@@ -19,7 +19,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 extended_node() ->
     {[{<<"name">>, <<"a_node">>},

--- a/src/oc_erchef/apps/chef_objects/test/chef_object_base_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_object_base_tests.erl
@@ -23,7 +23,7 @@
 -module(chef_object_base_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 depsolver_constraints_test_() ->
     {foreachx,

--- a/src/oc_erchef/apps/chef_objects/test/chef_role_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_role_tests.erl
@@ -23,7 +23,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 basic_role() ->
     {[

--- a/src/oc_erchef/apps/chef_objects/test/chef_sandbox_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_sandbox_tests.erl
@@ -23,7 +23,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("ej/include/ej.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 validate_sandbox_test_() ->
     [

--- a/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
@@ -20,8 +20,8 @@
 
 -module(chef_user_tests).
 
--include("../../include/chef_types.hrl").
--include("../../include/chef_osc_defaults.hrl").
+-include("chef_types.hrl").
+-include("chef_osc_defaults.hrl").
 -include_lib("ej/include/ej.hrl").
 -include_lib("eunit/include/eunit.hrl").
 

--- a/src/oc_erchef/apps/chef_objects/test/test_utils.erl
+++ b/src/oc_erchef/apps/chef_objects/test/test_utils.erl
@@ -17,10 +17,8 @@
 %% specific language governing permissions and limitations
 %% under the License.
 %%
-
 -module(test_utils).
 -export([
-
          mock/1,
          mock/2,
          unmock/1,
@@ -37,7 +35,7 @@
         ]).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/server_api_version.hrl").
+-include("server_api_version.hrl").
 
 %% helper functions for configuring mocking.
 

--- a/src/oc_erchef/apps/oc_chef_authz/itest/oc_chef_authz_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/itest/oc_chef_authz_SUITE.erl
@@ -23,9 +23,9 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include("../../include/oc_chef_authz.hrl").
--include("../../include/oc_chef_types.hrl").
--include("../../include/server_api_version.hrl").
+-include("oc_chef_authz.hrl").
+-include("oc_chef_types.hrl").
+-include("server_api_version.hrl").
 
 -compile([export_all]).
 

--- a/src/oc_erchef/apps/oc_chef_authz/itest/oc_chef_authz_policies_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/itest/oc_chef_authz_policies_SUITE.erl
@@ -23,9 +23,9 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
--include("../../include/oc_chef_authz.hrl").
--include("../../include/oc_chef_types.hrl").
--include("../../include/server_api_version.hrl").
+-include("oc_chef_authz.hrl").
+-include("oc_chef_types.hrl").
+-include("server_api_version.hrl").
 -compile([export_all]).
 
 %% Note: this is also defined in the schema test data

--- a/src/oc_erchef/apps/oc_chef_authz/itest/oc_chef_group_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/itest/oc_chef_group_SUITE.erl
@@ -25,8 +25,8 @@
 -compile(export_all).
 
 -include_lib("common_test/include/ct.hrl").
--include("../../include/oc_chef_types.hrl").
--include("../../include/chef_types.hrl").
+-include("oc_chef_types.hrl").
+-include("chef_types.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(CTX, chef_db:make_context(?API_MIN_VER, <<"req_id">>)).

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.erl
@@ -55,8 +55,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--include("../../include/server_api_version.hrl").
--include("../../include/oc_chef_authz.hrl").
+-include("server_api_version.hrl").
+-include("oc_chef_authz.hrl").
 -include("oc_chef_authz_db.hrl").
 
 -export_type([oc_chef_authz_context/0]).

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
@@ -6,8 +6,8 @@
 
 -module(oc_chef_authz_acl).
 
--include("../../include/oc_chef_types.hrl").
--include("../../include/chef_types.hrl").
+-include("oc_chef_types.hrl").
+-include("chef_types.hrl").
 
 
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_cleanup.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_cleanup.erl
@@ -60,7 +60,7 @@
 -define(DEFAULT_BATCH_SIZE, 2500).
 -define(DEFAULT_INTERVAL, 1000).
 
--include("../../include/oc_chef_authz.hrl").
+-include("oc_chef_authz.hrl").
 -include("oc_chef_authz_cleanup.hrl").
 
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.erl
@@ -23,8 +23,8 @@
 
 -module(oc_chef_authz_db).
 
--include("../../include/oc_chef_types.hrl").
--include("../../include/server_api_version.hrl").
+-include("oc_chef_types.hrl").
+-include("server_api_version.hrl").
 
 -export([container_record_to_authz_id/2,
          fetch_container/3,
@@ -41,12 +41,12 @@
 -compile([export_all]).
 -endif.
 
--include("../../include/oc_chef_authz.hrl").
+-include("oc_chef_authz.hrl").
 -include("oc_chef_authz_db.hrl").
 -include_lib("sqerl/include/sqerl.hrl").
 
 %% TODO Fix:
-%% -include("../../include/chef_types.hrl").
+%% -include("chef_types.hrl").
 %% can't include this because it also defines object_id
 %% So copied this over for the short term.
 -define(GLOBAL_PLACEHOLDER_ORG_ID, <<"00000000000000000000000000000000">>).

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
@@ -20,9 +20,9 @@
 %% Future directions:
 %% We will probably want to make the default starting group of a user configurable
 
--include("../../include/oc_chef_authz.hrl").
--include("../../include/oc_chef_types.hrl").
--include("../../include/chef_types.hrl").
+-include("oc_chef_authz.hrl").
+-include("oc_chef_types.hrl").
+-include("chef_types.hrl").
 
 %% This is an ACE in human readable form, with chef objects, not
 -record(hr_ace, {clients = [],

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_container.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_container.erl
@@ -5,9 +5,9 @@
 
 -module(oc_chef_container).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -behaviour(chef_object).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_cookbook_artifact.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_cookbook_artifact.erl
@@ -20,8 +20,8 @@
 
 -module(oc_chef_cookbook_artifact).
 
--include("../../include/chef_types.hrl").
--include("../../include/oc_chef_types.hrl").
+-include("chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 -behaviour(chef_object).

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_cookbook_artifact_version.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_cookbook_artifact_version.erl
@@ -20,8 +20,8 @@
 
 -module(oc_chef_cookbook_artifact_version).
 
--include("../../include/chef_types.hrl").
--include("../../include/oc_chef_types.hrl").
+-include("chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 -include_lib("ej/include/ej.hrl").
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_group.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_group.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_group).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 -behaviour(chef_object).

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_org_user_association.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_org_user_association.erl
@@ -5,9 +5,9 @@
 
 -module(oc_chef_org_user_association).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -behaviour(chef_object).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_org_user_invite.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_org_user_invite.erl
@@ -6,9 +6,9 @@
 
 -module(oc_chef_org_user_invite).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -behaviour(chef_object).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_organization.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_organization.erl
@@ -6,9 +6,9 @@
 
 -module(oc_chef_organization).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 
 -behaviour(chef_object).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy.erl
@@ -20,7 +20,7 @@
 
 -module(oc_chef_policy).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 -behaviour(chef_object).

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group.erl
@@ -20,7 +20,7 @@
 
 -module(oc_chef_policy_group).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 -behaviour(chef_object).

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group_revision_association.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group_revision_association.erl
@@ -21,7 +21,7 @@
 -module(oc_chef_policy_group_revision_association).
 
 -include_lib("mixer/include/mixer.hrl").
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 
 % TOD - is this supposed to be a chef_object? It looks kind of like one, but missing serveral things.
 -export([find_policy_revision_by_orgid_name_group_name/2,

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_revision.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_revision.erl
@@ -20,7 +20,7 @@
 
 -module(oc_chef_policy_revision).
 
--include("../../include/oc_chef_types.hrl").
+-include("oc_chef_types.hrl").
 -include_lib("mixer/include/mixer.hrl").
 
 -behaviour(chef_object).

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
@@ -29,7 +29,7 @@
 %%          test_setup/0,
 %%          test_cleanup/1]).
 
--include("../../include/oc_chef_authz.hrl").
+-include("oc_chef_authz.hrl").
 
 %-define(setup, oc_chef_authz_tests).
 -define(setup, test_utils).

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -23,7 +23,7 @@
 -type dict() :: dict:dict().
 -endif.
 
--include("../../include/chef_types.hrl").
+-include("chef_types.hrl").
 -include_lib("ej/include/ej.hrl").
 
 %% A binary() index is taken to be a data bag name.

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm.erl
@@ -17,7 +17,7 @@
 
 -module(chef_wm).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -type error() :: {error, term()}.
 -type http_verb() :: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS'.

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_clients.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_clients.erl
@@ -32,7 +32,7 @@
 %%
 -module(chef_wm_clients).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_cookbook_version.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_cookbook_version.erl
@@ -23,7 +23,7 @@
 
 -module(chef_wm_cookbook_version).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                           content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_cookbooks.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_cookbooks.erl
@@ -25,7 +25,7 @@
 -compile(export_all).
 -endif.
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_data.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_data.erl
@@ -21,7 +21,7 @@
 
 -module(chef_wm_data).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -24,7 +24,7 @@
 -module(chef_wm_depsolver).
 
 %% chef_wm behaviour callbacks
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 -behaviour(chef_wm).
 -export([auth_info/2,
          init/1,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_enforce.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_enforce.erl
@@ -30,7 +30,7 @@
          max_size/1
         ]).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 %% This is the max size allowed for incoming request bodies.
 -define(MAX_SIZE, 1000000).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environment_cookbooks.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environment_cookbooks.erl
@@ -23,7 +23,7 @@
 -module(chef_wm_environment_cookbooks).
 
 %% chef_wm behaviour callbacks
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 -behaviour(chef_wm).
 -export([auth_info/2,
          init/1,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environment_recipes.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environment_recipes.erl
@@ -23,7 +23,7 @@
 -module(chef_wm_environment_recipes).
 
 %% chef_wm behaviour callbacks
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 -behaviour(chef_wm).
 -export([auth_info/2,
          init/1,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environment_roles.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environment_roles.erl
@@ -23,7 +23,7 @@
 -module(chef_wm_environment_roles).
 
 %% chef_wm behaviour callbacks
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 -behaviour(chef_wm).
 -export([auth_info/2,
          init/1,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environments.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_environments.erl
@@ -22,7 +22,7 @@
 
 -module(chef_wm_environments).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_malformed.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_malformed.erl
@@ -20,8 +20,8 @@
 
 -module(chef_wm_malformed).
 
--include("../../include/chef_regex.hrl").
--include("../../include/oc_chef_wm.hrl").
+-include("chef_regex.hrl").
+-include("oc_chef_wm.hrl").
 
 -export([
          malformed_request_message/3

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_client.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_client.erl
@@ -21,7 +21,7 @@
 
 -module(chef_wm_named_client).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_data.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_data.erl
@@ -41,7 +41,7 @@
 
 -module(chef_wm_named_data).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_data_item.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_data_item.erl
@@ -22,7 +22,7 @@
 
 -module(chef_wm_named_data_item).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_environment.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_environment.erl
@@ -22,7 +22,7 @@
 
 -module(chef_wm_named_environment).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_node.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_node.erl
@@ -22,7 +22,7 @@
 
 -module(chef_wm_named_node).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_principal.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_principal.erl
@@ -21,7 +21,7 @@
 
 -module(chef_wm_named_principal).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_role.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_role.erl
@@ -22,7 +22,7 @@
 
 -module(chef_wm_named_role).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_sandbox.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_named_sandbox.erl
@@ -22,7 +22,7 @@
 -module(chef_wm_named_sandbox).
 
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_nodes.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_nodes.erl
@@ -32,7 +32,7 @@
 %%
 -module(chef_wm_nodes).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_object_identifiers.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_object_identifiers.erl
@@ -39,7 +39,7 @@
 
 -module(chef_wm_object_identifiers).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_roles.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_roles.erl
@@ -22,7 +22,7 @@
 
 -module(chef_wm_roles).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_sandboxes.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_sandboxes.erl
@@ -21,7 +21,7 @@
 
 -module(chef_wm_sandboxes).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_search.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_search.erl
@@ -26,8 +26,8 @@
 
 -module(chef_wm_search).
 
--include("../../include/oc_chef_wm.hrl").
--include("../../include/chef_solr.hrl").
+-include("oc_chef_wm.hrl").
+-include("chef_solr.hrl").
 
 -define(DEFAULT_BATCH_SIZE, 5).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_search_index.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_search_index.erl
@@ -22,7 +22,7 @@
 
 -module(chef_wm_search_index).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -40,7 +40,7 @@
          with_error_body/2
         ]).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% TODO: These types are just placeholders until we get all the types cleaned up
 -type ejson() :: {[tuple()]}.

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
@@ -22,7 +22,7 @@
 
 -module(oc_chef_action).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -export([log_action/2]).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_associations.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_associations.erl
@@ -8,8 +8,8 @@
 
 -module(oc_chef_associations).
 
--include("../../include/oc_chef_wm.hrl").
--include("../../include/oc_chef_authz.hrl").
+-include("oc_chef_wm.hrl").
+-include("oc_chef_authz.hrl").
 
 -export([deprovision_removed_user/3,
          provision_associated_user/3,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_object_db.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_object_db.erl
@@ -13,8 +13,8 @@
          bulk_delete_from_solr/3,
          delete_from_solr/1]).
 
--include("../../include/chef_types.hrl").
--include("../../include/oc_chef_types.hrl").
+-include("chef_types.hrl").
+-include("oc_chef_types.hrl").
 
 -type delete_type() ::chef_object() |
                     #oc_chef_container{} |

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl.erl
@@ -20,7 +20,7 @@
 
 -module(oc_chef_wm_acl).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
@@ -21,7 +21,7 @@
 
 -module(oc_chef_wm_acl_permission).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authenticate_user.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authenticate_user.erl
@@ -7,7 +7,7 @@
 
 -module(oc_chef_wm_authenticate_user).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -21,7 +21,7 @@
 
 -module(oc_chef_wm_base).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
 %% Complete webmachine callbacks

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_wm_containers).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_controls.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_controls.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_wm_controls).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_wm_groups).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_key_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_key_base.erl
@@ -19,7 +19,7 @@
 %%
 
 -module(oc_chef_wm_key_base).
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -export([create_object_with_embedded_key_data/2,
          update_object_embedded_key_data_v0/4,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
@@ -20,7 +20,7 @@
 
 -module(oc_chef_wm_keys).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_license.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_license.erl
@@ -7,7 +7,7 @@
 
 -module(oc_chef_wm_license).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_wm_named_container).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_wm_named_cookbook_artifact).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -behaviour(chef_wm).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact_version.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact_version.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_wm_named_cookbook_artifact_version).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -behaviour(chef_wm).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
@@ -20,7 +20,7 @@
 
 -module(oc_chef_wm_named_group).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_key.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_key.erl
@@ -23,7 +23,7 @@
 
 -module(oc_chef_wm_named_key).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,
                            content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_organization.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_organization.erl
@@ -5,7 +5,7 @@
 
 -module(oc_chef_wm_named_organization).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy.erl
@@ -6,7 +6,7 @@
 
 -module(oc_chef_wm_named_policy).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
@@ -22,7 +22,7 @@
 
 -module(oc_chef_wm_named_user).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_org_associations.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_org_associations.erl
@@ -18,7 +18,7 @@
 
 -module(oc_chef_wm_org_associations).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_org_invites.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_org_invites.erl
@@ -11,7 +11,7 @@
 
 -module(oc_chef_wm_org_invites).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 
 %% Webmachine resource callbacks

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
@@ -20,7 +20,7 @@
 
 -module(oc_chef_wm_organizations).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
@@ -6,7 +6,7 @@
 
 -module(oc_chef_wm_policies).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_groups.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_groups.erl
@@ -21,7 +21,7 @@
 
 -module(oc_chef_wm_policy_groups).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_server_api_version.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_server_api_version.erl
@@ -19,7 +19,7 @@
 
 -module(oc_chef_wm_server_api_version).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -mixin([{oc_chef_wm_base, [content_types_provided/2,
                            finish_request/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
@@ -15,7 +15,7 @@
 %% supervisor callbacks
 -export([init/1]).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% @spec start_link() -> ServerRet
 %% @doc API for starting the supervisor.

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_system_recovery.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_system_recovery.erl
@@ -7,7 +7,7 @@
 
 -module(oc_chef_wm_system_recovery).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_provided/2,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_users.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_users.erl
@@ -9,7 +9,7 @@
 -module(oc_chef_wm_users).
 
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
 -mixin([{oc_chef_wm_base, [content_types_accepted/2,

--- a/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
@@ -18,7 +18,7 @@
 -module(chef_wm_status_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 
 -define(CHECK_MODS, [chef_sql, chef_solr]).
 

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
@@ -17,7 +17,7 @@
 
 -module(oc_chef_action_tests).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 msg(Task) ->

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
@@ -19,7 +19,7 @@
 
 -module(oc_chef_wm_base_tests).
 
--include("../../include/oc_chef_wm.hrl").
+-include("oc_chef_wm.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 stats_hero_label_test_() ->

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -95,5 +95,7 @@
             {parse_transform, lager_transform},
             warnings_as_errors,
             debug_info,
-            {platform_define, "^[0-9]+", namespaced_types}
+            {platform_define, "^[0-9]+", namespaced_types},
+            {i, "include"},
+            {i, "../../include"}
            ]}.

--- a/src/oc_erchef/rebar.config.lock
+++ b/src/oc_erchef/rebar.config.lock
@@ -126,5 +126,6 @@
            {d,'CHEF_WM_DARKLAUNCH',xdarklaunch_req},
            {parse_transform,lager_transform},
            warnings_as_errors,debug_info,
-           {platform_define,"^[0-9]+",namespaced_types}]}.
-
+           {platform_define,"^[0-9]+",namespaced_types},
+           {i, "include"},
+           {i, "../../include"}]}.


### PR DESCRIPTION
Moving the relative path into rebar.config's erl_opts will make it
easier to upgrade to rebar3 when the time comes