### PR TITLE
Implement DELETE for Policyfile types

### DIFF
--- a/oc-chef-pedant/spec/api/policies/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/policies/complete_endpoint_spec.rb
@@ -396,7 +396,166 @@ describe "Policies API endpoint", :policies do
       end
 
     end
-  end
+  end # describe "Listing policies and policy groups"
+
+  describe "Named Policy Groups endpoint /policy_groups/:policy_group_name" do
+
+    let(:named_policy_group_url) { api_url("/policy_groups/example-policy-group") }
+
+    context "when the named group doesn't exist" do
+
+      it "GET /policy_groups/:policy_group_name returns a 404" do
+        expect(get(named_policy_group_url, requestor).code).to eq(404)
+      end
+
+      it "DELETE /policy_groups/:policy_group_name returns a 404" do
+        expect(delete(named_policy_group_url, requestor).code).to eq(404)
+      end
+
+    end
+
+    context "when the named group exists" do
+
+      let(:associated_policy_url) { "#{named_policy_group_url}/policies/some_policy_name" }
+
+      before do
+        put(associated_policy_url, requestor, payload: minimum_valid_policy_payload)
+      end
+
+      after do
+        delete(named_policy_group_url, requestor)
+      end
+
+      context "when no policies are assigned to the group" do
+
+        let(:expected_body) do
+          {
+            "uri" => api_url("policy_groups/example-policy-group"),
+            "policies" => {}
+          }
+        end
+
+        before do
+          # remove policy group association to clear out the policy group
+          delete(associated_policy_url, requestor)
+        end
+
+        it "GET /policy_groups/:policy_group_name returns 200 with an empty JSON Object" do
+          response = get(named_policy_group_url, requestor)
+          expect(response.code).to eq(200)
+          expect(parse(response.body)).to eq(expected_body)
+        end
+
+        it "DELETE /policy_groups/:policy_group_name returns 200 with an empty JSON Object" do
+          response = delete(named_policy_group_url, requestor)
+          expect(response.code).to eq(200)
+          expect(parse(response.body)).to eq(expected_body)
+        end
+
+      end
+
+      context "when policies are assigned to the group" do
+
+        let(:expected_body) do
+          {
+            "uri" => api_url("policy_groups/example-policy-group"),
+            "policies" => {
+              "some_policy_name" => { "revision_id" => "909c26701e291510eacdc6c06d626b9fa5350d25" }
+            }
+          }
+        end
+
+        it "GET /policy_groups/:policy_group_name returns 200 with a JSON Object showing associated policies" do
+          response = get(named_policy_group_url, requestor)
+          expect(response.code).to eq(200)
+          expect(parse(response.body)).to eq(expected_body)
+        end
+
+        it "DELETE /policy_groups/:policy_group_name returns 200 with a JSON Object showing associated policies" do
+          response = delete(named_policy_group_url, requestor)
+          expect(response.code).to eq(200)
+          expect(parse(response.body)).to eq(expected_body)
+        end
+
+        it "DELETE /policy_groups/:policy_group_name deletes policy associations" do
+          response = delete(named_policy_group_url, requestor)
+          expect(response.code).to eq(200)
+
+          expect(get(associated_policy_url, requestor).code).to eq(404)
+        end
+
+      end
+
+    end
+
+  end # describe "Named Policy Groups endpoint /policy_groups/:policy_group_name"
+
+  describe "Named policy endpoint /policies/:policy_name" do
+
+    context "when :policy_name doesn't exist" do
+
+      it "GET /policies/:policy_name returns a 404"
+
+      it "DELETE /policies/:policy_name returns 404"
+
+      it "POST /policies/:policy_name/revisions creates the policy name and policy revision"
+
+    end
+
+    context "when policy_name exists" do
+
+      it "GET /policies/:policy_name returns a list of revisions"
+
+      it "DELETE /policies/:policy_name deletes the thing and returns the list of revisions"
+
+      describe "creating a new revision" do
+
+        context "when the revision doesn't yet exist" do
+
+          it "POST /policies/:policy_name/revisions creates the policy revision"
+
+        end
+
+        context "when the revision exists" do
+
+          it "POST /policies/:policy_name/revisions returns 409"
+
+        end
+
+      end
+
+    end
+
+  end # describe "Named policy endpoint /policies/:policy_name"
+
+  describe "Named policy revision endpoint /policies/:policy_name/revisions/:revision_id" do
+
+    context "when the policy_name doesn't exist" do
+
+      it "GET /policies/:policy_name/revisions/:revision_id returns 404"
+
+      it "DELETE /policies/:policy_name/revisions/:revision_id returns 404"
+
+    end
+
+    context "when the policy_name exists but :revision_id doesn't" do
+
+      it "GET /policies/:policy_name/revisions/:revision_id returns 404"
+
+      it "DELETE /policies/:policy_name/revisions/:revision_id returns 404"
+
+    end
+
+    context "when the policy_name exists and :revision_id exists" do
+
+      it "GET /policies/:policy_name/revisions/:revision_id returns 200, with the policy as the body"
+
+      it "DELETE /policies/:policy_name/revisions/:revision_id returns 200, with the policy as the body"
+
+    end
+
+  end # describe "Named policy revision endpoint /policies/:policy_name/revisions/:revision_id"
+
 
   describe "Policy Group Revision Association Endpoint /policy_groups/:policy_group/policies/:policy_name", :policy_group_assoc do
 

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -89,7 +89,8 @@
          data_bag_exists/3,
          environment_exists/3,
          list_all_policy_revisions_by_orgid/2,
