### PR TITLE
Adding suse to package support for local addon installs.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_local.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_local.rb
@@ -8,7 +8,7 @@
 case node['platform_family']
 when 'debian'
   package_suffix = 'deb'
-when 'rhel'
+when 'rhel', 'suse'
   package_suffix = 'rpm'
 else
   # TODO: probably don't actually want to fail out?
@@ -28,7 +28,7 @@ node['private_chef']['addons']['packages'].each do |pkg|
     case node['platform_family']
     when 'debian'
       provider Chef::Provider::Package::Dpkg
-    when 'rhel'
+    when 'rhel', 'suse'
       provider Chef::Provider::Package::Rpm
     end
     source pkg_file


### PR DESCRIPTION
We have a couple customers using Suse/SLES even though it's not a supported platform. I'd like them to be able to use chef-server-ctl install addon <package> --path <path> to install their addons.

This is a pretty simple two line change for the local add-on wrapper to not fail when the platform is suse based, and instead use Zypper/RPM to install the packages.

Passed Wilson CI testing: http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/701/