### PR TITLE
system gem load support for dvm

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -241,10 +241,7 @@ wget --quiet https://www.postgresql.org/media/keys/ACCC4CF8.asc
 apt-key add ACCC4CF8.asc
 apt-get update
 apt-get install postgresql-9.2 -y
-echo "host    all             bofh            #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
-echo "host    oc_id           oc_id           #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
-echo "host    bifrost         bifrost         #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
-echo "host    opscode_chef    opscode_chef    #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
+echo "host    all             all             #{CS_VM_ADDRESS}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
 echo "listen_addresses='*'" >> /etc/postgresql/9.2/main/postgresql.conf
 service postgresql restart
 export PATH=/usr/lib/postgresql/9.2/bin:$PATH

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -46,6 +46,7 @@ vm:
     - rspec.failures
     - VERSION
     - partybus/config.rb
+
   cover:
     base_output_path: /vagrant/testdata/cover # maps to dev/testdata/cover
   node-attributes:
@@ -115,18 +116,15 @@ projects:
         dest_path: /opt/opscode/embedded/service/partybus
         reconfigure_on_load: false
         bundler: true
-
+  omnibus-ctl:
+    type: ruby #todo instead could callt his 'gem'?
+    system: true
+    external: true
   oc-chef-pedant:
     type: ruby
-    path: "oc-chef-pedant"
+    path: oc-chef-pedant
     database: opscode_chef
-    run: "bin/oc-chef-pedant -c /var/opt/opscode/oc-chef-pedant/etc/pedant_config.rb"
-
-  #TODO
-  # fixie:
-  #   type: ruby
-  #
-
+    run: bin/oc-chef-pedant -c /var/opt/opscode/oc-chef-pedant/etc/pedant_config.rb
 
 quickstart:
   oc_erchef:
@@ -138,7 +136,6 @@ quickstart:
   oc_bifrost:
     description: "Load oc_bifrost and oc-bifrost-pedant from /host. Start oc_bifrost into a console."
     load:
-      - oc-bifrost-pedant
       - oc_bifrost
     start:
       - oc_bifrost

--- a/dev/dvm/lib/dvm/project/project.rb
+++ b/dev/dvm/lib/dvm/project/project.rb
@@ -1,16 +1,21 @@
 require "mixlib/shellout"
 module DVM
   class Project
+    attr_reader :name, :project, :config, :service, :project_dir, :path, :external
     include DVM::Tools
-    attr_reader :name, :project, :config, :service, :project_dir, :path
     # TODO check required fields in config
     def initialize(project_name, config)
       @project = config['projects'][project_name]
-      @name = project['name'].nil? ? project_name : project['name']
-      @path = project['path'] || "src/#{name}"
+      @external = @project['external'] || false
+      @name = project.has_key?('name') ? project['name'] : project_name
+      if external
+        @path = project['path'] || "external-deps/#{name}"
+      else
+        @path = project['path'] || "src/#{name}"
+      end
+      @project_dir = "/host/#{path}"
       @config = config
       @service = @project['service']
-      @project_dir = "/host/#{path}"
     end
     def start(args, detach)
       raise DVM::DVMArgumentError, "Start not supported for #{name}"
@@ -50,8 +55,6 @@ module DVM
     def loaded?
       false
     end
-
-
 
     def load_dep(name, ignored_for_now)
       raise DVM::DVMArgumentError, "Load the project before loading deps." unless loaded?

--- a/dev/dvm/lib/dvm/project/ruby.rb
+++ b/dev/dvm/lib/dvm/project/ruby.rb
@@ -1,28 +1,49 @@
 module DVM
+  # Note that when 'system' is configured 'true', the project will
+  # be overlaid into the /opt/opscode/embedded/lib/ruby/gems/X/$project directory
+  # via bind mount.  This will ensure it's available for use in chef-server-ctl commands
+  # which aren't run from in the dvm substitute environment.
   class RubyProject < Project
     def initialize(project_name, config)
       super
     end
     def do_load(options)
-      if @project.has_key?('load')
-        # TODO this seems like a sane default for load behavior in Project, have it
-        # call subclass do_load if there is no such key. Will also let us quickly get new projects
-        # going.
-        @project['load'].each do |c|
-          run_command(c, c, cwd: @project_dir)
-        end
+      if @project['system']
+        load_system_ruby_project
       else
-        run_command("rm -rf .bundle/config && bundle install --path /opt/opscode/embedded/service/gem --no-binstubs", "Installing in-place...", cwd: @project_dir)
+        load_ruby_project
       end
+    end
+    def load_system_ruby_project
+      # For now we're not loading further gem deps - we can revisit that
+      # if/when we have a need to.
+      bind_mount(project_dir,   system_gem_path(name))
+    end
+    def load_ruby_project
+      # ruby projects that can be run as commands will be updated with a new bundler file in place,
+      # so that they can just be run via `dvm run #{name}` without having to mess around
+      # with the gems installed in package ruby.
+      run_command("rm -rf .bundle/config", cwd: project_dir)
+      run_command("bundle install --path /opt/opscode/embedded/service/gem --no-binstubs", "Installing in-place...", cwd: project_dir)
     end
     def unload
       unmount(@project_dir)
     end
     def loaded?
-      false
+      if project['system']
+        path_mounted?(project_dir)
+      else
+        # No real way to say loaded or not.
+        # Perhaps we could take a look at .bundle/config and see if it points to us?
+        false
+      end
     end
     def run(args)
-      exec "cd #{@project_dir} && #{@project['run']} #{args.join(" ")}"
+      if @project['system']
+        raise DVM::DVMArgumentError, 'Run not supported for system ruby projects - just use it normally via chef-server-ctl or otherwise, as it has been loaded into the server gemset.'
+      else
+        exec "cd #{@project_dir} && #{@project['run']} #{args.join(" ")}"
+      end
     end
   end
 end

--- a/dev/sync
+++ b/dev/sync
@@ -107,7 +107,7 @@ BEGIN {
     excludes += Array(config["vm"]["sync-exclude"]).map(&:to_s)
     excludes.uniq!
     args = ["--stats", "--archive", "--delete", "-z",
-            "--no-owner", "--no-group", "--rsync-path /usr/bin/rsync" ]
+            "--no-owner", "--no-group", "--rsync-path /usr/bin/rsync", "-k" ]
     command = [ "rsync", args, "-e", "\"#{@rsh}\"", excludes.map { |e| ["--exclude", e] },
                 "../", "#{@username}@#{@host}:/host" ].flatten.join(" ")
     # TODO - subproc to ignore INT signal, or move to different process group

--- a/external-deps/.gitignore
+++ b/external-deps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- adds a new 'system' attribute to ruby project config that specifies it is to replace a system/omnibus gem.
- fixes some mount issues - it now persists bind mounts  by default, and will not attempt to mount something that is already mounted. 
- changes sync to copy in symlinked  directories.  This will you to link gem sources loaded into dev/external-deps , without having to change where you want to work on the host.  (other updates to use this in other projects will follow in a separate PR).

That last one is the only one that I have some concern with - I seem to recall we had to turn off symlinks from sync, but I *think* it was file-level links causing headache and not directory level. 

I'll make a subsequent PR  so that we don't have to add redundant 3-line config entries for each gem we want to work on, but for now this gets it working. 