### PR TITLE
chef-server-ctl external service support

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -227,7 +227,7 @@ then
   echo "Bypassing server install, it appears done."
 else
   echo "PATH=/opt/opscode/embedded/bin:$PATH" > /root/.bashrc
-  sudo dpkg -i /installers/#{server_installer_name}
+  sudo dpkg -i "/installers/#{server_installer_name}"
 fi
 SCRIPT
 end

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -32,7 +32,7 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
 override :ruby, version: "2.1.4"
-
+override :'omnibus-ctl', version: "0.4.0"
 # creates required build directories
 dependency "preparation"
 

--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -28,7 +28,7 @@ build do
       file.print <<-EOH
 #!/bin/bash
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2015 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,14 +47,11 @@ export SVWAIT=30
 
 # Ensure the calling environment (disapproval look Bundler) does not infect our
 # Ruby environment if private-chef-ctl is called from a Ruby script.
-for ruby_env_var in RUBYOPT \\
-                    BUNDLE_BIN_PATH \\
-                    BUNDLE_GEMFILE \\
-                    GEM_PATH \\
-                    GEM_HOME
-do
-  unset $ruby_env_var
-done
+unset RUBYOPT
+unset BUNDLE_BIN_PATH
+unset BUNDLE_GEMFILE
+unset GEM_PATH
+unset GEM_HOME
 
 ID=`id -u`
 if [ $ID -ne 0 ]; then
@@ -62,7 +59,7 @@ if [ $ID -ne 0 ]; then
    exit 1
 fi
 
-#{install_dir}/embedded/bin/omnibus-ctl opscode #{install_dir}/embedded/service/omnibus-ctl "$@"
+#{install_dir}/embedded/service/omnibus-ctl/chef-server-ctl opscode #{install_dir}/embedded/service/omnibus-ctl "$@"
        EOH
     end
   end

