### PR TITLE
Document the 'granular' policy APIs

### DIFF
--- a/src/oc_erchef/raml-docs/policies.yml
+++ b/src/oc_erchef/raml-docs/policies.yml
@@ -37,3 +37,80 @@ get:
                 }
               }
             }
+
+/{policy_name}:
+  uriParameters:
+    policy_name:
+      displayName: policy name
+      type: string
+  get:
+    is: [ versioned ]
+    description: Lists all revisions of a policy with the given policy name.
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              {
+                "revisions": {
+                  "37f9b658cdd1d9319bac8920581723efcc2014304b5f3827ee0779e10ffbdcc9": {
+                  },
+                  "95040c199302c85c9ccf1bcc6746968b820b1fa25d92477ea2ec5386cd58b9c5": {
+                  },
+                  "d81e80ae9bb9778e8c4b7652d29b11d2111e763a840d0cadb34b46a8b2ca4347": {
+                  }
+                }
+              }
+  delete:
+    is: [ versioned ]
+    description: Deletes all revisions of a policy with the given name.
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              {
+                "revisions": {
+                  "37f9b658cdd1d9319bac8920581723efcc2014304b5f3827ee0779e10ffbdcc9": {
+                  },
+                  "95040c199302c85c9ccf1bcc6746968b820b1fa25d92477ea2ec5386cd58b9c5": {
+                  },
+                  "d81e80ae9bb9778e8c4b7652d29b11d2111e763a840d0cadb34b46a8b2ca4347": {
+                  }
+                }
+              }
+  /revisions:
+    post:
+      is: [ versioned ]
+      description: Creates a new policy revision without assigning it to a policy group.
+      body:
+        application/json:
+          example: !include examples/policy.json
+      responses:
+        201:
+          body:
+            application/json:
+              example: !include examples/policy.json
+        409:
+          description: A conflict response is returned when a policy with the given name and revision_id already exist.
+    /{revision_id}:
+      uriParameters:
+        revision_id:
+          displayName: revision id
+          type: string
+      get:
+        is: [ versioned ]
+        description: Retrieves a policy revision with the given name and revision id.
+        responses:
+          200:
+            body:
+              application/json:
+                example: !include examples/policy.json
+      delete:
+        is: [ versioned ]
+        description: Deletes the policy revision with the given name and revision id.
+        responses:
+          200:
+            body:
+              application/json:
+                example: !include examples/policy.json

--- a/src/oc_erchef/raml-docs/policy_groups.yml
+++ b/src/oc_erchef/raml-docs/policy_groups.yml
@@ -40,6 +40,49 @@ get:
                 }
               }
             }
+/{policy_group}:
+  uriParameters:
+    policy_group:
+      displayName: policy group
+      type: string
+  get:
+    is: [ versioned ]
+    description: Returns the policy revisions currently applied to the given policy group.
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              {
+                "uri": "https://chef.example/organizations/org1/policy_groups/dev",
+                "policies": {
+                  "aar": {
+                    "revision_id": "95040c199302c85c9ccf1bcc6746968b820b1fa25d92477ea2ec5386cd58b9c5"
+                  },
+                  "jenkins": {
+                    "revision_id": "613f803bdd035d574df7fa6da525b38df45a74ca82b38b79655efed8a189e073"
+                  }
+                }
+              }
+  delete:
+    is: [ versioned ]
+    description: Deletes the policy group and disassciates it from any policy revisions.
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              {
+                "uri": "https://chef.example/organizations/org1/policy_groups/dev",
+                "policies": {
+                  "aar": {
+                    "revision_id": "95040c199302c85c9ccf1bcc6746968b820b1fa25d92477ea2ec5386cd58b9c5"
+                  },
+                  "jenkins": {
+                    "revision_id": "613f803bdd035d574df7fa6da525b38df45a74ca82b38b79655efed8a189e073"
+                  }
+                }
+              }
 
 /{policy_group}/policies/{policy_name}:
   description: |


### PR DESCRIPTION
Document the following endpoints:
* /policies/:policy_name (GET, DELETE)
* /policies/:policy_name/revisions (POST)
* /policies/:policy_name/revisions/:revision_id (GET, DELETE)
* /policy_groups/:policy_group_name (GET, DELETE)

@chef/lob 