### PR TITLE
Allow standalone-like configurations in plugins

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -572,6 +572,8 @@ EOF
     end
 
     def generate_config_for_topology(topology, node_name)
+      # TODO(ssd): This can be cleaned up once the "default"
+      # topologies are also implemented using registered extensions
       case topology
       when "standalone","manual"
         PrivateChef[:api_fqdn] ||= node_name
@@ -579,8 +581,11 @@ EOF
       when "ha", "tier"
         gen_redundant(node_name, topology)
       else
-        if PrivateChef["registered_extensions"].key?(topology)
+        if PrivateChef["registered_extensions"].key?(topology) && server_config_required?
           gen_redundant(node_name, topology)
+        elsif PrivateChef["registered_extensions"].key?(topology) && !server_config_required?
+          PrivateChef[:api_fqdn] ||= node_name
+          gen_api_fqdn
         else
           Chef::Log.fatal("I do not understand topology #{PrivateChef.topology} - try standalone, manual, ha, or tier.")
           exit 55

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -266,12 +266,12 @@ EOF
       let(:my_gen_api_fqdn_no_throw) { Proc.new {} }
 
       it "calls the gen_backup callback of the custom topology for a backend node" do
-        PrivateChef.register_extension("custom_topo", gen_backend: my_gen_backend )
+        PrivateChef.register_extension("custom_topo", gen_backend: my_gen_backend, server_config_required: true)
         expect{ config_for("a_backend") }.to throw_symbol :my_gen_backend_called
       end
 
       it "calls the gen_frontend callback of the custom topology for a frontend node" do
-        PrivateChef.register_extension("custom_topo", gen_frontend: my_gen_frontend )
+        PrivateChef.register_extension("custom_topo", gen_frontend: my_gen_frontend, server_config_required: true)
         expect{ config_for("a_frontend") }.to throw_symbol :my_gen_frontend_called
       end
 
@@ -288,7 +288,7 @@ EOF
       end
 
       it "uses the default implementation for a callback that isn't provided" do
-        PrivateChef.register_extension("custom_topo", gen_api_fqdn: my_gen_api_fqdn_no_throw)
+        PrivateChef.register_extension("custom_topo", gen_api_fqdn: my_gen_api_fqdn_no_throw, server_config_required: true)
         rendered_config = config_for("a_backend")
         # test a known side-effect of teh current gen_backend function
         expect(rendered_config["private_chef"]["redis_lb"]["listen"]).to eq("0.0.0.0")


### PR DESCRIPTION
The previous code assumed that a plugin cares about frontend and backend
nodes. But in cases like AWS where we only have 1 type of node, this is
not the case.