### PR TITLE
Remove yanked celluloid from Gemfile.lock

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     buff-shell_out (0.2.0)
       buff-ruby_engine (~> 0.1.0)
     builder (3.2.2)
-    celluloid (0.16.1)
+    celluloid (0.16.0)
       timers (~> 4.0.0)
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
@@ -239,3 +239,6 @@ DEPENDENCIES
   omnibus-software!
   rake
   rspec
+
+BUNDLED WITH
+   1.10.0


### PR DESCRIPTION
I noticed in travis tests for a different branch that the omnibus tests failed to `bundle install`, which was because celluloid 0.16.1 was yanked, though it still appeared in our Gemfile.lock. This updates the bundle to use the previous version instead.

@chef/lob 