### PR TITLE
Adjust requestor selection to reflect actual query ordering

### DIFF
--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -452,9 +452,11 @@
                                 WHERE id = $1 AND key_name = $2">>}.
 
 % Couple of notes:
-% 1. Order by type is to ensure that our most likely case - a client key - comes up for
-%    checking first. In the future we may wish to add additional heuristics
-%    to increase the likelihood of matching early.
+% 1. Order by type DESC presently puts users ahead of clients.
+%    Consumers of this query may depend on that order. In the future
+%    we may wish to tune with heuristics to increase the likelihood of
+%    matching early, but consumers may have to be changed to
+%    accomodate such changes.
 % 2. expires_at is 'timestamp without timezone', which means storage as UTC.  We force
 %    current_timestamp to UTC to ensure a valid comparison.
 {fetch_requestors_by_name,

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -1242,11 +1242,12 @@ select_user_or_webui_key(Req, Requestors) ->
                     lager:error({no_such_key, Msg, erlang:get_stacktrace()}),
                     throw({no_such_key, WebKeyTag})
             end,
-            % Our query defaults to sorting clients first,
-            % but by definition web requests are user based.  This ensures that our
-            % requestor record is populated with user data (most importantly, requesting authz id)
-            % instead of client, in the event of a client/user name conflict.
-            [Requestor | _] = lists:reverse(Requestors),
+            % The query in chef_sql:fetch_actors_by_name (whence we get Requestors) sorts
+            % users before clients. By definition web requests are user based. Arbitrarily
+            % picking the first requestor from the list ensures that our requestor record is
+            % populated with user data (most importantly, requesting authz id) instead of
+            % client, in the event of a client/user name conflict.
+            [Requestor | _] = Requestors,
             [{Requestor, Key}];
         _ ->
             [{Requestor, Key} || #chef_requestor{public_key = Key} = Requestor <- Requestors]


### PR DESCRIPTION
This is to fix https://getchef.zendesk.com/agent/tickets/5374.

The comments appear to reflect an old state of affairs where clients were returned ahead of users. In fact users are sorted first by the ordering on `type DESC`, which means that if the web-request case wants to prioritize getting a user, it should _not_ reverse the list of requestors it gets after all.

I think a pedant test for this would fit naturally in `oc-chef-pedant/spec/api/keys/keys_spec.rb` in the existing section where a user and client share a name, but I don't yet know how to add `'X-Ops-Request-Source' => 'web'` to the ambient auth headers.