--- a/omnibus/files/private-chef-ctl-commands/chef-server-ctl
+++ b/omnibus/files/private-chef-ctl-commands/chef-server-ctl
@@ -1,0 +1,191 @@
+#!/opt/opscode/embedded/bin/ruby
+require 'rubygems'
+gem 'omnibus-ctl'
+require 'omnibus-ctl'
+
+module Omnibus
+  # This implements callbacks for handling commands related to the
+  # external services supported by Chef Server. As additional services
+  # are external-enabled, controls/configuration will need to be added here.
+  class ChefServerCtl < Omnibus::Ctl
+    # Note that as we expand our external service support,
+    # we may want to consider farming external_X functions to
+    # service-specific classes
+    def external_cleanse_postgresql(perform_delete)
+      postgres = external_services['postgresql']
+      exec_list = []
+      # NOTE a better way to handle this particular action may be through a chef_run of a 'cleanse' recipe,
+      # since here we're explicitly reversing the actions we did in-recipe to set the DBs up....
+      superuser = postgres['db_superuser']
+      [%w{oc_bifrost, bifrost},
+       %w{opscode-erchef, opscode_chef},
+       %w{oc_id, oc_id}].each do |service|
+        key, dbname = service
+        exec_list << "DROP DATABASE #{dbname}"
+        exec_list << "REVOKE \"#{running_package_config[key]['sql_user']}\" FROM \"#{superuser}\""
+        exec_list << "REVOKE \"#{running_package_config[key]['sql_ro_user']}\" FROM \"#{superuser}\""
+        exec_list << "DROP ROLE \"#{running_package_config[key]['sql_user']}\""
+        exec_list << "DROP ROLE \"#{running_package_config[key]['sql_ro_user']}\""
+      end
+      if perform_delete
+        delete_external_postgresql_data(exec_list, postgres)
+      else
+        path = File.join(backup_dir, 'postgresql-manual-cleanup.sql')
+        dump_exec_list_to_file(path, exec_list)
+        log warn_CLEANSE002_no_postgres_delete(path, postgres)
+      end
+    end
+
+    def delete_external_postgresql_data(exec_list, postgres)
+      last = nil
+      begin
+        require "pg"
+        connection = postgresql_connection(postgres)
+        while exec_list.length > 0
+          last = exec_list.shift
+          connection.exec(last)
+        end
+        puts "Chef Server databases and roles have been successsfully deleted from #{postgres['vip']}"
+      rescue StandardError => e
+        exec_list.insert(0, last) unless last.nil?
+        if exec_list.empty?
+          path = nil
+        else
+          path = Time.now.strftime('/root/%FT%R-chef-server-manual-postgresql-cleanup.sql')
+          dump_exec_list_to_file(path, exec_list)
+        end
+        # Note - we're just showing the error and not exiting, so that
+        # we don't block any other external cleanup that can happen
+        # independent of postgresql.
+        log err_CLEANSE001_postgres_failed(postgres, path, last, e.message)
+      ensure
+        connection.close if connection
+      end
+    end
+
+    def dump_exec_list_to_file(path, list)
+      File.open(path, 'w') do |file|
+        list.each { |line| file.puts line }
+      end
+    end
+
+    def external_status_postgresql(detail_level)
+      postgres = external_services['postgresql']
+      begin
+        require 'pg'
+        connection =postgresql_connection(postgres)
+        if detail_level == :sparse
+          # We connected, that's all we care about for sparse status
+          # We're going to keep the format similar to the existing output
+          "run: postgresql: connected OK to #{postgres['vip']}:#{postgres['port']}"
+          # to hopefully avoid breaking anyone who parses this.
+        else
+          postgres_verbose_status(postgres, connetion)
+        end
+      rescue StandardError => e
+        if detail_level == :sparse
+          "down: postgresql: failed to connect to #{postgres['vip']}:#{postgres['port']}: #{e.message.split("\n")[0]}"
+        else
+          log err_STAT001_postgres_failed(postgres, e.message)
+          Kernel.exit! 128
+        end
+      ensure
+        connection.close if connection
+      end
+    end
+
+    def postgresql_connection(postgres)
+      PGconn.open('user' => postgres['db_superuser'], 'host' => postgres['vip'],
+                  'password' => postgres['db_superuser_password'],
+                  'port' => postgres['port'], 'dbname' => 'template1')
+    end
+
+    def postgres_verbose_status(postgres, connection)
+      max_conn = connection.exec("SELECT setting FROM pg_settings WHERE name = 'max_connections'")[0]['setting']
+      total_conn = connection.exec('SELECT sum(numbackends) num FROM pg_stat_database')[0]['num']
+      version = connection.exec('SHOW server_version')[0]['server_version']
+      lock_result =  connection.exec('SELECT pid FROM pg_locks WHERE NOT GRANTED')
+      locks = lock_result.map { |r| r['pid'] }.join(",")
+      locks = 'none' if locks.nil? || locks.empty?
+<<EOM
+PostgreSQL
+  * Connected to PostgreSQL v#{version} on #{postgres['vip']}:#{postgres['port']}
+  * Connections: #{total_conn} active out of #{max_conn} maximum.
+  * Processes ids pending locks: #{locks}
+EOM
+    end
+
+    def err_STAT001_postgres_failed(postgres, message)
+<<EOM
+STAT001: An error occurred while attempting to get status from PostgreSQL
+         running on #{postgres['vip']}:#{postgres['port']}
+
+         The error report follows:
+
+#{format_multiline_message(12, message)}
+
+         See https://docs.chef.io/error_messages.html#stat001-postgres-failed
+         for more information.
+EOM
+    end
+
+    def err_CLEANSE001_postgres_failed(postgres, path, last, message)
+      msg = <<EOM
+CLEANSE001: While local cleanse of Chef Server succeeded, an error
+            occurred while deleting Chef Server data from the external
+            PostgreSQL server at #{postgres['vip']}.
+
+            The error reported was:
+
+#{format_multiline_message(16, message)}
+
+EOM
+      msg << <<-EOM unless last.nil?
+            This occurred when executing the following SQL statement:
+              #{last}
+EOM
+
+      msg << <<-EOM unless path.nil?
+            To complete cleanup of PostgreSQL, please log into PostgreSQL
+            on #{postgres['vip']} as superuser and execute the statements
+            that have been saved to the file below:
+
+              #{path}
+EOM
+
+      msg << <<EOM
+
+            See https://docs.chef.io/error_messages.html#cleanse001-postgres-failed
+            for more information.
+EOM
+     msg
+    end
+    def warn_CLEANSE002_no_postgres_delete(sql_path, postgres)
+      <<EOM
+CLEANSE002: Note that Chef Server data was not removed from your
+            remote PostgreSQL server because you did not specify
+            the '--with-external' option.
+
+            If you do wish to purge Chef Server data from PostgreSQL,
+            you can do by logging into PostgreSQL on
+            #{postgres['vip']}:#{postgres['port']}
+            and executing the appropriate SQL staements manually.
+
+            For your convenience, these statements have been saved
+            for you in:
+
+            #{sql_path}
+
+            See https://docs.chef.io/error_messages.html#cleanse002-postgres-not-purged
+            for more information.
+EOM
+    end
+
+  end
+end
+
+# This replaces the default bin/omnibus-ctl command
+ctl = Omnibus::ChefServerCtl.new(ARGV[0], true, "Chef Server")
+ctl.load_files(ARGV[1])
+arguments = ARGV[2..-1] # Get the rest of the command line arguments
+ctl.run(arguments)

--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -24,17 +24,15 @@ fi
 if [[ $type == 'CS' ]];
 then
     path='opscode'