-         find_all_policy_revisions_by_group_and_name/2]).
+         find_all_policy_revisions_by_group_and_name/2,
+         find_all_policy_revisions_associated_to_group/3]).
 
 -include("chef_db.hrl").
 -include("chef_types.hrl").
@@ -632,6 +633,16 @@ find_all_policy_revisions_by_group_and_name(#context{reqid=ReqId}, OrgId) ->
         {error, Error} ->
             {error, Error}
     end.
+
+find_all_policy_revisions_associated_to_group(#context{reqid=ReqId}, OrgId, GroupName) ->
+    case ?SH_TIME(ReqId, chef_sql, find_all_policy_revisions_associated_to_group, (OrgId, GroupName)) of
+        {ok, PolicyGroupPolicyRevisionIDs} ->
+            PolicyGroupPolicyRevisionIDs;
+        {error, Error} ->
+            {error, Error}
+    end.
+
+
 
 %% -------------------------------------
 %% private functions

--- a/src/oc_erchef/apps/chef_db/src/chef_sql.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_sql.erl
@@ -99,6 +99,7 @@
 
          %% policy_groups
          find_all_policy_revisions_by_group_and_name/1,
+         find_all_policy_revisions_associated_to_group/2,
 
          %% policies
          list_all_policy_revisions_by_orgid/1,
@@ -1556,6 +1557,17 @@ tuplize_policy_rev(Row) ->
 
 find_all_policy_revisions_by_group_and_name(OrgId) ->
     case sqerl:select(find_all_policy_revisions_by_group_and_name, [OrgId]) of
+        {ok, none} ->
+            {ok, []};
+        {ok, Rows } ->
+            Processed = policy_rev_by_group_rows_to_tuple(Rows, []),
+            {ok, Processed};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+find_all_policy_revisions_associated_to_group(OrgId, GroupName) ->
+    case sqerl:select(find_all_policy_revisions_associated_to_group, [OrgId, GroupName]) of
         {ok, none} ->
             {ok, []};
         {ok, Rows } ->

--- a/src/oc_erchef/apps/oc_chef_authz/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/oc_chef_authz/priv/pgsql_statements.config
@@ -179,6 +179,12 @@
   LEFT JOIN policy_revisions AS r ON (g.policy_revision_revision_id = r.revision_id)
       WHERE (g.org_id = $1)">>}.
 
+ {find_all_policy_revisions_associated_to_group,
+  <<"SELECT g.id, g.policy_group_name, g.policy_group_authz_id,
+            g.policy_revision_revision_id, g.policy_revision_name
+       FROM policy_revisions_policy_groups_association AS g
+  LEFT JOIN policy_revisions AS r ON (g.policy_revision_revision_id = r.revision_id)
+      WHERE (g.org_id = $1 AND g.policy_group_name = $2)">>}.
 
  {find_client_name_in_authz_ids, <<"SELECT name, authz_id FROM clients WHERE authz_id = ANY($1)">>}.
  {find_client_authz_id_in_names, <<"SELECT authz_id FROM clients WHERE org_id = $1 AND name = ANY($2)">>}.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy.erl
@@ -201,12 +201,8 @@ fields_for_insert(#oc_chef_policy{
     [Id, AuthzId, OrgId, Name, LastUpdatedBy].
 
 
-delete(ObjectRec = #oc_chef_policy{
-                      org_id = OrgId,
-                      last_updated_by = _AuthzId,
-                      authz_id = _PolicyAuthzId
-                     }, CallbackFun) ->
-    CallbackFun({delete_query(ObjectRec), [name(ObjectRec), OrgId]}).
+delete(ObjectRec = #oc_chef_policy{id = ID}, CallbackFun) ->
+    CallbackFun({delete_query(ObjectRec), [ID]}).
 
 set_api_version(ObjectRec, Version) ->
     ObjectRec#oc_chef_policy{server_api_version = Version}.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group.erl
@@ -165,12 +165,8 @@ fields_for_insert(#oc_chef_policy_group{
     [Id, AuthzId, OrgId, Name, LastUpdatedBy].
 
 
-delete(ObjectRec = #oc_chef_policy_group{
-                      org_id = OrgId,
-                      last_updated_by = _AuthzId,
-                      authz_id = _PolicyAuthzId
-                     } = PolicyGroup, CallbackFun) ->
-    CallbackFun({delete_query(PolicyGroup), [name(ObjectRec), OrgId]}).
+delete(#oc_chef_policy_group{id = Id} = PolicyGroup, CallbackFun) ->
+    CallbackFun({delete_query(PolicyGroup), [ Id]}).
 
 
 set_api_version(ObjectRec, Version) ->

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_revision.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_revision.erl
@@ -109,8 +109,8 @@ valid_cookbook_lock(CookbookLockJson) ->
 %%%%%%%%%%%%%%%%%%%%
 
 
-authz_id(#oc_chef_policy_revision{}) ->
-    error(not_implemented).
+authz_id(#oc_chef_policy_revision{policy_authz_id = AuthzID}) ->
+    AuthzID.
 
 fields_for_update(#oc_chef_policy_revision{}) ->
     error(not_implemented).
@@ -220,11 +220,8 @@ decompress_record(#oc_chef_policy_revision{
     SerializedObject = jiffy:decode(chef_db_compression:decompress(CompressedSerializedObject)),
     Revision#oc_chef_policy_revision{serialized_object = SerializedObject}.
 
-delete(ObjectRec = #oc_chef_policy_revision{
-                      org_id = OrgId,
-                      last_updated_by = _AuthzId
-                     }, CallbackFun) ->
-    CallbackFun({delete_query(ObjectRec), [name(ObjectRec), OrgId]}).
+delete(ObjectRec = #oc_chef_policy_revision{id = ID}, CallbackFun) ->
+    CallbackFun({delete_query(ObjectRec), [ID]}).
 
 set_api_version(ObjectRec, Version) ->
     ObjectRec#oc_chef_policy_revision{server_api_version = Version}.

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
@@ -146,14 +146,14 @@ functional_tests(Config) ->
     ok.
 
 test_init(_Config) ->
-    {OkOrError, _State} = oc_chef_wm_named_policy:init([]),
+    {OkOrError, _State} = oc_chef_wm_policy_group_policy_rev:init([]),
     ?assertEqual(ok, OkOrError).
 
 test_validate_json(_Config) ->
-    Result = oc_chef_wm_named_policy:validate_json(?POLICY_FILE_MINIMAL_EXAMPLE, "some_policy_name"),
+    Result = oc_chef_wm_policy_group_policy_rev:validate_json(?POLICY_FILE_MINIMAL_EXAMPLE, "some_policy_name"),
     Expected = jiffy:decode(?POLICY_FILE_MINIMAL_EXAMPLE),
     ?assertEqual(Expected, Result),
-    Result2 = oc_chef_wm_named_policy:validate_json(?POLICY_FILE_CANONICAL_EXAMPLE, "some_policy_name"),
+    Result2 = oc_chef_wm_policy_group_policy_rev:validate_json(?POLICY_FILE_CANONICAL_EXAMPLE, "some_policy_name"),
     Expected2 = jiffy:decode(?POLICY_FILE_CANONICAL_EXAMPLE),
     ?assertEqual(Expected2, Result2),
     ok.
@@ -173,7 +173,7 @@ test_policy_permissions_get_404(Config) ->
     DbContext = proplists:get_value(context, Config),
     QueryRecord = make_query_record_404(Config),
     % 404s
-    Result = oc_chef_wm_named_policy:policy_permissions_objects('GET', not_found, QueryRecord, DbContext),
+    Result = oc_chef_wm_policy_group_policy_rev:policy_permissions_objects('GET', not_found, QueryRecord, DbContext),
     Expected = {halt, 404, {[{<<"error">>, [<<"Cannot load policy nope in policy group nope">>]}]}},
     ?assertEqual(Expected, Result),
     ok.
@@ -182,7 +182,7 @@ test_policy_permissions_delete_404(Config) ->
     DbContext = proplists:get_value(context, Config),
     QueryRecord = make_query_record_404(Config),
     % 404s
-    Result = oc_chef_wm_named_policy:policy_permissions_objects('DELETE', not_found, QueryRecord, DbContext),
+    Result = oc_chef_wm_policy_group_policy_rev:policy_permissions_objects('DELETE', not_found, QueryRecord, DbContext),
     Expected = {halt, 404, {[{<<"error">>, [<<"Cannot load policy nope in policy group nope">>]}]}},
     ?assertEqual(Expected, Result),
     ok.
@@ -191,7 +191,7 @@ test_policy_permissions_put_404_prereqs_dont_exist(Config) ->
     DbContext = proplists:get_value(context, Config),
     QueryRecord = make_query_record_404(Config),
     % 404s
-    Result = oc_chef_wm_named_policy:policy_permissions_objects('PUT', not_found, QueryRecord, DbContext),
+    Result = oc_chef_wm_policy_group_policy_rev:policy_permissions_objects('PUT', not_found, QueryRecord, DbContext),
     Expected = [{create_in_container, policy_group}, {create_in_container, policies}],
     ?assertEqual(Expected, Result),
     ok.
@@ -269,7 +269,7 @@ test_policy_permissions_put_404_prereqs_exist(Config) ->
             policy = Policy,
             policy_group = PolicyGroup
             },
-    Result = oc_chef_wm_named_policy:policy_permissions_objects('PUT', not_found, QueryAssoc, DbContext),
+    Result = oc_chef_wm_policy_group_policy_rev:policy_permissions_objects('PUT', not_found, QueryAssoc, DbContext),
     % These get reversed by list head-tail stuff compared to the asssociation exists case
     Expected = [{policy_group, ?AUTHZ_ID5}, {policy, ?AUTHZ_ID4}],
     ?assertEqual(Expected, Result),
@@ -279,7 +279,7 @@ test_policy_permissions_get_when_exists(Config) ->
     DbContext = proplists:get_value(context, Config),
     CreatedAssocWithObjects = make_query_record_exists(Config),
     ReturnedAssoc = oc_chef_policy_group_revision_association:find_policy_revision_by_orgid_name_group_name(CreatedAssocWithObjects, DbContext),
-    Result = oc_chef_wm_named_policy:policy_permissions_objects('GET', ReturnedAssoc, CreatedAssocWithObjects, DbContext),
+    Result = oc_chef_wm_policy_group_policy_rev:policy_permissions_objects('GET', ReturnedAssoc, CreatedAssocWithObjects, DbContext),
     Expected = [{policy, ?AUTHZ_ID4}, {policy_group, ?AUTHZ_ID5}],
     ?assertEqual(Expected, Result),
     delete_all_policy_data().
@@ -288,7 +288,7 @@ test_policy_permissions_put_when_exists(Config) ->
     DbContext = proplists:get_value(context, Config),
     CreatedAssocWithObjects = make_query_record_exists(Config),
     ReturnedAssoc = oc_chef_policy_group_revision_association:find_policy_revision_by_orgid_name_group_name(CreatedAssocWithObjects, DbContext),
-    Result = oc_chef_wm_named_policy:policy_permissions_objects('PUT', ReturnedAssoc, CreatedAssocWithObjects, DbContext),
+    Result = oc_chef_wm_policy_group_policy_rev:policy_permissions_objects('PUT', ReturnedAssoc, CreatedAssocWithObjects, DbContext),
     Expected = [{policy, ?AUTHZ_ID4}, {policy_group, ?AUTHZ_ID5}],
     ?assertEqual(Expected, Result),
     delete_all_policy_data().

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -128,6 +128,7 @@
 {["server_api_version"], oc_chef_wm_server_api_version, []}.
 %% Policy endpoints
 {["organizations", organization_id, "policies"], oc_chef_wm_policies, []}.
+{["organizations", organization_id, "policy_groups", policy_group], oc_chef_wm_named_policy_group, []}.
 {["organizations", organization_id, "policy_groups", policy_group, "policies", policy_name], oc_chef_wm_named_policy, []}.
 {["organizations", organization_id, "policy_groups"], oc_chef_wm_policy_groups, []}.
 

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -130,6 +130,7 @@
 {["organizations", organization_id, "policies"], oc_chef_wm_policies, []}.
 {["organizations", organization_id, "policies", policy_name], oc_chef_wm_named_policy, []}.
 {["organizations", organization_id, "policies", policy_name, "revisions"], oc_chef_wm_named_policy_revisions, []}.
+{["organizations", organization_id, "policies", policy_name, "revisions", revision_id], oc_chef_wm_named_policy_named_revision, []}.
 {["organizations", organization_id, "policy_groups", policy_group], oc_chef_wm_named_policy_group, []}.
 {["organizations", organization_id, "policy_groups", policy_group, "policies", policy_name], oc_chef_wm_policy_group_policy_rev, []}.
 {["organizations", organization_id, "policy_groups"], oc_chef_wm_policy_groups, []}.

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -129,7 +129,7 @@
 %% Policy endpoints
 {["organizations", organization_id, "policies"], oc_chef_wm_policies, []}.
 {["organizations", organization_id, "policy_groups", policy_group], oc_chef_wm_named_policy_group, []}.
-{["organizations", organization_id, "policy_groups", policy_group, "policies", policy_name], oc_chef_wm_named_policy, []}.
+{["organizations", organization_id, "policy_groups", policy_group, "policies", policy_name], oc_chef_wm_policy_group_policy_rev, []}.
 {["organizations", organization_id, "policy_groups"], oc_chef_wm_policy_groups, []}.
 
 %% Cookbook artifact endpoints

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -128,6 +128,8 @@
 {["server_api_version"], oc_chef_wm_server_api_version, []}.
 %% Policy endpoints
 {["organizations", organization_id, "policies"], oc_chef_wm_policies, []}.
+{["organizations", organization_id, "policies", policy_name], oc_chef_wm_named_policy, []}.
+{["organizations", organization_id, "policies", policy_name, "revisions"], oc_chef_wm_named_policy_revisions, []}.
 {["organizations", organization_id, "policy_groups", policy_group], oc_chef_wm_named_policy_group, []}.
 {["organizations", organization_id, "policy_groups", policy_group, "policies", policy_name], oc_chef_wm_policy_group_policy_rev, []}.
 {["organizations", organization_id, "policy_groups"], oc_chef_wm_policy_groups, []}.

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -153,7 +153,9 @@ not_found_message(association, {Name, OrgName} ) ->
 not_found_message(invitation, Id) ->
     {[{<<"error">>, iolist_to_binary(["Cannot find association request: ", Id])}]};
 not_found_message(key, {OwnerName, KeyName}) ->
-    {[{<<"error">>, iolist_to_binary(["There is no key named ", KeyName, " associated with ", OwnerName, "."])}]}.
+    {[{<<"error">>, iolist_to_binary(["There is no key named ", KeyName, " associated with ", OwnerName, "."])}]};
+not_found_message(policy_group, Name) ->
+    error_message_envelope(iolist_to_binary(["policy_group '", Name, "' not found"])).
 
 
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -579,6 +579,8 @@ set_authz_id(Id, #group_state{} = G, group) ->
     G#group_state{group_authz_id = Id};
 set_authz_id(Id, #policy_state{} = P, policy_group) ->
     P#policy_state{policy_group_authz_id = Id, created_policy_group = true};
+set_authz_id(Id, #named_policy_revisions_state{} = P, policies) ->
+    P#named_policy_revisions_state{policy_authz_id = Id};
 set_authz_id(Id, #policy_state{} = P, policies) ->
     P#policy_state{policy_authz_id = Id, created_policy = true};
 set_authz_id(Id, #organization_state{} = O, organization) ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy.erl
@@ -1,0 +1,118 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Daniel DeLeo <dan@chef.io>
+%% Copyright 2015 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+%% /policies/:policy_name
+-module(oc_chef_wm_named_policy).
+
+-include("oc_chef_wm.hrl").
+
+%% Webmachine resource callbacks
+-mixin([{oc_chef_wm_base, [content_types_accepted/2,
+                           content_types_provided/2,
+                           finish_request/2,
+                           malformed_request/2,
+                           ping/2,
+                           forbidden/2,
+                           is_authorized/2,
+                           service_available/2]}]).
+
+-export([allowed_methods/2,
+         resource_exists/2]).
+
+%% chef_wm behavior callbacks
+-behaviour(chef_wm).
+-export([auth_info/2,
+         init/1,
+         init_resource_state/1,
+         malformed_request_message/3,
+         request_type/0,
+         validate_request/3,
+         delete_resource/2,
+         to_json/2]).
+
+
+init(Config) ->
+    oc_chef_wm_base:init(?MODULE, Config).
+
+init_resource_state(_Config) ->
+    {ok, #named_policy_revisions_state{}}.
+
+request_type() ->
+    "named_policy_revisions".
+
+allowed_methods(Req, State) ->
+    {['GET', 'DELETE'], Req, State}.
+
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
+validate_request(_Verb, Req, #base_state{resource_state = NamedPolicyState} = State) ->
+    Name = wrq:path_info(policy_name, Req),
+    UpdatedResourceState = NamedPolicyState#named_policy_revisions_state{policy_name = Name},
+    {Req, State#base_state{resource_state = UpdatedResourceState}}.
+
+
+auth_info(Req, #base_state{chef_db_context = DbContext,
+                           organization_guid = OrgId,
+                           resource_state = NamedPolicyState} = State) ->
+    PolicyName = wrq:path_info(policy_name, Req),
+    case chef_db:fetch(#oc_chef_policy{org_id = OrgId, name = PolicyName}, DbContext) of
+        not_found ->
+            {{halt, 404}, Req, State#base_state{log_msg = policy_not_found}};
+        #oc_chef_policy{authz_id = AuthzID} = Policy ->
+            StateWithPolicy = State#base_state{
+                    resource_state = NamedPolicyState#named_policy_revisions_state{
+                        policy_record = Policy}},
+            {{object, AuthzID}, Req, StateWithPolicy}
+    end.
+
+%% This comes after auth_info/2 so if we made it here, it exists
+resource_exists(Req, State) ->
+    {true, Req, State}.
+
+malformed_request_message(Any, _Req, _State) ->
+    error({unexpected_malformed_request_message, Any}).
+
+delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
+                                 organization_guid = OrgId,
+                                 resource_state = #named_policy_revisions_state{
+                                    policy_record = PolicyRecord,
+                                    policy_name = PolicyName}} = State) ->
+    Revisions = chef_db:list(#oc_chef_policy_revision{org_id = OrgId, name = PolicyName},
+                              DbContext),
+    RevisionsMap = build_revisions_map(Revisions, {[]}),
+    EJSON = chef_json:encode(RevisionsMap),
+    ok = oc_chef_wm_base:delete_object(DbContext, PolicyRecord, RequestorId),
+    {true, wrq:set_resp_body(EJSON, Req), State}.
+
+to_json(Req, #base_state{chef_db_context = DbContext,
+                         organization_guid = OrgId,
+                         resource_state = #named_policy_revisions_state{
+                            policy_name = PolicyName}} = State) ->
+    Revisions = chef_db:list(#oc_chef_policy_revision{org_id = OrgId, name = PolicyName},
+                             DbContext),
+    RevisionsMap = build_revisions_map(Revisions, {[]}),
+    {chef_json:encode(RevisionsMap), Req, State}.
+
+build_revisions_map([Revision|Rest],EJSON) ->
+    Updated = ej:set_p({"revisions", Revision}, EJSON, {[]}),
+    build_revisions_map(Rest, Updated);
+build_revisions_map([], EJSON) ->
+    EJSON.

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_group.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_group.erl
@@ -1,0 +1,135 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Daniel DeLeo <dan@chef.io>
+%% Copyright 2015 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+
+-module(oc_chef_wm_named_policy_group).
+
+-include("oc_chef_wm.hrl").
+
+%% Webmachine resource callbacks
+-mixin([{oc_chef_wm_base, [content_types_accepted/2,
+                           content_types_provided/2,
+                           finish_request/2,
+                           malformed_request/2,
+                           ping/2,
+                           forbidden/2,
+                           is_authorized/2,
+                           service_available/2]}]).
+
+-export([allowed_methods/2,
+         post_is_create/2,
+         resource_exists/2]).
+
+%% chef_wm behavior callbacks
+-behaviour(chef_wm).
+-export([auth_info/2,
+         init/1,
+         init_resource_state/1,
+         malformed_request_message/3,
+         request_type/0,
+         validate_request/3,
+         delete_resource/2,
+         to_json/2]).
+
+
+init(Config) ->
+    oc_chef_wm_base:init(?MODULE, Config).
+
+post_is_create(Req, State) ->
+    {false, Req, State}.
+
+init_resource_state(_Config) ->
+    {ok, #policy_group_state{}}.
+
+request_type() ->
+    "named_policy_group".
+
+allowed_methods(Req, State) ->
+    {['GET', 'DELETE'], Req, State}.
+
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
+validate_request(_Verb, Req, State) ->
+    {Req, State}.
+
+auth_info(Req, #base_state{chef_db_context = DbContext,
+                           organization_guid = OrgId} = State) ->
+    PolicyGroupName = wrq:path_info(policy_group, Req),
+    case chef_db:fetch(#oc_chef_policy_group{org_id = OrgId, name = PolicyGroupName}, DbContext) of
+        not_found ->
+            Message= chef_wm_util:not_found_message(policy_group, PolicyGroupName),
+            Req1 = chef_wm_util:set_json_body(Req, Message),
+            {{halt, 404}, Req1, State#base_state{log_msg = policy_group_not_found}};
+        #oc_chef_policy_group{authz_id = AuthzId} = PolicyGroup ->
+            UpdatedPolicyState = #policy_group_state{policy_group = PolicyGroup},
+            {{object, AuthzId}, Req, State#base_state{resource_state = UpdatedPolicyState}}
+    end.
+
+resource_exists(Req, State) ->
+    %% This comes after auth_info/2 so if we made it here, it exists
+    {true, Req, State}.
+
+malformed_request_message(Any, _Req, _State) ->
+    error({unexpected_malformed_request_message, Any}).
+
+delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 requestor_id = RequestorId,
+                                 reqid = ReqId,
+                                 organization_guid = OrgId,
+                                 resource_state = #policy_group_state{
+                                                     policy_group = PolicyGroup}
+                                } = State) ->
+    PolicyGroupName = PolicyGroup#oc_chef_policy_group.name,
+    DeletedPolicyGroupJSON = build_policy_revisions_json(Req, ReqId, DbContext, OrgId, PolicyGroupName),
+    %% CASCADE takes care of the policy group to policy revision association
+    %% rows in the DB.
+    ok = oc_chef_wm_base:delete_object(DbContext, PolicyGroup, RequestorId),
+    {true, wrq:set_resp_body(DeletedPolicyGroupJSON, Req), State}.
+
+-spec to_json(#wm_reqdata{}, #base_state{}) -> {binary(), #wm_reqdata{}, #base_state{}}.
+to_json(Req, #base_state{chef_db_context = DbContext,
+                         organization_guid = OrgId,
+                         reqid = ReqId,
+                         resource_state = #policy_group_state{
+                            policy_group = PolicyGroup}} = State) ->
+    PolicyGroupName = PolicyGroup#oc_chef_policy_group.name,
+    ResponseBody = build_policy_revisions_json(Req, ReqId, DbContext, OrgId, PolicyGroupName),
+    {ResponseBody, Req, State}.
+
+build_policy_revisions_json(Req, ReqId, DbContext, OrgId, PolicyGroupName) ->
+    case chef_db:find_all_policy_revisions_associated_to_group(DbContext, OrgId, PolicyGroupName) of
+        {error, Why} ->
+            Report = {find_all_policy_revisions_by_group_and_name, {Why, ReqId}},
+            lager:error("~p", [Report]),
+            error(Report);
+
+        PolicyRevisionIDs ->
+            URI = oc_chef_wm_routes:route(policy_group, Req, [{name, PolicyGroupName}]),
+            BaseEJSON = ej:set_p({"uri"}, {[{<<"policies">>,{[]}}]}, URI),
+            EJSONWithPolicies = build_nested_list_data(PolicyRevisionIDs, BaseEJSON),
+            chef_json:encode(EJSONWithPolicies)
+    end.
+
+build_nested_list_data([Row|Rest], EJSON) ->
+    {_PolicyGroupName, PolicyName, RevisionID} = Row,
+    NewEJSON = ej:set_p({"policies", PolicyName, "revision_id"}, EJSON, RevisionID),
+    build_nested_list_data(Rest, NewEJSON);
+build_nested_list_data([], EJSON) ->
+    EJSON.

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_named_revision.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_named_revision.erl
@@ -1,0 +1,111 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Daniel DeLeo <dan@chef.io>
+%% Copyright 2015 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+%% /policies/:policy_name/revisions/:revision_id
+-module(oc_chef_wm_named_policy_named_revision).
+
+-include("oc_chef_wm.hrl").
+
+%% Webmachine resource callbacks
+-mixin([{oc_chef_wm_base, [content_types_accepted/2,
+                           content_types_provided/2,
+                           finish_request/2,
+                           malformed_request/2,
+                           ping/2,
+                           forbidden/2,
+                           is_authorized/2,
+                           service_available/2]}]).
+
+-export([allowed_methods/2,
+         resource_exists/2]).
+
+%% chef_wm behavior callbacks
+-behaviour(chef_wm).
+-export([auth_info/2,
+         init/1,
+         init_resource_state/1,
+         malformed_request_message/3,
+         request_type/0,
+         validate_request/3,
+         delete_resource/2,
+         to_json/2]).
+
+
+init(Config) ->
+    oc_chef_wm_base:init(?MODULE, Config).
+
+init_resource_state(_Config) ->
+    {ok, #named_policy_named_rev_state{}}.
+
+request_type() ->
+    "named_policy_named_revision".
+
+allowed_methods(Req, State) ->
+    {['GET', 'DELETE'], Req, State}.
+
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
+validate_request(_Verb, Req, #base_state{resource_state = NamedPolicyState} = State) ->
+    Name = wrq:path_info(policy_name, Req),
+    RevisionID = wrq:path_info(revision_id, Req),
+    UpdatedResourceState = NamedPolicyState#named_policy_named_rev_state{policy_name = Name, revision_id = RevisionID},
+    {Req, State#base_state{resource_state = UpdatedResourceState}}.
+
+
+auth_info(Req, #base_state{chef_db_context = DbContext,
+                           organization_guid = OrgId,
+                           resource_state = NamedPolicyNamedRevState} = State) ->
+    PolicyName = wrq:path_info(policy_name, Req),
+    RevisionID = wrq:path_info(revision_id, Req),
+    case chef_db:fetch(#oc_chef_policy_revision{org_id = OrgId, name = PolicyName, revision_id = RevisionID}, DbContext) of
+        not_found ->
+            {{halt, 404}, Req, State#base_state{log_msg = policy_not_found}};
+        #oc_chef_policy_revision{policy_authz_id = AuthzID} = PolicyRev ->
+            StateWithPolicyRev = State#base_state{
+                    resource_state = NamedPolicyNamedRevState#named_policy_named_rev_state{
+                        policy_revision_record = PolicyRev}},
+            {{object, AuthzID}, Req, StateWithPolicyRev}
+    end.
+
+%% This comes after auth_info/2 so if we made it here, it exists
+resource_exists(Req, State) ->
+    {true, Req, State}.
+
+malformed_request_message(Any, _Req, _State) ->
+    error({unexpected_malformed_request_message, Any}).
+
+delete_resource(Req, #base_state{chef_db_context = DbContext,
+                                 resource_state = #named_policy_named_rev_state{
+                                    policy_revision_record = PolicyRevRecord}} = State) ->
+    case chef_db:delete(PolicyRevRecord, DbContext) of
+        {error, Reason} ->
+            {{halt, 500}, Req, State#base_state{log_msg = Reason}};
+        _Count ->
+            CompressedObject = PolicyRevRecord#oc_chef_policy_revision.serialized_object,
+            JSON = chef_db_compression:decompress(CompressedObject),
+            {true, wrq:set_resp_body(JSON, Req), State}
+    end.
+
+to_json(Req, #base_state{resource_state = #named_policy_named_rev_state{
+                            policy_revision_record = PolicyRevRecord}} = State) ->
+    CompressedObject = PolicyRevRecord#oc_chef_policy_revision.serialized_object,
+    JSON = chef_db_compression:decompress(CompressedObject),
+    {JSON, Req, State}.
+

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_revisions.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_revisions.erl
@@ -1,0 +1,156 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%% @author Daniel DeLeo <dan@chef.io>
+%% Copyright 2015 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+%% /policies/:policy_name/revisions
+-module(oc_chef_wm_named_policy_revisions).
+
+-include("oc_chef_wm.hrl").
+
+%% Webmachine resource callbacks
+-mixin([{oc_chef_wm_base, [content_types_accepted/2,
+                           content_types_provided/2,
+                           finish_request/2,
+                           malformed_request/2,
+                           ping/2,
+                           forbidden/2,
+                           is_authorized/2,
+                           service_available/2]}]).
+
+-export([allowed_methods/2,
+         post_is_create/2,
+         resource_exists/2]).
+
+%% chef_wm behavior callbacks
+-behaviour(chef_wm).
+-export([auth_info/2,
+         init/1,
+         init_resource_state/1,
+         malformed_request_message/3,
+         request_type/0,
+         validate_request/3,
+         create_path/2,
+         from_json/2]).
+
+
+init(Config) ->
+    oc_chef_wm_base:init(?MODULE, Config).
+
+post_is_create(Req, State) ->
+    {true, Req, State}.
+
+init_resource_state(_Config) ->
+    {ok, #named_policy_revisions_state{}}.
+
+request_type() ->
+    "named_policy_revisions".
+
+allowed_methods(Req, State) ->
+    {['POST'], Req, State}.
+
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
+validate_request(_Verb, Req, #base_state{resource_state = NamedPolicyRevisionsState} = State) ->
+    Name = wrq:path_info(policy_name, Req),
+    Body = wrq:req_body(Req),
+    {ok, Policy} = oc_chef_policy_revision:parse_binary_json(Body),
+    validate_name(Name, Policy),
+    UpdatedResourceState = NamedPolicyRevisionsState#named_policy_revisions_state{policy_name = Name, policy_revision_data = Policy},
+    {Req, State#base_state{resource_state = UpdatedResourceState}}.
+
+validate_name(NameFromReq, Policy) ->
+    NameFromJson = erlang:binary_to_list(ej:get({<<"name">>}, Policy)),
+    case ibrowse_lib:url_encode(NameFromJson) =:= ibrowse_lib:url_encode(NameFromReq) of
+        true ->
+            ok;
+        false ->
+            erlang:throw({mismatch, {<<"name">>, NameFromJson, NameFromReq}})
+    end.
+
+
+auth_info(Req, #base_state{chef_db_context = DbContext,
+                           organization_guid = OrgId,
+                           resource_state = NamedPolicyRevisionsState} = State) ->
+    PolicyName = wrq:path_info(policy_name, Req),
+    case chef_db:fetch(#oc_chef_policy{org_id = OrgId, name = PolicyName}, DbContext) of
+        not_found ->
+            StateWithFlag = NamedPolicyRevisionsState#named_policy_revisions_state{create_policy = true},
+            BaseStateWithFlag = State#base_state{resource_state = StateWithFlag},
+            {{create_in_container, policies}, Req, BaseStateWithFlag};
+        #oc_chef_policy{authz_id = AuthzID} = Policy ->
+            StateWithPolicy = NamedPolicyRevisionsState#named_policy_revisions_state{
+                    policy_record = Policy, policy_authz_id = AuthzID},
+            BaseStateWithPolicy = State#base_state{resource_state = StateWithPolicy},
+            {{object, AuthzID}, Req, BaseStateWithPolicy}
+    end.
+
+%% This comes after auth_info/2 so if we made it here, it exists
+resource_exists(Req, State) ->
+    {true, Req, State}.
+
+malformed_request_message(Any, _Req, _State) ->
+    error({unexpected_malformed_request_message, Any}).
+
+create_path(Req, #base_state{resource_state = NamedPolicyRevisionsState} = State) ->
+    #named_policy_revisions_state{policy_name = PolicyName, policy_revision_data = PolicyData} = NamedPolicyRevisionsState,
+    RevisionID = ej:get({<<"revision_id">>}, PolicyData),
+    { "policies/" ++ PolicyName ++ "/revisions/" ++ binary_to_list(RevisionID), Req, State}.
+
+from_json(Req, #base_state{chef_db_context = DbContext,
+                           requestor_id = RequestorId,
+                           organization_guid = OrgId,
+                           api_version = ApiVersion,
+                           resource_state = #named_policy_revisions_state{
+                                policy_authz_id = PolicyAuthzID,
+                                policy_name = PolicyName,
+                                policy_revision_data = PolicyData}} = State) ->
+    create_policy_if_needed(State),
+    PolicyRevForInsert = oc_chef_policy_revision:new_record(ApiVersion, OrgId, PolicyAuthzID, PolicyData),
+    case chef_db:create(PolicyRevForInsert, DbContext, RequestorId) of
+        {conflict, _} ->
+            LogMsg = {policy_revision, name_conflict, PolicyName},
+            RevisionID = ej:get({"revision_id"}, PolicyData),
+            ConflictMsg = "Policy '" ++ PolicyName ++ "' with revision_id '" ++ binary_to_list(RevisionID) ++ " already exists.",
+            {{halt, 409}, chef_wm_util:set_json_body(Req, ConflictMsg),
+             State#base_state{log_msg = LogMsg}};
+        ok ->
+            Uri = oc_chef_wm_routes:route(policy, Req, [{name, PolicyName}]),
+            ReqWithURI = chef_wm_util:set_uri_of_created_resource(Uri, Req),
+            ReqWithBody = chef_wm_util:set_json_body(ReqWithURI, PolicyData),
+            {true, ReqWithBody, State};
+        Error ->
+            {{halt, 500}, Req, State#base_state{log_msg = Error}}
+    end.
+
+create_policy_if_needed(#base_state{resource_state = #named_policy_revisions_state{
+                    create_policy = false,
+                    policy_record = PolicyRecord}}) ->
+    PolicyRecord;
+create_policy_if_needed(#base_state{chef_db_context = DbContext,
+                           requestor_id = RequestorId,
+                           organization_guid = OrgId,
+                           api_version = ApiVersion,
+                           resource_state = #named_policy_revisions_state{
+                                policy_authz_id = AuthzId,
+                                policy_name = Name}}) ->
+    PolicyRecord = oc_chef_policy:new_record(ApiVersion, OrgId, AuthzId, Name),
+    ok = chef_db:create(PolicyRecord, DbContext, RequestorId),
+    PolicyRecord.
+
+

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_group_policy_rev.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_group_policy_rev.erl
@@ -4,7 +4,7 @@
 %% @author Jean Rouge <jean@chef.io>
 %% Copyright 2013-2015 Chef Software, Inc. All Rights Reserved.
 
--module(oc_chef_wm_named_policy).
+-module(oc_chef_wm_policy_group_policy_rev).
 
 -include("oc_chef_wm.hrl").
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_routes.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_routes.erl
@@ -93,6 +93,7 @@ org_route(principal, Req, Args) -> route_organization_rest_object("principals", 
 org_route(client, Req, Args) -> route_organization_rest_object("clients", Req, Args);
 org_route(container, Req, Args) -> route_organization_rest_object("containers", Req, Args);
 org_route(policy, Req, Args) -> route_organization_rest_object("policies", Req, Args);
+org_route(policy_group, Req, Args) -> route_organization_rest_object("policy_groups", Req, Args);
 org_route(group, Req, Args) -> route_organization_rest_object("groups", Req, Args);
 org_route(association, Req, Args) -> route_organization_rest_object("users", Req, Args);
 org_route(invite, Req, Args) -> route_organization_rest_object("association_requests", Req, Args);

--- a/src/oc_erchef/include/oc_chef_wm.hrl
+++ b/src/oc_erchef/include/oc_chef_wm.hrl
@@ -338,6 +338,11 @@
           oc_chef_policy_group_revision_association :: #oc_chef_policy_group_revision_association{}
          }).
 
+-record(policy_group_state, {
+          policy_group,
+          policy_group_authz_id
+         }).
+
 -record(acl_state, {
           type,
           authz_id,

--- a/src/oc_erchef/include/oc_chef_wm.hrl
+++ b/src/oc_erchef/include/oc_chef_wm.hrl
@@ -347,6 +347,14 @@
           policy_data_for_response
          }).
 
+-record(named_policy_named_rev_state, {
+          policy_name,
+          revision_id,
+          policy_record,
+          policy_revision_record,
+          policy_authz_id
+         }).
+
 -record(policy_group_state, {
           policy_group,
           policy_group_authz_id

--- a/src/oc_erchef/include/oc_chef_wm.hrl
+++ b/src/oc_erchef/include/oc_chef_wm.hrl
@@ -338,6 +338,15 @@
           oc_chef_policy_group_revision_association :: #oc_chef_policy_group_revision_association{}
          }).
 
+-record(named_policy_revisions_state, {
+          policy_name,
+          create_policy = false,
+          policy_record,
+          policy_revision_data,
+          policy_authz_id,
+          policy_data_for_response
+         }).
+
 -record(policy_group_state, {
           policy_group,
           policy_group_authz_id


### PR DESCRIPTION
:construction: This only implements some of the required APIs :construction: 

Implements DELETE for policies, policy groups and policy revisions, along with some related GET APIs that will be used client-side for backup/undo functionality.
