### PR TITLE
Update openssl cookbook dependency

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
@@ -14,4 +14,4 @@ end
 depends          'enterprise' # grabbed via Berkshelf + Git
 depends          'apt'
 depends          'yum', '~> 3.0'
-depends          'openssl', '>= 4.2'
+depends          'openssl', '>= 4.4'


### PR DESCRIPTION
Update openssl cookbook dependency to 4.4, so that newly generated x509 certificates will be signed with the SHA256 algorithm instead of SHA1.