### PR TITLE
Implemented Version 1 of Server Admins

### DIFF
--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -21,6 +21,10 @@ source path: "#{project.files_path}/private-chef-ctl-commands"
 dependency "highline-gem"
 dependency "sequel-gem"
 dependency "omnibus-ctl"
+# TODO
+# chef-server-ctl server-admins commands dep, will be removed in server-admins V2
+# https://gist.github.com/tylercloke/a8d4bc1b915b958ac160#version-2
+dependency "rest-client-gem"
 
 build do
   block do

--- a/omnibus/config/software/rest-client-gem.rb
+++ b/omnibus/config/software/rest-client-gem.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rest-client"
+default_version "1.8.0"
+
+dependency "ruby"
+dependency "rubygems"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  gem "install rest-client" \
+      " --version '#{version}'" \
+      " --bindir '#{install_dir}/embedded/bin'" \
+      " --no-ri --no-rdoc", env: env
+end

--- a/omnibus/files/private-chef-ctl-commands/server_admins.rb
+++ b/omnibus/files/private-chef-ctl-commands/server_admins.rb
@@ -1,0 +1,193 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'restclient'
+require 'json'
+require 'pg'
+
+PLACEHOLDER_GLOBAL_ORG_ID = "00000000000000000000000000000000"
+
+add_command_under_category "grant-server-admin-permissions", "server-admins", "Grant a user the ability to create other users by added the user to the server-admins group.", 2 do
+
+  cmd_args = ARGV[3..-1]
+  if cmd_args.length != 1
+    msg = "Username is the only argument to grant-server-admin-permissions.\nPlease pass a single argument."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  username = cmd_args[0]
+
+  db = setup_erchef_db
+  server_admins_authz_id = get_server_admins_authz_id(db)
+  user_authz_id = get_user_authz_id(db, username)
+
+  bifrost_config = running_service_config('oc_bifrost')
+  superuser_id = bifrost_config['superuser_id']
+  vip = bifrost_config['vip']
+  port = bifrost_config['port']
+
+  # put the user in the server-admins authz group
+  headers = {
+    :content_type => :json,
+    :accept => :json,
+    'X-Ops-Requesting-Actor-Id' => superuser_id
+  }
+
+  base_url = "http://#{vip}:#{port}"
+
+  RestClient.put("#{base_url}/groups/#{server_admins_authz_id}/actors/#{user_authz_id}", "{}", headers)
+
+  puts "User #{username} was added to server-admins. This user can now list, read, create, and delete users (even for orgs they are not members of) for this Chef Server."
+end
+
+add_command_under_category "remove-server-admin-permissions", "server-admins", "Remove all special permission granted to a user from being a server-admin.", 2 do
+
+  cmd_args = ARGV[3..-1]
+  if cmd_args.length != 1
+    msg = "Username is the only argument to remove-server-admin-permissions.\nPlease pass a single argument."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  username = cmd_args[0]
+
+  if username.downcase == 'pivotal'
+    msg = "You cannot remove the base superuser pivotal from server-admins."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  bifrost_config = running_service_config('oc_bifrost')
+  superuser_id = bifrost_config['superuser_id']
+  vip = bifrost_config['vip']
+  port = bifrost_config['port']
+
+  db = setup_erchef_db
+  server_admins_authz_id = get_server_admins_authz_id(db)
+  user_authz_id = get_user_authz_id(db, username)
+
+  # put the user in the server-admins authz group
+  headers = {
+    :content_type => :json,
+    :accept => :json,
+    'X-Ops-Requesting-Actor-Id' => superuser_id
+  }
+
+  base_url = "http://#{vip}:#{port}"
+
+  results = JSON.parse(RestClient.get("#{base_url}/groups/#{server_admins_authz_id}", headers))
+
+  users = db.exec_params("SELECT * from USERS WHERE authz_id IN #{create_sql_collection_string(results['actors'])}")
+  user_found = false
+  users.each do |user|
+    if username == user['username']
+      user_found = true
+      break
+    end
+  end
+
+  if !user_found
+    msg = "User #{username} is not a member of server-admins so it cannot be removed."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  RestClient.delete("#{base_url}/groups/#{server_admins_authz_id}/actors/#{user_authz_id}", headers)
+
+  puts "User #{username} was removed from server-admins. This user can no longer list, read, create, and delete users for this Chef Server except for where they have default permissions (such as within an org)."
+
+end
+
+add_command_under_category "list-server-admins", "server-admins", "List users that have server-admins permissions.", 2 do
+  cmd_args = ARGV[3..-1]
+  if cmd_args.length != 0
+    msg = "This command does not accept arguments."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  bifrost_config = running_service_config('oc_bifrost')
+  superuser_id = bifrost_config['superuser_id']
+  vip = bifrost_config['vip']
+  port = bifrost_config['port']
+
+  db = setup_erchef_db
+  server_admins_authz_id = get_server_admins_authz_id(db)
+
+  # get all the user authz_ids for all memebers of the server-admins authz group
+  headers = {
+    :content_type => :json,
+    :accept => :json,
+    'X-Ops-Requesting-Actor-Id' => superuser_id
+  }
+
+  base_url = "http://#{vip}:#{port}"
+
+  results = JSON.parse(RestClient.get("#{base_url}/groups/#{server_admins_authz_id}", headers))
+
+  # get the user's authz id
+  users = db.exec_params("SELECT * from USERS WHERE authz_id IN #{create_sql_collection_string(results['actors'])}")
+  users.each do |user|
+    puts user['username']
+  end
+end
+
+# returns string in format '('item1','item2',...,'itemN')'
+def create_sql_collection_string(arr)
+  str = arr.join("','")
+  "('#{str}')"
+end
+
+def setup_erchef_db
+  erchef_config = running_service_config('opscode-erchef')
+  pg_config = running_service_config('postgresql')
+  ::PGconn.open('user' => erchef_config['sql_user'],
+                'host' => pg_config['vip'],
+                'password' => erchef_config['sql_password'],
+                'port' => pg_config['port'],
+                'dbname' => 'opscode_chef')
+end
+
+def get_server_admins_authz_id(db)
+  server_admins_erchef_group = db.exec_params("SELECT authz_id FROM groups WHERE name='server-admins' AND org_id='#{PLACEHOLDER_GLOBAL_ORG_ID}'")
+
+  if server_admins_erchef_group.ntuples == 0
+    msg = "The server-admins global group was not found. Please finish upgrading your Chef Server by following the documentation before using Server Admins related commands."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  if server_admins_erchef_group.ntuples != 1
+    msg = "More than one server-admins global group was found. Please contact a sysadmin or support (#{server_admins_erchef_group.ntuples} groups found)."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  server_admins_erchef_group.first['authz_id']
+end
+
+def get_user_authz_id(db, username)
+  user = db.exec_params("SELECT authz_id FROM users WHERE username='#{username}'")
+
+  if user.ntuples != 1
+    msg = "User #{username} was not found."
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+
+  user.first['authz_id']
+end

