### PR TITLE
postgres preflight check  finalization 

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -38,6 +38,20 @@ class PreflightValidator
                   node['enterprise']['name'] =>  PrivateChef }
     EnterpriseChef::Helpers.backend? faux_node
   end
+
+  # Helper function that let get the correct top-level value for a service
+  # node entry, givent that we haven't yet merged PrivateChef
+  # into the node.
+  def service_key_value(service_name, key)
+    # Ugh: config key munging pain redux
+    alt_service_name = (service_name == 'opscode-erchef' ? 'opscode_erchef' : service_name)
+    if PrivateChef.has_key?(alt_service_name)
+      if PrivateChef[alt_service_name].has_key?(key)
+        return PrivateChef[alt_service_name][key]
+      end
+    end
+    return node['private_chef'][service_name][key]
+  end
 end
 
 class PreflightChecks

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -40,7 +40,7 @@ class PreflightValidator
   end
 
   # Helper function that let get the correct top-level value for a service
-  # node entry, givent that we haven't yet merged PrivateChef
+  # node entry, given that we haven't yet merged PrivateChef
   # into the node.
   def service_key_value(service_name, key)
     # Ugh: config key munging pain redux
@@ -65,9 +65,10 @@ class PreflightChecks
   # Stop the run immediately if a validation failure occurs, bypassing normal error handlers
   # so we can output the error message without a stack trace to muddy things.
   #
-  # Validators are expected to be run after chef-server.rb entries are ingested, but before any
-  # defaults are configured via libraries/private_chef.rb. This allows us to check the values that
-  # are explicitly configured independetly of the defaults set in the recipe.
+  # Validators are expected to be run after chef-server.rb entries are loaded but before
+  # they're ingested into the node, and before any defaults are configured via libraries/private_chef.rb
+  # This allows us to check the values that are explicitly configured independently of
+  # the defaults set in the recipe.
   def run!
     begin
       PostgresqlPreflightValidator.new(node).run!

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -207,7 +207,7 @@ CSPG002: You have not set a database superuser name under
          chef-server.rb.  This is required for external database support - please set
          it now and then re-run 'chef-server-ctl reconfigure'.
 
-         See https://docs.chef.io/TODO-external-pg-chef-server-configuration
+         See https://docs.chef.io/server_components.html#postgresql-settings
          for more information.
 EOM
   end
@@ -219,7 +219,7 @@ CSPG003: You have not set a database superuser password under
          required for external database support - please set it now and then
          re-run 'chef-server-ctl reconfigure'.
 
-         See documentation at https://docs.chef.io/TODO-external-pg-chef-server-configuration
+         See https://docs.chef.io/server_components.html#postgresql-settings
          for more information.
 EOM
   end
@@ -230,7 +230,7 @@ CSPG004: Because postgresql['external'] is set to true, you must also set
          postgresql['vip'] to the host or IP of an external postgres database
          in chef-server.rb.
 
-         See documentation at https://docs.chef.io/TODO-external-pg-chef-server-configuration
+         See https://docs.chef.io/server_components.html#postgresql-settings
          for more information.
 EOM
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -214,7 +214,7 @@ private
 CSPG001: The value of postgresql['external'] must be set prior to the initial
          run of chef-server-ctl reconfigure and cannot be changed.
 
-         See https://docs.chef.io/TODO-external-pg-upgrade-existing-installation
+         See https://docs.chef.io/error_messages.html#cspg001-changed-setting
          for more information on how you can transition an existing chef-server
          to a new instance configured for an external database and vice-versa.
 EOM
@@ -263,7 +263,7 @@ CSPG010: I cannot make a connection to the host #{cs_pg_attr['vip']}.  Please
          you have configured postgresql['port'] if it's not the standard
          port 5432, then run 'chef-server-ctl reconfigure' again.
 
-         See https://docs.chef.io/TODO-external-pg-config#networking
+         See https://docs.chef.io/error_messages.html#cspg010-cannot-connect
          for more information about postgresql networking requirements.
 EOM
   end