-    ctl_cmd='private-chef-ctl'
+    ctl_cmd='chef-server-ctl'
     config_name='*chef*.rb'
     ha=$(egrep -qs 'topology[[:space:]]+.*ha' /etc/opscode/*chef*.rb)$?
 
     if [[ ! -e "/opt/$path/bin/$ctl_cmd" ]];
     then
-        echo "ERROR: Enterprise or Chef Server may not be installed."
+        echo "ERROR: Chef Server may not be installed."
         exit 1
     fi
-
-    echo "Gathering logs from Enterprise or Chef Server."
 elif [[ $type == 'OSC' ]];
 then
     path='chef-server'
@@ -43,11 +41,11 @@ then
 
     if [[ ! -e "/opt/$path/bin/$ctl_cmd" ]];
     then
-        echo "ERROR: Open Source Chef server may not be installed."
+        echo "ERROR: Open Source Chef Server 11 may not be installed."
         exit 1
     fi
 
-    echo "Gathering logs from Open Source Chef server."
+    echo "Gathering logs from Open Source Chef server 11."
 elif [[ $type == 'Analytics' ]];
 then
     path='opscode-analytics'
@@ -64,7 +62,7 @@ then
 else
     echo "Usage: gather-logs [ CS | OSC | Analytics ]"
     echo "CS - Enterprise or Chef Server (default)"
-    echo "OSC - Open Source Chef server"
+    echo "OSC - Open Source Chef Server 11"
     echo "Analytics - Opscode Analytics server"
     exit 1
 fi
@@ -116,27 +114,29 @@ fi
 # There are two cases in which this could fail:
 # 1) We've configure postgresql to listen on a different local socket. Most users don't do this, but it is possible.
 # 2) Postgresql isn't running.
-# Since the general goal of this script is to collect whatever we can for support but not present confusing errors to 
-# the user, we went for a test that covered (2) easily. If we can do something smart that would account for (1) that 
+# Since the general goal of this script is to collect whatever we can for support but not present confusing errors to
+# the user, we went for a test that covered (2) easily. If we can do something smart that would account for (1) that
 # would be cool, but my sense is that this is OK for now.
 
 if [[ -S "/tmp/.s.PGSQL.5432" ]]; then
-    if [[ $type == 'CS' ]];
-    then
-        echo "SELECT CURRENT_TIMESTAMP; SELECT * FROM pg_stat_activity;" | su -l $POSTGRESQL_UNIX_USER -c 'psql opscode_chef' > "$tmpdir/pg_stat_activity.txt"
-
-        echo "SELECT * FROM sqitch.tags;" | su -l $POSTGRESQL_UNIX_USER -c 'psql opscode_chef' > "$tmpdir/opscode_chef_sqitch_tags.txt"
-        echo "SELECT * FROM sqitch.tags;" | su -l $POSTGRESQL_UNIX_USER -c 'psql bifrost' > "$tmpdir/bifrost_sqitch_tags.txt"
-
-        su -m $POSTGRESQL_UNIX_USER -c 'ulimit -a' > "$tmpdir/ulimit_a_opscode-pgsql.txt"
-    fi
     if [[ $type == 'Analytics' ]];
     then
         echo "SELECT CURRENT_TIMESTAMP; SELECT * FROM pg_stat_activity;" | su -l chef-pgsql -c 'psql actions' > "$tmpdir/pg_stat_activity.txt"
-
         echo "SELECT * FROM schema_migrations;" | su -l chef-pgsql -c 'psql actions' > "$tmpdir/actions_schema_migrations.txt"
-
         su -m chef-pgsql -c 'ulimit -a'> "$tmpdir/ulimit_a_chef-pgsql.txt"
+    fi
+fi
+
+
+if [[ $type == 'CS' ]];
+then
+    # postgres server may be external - we'll go ahead and try to gather what we can in any case, and just capture errors to the output
+    # without showing them to the user
+    echo "SELECT CURRENT_TIMESTAMP; SELECT * FROM pg_stat_activity;" | chef-server-ctl psql oc_erchef  --options -tA > "$tmpdir/pg_stat_activity.txt" 2>&1
+    echo "SELECT * FROM sqitch.tags;" |  chef-server-ctl psql oc_erchef --options -tA  > "$tmpdir/opscode_chef_sqitch_tags.txt" 2>&1
+    echo "SELECT * FROM sqitch.tags;" |  chef-server-ctl psql bifrost --options -tA > "$tmpdir/bifrost_sqitch_tags.txt" 2>&1
+    if [[ -S "/tmp/.s.PGSQL.5432" ]]; then
+        su -m $POSTGRESQL_UNIX_USER -c 'ulimit -a' > "$tmpdir/ulimit_a_opscode-pgsql.txt"
     fi
 fi
 


### PR DESCRIPTION
The commit messages have full details., but TL;DR: 

Adds external service support in chef-server-ctl.  Adds generalized behavior to support  'status', 'service-list', 'cleanse' for external services.  Disables other runsv commands used specifically against services flagged as external.  Adds external postgresql support for the  commands above. 

gather-logs has been updated to use chef-server-ctl psql for chef server postgres, which already handles remote v local correctly. 

Remaining work: 
* [x] override omnibus-ctl version if we don't change default in omnibus-software
* [x] {Possibly} - move some of the helper functions that determine internal v external services to the base Omibus::Ctl class -- but that only makes sense if we will be standardizing on this method of external service handling. 


ping @chef/lob 