--- a/omnibus/files/private-chef-upgrades/001/028_server_admins_global_group.rb
+++ b/omnibus/files/private-chef-upgrades/001/028_server_admins_global_group.rb
@@ -1,0 +1,19 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+    # Make sure API is down
+    stop_services(["nginx", "opscode-erchef"])
+
+    start_services(["oc_bifrost", "postgresql"])
+    force_restart_service("opscode-chef-mover")
+    log "Creating global group server-admins with read and create access on users container"
+
+    run_command("/opt/opscode/embedded/bin/escript " +
+    		"/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +
+		"mover_server_admins_global_group_callback " +
+		"normal " +
+		"mover_transient_queue_batch_migrator")
+
+    stop_services(["opscode-chef-mover"])
+  end
+end

--- a/omnibus/files/private-chef-upgrades/001/029_server_admins_existing_user_read_access.rb
+++ b/omnibus/files/private-chef-upgrades/001/029_server_admins_existing_user_read_access.rb
@@ -1,0 +1,19 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+    # Make sure API is down
+    stop_services(["nginx", "opscode-erchef"])
+
+    start_services(["oc_bifrost", "postgresql"])
+    force_restart_service("opscode-chef-mover")
+    log "Granting READ permission on all existing users to the global group server-admins"
+
+    run_command("/opt/opscode/embedded/bin/escript " +
+                "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +
+                "mover_server_admins_existing_users_read_permissions_callback " +
+                "normal " +
+                "mover_transient_queue_batch_migrator")
+
+    stop_services(["opscode-chef-mover"])
+  end
+end