@@ -276,7 +276,7 @@ CSPG011: I could not authenticate to #{cs_pg_attr['vip']} as
          chef-server.rb under "postgresql['db_superuser_password'] is correct
          for this user.
 
-         See https://docs.chef.io/TODO-external-pg-chef-server-configuration
+         See https://docs.chef.io/error_messages.html#cspg011-cannot-authenticate
          for more information.
 EOM
   end
@@ -290,7 +290,7 @@ CSPG012: There is a missing or incorrect pg_hba.conf entry for the
          allow the application accounts to connect from all Chef Server
          nodes.
 
-         See https://docs.chef.io/TODO-external-pg-config#pg_hba
+         See https://docs.chef.io/error_messages.html#cspg012-incorrect-rules
          for more information.
 EOM
   end
@@ -300,7 +300,7 @@ CSPG013: The superuser account '#{cs_pg_attr['db_superuser']}' does not have
          superuser access to the to the database specified.  At minimum, this
          user must be granted CREATE DATABASE and CREATE ROLE privileges.
 
-         See https://docs.chef.io/TODO-external-pg-config#access_levels
+         See https://docs.chef.io/error_messages.html#cspg013-incorrect-permissions
          for more information.
 EOM
   end
@@ -310,7 +310,7 @@ EOM
 CSPG014: Chef Server currently requires PostgreSQL version 9.2 or greater.
          The database you have provided is running version #{ver}.
 
-         See https://docs.chef.io/TODO-external-pg-config#requirements
+         See https://docs.chef.io/error_messages.html#cspg014-incorrect-version
          for more information.
 EOM
   end
@@ -321,7 +321,7 @@ CSPG015: The database server you provided does not have the default database
          template1 available.  Please create the template1 database before
          proceeding.
 
-         See https://docs.chef.io/TODO-external-pg-config#requirements
+         See https://docs.chef.io/error_messages.html#cspg015-missing-database
          for more information.
 EOM
   end
@@ -332,7 +332,7 @@ EOM
 CSPG016: The Chef Server database named '#{dbname}' already exists on the
          PostgreSQL server. Please remove it before proceeding.
 
-         See https://docs.chef.io/TODO-external-pg-config#requirements
+         See https://docs.chef.io/error_messages.html#cspg016-database-exists
          for more information.
 EOM
   end
@@ -341,11 +341,11 @@ EOM
 <<EOM
 CSPG017: The Chef Server database role/user named '#{username}' already exists
          on the PostgreSQL server. If possible, please remove this user
-         via 'DROP ROLE "#{username}"\' before proceeding, or reference the
+         via 'DROP ROLE "#{username}"' before proceeding, or reference the
          troubleshooting link below for information about configuring
          Chef Server to use an alternative user name.
 
-         See https://docs.chef.io/TODO-external-pg-config#requirements
+         See https://docs.chef.io/error_messages.html#cspg017-user-exists
          for more information.
 EOM
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -70,7 +70,7 @@ class PostgresqlPreflightValidator < PreflightValidator
     # the default value of 'false' will be in place, and having a
     # differing value is valid.
     if OmnibusHelper.has_been_bootstrapped? && backend?  && previous_run
-      if cs_pg_attr.has_key? 'external' && (cs_pg_attr['external'] != previous_run['postgresql']['external'])
+      if (cs_pg_attr.has_key? 'external') && (cs_pg_attr['external'] != previous_run['postgresql']['external'])
         fail_with err_CSPG001_cannot_change_external_flag
       end
     else


### PR DESCRIPTION
This PR finalizes the postgresql preflight checks after another round of testing on RDS, and replaces  the TODO urls for help/documentation. 

* bug fixed which prevented CSPG001 from being detected
* Updated URLs to final permanent values for all CSPG??? errors. 
* made postgresql version check a minimum version check, so instead of exactly 9.2 it now looks for 9.x where x >=2
* added new error CSPG017 that occurs when  required roles already exist in the external database.  
