### PR TITLE
not for merge:  chef-server-ctl cluster-join PoC

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -7,7 +7,7 @@ CS_VM_ADDRESS="192.168.33.100"
 DB_VM_ADDRESS="192.168.33.150"
 DB_SUPERUSER="bofh"
 DB_SUPERPASS="i1uvd3v0ps"
-
+CS_VM_2_ADDRESS="192.168.33.101"
 
 Vagrant.configure("2") do |config|
   attributes = load_settings
@@ -22,18 +22,35 @@ Vagrant.configure("2") do |config|
   config.vm.define("chef-server", primary: true) do |c|
     define_chef_server(c, attributes)
   end
+  config.vm.define("chef-server-node") do |c|
+    define_chef_server(c, attributes, true)
+  end
 end
 
 
-def define_chef_server(config, attributes)
+def define_chef_server(config, attributes, secondary = false)
+  # Ugh come back to this - don'tprompt twice!
   provisioning, installer, installer_path = prepare()
-  config.vm.hostname = "api.chef-server.dev"
-  config.vm.network "private_network", ip: CS_VM_ADDRESS
+
+  if secondary
+    ip = CS_VM_2_ADDRESS
+    host = "node.chef-server.dev"
+    mem = 2048
+    cpus = 2
+  else
+    ip = CS_VM_ADDRESS
+    host = "api.chef-server.dev"
+    mem = attributes["vm"]["memory"]
+    cpus = attributes["vm"]["cpus"]
+  end
+
+  config.vm.hostname = host
+  config.vm.network "private_network", ip: ip
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id,
-                  "--name", "chef-server",
-                  "--memory", attributes["vm"]["memory"],
-                  "--cpus", attributes["vm"]["cpus"],
+                  "--name", host,
+                  "--memory", mem,
+                  "--cpus", cpus,
                   "--usb", "off",
                   "--usbehci", "off"
     ]
@@ -43,9 +60,11 @@ def define_chef_server(config, attributes)
     json = {
       "packages" => attributes["vm"]["packages"],
       "tz" => host_timezone,
-      "omnibus-autoload" => attributes["vm"]["omnibus-autoload"]
+      "omnibus-autoload" => attributes["vm"]["omnibus-autoload"],
+      "dvm" => {}
     }.merge attributes["vm"]["node-attributes"]
 