--- a/src/chef-mover/src/mover_server_admins_existing_users_read_permissions_callback.erl
+++ b/src/chef-mover/src/mover_server_admins_existing_users_read_permissions_callback.erl
@@ -1,0 +1,94 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Tyler Cloke <tyler@chef.io>
+%% @copyright 2015 Chef Software, Inc.
+%%
+%% This migration iterates through all existing users and grants
+%% the server-admins global group READ access on them, as having
+%% access on the container does not update permissions for
+%% existing users.
+
+-module(mover_server_admins_existing_users_read_permissions_callback).
+
+-export([
+         migration_init/0,
+         migration_complete/0,
+         migration_type/0,
+         supervisor/0,
+         migration_start_worker_args/2,
+         migration_action/2,
+         next_object/0,
+         error_halts_migration/0,
+         reconfigure_object/2,
+         needs_account_dets/0
+        ]).
+
+-define(GLOBAL_PLACEHOLDER_ORG_ID, <<"00000000000000000000000000000000">>).
+
+-record(user, {username, authz_id}).
+-record(group, {authz_id}).
+
+migration_init() ->
+    mv_oc_chef_authz_http:create_pool(),
+    mover_transient_migration_queue:initialize_queue(?MODULE, get_users()).
+
+migration_action(UserRecord, _AcctInfo) ->
+    Username = UserRecord#user.username,
+    UserAuthzid = UserRecord#user.authz_id,
+    BifrostSuperuserId = mv_oc_chef_authz:superuser_id(),
+    ServerAdminsAuthzId = get_server_admins_authz_id(),
+    add_permission_to_existing_user_for_server_admins(BifrostSuperuserId, Username, ServerAdminsAuthzId, UserAuthzid, read),
+    add_permission_to_existing_user_for_server_admins(BifrostSuperuserId, Username, ServerAdminsAuthzId, UserAuthzid, update),
+    add_permission_to_existing_user_for_server_admins(BifrostSuperuserId, Username, ServerAdminsAuthzId, UserAuthzid, delete).
+
+add_permission_to_existing_user_for_server_admins(BifrostSuperuserId, Username, ServerAdminsAuthzId, UserAuthzid, Permission) ->
+    case mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserId, group,  ServerAdminsAuthzId, actor, UserAuthzid, Permission) of
+	{error, Error} ->
+	    lager:error("Failed to update " ++ Permission ++ " permission for user " ++ Username ++ " with error:"),
+	    lager:error(Error),
+	    throw(migration_error);
+	_ ->
+	    ok
+    end.
+
+get_users() ->
+    {ok, Users} = sqerl:select(get_users_sql(), [], rows_as_records, [user, record_info(fields, user)]),
+    Users.
+
+get_users_sql() ->
+    <<"SELECT username, authz_id FROM users WHERE NOT username='pivotal'">>.
+
+get_server_admins_authz_id() ->
+    {ok, [ServerAdmin]} = sqerl:select(get_server_admins_authz_id_sql(), [], rows_as_records, [group, record_info(fields, group)]),
+    ServerAdmin#group.authz_id.
+
+get_server_admins_authz_id_sql() ->
+    erlang:iolist_to_binary([<<"SELECT authz_id FROM groups WHERE name='server-admins' and org_id='">>, ?GLOBAL_PLACEHOLDER_ORG_ID , <<"'">>]).
+
+migration_complete() ->
+    mv_oc_chef_authz_http:delete_pool().
+
+%%
+%% Generic mover callback functions for
+%% a transient queue migration
+%%
+needs_account_dets() ->
+    false.
+
+migration_start_worker_args(Object, AcctInfo) ->
+    [Object, AcctInfo].
+
+next_object() ->
+    mover_transient_migration_queue:next(?MODULE).
+
+migration_type() ->
+    <<"users_read_access_on_server_admins">>.
+
+supervisor() ->
+    mover_transient_worker_sup.
+
+error_halts_migration() ->
+    true.
+
+reconfigure_object(_ObjectId, _AcctInfo) ->
+    ok.

