### PR TITLE
Renamed apps/*/test_utils

### DIFF
--- a/src/oc_erchef/apps/chef_db/test/chef_db_test_utils.erl
+++ b/src/oc_erchef/apps/chef_db/test/chef_db_test_utils.erl
@@ -19,7 +19,7 @@
 %% under the License.
 %%
 
--module(test_utils).
+-module(chef_db_test_utils).
 
 -export([test_setup/0,
          test_cleanup/1,

--- a/src/oc_erchef/apps/chef_db/test/chef_db_tests.erl
+++ b/src/oc_erchef/apps/chef_db/test/chef_db_tests.erl
@@ -183,7 +183,7 @@ fetch_cookbook_versions_test_() ->
     }.
 
 set_app_env() ->
-    test_utils:start_stats_hero(),
+    chef_db_test_utils:start_stats_hero(),
     application:set_env(chef_db, couchdb_host, "localhost"),
     application:set_env(chef_db, couchdb_port, 5984),
     spawn_stats_hero_worker().
@@ -199,5 +199,5 @@ stats_hero_config() ->
      {request_action, "ACTION"},
      {org_name, "myorg"},
      {request_id, ?REQ_ID},
-     {label_fun, {test_utils, stats_hero_label}},
+     {label_fun, {chef_db_test_utils, stats_hero_label}},
      {upstream_prefixes, [<<"rdbms">>, <<"couchdb">>, <<"solr">>]}].

--- a/src/oc_erchef/apps/chef_objects/test/chef_cert_http_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cert_http_tests.erl
@@ -43,7 +43,7 @@ simple_test_() ->
     {foreach,
      fun() ->
              setup_env(),
-             test_utils:mock(MockedModules)
+             chef_objects_test_utils:mock(MockedModules)
      end,
      fun(_) ->
               meck:unload()

--- a/src/oc_erchef/apps/chef_objects/test/chef_client_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_client_tests.erl
@@ -26,13 +26,13 @@
 -include_lib("ej/include/ej.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(VD(D), test_utils:versioned_desc(Version,D)).
--define(VDD(D), test_utils:versioned_desc(Version, iolist_to_binary(["[deprecated] ", D]))).
+-define(VD(D), chef_objects_test_utils:versioned_desc(Version,D)).
+-define(VDD(D), chef_objects_test_utils:versioned_desc(Version, iolist_to_binary(["[deprecated] ", D]))).
 
 
 assemble_client_ejson_test_() ->
-    test_utils:make_deprecated_tests(fun assemble_client_ejson_deprecated_tests/1) ++
-    test_utils:make_non_deprecated_tests(fun assemble_client_ejson_non_deprecated_tests/1).
+    chef_objects_test_utils:make_deprecated_tests(fun assemble_client_ejson_deprecated_tests/1) ++
+    chef_objects_test_utils:make_non_deprecated_tests(fun assemble_client_ejson_non_deprecated_tests/1).
 
 assemble_client_ejson_deprecated_tests(Version) ->
     [{?VDD("obtain expected EJSON"),
@@ -95,9 +95,9 @@ assemble_client_ejson_non_deprecated_tests(Version) ->
     ].
 
 parse_binary_json_test_() ->
-    test_utils:make_all_versions_tests(fun parse_binary_json_tests/1) ++
-    test_utils:make_deprecated_tests(fun parse_binary_json_deprecated_tests/1) ++
-    test_utils:make_non_deprecated_tests(fun parse_binary_json_non_deprecated_tests/1).
+    chef_objects_test_utils:make_all_versions_tests(fun parse_binary_json_tests/1) ++
+    chef_objects_test_utils:make_deprecated_tests(fun parse_binary_json_deprecated_tests/1) ++
+    chef_objects_test_utils:make_non_deprecated_tests(fun parse_binary_json_non_deprecated_tests/1).
 
 
 %% These are stable behaviors across all supported api versions.
@@ -192,8 +192,8 @@ parse_binary_json_non_deprecated_tests(Version) ->
 
 
 new_record_test_() ->
-    test_utils:make_deprecated_tests(fun new_record_deprecated_tests/1) ++
-    test_utils:make_non_deprecated_tests(fun new_record_tests/1).
+    chef_objects_test_utils:make_deprecated_tests(fun new_record_deprecated_tests/1) ++
+    chef_objects_test_utils:make_non_deprecated_tests(fun new_record_tests/1).
 
 
 new_record_tests(Version) ->
@@ -248,9 +248,9 @@ new_record_deprecated_tests(Version) ->
     ].
 
 update_from_ejson_test_() ->
-    test_utils:make_deprecated_tests(fun update_from_ejson_deprecated_tests/1) ++
-    test_utils:make_non_deprecated_tests(fun update_from_ejson_tests/1) ++
-    test_utils:make_all_versions_tests(fun update_from_ejson_common_tests/1).
+    chef_objects_test_utils:make_deprecated_tests(fun update_from_ejson_deprecated_tests/1) ++
+    chef_objects_test_utils:make_non_deprecated_tests(fun update_from_ejson_tests/1) ++
+    chef_objects_test_utils:make_all_versions_tests(fun update_from_ejson_common_tests/1).
 
 update_from_ejson_tests(Version) ->
     [

--- a/src/oc_erchef/apps/chef_objects/test/chef_key_base_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_key_base_tests.erl
@@ -92,8 +92,8 @@ set_public_key_test_() ->
 
 maybe_generate_key_pair_test_() ->
     {setup,
-     fun test_utils:keygen_setup/0,
-     fun test_utils:keygen_cleanup/1,
+     fun chef_objects_test_utils:keygen_setup/0,
+     fun chef_objects_test_utils:keygen_cleanup/1,
      [
       {"when called with create_key true, a key pair is generated and passed into the continuation fun",
       fun() ->
@@ -117,8 +117,8 @@ maybe_generate_key_pair_test_() ->
 maybe_generate_key_pair_deprecated_test_() ->
     KeyData = public_key_data(),
     {setup,
-     fun test_utils:keygen_setup/0,
-     fun test_utils:keygen_cleanup/1,
+     fun chef_objects_test_utils:keygen_setup/0,
+     fun chef_objects_test_utils:keygen_cleanup/1,
      [{"when private_key is specified, the response contains a public and private key",
        fun() ->
          EJ = {[{<<"private_key">>, true}]},

--- a/src/oc_erchef/apps/chef_objects/test/chef_objects_test_utils.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_objects_test_utils.erl
@@ -17,7 +17,7 @@
 %% specific language governing permissions and limitations
 %% under the License.
 %%
--module(test_utils).
+-module(chef_objects_test_utils).
 -export([
          mock/1,
          mock/2,
@@ -62,7 +62,6 @@ bcrypt_setup() ->
     application:set_env(bcrypt, default_log_rounds, 4),
     [ ensure_start(App) || App <- [crypto, bcrypt] ],
     ok.
-
 
 bcrypt_cleanup(_) ->
     error_logger:tty(false),

--- a/src/oc_erchef/apps/chef_objects/test/chef_password_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_password_tests.erl
@@ -29,8 +29,8 @@
 
 encrypt_test_() ->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      [{"encrypts a password",
        fun() ->
                {Hashed, Salt, Type} = chef_password:encrypt("fizzbuzz"),
@@ -47,8 +47,8 @@ encrypt_test_() ->
 
 bcrypt_round_trip_test_() ->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      [
       {"basic roundtrip", generator,
        fun() ->
@@ -76,8 +76,8 @@ bcrypt_round_trip_test_() ->
 
 cross_type_test_() ->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      [
       {"treats a OSC_DEFAULT_HASH_TYPE as a DEFAULT_HASH_TYPE",
        fun() ->
@@ -90,10 +90,10 @@ cross_type_test_() ->
 unmigrated_round_trip_test_() ->
     {setup,
      fun() ->
-             test_utils:bcrypt_setup(),
+             chef_objects_test_utils:bcrypt_setup(),
              osc_sha1_examples() ++ ec_sha1_examples()
      end,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      fun(Examples) ->
              [
 
@@ -105,10 +105,10 @@ unmigrated_round_trip_test_() ->
 migrated_round_trip_test_() ->
     {setup,
      fun() ->
-            test_utils:bcrypt_setup(),
+            chef_objects_test_utils:bcrypt_setup(),
             osc_migrated_examples() ++ ec_migrated_examples()
      end,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      fun(MigratedExamples) ->
              [
               [ ?_assertEqual(true, chef_password:verify(Pass, Prev))
@@ -125,8 +125,8 @@ migrated_round_trip_test_() ->
 
 upgrade_test_() ->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      [
        {"upgrades password data when current form is sha1", generator,
        fun() ->

--- a/src/oc_erchef/apps/chef_objects/test/chef_s3_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_s3_tests.erl
@@ -55,7 +55,7 @@ make_key_test() ->
 }).
 setup_s3(InternalS3Url, ExternalS3Url) ->
     MockedModules = [mini_s3],
-    test_utils:mock(MockedModules, [passthrough]),
+    chef_objects_test_utils:mock(MockedModules, [passthrough]),
     application:set_env(chef_objects, s3_platform_bucket_name, "testbucket"),
     application:set_env(chef_objects, s3_access_key_id, "super_id"),
     application:set_env(chef_objects, s3_secret_key_id, "super_secret"),
@@ -94,7 +94,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                {InternalS3Url, ExternalS3Url, ExpectedExpiry}
        end,
        fun(_) ->
-               test_utils:unmock(MockedModules)
+               chef_objects_test_utils:unmock(MockedModules)
        end,
        [
         fun({_InternalS3Url, _ExternalS3Url, ExpectedExpiry}) ->
@@ -104,7 +104,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                           Expect_s3_url(Method, HostHeaderUrl, ExpectedExpiry),
                           chef_s3:generate_presigned_url(OrgId, Lifetime, Method,
                                                          Checksum, HostHeaderUrl),
-                          test_utils:validate_modules(MockedModules)
+                          chef_objects_test_utils:validate_modules(MockedModules)
                   end}
                  || Method <- [put, get]] ++
                     [{" (batch checksums)",
@@ -115,7 +115,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                               Expect_s3_url(put, HostHeaderUrl, ExpectedExpiry),
                               chef_s3:generate_presigned_urls(OrgId, Lifetime, put,
                                                               Checksums, HostHeaderUrl),
-                              test_utils:validate_modules(MockedModules)
+                              chef_objects_test_utils:validate_modules(MockedModules)
                       end}]
         end]}},
 
@@ -131,7 +131,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                {InternalS3Url, ExternalS3Url, ExpectedExpiry}
        end,
        fun(_) ->
-               test_utils:unmock(MockedModules)
+               chef_objects_test_utils:unmock(MockedModules)
        end,
        [
         fun({InternalS3Url, _ExternalS3Url, ExpectedExpiry}) ->
@@ -141,7 +141,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                           Expect_s3_url(Method, InternalS3Url, ExpectedExpiry),
                           chef_s3:generate_presigned_url(OrgId, Lifetime, Method,
                                                          Checksum, HostHeaderUrl),
-                          test_utils:validate_modules(MockedModules)
+                          chef_objects_test_utils:validate_modules(MockedModules)
                   end}
                  || Method <- [put, get]] ++
                     [{" (batch checksums)",
@@ -152,7 +152,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                               Expect_s3_url(put, InternalS3Url, ExpectedExpiry),
                               chef_s3:generate_presigned_urls(OrgId, Lifetime, put,
                                                               Checksums, HostHeaderUrl),
-                              test_utils:validate_modules(MockedModules)
+                              chef_objects_test_utils:validate_modules(MockedModules)
                       end}]
         end]}},
 
@@ -168,7 +168,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                {InternalS3Url, ExternalS3Url, ExpectedExpiry}
        end,
        fun(_) ->
-               test_utils:unmock(MockedModules)
+               chef_objects_test_utils:unmock(MockedModules)
        end,
        [
         fun({_InternalS3Url, ExternalS3Url, ExpectedExpiry}) ->
@@ -178,7 +178,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                           Expect_s3_url(Method, ExternalS3Url, ExpectedExpiry),
                           chef_s3:generate_presigned_url(OrgId, Lifetime, Method,
                                                          Checksum, HostHeaderUrl),
-                          test_utils:validate_modules(MockedModules)
+                          chef_objects_test_utils:validate_modules(MockedModules)
                   end}
                  || Method <- [put, get]] ++
                     [{" (batch checksums)",
@@ -189,7 +189,7 @@ generate_presigned_url_uses_configured_s3_url_test_() ->
                               Expect_s3_url(put, ExternalS3Url, ExpectedExpiry),
                               chef_s3:generate_presigned_urls(OrgId, Lifetime, put,
                                                               Checksums, HostHeaderUrl),
-                              test_utils:validate_modules(MockedModules)
+                              chef_objects_test_utils:validate_modules(MockedModules)
                       end}]
         end]}}
     ].
@@ -200,7 +200,7 @@ checksum_test_() ->
      fun() ->
              %% Temporarily disable logging chef_s3:delete_checksums/2
              error_logger:tty(false),
-             test_utils:mock(MockedModules, [passthrough]),
+             chef_objects_test_utils:mock(MockedModules, [passthrough]),
              meck:expect(chef_s3, get_internal_config, fun() -> mock_config end),
              application:set_env(chef_objects, s3_platform_bucket_name, "testbucket"),
 
@@ -276,7 +276,7 @@ checksum_test_() ->
      fun(_OrgId) ->
              %% Re-enable logging
              error_logger:tty(true),
-             test_utils:unmock(MockedModules)
+             chef_objects_test_utils:unmock(MockedModules)
      end,
      [
       fun(OrgId) ->
@@ -295,7 +295,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, []}},
                                      chef_s3:check_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                 end},
 
                {"Fetch: Finds all the checksums (greater than parallel limit)",
@@ -319,7 +319,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, []}},
                                      chef_s3:check_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                 end},
 
               {"Fetch: Missing one of the checksums",
@@ -334,7 +334,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, []}},
                                      chef_s3:check_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                 end},
                {"Fetch: Error for one of the checksums",
                 fun() ->
@@ -348,7 +348,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, [<<"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbd">>]}},
                                      chef_s3:check_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                 end},
                {"Fetch: Timeout!",
                 %% 20 seconds is waaaaaaay liberal here
@@ -362,7 +362,7 @@ checksum_test_() ->
                                                     {timeout, [<<"cccccccccccccccccccccccccccccccf">>]},
                                                     {error, []}},
                                                    chef_s3:check_checksums(OrgId, Checksums)),
-                                      test_utils:validate_modules(MockedModules)
+                                      chef_objects_test_utils:validate_modules(MockedModules)
                               end}
                },
                {"Fetch: One of each",
@@ -376,7 +376,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, [<<"cccccccccccccccccccccccccccccccd">>]}},
                                      chef_s3:check_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                 end},
                {"Fetch: All files are already in the system!",
                 fun() ->
@@ -404,7 +404,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, []}},
                                      chef_s3:delete_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                  end},
                 {"Delete: Multiple chunk groups",
                  fun() ->
@@ -429,7 +429,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, []}},
                                      chef_s3:delete_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                  end},
                 {"Delete: Missing one of the checksums",
                  fun() ->
@@ -443,7 +443,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, []}},
                                      chef_s3:delete_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                  end},
                 {"Delete: Error for one of the checksums",
                  fun() ->
@@ -457,7 +457,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, [<<"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbd">>]}},
                                      chef_s3:delete_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                  end},
                 {"Delete: Timeout!",
                  %% 20 seconds is waaaaaaay liberal here
@@ -471,7 +471,7 @@ checksum_test_() ->
                                                     {timeout, [<<"cccccccccccccccccccccccccccccccf">>]},
                                                     {error, []}},
                                                    chef_s3:delete_checksums(OrgId, Checksums)),
-                                      test_utils:validate_modules(MockedModules)
+                                      chef_objects_test_utils:validate_modules(MockedModules)
                               end}
                 },
                 {"Delete: One of each",
@@ -485,7 +485,7 @@ checksum_test_() ->
                                       {timeout, []},
                                       {error, [<<"cccccccccccccccccccccccccccccccd">>]}},
                                      chef_s3:delete_checksums(OrgId, Checksums)),
-                        test_utils:validate_modules(MockedModules)
+                        chef_objects_test_utils:validate_modules(MockedModules)
                  end}
               ]
       end]}.

--- a/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
@@ -26,14 +26,14 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
--define(VD(D), test_utils:versioned_desc(Version,D)).
--define(VDD(D), test_utils:versioned_desc(Version, iolist_to_binary(["[deprecated] ", D]))).
+-define(VD(D), chef_objects_test_utils:versioned_desc(Version,D)).
+-define(VDD(D), chef_objects_test_utils:versioned_desc(Version, iolist_to_binary(["[deprecated] ", D]))).
 
 assemble_user_ejson_test_() ->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
-     test_utils:make_all_versions_tests(fun assemble_user_ejson_tests/1) }.
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
+     chef_objects_test_utils:make_all_versions_tests(fun assemble_user_ejson_tests/1) }.
 
 assemble_user_ejson_tests(Version) ->
     [{?VD("obtain expected EJSON"),
@@ -67,14 +67,14 @@ assemble_user_ejson_tests(Version) ->
 
 assemble_user_ejson_non_deprecated_test_() ->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
-     test_utils:make_non_deprecated_tests(fun assemble_user_ejson_non_deprecated_tests/1) }.
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
+     chef_objects_test_utils:make_non_deprecated_tests(fun assemble_user_ejson_non_deprecated_tests/1) }.
 
 assemble_user_ejson_non_deprecated_tests(Version)->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      [{?VD("obtain expected EJSON"),
        fun() ->
                User = make_valid_user_record(Version),
@@ -85,11 +85,11 @@ assemble_user_ejson_non_deprecated_tests(Version)->
      ]}.
 
 assemble_user_ejson_deprecated_test_() ->
-    test_utils:make_deprecated_tests(fun assemble_user_ejson_deprecated_tests/1).
+    chef_objects_test_utils:make_deprecated_tests(fun assemble_user_ejson_deprecated_tests/1).
 assemble_user_ejson_deprecated_tests(Version) ->
     {setup,
-     fun test_utils:bcrypt_setup/0,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_setup/0,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
     [{?VDD("obtain expected EJSON"),
       fun() ->
               User = make_valid_user_record(Version),
@@ -120,7 +120,7 @@ assemble_user_ejson_deprecated_tests(Version) ->
     ]}.
 
 parse_binary_json_deprecated_test_() ->
-    test_utils:make_deprecated_tests(fun parse_binary_json_deprecated_tests/1).
+    chef_objects_test_utils:make_deprecated_tests(fun parse_binary_json_deprecated_tests/1).
 
 parse_binary_json_deprecated_tests(Version) ->
     [{?VDD("a null public_key is removed for create"),
@@ -168,7 +168,7 @@ parse_binary_json_deprecated_tests(Version) ->
     ].
 
 parse_binary_json_test_() ->
-    test_utils:make_all_versions_tests(fun parse_binary_json_tests/1).
+    chef_objects_test_utils:make_all_versions_tests(fun parse_binary_json_tests/1).
 
 parse_binary_json_tests(Version) ->
     [{?VD("Can create user when all required fields are present"),
@@ -272,7 +272,7 @@ parse_binary_json_tests(Version) ->
     ].
 
 parse_binary_json_non_deprecated_test_() ->
-    test_utils:make_non_deprecated_tests(fun parse_binary_json_non_deprecated_tests /1).
+    chef_objects_test_utils:make_non_deprecated_tests(fun parse_binary_json_non_deprecated_tests /1).
 
 parse_binary_json_non_deprecated_tests(Version) ->
     [{?VD("Public key is rejected as a field for update, even when valid"),
@@ -337,17 +337,17 @@ parse_binary_json_non_deprecated_tests(Version) ->
     ].
 
 update_record_test_() ->
-    test_utils:make_all_versions_tests(fun update_record_tests/1).
+    chef_objects_test_utils:make_all_versions_tests(fun update_record_tests/1).
 
 update_record_tests(Version) ->
     {setup,
      fun() ->
-        test_utils:bcrypt_setup(),
+        chef_objects_test_utils:bcrypt_setup(),
         SerializedAsEJson = {base_user_record_as_ejson(Version) ++
                              persisted_serializable_fields() },
         make_valid_user_record(chef_json:encode(SerializedAsEJson), Version)
      end,
-     fun test_utils:bcrypt_cleanup/1,
+     fun chef_objects_test_utils:bcrypt_cleanup/1,
      fun(User) ->
         UpdateAsEJson = {[ {<<"username">>, <<"martha">>},
                         {<<"email">>, <<"new_email@somewhere.com">>},
@@ -435,7 +435,7 @@ update_record_tests(Version) ->
     }.
 
 new_record_test() ->
-    test_utils:bcrypt_setup(),
+    chef_objects_test_utils:bcrypt_setup(),
     UserData = {[
                  {<<"name">>, <<"bob">>},
                  {<<"password">>, <<"top secret 123456">>}
@@ -445,7 +445,7 @@ new_record_test() ->
     ?assertEqual(<<"bob">>, chef_user:name(User)),
     ?assertEqual(null, User#chef_user.external_authentication_uid),
     ?assertEqual(false, User#chef_user.recovery_authentication_enabled),
-    test_utils:bcrypt_cleanup(ignore).
+    chef_objects_test_utils:bcrypt_cleanup(ignore).
 
 new_record_no_password_test() ->
     UserData = {[ {<<"name">>, <<"bob">>} ]},

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_test_utils.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_test_utils.erl
@@ -20,7 +20,7 @@
 %% under the License.
 %%
 
--module(test_utils).
+-module(oc_chef_authz_test_utils).
 
 -export([
          test_setup/0

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
@@ -55,7 +55,7 @@ resource_test_() ->
     fun() ->
             error_logger:tty(false),
             automeck:mocks(?AUTOMECK_FILE(resource)),
-            test_utils:test_setup() end,
+            oc_chef_authz_test_utils:test_setup() end,
      fun(_) -> meck:unload() end,
      [fun({_Server, Superuser}) ->
           %% Resource creation
@@ -110,7 +110,7 @@ get_acl_from_resource_test_() ->
      fun() ->
              error_logger:tty(false),
              automeck:mocks(?AUTOMECK_FILE(get_acl)),
-             test_utils:test_setup() end,
+             oc_chef_authz_test_utils:test_setup() end,
      fun(_) -> meck:unload() end,
      [fun({_Server, Superuser}) ->
               {"get the acl for a newly created resource",
@@ -141,7 +141,7 @@ is_authorized_on_resource_test_() ->
     {foreach,
      fun() ->
              error_logger:tty(false),
-             test_utils:test_setup()
+             oc_chef_authz_test_utils:test_setup()
      end,
      fun(_) ->
              meck:unload()
@@ -198,7 +198,7 @@ bulk_actor_is_authorized_test_() ->
     {foreach,
      fun() ->
              error_logger:tty(false),
-             test_utils:test_setup(),
+             oc_chef_authz_test_utils:test_setup(),
               start_apps(),
               meck:new(oc_httpc),
               Server = "http://127.0.0.1:9463",
@@ -331,7 +331,7 @@ get_container_aid_for_object_test_() ->
      fun() ->
              error_logger:tty(false),
              automeck:mocks(?AUTOMECK_FILE(container_aid)),
-              test_utils:test_setup() end,
+              oc_chef_authz_test_utils:test_setup() end,
      fun(_) -> meck:unload() end,
      [fun({Context, _Superuser}) ->
               {"Can we get a real container",
@@ -345,7 +345,7 @@ create_entity_if_authorized_test_() ->
     {foreach,
      fun() ->
              error_logger:tty(false),
-             test_utils:test_setup() end,
+             oc_chef_authz_test_utils:test_setup() end,
      fun(_) -> meck:unload() end,
     [fun({Server, _Superuser}) ->
              automeck:mocks(?AUTOMECK_FILE(create_if_authorized1)),

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
@@ -58,8 +58,8 @@ msg_with_payload(Task) ->
 oc_chef_action_test_() ->
     MockedModules = [bunnyc],
     {foreach,
-     fun() -> test_util:setup(MockedModules) end,
-     fun(_) -> test_util:cleanup(MockedModules) end,
+     fun() -> oc_chef_wm_test_utils:setup(MockedModules) end,
+     fun(_) -> oc_chef_wm_test_utils:cleanup(MockedModules) end,
      [
       {"add a msg to the queue",
        fun() ->
@@ -102,8 +102,8 @@ log_action_routing_test_() ->
     MockedModules = [wrq],
     State = make_state(),
     {foreach,
-     fun() -> test_util:setup(MockedModules) end,
-     fun(_) -> test_util:cleanup(MockedModules) end,
+     fun() -> oc_chef_wm_test_utils:setup(MockedModules) end,
+     fun(_) -> oc_chef_wm_test_utils:cleanup(MockedModules) end,
      [
             {"logging action for GET /clients doesn't log",
              fun() ->
@@ -140,8 +140,8 @@ task_for_cookbooks_test_() ->
     MockedModules = [wrq],
     State = #base_state{resource_state=#cookbook_state{}},
     {foreach,
-     fun() -> test_util:setup(MockedModules) end,
-     fun(_) -> test_util:cleanup(MockedModules) end,
+     fun() -> oc_chef_wm_test_utils:setup(MockedModules) end,
+     fun(_) -> oc_chef_wm_test_utils:cleanup(MockedModules) end,
      [
             {"PUT with 201 is create",
              fun() -> meck:expect(wrq, method, fun(req) -> 'PUT' end),
@@ -175,8 +175,8 @@ key_for_method_test() ->
 extract_entity_info_test_() ->
     MockedModules = [chef_wm_util],
     {foreach,
-     fun() -> test_util:setup(MockedModules) end,
-     fun(_) -> test_util:cleanup(MockedModules) end,
+     fun() -> oc_chef_wm_test_utils:setup(MockedModules) end,
+     fun(_) -> oc_chef_wm_test_utils:cleanup(MockedModules) end,
      [{"client entity info",
        fun() -> State = #client_state{client_data = {[{<<"name">>,<<"node-foo">>}]} },
                 meck:expect(chef_wm_util,object_name, fun(client, req) -> undefined end),
@@ -323,7 +323,7 @@ end_to_end_test_() ->
                         resource_state=#node_state{node_data = {[{<<"name">>,<<"db">>}]} }},
     ok = application:set_env(oc_chef_wm, actions_fqdn, HostFQDN),
     {foreach,
-     fun() -> test_util:setup(MockedModules),
+     fun() -> oc_chef_wm_test_utils:setup(MockedModules),
               meck:expect(chef_wm_util,object_name, fun(node, req) -> undefined end),
               meck:expect(wrq, response_code, fun(req) -> 201 end),
               meck:expect(chef_wm_util,object_name, fun(node, req) -> undefined end),
@@ -338,7 +338,7 @@ end_to_end_test_() ->
                               end
                           end)
      end,
-     fun(_) -> test_util:cleanup(MockedModules) end,
+     fun(_) -> oc_chef_wm_test_utils:cleanup(MockedModules) end,
      [{"end to end client test, action create with no payload",
        fun() -> ExpectedMsg = msg(<<"create">>),
                 meck:expect(wrq, method, fun(req) -> 'POST' end),

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_test_utils.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_test_utils.erl
@@ -1,4 +1,4 @@
--module(test_util).
+-module(oc_chef_wm_test_utils).
 
 -include_lib("eunit/include/eunit.hrl").
 


### PR DESCRIPTION
We have 3 modules called test_utils. We're probably only getting away
with this because of how rebar2 handles paths.

The following four files have been renamed:

apps/chef_db/test_utils.erl -> chef_db_test_utils.erl
apps/chef_objects/test_utils.erl -> chef_objects_test_utils.erl
apps/oc_chef_authz/test_utils.erl -> oc_chef_authz_test_utils.erl
apps/oc_chef_wm/test_util.erl -> oc_chef_wm_test_utils.erl