+    json['dvm']['no-reconfigure'] = true if secondary
     if attributes["vm"]["postgresql"]["start"] and attributes["vm"]["postgresql"]["use-external"]
       # TODO make this stuff common - we have these values in 2-3 places now...
       pg = { "postgresql['external']" => true,
@@ -75,7 +94,8 @@ def define_chef_server(config, attributes)
       chef.binary_path = "/opt/opscode/embedded/bin"
       chef.node_name = config.vm.hostname
       chef.cookbooks_path = "cookbooks"
-      chef.add_recipe("provisioning::chef-server")
+      chef.add_recipe("provisioning::default")
+      chef.add_recipe("provisioning::chef-server") unless secondary
       chef.add_recipe("dev::dvm")
       chef.add_recipe("dev::system")
       chef.add_recipe("dev::user-env")

--- a/dev/cookbooks/dev/recipes/dvm.rb
+++ b/dev/cookbooks/dev/recipes/dvm.rb
@@ -53,4 +53,5 @@ end
 bash "reconfigure-chef-server" do
   user 'root'
   code "chef-server-ctl reconfigure"
+  not_if { node['dvm']['no-reconfigure'] }
 end

--- a/dev/cookbooks/provisioning/recipes/chef-server.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-server.rb
@@ -7,6 +7,8 @@ template "/etc/opscode/chef-server.rb" do
   owner "root"
   group "root"
   action :create
+  variables( fqdn: 'api.chef-server.dev',
+             ip: '192.168.33.100' )
 end
 
 

--- a/dev/cookbooks/provisioning/recipes/chef-server.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-server.rb
@@ -1,33 +1,4 @@
-# Bare minimum packages for other stuff to work:
-execute "apt-get-update" do
-  command "apt-get update"
-  ignore_failure true
-  not_if do
-    File.exists?('/var/chef/cache/apt-update-done')
-  end
-end
 
-file "/var/chef/cache/apt-update-done" do
-  action :create
-end
-package "build-essential"
-package "git"
-
-
-template "/etc/hosts" do
-  source "hosts.erb"
-  owner "root"
-  group "root"
-  action :create
-  variables({"fqdns" => ["api.chef-server.dev",  "manage.chef-server.dev"]})
-end
-
-directory "/etc/opscode" do
-  owner "root"
-  group "root"
-  recursive true
-  action :create
-end
 
 # Note that we do not run reconfigure at this time
 # We will allow the dvm recipe to handle when that should occur.
@@ -37,18 +8,5 @@ template "/etc/opscode/chef-server.rb" do
   group "root"
   action :create
 end
-# Install required external packages.
-# TODO eventually support auto-download of these packages from packagecloud
- #node['chef-server']['installers'].each do |package_name|
-  #package package_name do
-    #source "/installers/#{package_name}"
-    #provider Chef::Provider::Package::Dpkg
-    #action :install
-    #not_if { File.exists? "/var/chef/cache/#{package_name}-installed" }
-  #end
-  #file "/var/chef/cache/#{package_name}-installed" do
-    #action :create
-  #end
 
-#end
 

--- a/dev/cookbooks/provisioning/recipes/default.rb
+++ b/dev/cookbooks/provisioning/recipes/default.rb
@@ -1,0 +1,30 @@
+template "/etc/hosts" do
+  source "hosts.erb"
+  owner "root"
+  group "root"
+  action :create
+  variables({"fqdns" => {"api.chef-server.dev" => "192.168.33.100",  "node.chef-server.dev" => "192.168.33.101"}})
+end
+
+directory "/etc/opscode" do
+  owner "root"
+  group "root"
+  recursive true
+  action :create
+end
+
+# Bare minimum packages for other stuff to work:
+execute "apt-get-update" do
+  command "apt-get update"
+  ignore_failure true
+  not_if do
+    File.exists?('/var/chef/cache/apt-update-done')
+  end
+end
+
+file "/var/chef/cache/apt-update-done" do
+  action :create
+end
+package "build-essential"
+package "git"
+

--- a/dev/cookbooks/provisioning/templates/default/chef-server.rb.erb
+++ b/dev/cookbooks/provisioning/templates/default/chef-server.rb.erb
@@ -1,6 +1,16 @@
-api_fqdn "api.chef-server.dev"
+api_fqdn "#{@fqdn}"
 
-topology "standalone"
-<% node['provisioning']['chef-server-config'].each_pair do |k, v| %>
-<%= k%>=<%= v%>
-<% end %>
+# topology "standalone"
+# <% node['provisioning']['chef-server-config'].each_pair do |k, v| %>
+# <%= k%>=<%= v%>
+# <% end %>
+#
+topology "tier"
+server "#{@fqdn}",
+  :ipaddress => "#{@ip}",
+  :role => "backend",
+  :bootstrap => true
+
+backend_vip "#{@fqdn}",
+  :ipaddress => "#{@ip}",
+  :device => "eth1"

--- a/dev/cookbooks/provisioning/templates/default/hosts.erb
+++ b/dev/cookbooks/provisioning/templates/default/hosts.erb
@@ -1,6 +1,7 @@
 127.0.0.1 localhost
-<% @fqdns.each do |fqdn| %>
-192.168.33.100  <%=fqdn.split(".")[0]%>
+
+<% @fqdns.each_pair do |k, v| %>
+<%= v%> <%= k%>
 <% end %>
 
 ::1 localhost ip6-localhost ip6-loopback

--- a/dev/dvm/lib/dvm/project/erlang.rb
+++ b/dev/dvm/lib/dvm/project/erlang.rb
@@ -92,15 +92,16 @@ EOM
       purge_links
       if File.exists?("#{base_sv_path}/sys.config")
         FileUtils.ln_s("#{base_sv_path}/sys.config", "#{relpath}/sys.config")
-      else
-        FileUtils.ln_s("#{base_sv_path}/etc/sys.config", "#{relpath}/etc/sys.config")
+      end
+      if File.exists?("#{base_sv_path}/vm.args")
+        FileUtils.ln_s("#{base_sv_path}/vm.args", "#{relpath}/vm.args")
       end
 
       FileUtils.ln_s("/var/log/opscode/#{service["name"]}", "#{relpath}/log")
     end
 
     def purge_links
-      FileUtils.rm_rf(["#{relpath}/log", "#{relpath}/sys.config", "#{relpath}/etc/sys.config"])
+      FileUtils.rm_rf(["#{relpath}/log", "#{relpath}/vm.args", "#{relpath}/sys.config", "#{relpath}/etc/sys.config"])
     end
 
     def do_load(options)

--- a/dev/sync
+++ b/dev/sync
@@ -28,11 +28,10 @@ while true do
     # Removing this - having it regularly flickering up and calling attention
     # to itself has proven annoying...
     #@screen.set_status("Syncing...")
-    r = do_sync
+    output = do_sync
     # Prevent scrolling and resizing from doing ugly things...
     @screen.clear
     @screen.say_at(1, 1, banner)
-    output = parse_results(r)
     interrupted = false
     refresh_stats(output)
     sleep(INTERVAL)
@@ -78,9 +77,15 @@ BEGIN {
       k, v = line.split(" ")
       ssh_info[k.strip] = v.strip
     end
+    ssh_info2 = {}
+    `vagrant ssh-config chef-server-node`.split("\n").each do |line|
+      k, v = line.split(" ")
+      ssh_info2[k.strip] = v.strip
+    end
     @username = ssh_info["User"]
     @host = ssh_info["HostName"]
     @rsh = "ssh -p #{ssh_info["Port"]} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q -i #{ssh_info["IdentityFile"]}"
+    @rsh2 = "ssh -p #{ssh_info2["Port"]} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q -i #{ssh_info2["IdentityFile"]}"
     @screen = Screen.new
     @screen.clear
     @screen.say_at(1, 1, banner)
@@ -106,14 +111,19 @@ BEGIN {
     excludes += ['.vagrant/']
     excludes += Array(config["vm"]["sync-exclude"]).map(&:to_s)
     excludes.uniq!
-    args = ["--stats", "--archive", "--delete", "-z",
-            "--no-owner", "--no-group", "--rsync-path /usr/bin/rsync", "-k" ]
-    command = [ "rsync", args, "-e", "\"#{@rsh}\"", excludes.map { |e| ["--exclude", e] },
-                "../", "#{@username}@#{@host}:/host" ].flatten.join(" ")
-    # TODO - subproc to ignore INT signal, or move to different process group
-    # to avoid Ctrl+C interrupting it.
-    r = `#{command}`
-    [ Time.now - start, r.split("\n") ]
+    out = ""
+    r = ""
+    [@rsh, @rsh2].each do |rsh|
+      args = ["--stats", "--archive", "--delete", "-z",
+              "--no-owner", "--no-group", "--rsync-path /usr/bin/rsync", "-k" ]
+      command = [ "rsync", args, "-e", "\"#{rsh}\"", excludes.map { |e| ["--exclude", e] },
+                  "../", "#{@username}@#{@host}:/host" ].flatten.join(" ")
+      # TODO - subproc to ignore INT signal, or move to different process group
+      # to avoid Ctrl+C interrupting it.
+      r = `#{command}`
+      out = parse_results( [ Time.now - start, r.split("\n") ])
+    end
+    out
   end
 
   def suspend

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -197,6 +197,7 @@ default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
 default['private_chef']['opscode-erchef']['sql_password'] = "snakepliskin"
 default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
 default['private_chef']['opscode-erchef']['sql_ro_password'] = "shmunzeltazzen"
+
 # Pool configuration for postgresql connections
 #
 # db_pool_size - the number of pgsql connections in the pool

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -50,6 +50,7 @@ template erchef_vm do
   mode "644"
   variables(:name => "erchef@#{node['api_fqdn']}")
 end
+
 template erchef_config do
   source "oc_erchef.config.erb"
   owner OmnibusHelper.new(node).ownership['owner']

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -32,6 +32,7 @@ enable_ssl = ldap_authentication_enabled ? node['private_chef']['ldap']['enable_
 ldap_encryption_type = ldap_authentication_enabled ? node['private_chef']['ldap']['encryption_type'] : nil
 
 erchef_config = File.join(opscode_erchef_dir, "sys.config")
+erchef_vm = File.join(opscode_erchef_dir, "vm.args")
 
 rabbitmq = OmnibusHelper.new(node).rabbitmq_configuration
 
@@ -42,6 +43,13 @@ actions_password = rabbitmq['actions_password']
 actions_vhost = rabbitmq['actions_vhost']
 actions_exchange = rabbitmq['actions_exchange']
 
+template erchef_vm do
+  source "erchef-vm.args.erb"
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
+  mode "644"
+  variables(:name => "erchef@#{node['api_fqdn']}")
+end
 template erchef_config do
   source "oc_erchef.config.erb"
   owner OmnibusHelper.new(node).ownership['owner']
@@ -80,6 +88,10 @@ end
 
 link "/opt/opscode/embedded/service/opscode-erchef/sys.config" do
   to erchef_config
+end
+
+link "/opt/opscode/embedded/service/opscode-erchef/vm.args" do
+  to erchef_vm
 end
 
 component_runit_service "opscode-erchef"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/erchef-vm.args.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/erchef-vm.args.erb
@@ -1,6 +1,5 @@
-## Name of the node
 ## TODO we're going to needto templatize this!
--name erchef@127.0.0.1
+-name <%=@name%>
 
 ## Cookie for distributed erlang
 -setcookie erchef

--- a/omnibus/files/private-chef-ctl-commands/cluster.rb
+++ b/omnibus/files/private-chef-ctl-commands/cluster.rb
@@ -1,0 +1,79 @@
+require "optparse"
+DESC = "Reconfigure this server to join an existing cluster.  Provide the FQDN of the cluster or any single node in it."
+
+add_command_under_category "cluster-join", "high-availability", DESC, 2 do
+  def scarywarning(myname)
+    log <<EOM
+  * * * * * * * * * * * * * WARNING * * * * * * * * * * * * * *
+
+   This will join this Chef Server Node to an existing cluster
+   and replace all configuration present /etc/opscode.
+
+   This node's FQDN is '#{myname}'.
+
+   Press CTRL+C now if the remote host will not be able to reach this node
+   using that name. This node will not be able to join the cluster
+   if the remote node can't reach it.
+
+   If there is a different FQDN to use, specify it with the --fqdn option.
+
+  * * * * * * * * * * * * * WARNING * * * * * * * * * * * * * *
+EOM
+  end
+
+  my_name = `hostname`.chomp
+  banner = <<EOM
+Usage: #{@exename} cluster-join REMOTE-FQDN [--fqdn THIS-HOST-FQDN] [--help]
+
+REMOTE-FQDN is the name of a remote Chef Server in the cluster. This name should be
+resolvable via DNS or hosts file.  Note that if it's a fully qualified name (eg host.example.com)
+then the fqdn of this host must also be a fully qualified name.
+EOM
+  opt_parser = OptionParser.new do |opts|
+    opts.banner = banner
+
+    opts.on("-h", "--help", "Shows help.") do
+      log opts
+      raise SystemExit.new(0, "help")
+    end
+    opts.on("-f", "--fqdn FQDN", "Fully qualified name of this host, resolvable via hostsfile or dns from the remote Chef Server node") do |name|
+      my_name = name
+    end
+  end
+  # Ugly hack because Ctl doens't give us a clean set of args, and other
+  # global option (--verbose, -q ) are permitted  - so remove anything we
+  # don't want to see.
+  cmd_args = ARGV[3..-1].reject { |arg| arg.start_with?("-") && !(arg == "--fqdn" || arg == "-f" ) }
+  begin
+    opt_parser.parse!(cmd_args)
+  rescue OptionParser::MissingArgument => e
+    puts e.msg
+    raise SystemError(1, e.msg)
+  end
+  if cmd_args.include? "help"  || cmd_args.length != 2
+    # ... we really need to fix base Ctl to allow for "help command-name"
+    usage
+    raise SystemExit.new(1, "fail")
+  end
+  puts "***** #{cmd_args}"
+  remotenode = cmd_args[0]
+  scarywarning(my_name)
+  `mkdir -p /etc/opscode`
+  `rm -rf /etc/opscode/*`
+  run_command "/opt/opscode/embedded/service/omnibus-ctl/node_connector.es #{my_name} #{remotenode}"
+  if $?.status == 0
+    # Okay! This means we've gotten all of our config, have a proper chef-server.rb -
+    # so we'll reconfigure and be done.
+    log "Registration complete!"
+    log "Reconfiguring chef-server, this may take up to three minutes."
+    # Make reconfigure quiet.
+    @quiet = true
+    reconfigure(true)
+    log "This node can now be added to the load balancer rotation."
+    log "Happy Cheffing!"
+
+  else
+    raise SystemExit.new($?.status, "fail")
+  end
+
+end

--- a/omnibus/files/private-chef-ctl-commands/cluster.rb
+++ b/omnibus/files/private-chef-ctl-commands/cluster.rb
@@ -40,9 +40,8 @@ EOM
       my_name = name
     end
   end
-  # Ugly hack because Ctl doens't give us a clean set of args, and other
-  # global option (--verbose, -q ) are permitted  - so remove anything we
-  # don't want to see.
+  # We really need to fix Ctl base to give us a clean set of args - we shouldn't have to
+  # worry about ARGV[4...] or dealing with the possible presence of global args.
   cmd_args = ARGV[3..-1].reject { |arg| arg.start_with?("-") && !(arg == "--fqdn" || arg == "-f" ) }
   begin
     opt_parser.parse!(cmd_args)
@@ -61,17 +60,17 @@ EOM
   `mkdir -p /etc/opscode`
   `rm -rf /etc/opscode/*`
   run_command "/opt/opscode/embedded/service/omnibus-ctl/node_connector.es #{my_name} #{remotenode}"
-  if $?.status == 0
+  if $?.exitstatus == 0
     # Okay! This means we've gotten all of our config, have a proper chef-server.rb -
     # so we'll reconfigure and be done.
     log "Registration complete!"
     log "Reconfiguring chef-server, this may take up to three minutes."
     # Make reconfigure quiet.
     @quiet = true
-    reconfigure(true)
+    reconfigure(false)
     log "This node can now be added to the load balancer rotation."
     log "Happy Cheffing!"
-
+    0
   else
     raise SystemExit.new($?.status, "fail")
   end

--- a/omnibus/files/private-chef-ctl-commands/node_connector.es
+++ b/omnibus/files/private-chef-ctl-commands/node_connector.es
@@ -1,0 +1,66 @@
+#!/usr/bin/env escript
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
+%% %% ex: ts=4 sw=4 et ft=erlang
+%%! -hidden
+%%
+%% Copyright (c) 2015 Chef Software, Inc
+%%
+%% @author Marc Pardise <marc@chef.io>
+% using compiled mode gives more informative error traces
+-mode(compile).
+
+%   TODO data will be encrypted using a key generated on the originating
+%   server, and captured by the provisioning tools.  The key should be
+%   an argument to the script.
+main([MyHost, RemoteHost]) ->
+    HomeTeam = binary_to_atom(iolist_to_binary(["guest@", MyHost] ), utf8),
+    AwayTeam = binary_to_atom(iolist_to_binary(["erchef@", RemoteHost] ), utf8),
+    net_kernel:start([HomeTeam, longnames]),
+    erlang:set_cookie(node(), 'erchef'),
+    register(guest_node, self()),
+    % We'll want some nice pretty error handling here -
+    % retries for a sufficient period perhaps, since we mightbe waiting for the
+    % node to come online.
+    true = net_kernel:connect_node(AwayTeam),
+    % { Action, NodeName, Role }
+    case rpc:call(AwayTeam, oc_erchef_dist, register_node, [HomeTeam, frontend]) of
+        {badrpc, Any} ->
+            io:fwrite("rpc to remote node failed: ~p~n", [Any]),
+            halt(16);
+        ok ->
+            capture_config(RemoteHost, 0),
+            halt(0)
+    end.
+
+% establishconnection to the named remote node
+% tell it that we exist and need to be registered.
+% wait for our data on a backchannel - we'll listenwith gen_tcp
+%   - chef-server.rb
+%   - webui_priv.pem
+%   - webui_pub.pem
+%   - pivotal.pem
+%   - pivotal.rb
+%   - private-chef-secrets.json
+% initially this will not really do a whole lot with disterl
+capture_config(Host, Port) ->
+    receive
+        { proceed_registration, _, NewPort } ->
+            % TODO message back with lenght/checcksum?
+            capture_config(Host, NewPort);
+        { config_data, FileName } ->
+            fetch_file(FileName, Host, Port),
+            capture_config(Host, Port);
+        registration_complete ->
+            ok
+    end.
+
+fetch_file(Path, RemoteHost, Port) ->
+    {ok, Sock} = gen_tcp:connect(RemoteHost, Port, [binary, {packet, 4}, {active, false}]),
+    % packet length indicator of 4 means we should be able to fit
+    % whatever the host is sending in a single rqeuest.  Still, we'll
+    % want to make this more robust when it's for real
+    {ok, Data} = gen_tcp:recv(Sock, 0),
+    gen_tcp:close(Sock),
+    {ok, Fd} = file:open(Path, write),
+    file:write(Fd, Data),
+    file:close(Fd).

--- a/omnibus/files/private-chef-ctl-commands/node_connector.es
+++ b/omnibus/files/private-chef-ctl-commands/node_connector.es
@@ -15,7 +15,7 @@
 main([MyHost, RemoteHost]) ->
     HomeTeam = binary_to_atom(iolist_to_binary(["guest@", MyHost] ), utf8),
     AwayTeam = binary_to_atom(iolist_to_binary(["erchef@", RemoteHost] ), utf8),
-    net_kernel:start([HomeTeam, longnames]),
+    {ok, _} = net_kernel:start([HomeTeam, longnames]),
     erlang:set_cookie(node(), 'erchef'),
     register(guest_node, self()),
     % We'll want some nice pretty error handling here -

--- a/src/chef-mover/scripts/migrate
+++ b/src/chef-mover/scripts/migrate
@@ -41,6 +41,7 @@
 %% the script will exit with exit code 1. Otherwise it will exit
 %% with exit code0, including if there are no orgs to migrate.
 
+M/
 
 
 -define(SELF, 'migrate-script@127.0.0.1').

--- a/src/oc_erchef/src/oc_erchef_dist.erl
+++ b/src/oc_erchef/src/oc_erchef_dist.erl
@@ -1,0 +1,69 @@
+-module(oc_erchef_dist).
+
+-export([register_node/2]).
+-include_lib("kernel/include/inet.hrl").
+% Invoked via RPC when a new node wishes to become a front-end
+% and needs appropriate config data to be provided to it.
+% TODO we'll want to encrypt this data with a key generated
+% during our own provisioning. But hey, PoC and all that.
+%
+register_node(Node, Role) ->
+    spawn(fun() -> send_files(Node, Role) end),
+    ok.
+
+send_files(Node, Role) ->
+    % So this temporary thing will block us from
+    {ok, ListenSocket} = gen_tcp:listen(0, [{packet, 4}, {active,false}]),
+    {ok, Port} = inet:port(ListenSocket),
+    % Tihs was quick and dirty - some otheroptions include spawning an http server
+    % that only accepts requests from this host, or adding a WM endpoointthat
+    % does basic authentication by querying this gen-server for a temp auth token we provide,
+    % etc, etc...
+    {guest_node, Node} ! {proceed_registration, Role, Port},
+
+    send_file_raw(Node, "/etc/opscode/chef-server.rb", ListenSocket, chef_server_rb(Node, Role)),
+    ToSend = [ "/etc/opscode/webui_priv.pem", "/etc/opscode/webui_pub.pem",
+               "/etc/opscode/pivotal.pem", "/etc/opscode/private-chef-secrets.json" ],
+    [ send_file(Node, File, ListenSocket) || File <- ToSend ],
+    gen_tcp:close(ListenSocket),
+    {guest_node, Node}  ! registration_complete,
+    ok.
+
+% Cheating, sorry - once our own topology is actually an FE, we can
+% just grab ours and replace the api_fqdn.  Instead we'll just give a suitable
+    % file for the new node to treat us as a FA.
+% file for t pretend like we're
+% a backend,
+chef_server_rb(NodeName, frontend) ->
+    [_, FQDN] = re:split(atom_to_list(NodeName), "@", [{return, list}]),
+    {ok,  #hostent{ h_addr_list = Ip}} = inet:gethostbyname(FQDN),
+    Addr = inet:ntoa(hd(Ip)),
+    D =
+    [ <<"api_fqdn \"">>, FQDN, <<"\"\n">>,
+      <<"topology \"tier\"\n">>,
+      <<"server 'api.chef-server.dev',\n">>,
+      <<"     ip_address: '192.168.33.100',\n">>,
+      <<"     role: 'backend'\n">>,
+
+      <<"server '">>, FQDN, <<"',\n">>,
+      <<"     ip_address: '">>, Addr, <<"',\n">>,
+      <<"     role: 'frontend'\n">>,
+
+      <<"backend_vip 'api.chef-server.dev',\n">>,
+      <<"     ipaddress: '192.168.33.100',\n">>,
+      <<"     device: 'eth1'\n">>],
+    lager:error("D: ~p", [D]),
+    D.
+
+
+send_file(Node, Name, ListenSocket) ->
+    {ok, Bin} = file:read_file(Name) ,
+    send_file_raw(Node, Name, ListenSocket, Bin).
+
+send_file_raw(Node, FileName, ListenSocket, Data) ->
+    {guest_node, Node} ! { config_data, FileName },
+    {ok, Socket} = gen_tcp:accept(ListenSocket),
+    Result = gen_tcp:send(Socket, Data),
+    lager:error("Send Result: ~p", [Result]),
+    gen_tcp:close(Socket),
+    ok.


### PR DESCRIPTION
It's ugly, but it works.  This shows it's possible without a lot of pain for a node to join an existing cluster without knowing anything about it except its fqdn beforehand. 

Some things that have to be done better; 

* I had to pretend the base chef-server node was a back end in a tiered topology, so that it would auto-configure itself to expose public services on 0.0.0.0   instead of 127.0.0.1.  Once we do the topo and role cleanup (or just support external rabbit..) this won't be needed.  
* The RPC/messaging/tcp stuff is a total hack and is pretty fragile. We'll want to use a state machine that tracks 
* This doesn't address leader handling because I realized it doesn't need to: any FE server can allow any other FE server to come online. There's nothing special that needs doing before that new FE is even configured. 
* nothing is encrypted over the wire at the moment, we're transmitting over tcp secrets, keys, etc to anyone how knows the right way to ask.  I have some ideas here - maybe implement a per-server passphrase to encrypt/decrypt  that the client needs to know about, though that does reduce the simplicity of it slighty.  

ping @chef/lob and  cc/ @manderson26 because I think  you'll find it fun. 


