### PR TITLE
Add production section to newrelic config

### DIFF
--- a/omnibus/RELEASE_NOTES.md
+++ b/omnibus/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Chef Server Release Notes
 
+## 12.1.3 (Unreleased)
+
+Take extra steps to ensure that unless newrelic support is expressly
+configured, the service will not call home to newrelic. This fixes a
+problem that affects 12.1.0, 12.1.1, 12.1.2.
+
 ## 12.1.2 (2015-07-16)
 
 Fix issue where chef-server-ctl install could not fetch remote packages via apt.

--- a/src/oc-id/config/newrelic.yml
+++ b/src/oc-id/config/newrelic.yml
@@ -2,3 +2,5 @@ development:
   app_name: oc-id (Development)
   monitor_mode: false
   developer_mode: true
+production:
+  monitor_mode: false


### PR DESCRIPTION
Disables new relic in production in on-prem installations.