--- a/src/chef-mover/src/mover_server_admins_global_group_callback.erl
+++ b/src/chef-mover/src/mover_server_admins_global_group_callback.erl
@@ -1,0 +1,196 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Tyler Cloke <tyler@chef.io>
+%% @copyright 2015 Chef Software, Inc.
+%%
+%% This migration sets up a global group called server-admins.
+%% It also grants READ and CREATE permissions on the users container
+%% to the server-admins group.
+%%
+-module(mover_server_admins_global_group_callback).
+
+-export([
+         migration_init/0,
+         migration_complete/0,
+         migration_type/0,
+         supervisor/0,
+         migration_start_worker_args/2,
+         migration_action/2,
+         next_object/0,
+         error_halts_migration/0,
+         reconfigure_object/2,
+         needs_account_dets/0
+        ]).
+
+-include("mover.hrl").
+-include("mv_oc_chef_authz.hrl").
+
+-define(GLOBAL_PLACEHOLDER_ORG_ID, <<"00000000000000000000000000000000">>).
+
+-record(container, {authz_id}).
+-record(user, {authz_id}).
+-record(mover_chef_group, {
+          id,
+          org_id,	  
+          authz_id,
+          name,
+          last_updated_by,
+          created_at,
+          updated_at
+         }).
+
+
+migration_init() ->
+    mv_oc_chef_authz_http:create_pool(),
+    mover_transient_migration_queue:initialize_queue(?MODULE, [?GLOBAL_PLACEHOLDER_ORG_ID]).
+
+migration_action(GlobalOrgId, _AcctInfo) ->
+    BifrostSuperuserAuthzId = mv_oc_chef_authz:superuser_id(),
+    ErchefSuperuserAuthzId = get_erchef_superuser_authz_id(),
+    ServerAdminsAuthzId = case create_server_admins_authz_group(BifrostSuperuserAuthzId) of
+        AuthzId when is_binary(AuthzId) ->
+            AuthzId;
+        AuthzError ->
+            lager:error("Could not create new authz group for server-admins."),
+            throw(AuthzError)
+    end,
+    
+    case create_server_admins_global_group(ServerAdminsAuthzId, GlobalOrgId) of
+        {chef_sql, {GroupError, _}} ->
+	    lager:error("Could not create new erchef group for server-admins."),
+            throw(GroupError);
+	_ -> true
+    end,
+
+    %% Put pivotal in the global group
+    mv_oc_chef_authz:add_to_group(ServerAdminsAuthzId, actor, ErchefSuperuserAuthzId, BifrostSuperuserAuthzId),
+
+    %% Grant server-admins global group permissions on users container 
+    UserContainerAuthzId = get_user_container_authz_id(),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, UserContainerAuthzId, read),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, UserContainerAuthzId, create),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, UserContainerAuthzId, update),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, UserContainerAuthzId, delete),
+
+    %% Grant server-admins read permissions on itself
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, group, ServerAdminsAuthzId, read),
+
+    %% Grant pivotal permissions on server-admins global group
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, actor, ErchefSuperuserAuthzId, group, ServerAdminsAuthzId, create),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, actor, ErchefSuperuserAuthzId, group, ServerAdminsAuthzId, read),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, actor, ErchefSuperuserAuthzId, group, ServerAdminsAuthzId, update),
+    ok.
+
+%% Vendored from chef_objects.erl
+chef_object_flatten_group(ObjectRec) ->
+    [_RecName|Tail] = tuple_to_list(ObjectRec),
+    %% We detect if any of the fields in the record have not been set
+    %% and throw an error
+    case lists:any(fun is_undefined/1, Tail) of
+        true -> error({undefined_in_record, ObjectRec});
+        false -> ok
+    end,
+    Tail.
+
+throw_not_found(Type) ->
+    lager:error("Bifrost could not find the " ++ Type ++ " permission on the users container."),
+    throw(not_found).
+
+throw_server_error() ->
+    lager:error("There was an error communicating with bifrost."),
+    throw(server_error).
+
+create_server_admins_authz_group(SuperuserAuthzId) ->
+    case mv_oc_chef_authz:create_resource(SuperuserAuthzId, group) of
+        {ok, AuthzId} ->
+            AuthzId;
+        {error, _} = Error ->
+            Error
+    end.
+
+get_user_container_authz_id() ->
+    {ok, [Container]} = sqerl:select(users_container_query(), [], rows_as_records, [container, record_info(fields, container)]),
+    Container#container.authz_id.
+
+users_container_query() ->
+    <<"SELECT authz_id FROM containers WHERE name='users'">>.
+
+get_erchef_superuser_authz_id() ->
+    {ok, [User]} = sqerl:select(get_erchef_superuser_authz_id_sql(), [], rows_as_records, [user, record_info(fields, user)]),
+    User#user.authz_id.
+
+get_erchef_superuser_authz_id_sql() ->
+    <<"SELECT authz_id FROM users WHERE username='pivotal'">>.
+
+create_server_admins_global_group(ServerAdminsAuthzId, GlobalOrgId) ->
+    RequestorId = mv_oc_chef_authz:superuser_id(),                                                      
+    Object = new_group_record(GlobalOrgId, ServerAdminsAuthzId, <<"server-admins">>, RequestorId),
+    create_insert(Object, ServerAdminsAuthzId, RequestorId).
+
+insert_group_sql() ->
+    <<"INSERT INTO groups (id, org_id, authz_id, name,"
+      " last_updated_by, created_at, updated_at) VALUES"
+      " ($1, $2, $3, $4, $5, $6, $7)">>.
+
+%% Similar to mover_policies_containers_creation_callback.erl
+new_group_record(OrgId, AuthzId, Name, RequestorId) ->
+    Now = os:timestamp(),
+    Id = chef_object_base_make_org_prefix_id(OrgId, Name),
+    #mover_chef_group{id = Id,
+                      authz_id = AuthzId,
+                      org_id = OrgId,
+                      name = Name,
+                      last_updated_by = RequestorId,
+                      created_at = Now,
+                      updated_at = Now}.
+
+is_undefined(undefined) ->
+    true;
+is_undefined(_) ->
+    false.
+
+create_insert(#mover_chef_group{} = Object, AuthzId, _RequestorId) ->
+    case chef_sql_create_group(chef_object_flatten_group(Object)) of
+        {ok, 1} ->
+            AuthzId;
+        Error ->
+            {chef_sql, {Error, Object}}
+    end.
+
+chef_sql_create_group(Args) ->
+    sqerl:execute(insert_group_sql(), Args).
+
+%% vendored from chef_object_base
+chef_object_base_make_org_prefix_id(OrgId, Name) ->
+    %% assume couchdb guid where trailing part has uniqueness
+    <<_:20/binary, OrgSuffix:12/binary>> = OrgId,
+    Bin = iolist_to_binary([OrgId, Name, crypto:rand_bytes(6)]),
+    <<ObjectPart:80, _/binary>> = crypto:hash(md5, Bin),
+    iolist_to_binary(io_lib:format("~s~20.16.0b", [OrgSuffix, ObjectPart])).
+
+migration_complete() ->
+    mv_oc_chef_authz_http:delete_pool().
+%%
+%% Generic mover callback functions for
+%% a transient queue migration
+%%
+needs_account_dets() ->
+    false.
+
+migration_start_worker_args(Object, AcctInfo) ->
+    [Object, AcctInfo].
+
+next_object() ->
+    mover_transient_migration_queue:next(?MODULE).
+
+migration_type() ->
+    <<"server_admins">>.
+
+supervisor() ->
+    mover_transient_worker_sup.
+
+error_halts_migration() ->
+    true.
+
+reconfigure_object(_ObjectId, _AcctInfo) ->
+    ok.

--- a/src/chef-mover/src/mv_oc_chef_authz.erl
+++ b/src/chef-mover/src/mv_oc_chef_authz.erl
@@ -28,7 +28,7 @@
 %% d0fa517e23483ca9555721a0ebae681e30f9d104 (tag 1.6.4).
 %%
 %% Functions and record types will be slightly modified to meet the needs of
-%% mover_policies_containers_creation_callback.
+%% mover_policies_containers_creation_callback and mover_server_admins_global_group_callback.
 %%
 %% Any code with an external dependency on oc_chef_authz_db has been commented
 %% out. If you need that code, feel free to uncomment it, but be sure to vendor

--- a/src/chef-server-bootstrap/bin/bootstrap-platform
+++ b/src/chef-server-bootstrap/bin/bootstrap-platform
@@ -40,11 +40,19 @@ class BootstrapPlatform
 
     db = Sequel.connect("#{config['db_driver']}://#{config['db_user']}:#{config['db_password']}@#{config['db_host']}:#{config['db_port']}/opscode_chef")
 
-    #################################
-    # create superuser authz object #
-    #################################
+    #########################
+    # create  authz objects #
+    #########################
 
-    superuser_authz_id = create_object_in_authz("actors", config['bifrost_superuser_id'], config['bifrost_host'], config['bifrost_port'])
+    bifrost_superuser_id = config['bifrost_superuser_id']
+    bifrost_host         = config['bifrost_host']
+    bifrost_port         = config['bifrost_port']
+
+    # for superuser
+    superuser_authz_id = create_object_in_authz("actors", bifrost_superuser_id, bifrost_host, bifrost_port)
+
+    # for server-admins global group
+    server_admins_authz_id = create_object_in_authz("groups", bifrost_superuser_id, bifrost_host, bifrost_port)
 
     ####################
     # create superuser #
@@ -71,7 +79,7 @@ class BootstrapPlatform
     user_created_time = Time.now.utc
     user['created_at'] = user_created_time
     user['updated_at'] = user_created_time
-    user['last_updated_by'] = config['bifrost_superuser_id']
+    user['last_updated_by'] = bifrost_superuser_id
 
     # indicates public_key instead of cert
     user['pubkey_version'] = 0
@@ -85,7 +93,27 @@ class BootstrapPlatform
     ##############################
     # create superuser container #
     ##############################
-    create_global_containers(superuser_authz_id, PLACEHOLDER_GLOBAL_ORG_ID, db, config['bifrost_host'], config['bifrost_port'])
+    global_container_authz_ids = create_global_containers(superuser_authz_id, PLACEHOLDER_GLOBAL_ORG_ID, db, bifrost_host, bifrost_port)
+
+    #####################################
+    # create server-admins global group #
+    #####################################
+    create_server_admins_global_group(db, superuser_authz_id, PLACEHOLDER_GLOBAL_ORG_ID, server_admins_authz_id)
+    # grant this object create and read on the users container
+    grant_authz_object_permission("create", "groups", "containers", global_container_authz_ids['users'], server_admins_authz_id, superuser_authz_id, bifrost_host, bifrost_port)
+    grant_authz_object_permission("read",   "groups", "containers", global_container_authz_ids['users'], server_admins_authz_id, superuser_authz_id, bifrost_host, bifrost_port)
+    grant_authz_object_permission("update", "groups", "containers", global_container_authz_ids['users'], server_admins_authz_id, superuser_authz_id, bifrost_host, bifrost_port)
+    grant_authz_object_permission("delete", "groups", "containers", global_container_authz_ids['users'], server_admins_authz_id, superuser_authz_id, bifrost_host, bifrost_port)
+    # Finally, grant server-admins read permissions on itself
+    grant_authz_object_permission("read", "groups", "groups", server_admins_authz_id, server_admins_authz_id, bifrost_superuser_id, bifrost_host, bifrost_port)
+
+    #############################################
+    # put pivotal in server-admins global group #
+    #############################################
+    grant_authz_object_permission("create", "actors", "groups", server_admins_authz_id, superuser_authz_id, bifrost_superuser_id, bifrost_host, bifrost_port)
+    grant_authz_object_permission("read",   "actors", "groups", server_admins_authz_id, superuser_authz_id, bifrost_superuser_id, bifrost_host, bifrost_port)
+    grant_authz_object_permission("update", "actors", "groups", server_admins_authz_id, superuser_authz_id, bifrost_superuser_id, bifrost_host, bifrost_port)
+    insert_authz_actor_into_group(server_admins_authz_id, superuser_authz_id,  superuser_authz_id, bifrost_host, bifrost_port)
   end
 
   private
@@ -102,13 +130,56 @@ class BootstrapPlatform
     JSON.parse(result)["id"]
   end
 
+  def insert_authz_actor_into_group(group_id, actor_id, requester_id, bifrost_host, bifrost_port)
+    headers = {
+      :content_type => :json,
+      :accept => :json,
+      'X-Ops-Requesting-Actor-Id' => requester_id
+    }
+
+    RestClient.put("http://#{bifrost_host}:#{bifrost_port}/groups/#{group_id}/actors/#{actor_id}", "{}", headers)
+  end
+
+  def grant_authz_object_permission(permission_type, granted_to_object_type, granted_on_object_type, granted_on_id, granted_to_id, requester_id, bifrost_host, bifrost_port)
+    base_url = "http://#{bifrost_host}:#{bifrost_port}/#{granted_on_object_type}/#{granted_on_id}/acl"
+    headers = {
+      :content_type => :json,
+      :accept => :json,
+      'X-Ops-Requesting-Actor-Id' => requester_id
+    }
+
+    # grant create perm
+    full_url = "#{base_url}/#{permission_type}"
+    original_create = JSON.parse(RestClient.get(full_url, headers))
+    original_create[granted_to_object_type] << granted_to_id
+    RestClient.put(full_url, original_create.to_json, headers)
+  end
+
   def create_global_containers(superuser_authz_id, placeholder_id, db, bifrost_host, bifrost_port)
+    global_container_authz_ids = {}
     %w(organizations users).each do |name|
       authz_id = create_object_in_authz("containers", superuser_authz_id, bifrost_host, bifrost_port)
+      global_container_authz_ids[name] = authz_id
       created_time = Time.now.utc
       db[:containers].insert(:name => name, :id => authz_id, :org_id => placeholder_id, :last_updated_by => superuser_authz_id, :authz_id => authz_id, :created_at => created_time.to_s[0..18], :updated_at => created_time.to_s[0..18])
     end
+    global_container_authz_ids
   end
+
+  def create_server_admins_global_group(db, superuser_authz_id, placeholder_id, precreated_authz_id)
+    created_time = Time.now.utc.to_s[0..18]
+
+    server_admins = {}
+    server_admins['id'] = UUID.new.generate(:compact)
+    server_admins['org_id'] = placeholder_id
+    server_admins['authz_id'] = precreated_authz_id
+    server_admins['name'] = 'server-admins'
+    server_admins['last_updated_by'] = superuser_authz_id
+    server_admins['created_at'] = created_time
+    server_admins['updated_at'] = created_time
+    db[:groups].insert(server_admins)
+  end
+    
 end
 
 if __FILE__ == $0


### PR DESCRIPTION
Implemented Version 1 of [Server Admins](https://gist.github.com/tylercloke/a8d4bc1b915b958ac160).

### Description

Version 1 of Server Admins. Implements flexible user create and read perms.

Now, a global group, called server-admins, will be set up on bootstrap and migration
of existing chef-servers. This global group will have create and read permissions on
the users container, meaning any user placed in the server-admins global group will
have permissions to create and read users system-wide, granting much needed flexability
around our user management for larger orgs. As a side-effect, `knife user` is now
relevant again.

A second migration updates existing users (except pivotal) read, update, and delete permissions to grant server-admins access, as changing container permissions does not update existing objects.

A new set of chef-server-clt tools were added to manage server-admins under Server Admins Commands:
+ grant-server-admin-permissions
Add an existing user to the server-admins global group.
+ list-server-admins
Show all users in the server-admins global group. Should contain pivotal.
+ remove-server-admin-permissions
Removes an existing user from the server-admins global group, removing all special permissions they have.

### Details

Ping @chef/lob 

[Current build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/799/downstreambuildview/)

Questions (please help reviewers):
- [x]  Members of this global group will have READ and CREATE permissions on users. We are not granting UPDATE and DELETE because then a lowly server-admin could mess with pivotal. On the other hand, results in CRUDG behavior where admins could only DELETE / EDIT users they personally created with their own user (vs `chef-server-ctl`) and not migrated users / users they didn't personally create. What do y'all think? I think there are valid arguments for both sides. Its something we could always add in the future with a migration very similar to `mover_server_admins_existing_users_read_permissions_callback.erl`.
- [x] Should we prevent `pivotal` from being removed from the `server-admins` global group via the new `chef-server-ctl` commands?

TODO
- [x] Need one more migration to update the READ permission on existing users, since updating the container does not update the permission for existing objects.
- [x] [Documentation](https://gist.github.com/tylercloke/4f2f55aae84c43349ada)
- [ ] Write basic `chef-server-acceptance` tests and run though upgrade battery.
- [ ] I am doing CRUD, should GRANT be included (seems like no)?