### PR TITLE
Node policy integration

### DIFF
--- a/oc-chef-pedant/spec/api/nodes/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/nodes/complete_endpoint_spec.rb
@@ -153,6 +153,197 @@ describe "Testing the Nodes API endpoint", :nodes do
         rejects_invalid_value 'anything_else'
       end
 
+      context "when validating 'policy_name' field" do
+
+        let(:default_resource_attributes) { new_node(node_name) }
+
+        let(:request_payload) do
+          new_node(node_name).tap do |node_data|
+            node_data["policy_name"] = policy_name
+          end
+        end
+
+        shared_examples_for "valid_policy_name" do
+
+          it "accepts the policy_name field" do
+            response = post(request_url, requestor, payload: request_payload)
+            expect(response.code).to eq(201)
+
+            get_response = get(resource_url, requestor)
+
+            expect(get_response.code).to eq(200)
+            returned_resource = parse(get_response.body)
+            expect(returned_resource["policy_name"]).to eq(policy_name)
+          end
+
+        end
+
+        context "when policy_name is valid" do
+
+          context "with a simple valid policy name" do
+
+            let(:policy_name) { "example-policy" }
+
+            include_examples "valid_policy_name"
+
+          end
+
+          context "with a maximum length policy name" do
+
+            let(:policy_name) { "d" * 255 }
+
+            include_examples "valid_policy_name"
+
+          end
+
+          context "with a policy name containing every valid character" do
+
+            let(:policy_name) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
+
+            include_examples "valid_policy_name"
+
+          end
+
+        end
+
+        context "when policy name is invalid" do
+
+          shared_examples_for "invalid_policy_name" do
+
+            let(:expected_response) { "{\"error\":[\"Field 'policy_name' invalid\"]}" }
+
+            it "rejects the policy_name field" do
+              response = post(request_url, requestor, payload: request_payload)
+              expect(response.code).to eq(400)
+              expect(response.body).to eq(expected_response)
+            end
+
+          end
+
+          context "when it's not a string" do
+
+            let(:policy_name) { 42 }
+
+            include_examples "invalid_policy_name"
+
+          end
+
+          context "when it's too long" do
+
+            let(:policy_name) { "F" * 256 }
+
+            include_examples "invalid_policy_name"
+
+          end
+
+          [ ' ', '+', '!' ].each do |invalid_char|
+            context "because the policy_name contains invalid character #{invalid_char}" do
+
+              let(:policy_name) { "invalid-char" + invalid_char }
+
+              include_examples "invalid_policy_name"
+
+            end
+          end
+        end
+
+      end
+
+      context "when validating 'policy_group' field" do
+
+        let(:default_resource_attributes) { new_node(node_name) }
+
+        let(:request_payload) do
+          new_node(node_name).tap do |node_data|
+            node_data["policy_group"] = policy_group
+          end
+        end
+
+        shared_examples_for "valid_policy_group" do
+
+          it "accepts the policy_group field" do
+            response = post(request_url, requestor, payload: request_payload)
+            expect(response.code).to eq(201)
+
+            get_response = get(resource_url, requestor)
+
+            expect(get_response.code).to eq(200)
+            returned_resource = parse(get_response.body)
+            expect(returned_resource["policy_group"]).to eq(policy_group)
+          end
+
+        end
+
+        context "when policy_group is valid" do
+
+          context "with a simple valid policy name" do
+
+            let(:policy_group) { "example-policy" }
+
+            include_examples "valid_policy_group"
+
+          end
+
+          context "with a maximum length policy name" do
+
+            let(:policy_group) { "d" * 255 }
+
+            include_examples "valid_policy_group"
+
+          end
+
+          context "with a policy name containing every valid character" do
+
+            let(:policy_group) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
+
+            include_examples "valid_policy_group"
+
+          end
+
+        end
+
+        context "when policy name is invalid" do
+
+          shared_examples_for "invalid_policy_group" do
+
+            let(:expected_response) { "{\"error\":[\"Field 'policy_group' invalid\"]}" }
+
+            it "rejects the policy_group field" do
+              response = post(request_url, requestor, payload: request_payload)
+              expect(response.code).to eq(400)
+              expect(response.body).to eq(expected_response)
+            end
+
+          end
+
+          context "when it's not a string" do
+
+            let(:policy_group) { 42 }
+
+            include_examples "invalid_policy_group"
+
+          end
+
+          context "when it's too long" do
+
+            let(:policy_group) { "F" * 256 }
+
+            include_examples "invalid_policy_group"
+
+          end
+
+          [ ' ', '+', '!' ].each do |invalid_char|
+            context "because the policy_group contains invalid character #{invalid_char}" do
+
+              let(:policy_group) { "invalid-char" + invalid_char }
+
+              include_examples "invalid_policy_group"
+
+            end
+          end
+        end
+      end
+
       validates_node_attribute 'normal'
       validates_node_attribute 'default'
       validates_node_attribute 'override'
@@ -265,6 +456,197 @@ describe "Testing the Nodes API endpoint", :nodes do
       validates_run_list
 
       rejects_invalid_keys
+
+      context "when validating 'policy_name' field" do
+
+        let(:default_resource_attributes) { new_node(node_name) }
+
+        let(:request_payload) do
+          new_node(node_name).tap do |node_data|
+            node_data["policy_name"] = policy_name
+          end
+        end
+
+        shared_examples_for "valid_policy_name" do
+
+          it "accepts the policy_name field" do
+            response = put(request_url, requestor, payload: request_payload)
+            expect(response.code).to eq(200)
+
+            get_response = get(resource_url, requestor)
+
+            expect(get_response.code).to eq(200)
+            returned_resource = parse(get_response.body)
+            expect(returned_resource["policy_name"]).to eq(policy_name)
+          end
+
+        end
+
+        context "when policy_name is valid" do
+
+          context "with a simple valid policy name" do
+
+            let(:policy_name) { "example-policy" }
+
+            include_examples "valid_policy_name"
+
+          end
+
+          context "with a maximum length policy name" do
+
+            let(:policy_name) { "d" * 255 }
+
+            include_examples "valid_policy_name"
+
+          end
+
+          context "with a policy name containing every valid character" do
+
+            let(:policy_name) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
+
+            include_examples "valid_policy_name"
+
+          end
+
+        end
+
+        context "when policy name is invalid" do
+
+          shared_examples_for "invalid_policy_name" do
+
+            let(:expected_response) { "{\"error\":[\"Field 'policy_name' invalid\"]}" }
+
+            it "rejects the policy_name field" do
+              response = put(request_url, requestor, payload: request_payload)
+              expect(response.code).to eq(400)
+              expect(response.body).to eq(expected_response)
+            end
+
+          end
+
+          context "when it's not a string" do
+
+            let(:policy_name) { 42 }
+
+            include_examples "invalid_policy_name"
+
+          end
+
+          context "when it's too long" do
+
+            let(:policy_name) { "F" * 256 }
+
+            include_examples "invalid_policy_name"
+
+          end
+
+          [ ' ', '+', '!' ].each do |invalid_char|
+            context "because the policy_name contains invalid character #{invalid_char}" do
+
+              let(:policy_name) { "invalid-char" + invalid_char }
+
+              include_examples "invalid_policy_name"
+
+            end
+          end
+        end
+
+      end
+
+      context "when validating 'policy_group' field" do
+
+        let(:default_resource_attributes) { new_node(node_name) }
+
+        let(:request_payload) do
+          new_node(node_name).tap do |node_data|
+            node_data["policy_group"] = policy_group
+          end
+        end
+
+        shared_examples_for "valid_policy_group" do
+
+          it "accepts the policy_group field" do
+            response = put(request_url, requestor, payload: request_payload)
+            expect(response.code).to eq(200)
+
+            get_response = get(resource_url, requestor)
+
+            expect(get_response.code).to eq(200)
+            returned_resource = parse(get_response.body)
+            expect(returned_resource["policy_group"]).to eq(policy_group)
+          end
+
+        end
+
+        context "when policy_group is valid" do
+
+          context "with a simple valid policy name" do
+
+            let(:policy_group) { "example-policy" }
+
+            include_examples "valid_policy_group"
+
+          end
+
+          context "with a maximum length policy name" do
+
+            let(:policy_group) { "d" * 255 }
+
+            include_examples "valid_policy_group"
+
+          end
+
+          context "with a policy name containing every valid character" do
+
+            let(:policy_group) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqurstuvwxyz0123456789-_:.' }
+
+            include_examples "valid_policy_group"
+
+          end
+
+        end
+
+        context "when policy name is invalid" do
+
+          shared_examples_for "invalid_policy_group" do
+
+            let(:expected_response) { "{\"error\":[\"Field 'policy_group' invalid\"]}" }
+
+            it "rejects the policy_group field" do
+              response = put(request_url, requestor, payload: request_payload)
+              expect(response.code).to eq(400)
+              expect(response.body).to eq(expected_response)
+            end
+
+          end
+
+          context "when it's not a string" do
+
+            let(:policy_group) { 42 }
+
+            include_examples "invalid_policy_group"
+
+          end
+
+          context "when it's too long" do
+
+            let(:policy_group) { "F" * 256 }
+
+            include_examples "invalid_policy_group"
+
+          end
+
+          [ ' ', '+', '!' ].each do |invalid_char|
+            context "because the policy_group contains invalid character #{invalid_char}" do
+
+              let(:policy_group) { "invalid-char" + invalid_char }
+
+              include_examples "invalid_policy_group"
+
+            end
+          end
+        end
+      end
 
       context 'with a canonical payload' do
         let(:existing_default_attributes){node['default']}

--- a/omnibus/files/private-chef-upgrades/001/027_node_policyfile_fields.rb
+++ b/omnibus/files/private-chef-upgrades/001/027_node_policyfile_fields.rb
@@ -1,0 +1,7 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+    run_sqitch("@node-policyfile-fields", "@1.0.4")
+  end
+end
+

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -30,12 +30,14 @@
 
 {insert_node,
  <<"INSERT INTO nodes (id, authz_id, org_id, name, environment,"
+   " policy_name, policy_group,"
    " last_updated_by, created_at, updated_at, serialized_object ) VALUES"
-   " ($1, $2, $3, $4, $5, $6, $7, $8, $9)">>}.
+   " ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)">>}.
 
 {update_node_by_id,
- <<"UPDATE nodes SET environment= $1, last_updated_by= $2, updated_at= $3, "
-   "serialized_object= $4 WHERE id= $5">>}.
+ <<"UPDATE nodes SET environment= $1, policy_name= $2, policy_group= $3, "
+   "last_updated_by= $4, updated_at= $5, "
+   "serialized_object= $6 WHERE id= $7">>}.
 
 {delete_node_by_id, <<"DELETE FROM nodes WHERE id= $1">>}.
 

--- a/src/oc_erchef/apps/chef_objects/src/chef_node.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_node.erl
@@ -149,8 +149,8 @@ is_indexed(_ObjectRec) ->
 -spec ejson_for_indexing(#chef_node{}, ejson_term()) -> ejson_term().
 ejson_for_indexing(#chef_node{name = Name,
                               environment = Environment,
-                              policy_name = _PName,
-                              policy_group = _PGroup}, Node) ->
+                              policy_name = PName,
+                              policy_group = PGroup}, Node) ->
     Defaults = ej:get({<<"default">>}, Node, ?EMPTY_EJSON_HASH),
     Normal = ej:get({<<"normal">>}, Node, ?EMPTY_EJSON_HASH),
     Override = ej:get({<<"override">>}, Node, ?EMPTY_EJSON_HASH),
@@ -169,9 +169,8 @@ ejson_for_indexing(#chef_node{name = Name,
                                    %% FIXME: nodes may have environment in the db, but not in JSON
                                    %% or not set at all (pre-environments nodes).
                                    {<<"chef_environment">>, Environment},
-                                   %% TODO: add policyfile stuff once there's pedant tests.
-                                   %% {<<"policy_name">>, PName},
-                                   %% {<<"policy_group">>, PGroup},
+                                   {<<"policy_name">>, PName},
+                                   {<<"policy_group">>, PGroup},
                                    {<<"recipe">>, extract_recipes(RunList)},
                                    {<<"role">>, extract_roles(RunList)},
                                    {<<"run_list">>, RunList}]),

--- a/src/oc_erchef/apps/chef_objects/src/chef_node.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_node.erl
@@ -76,12 +76,16 @@
           {<<"override">>, chef_json_validator:attribute_spec()},
           {<<"automatic">>, chef_json_validator:attribute_spec()},
 
-          {<<"run_list">>, chef_json_validator:run_list_spec()}
+          {<<"run_list">>, chef_json_validator:run_list_spec()},
+
+          {{opt, <<"policy_name">> }, {string_match, chef_regex:regex_for(policy_file_name)}},
+          {{opt, <<"policy_group">> }, {string_match, chef_regex:regex_for(policy_file_name)}}
          ]}).
 
 -define(VALID_KEYS,
         [<<"name">>, <<"chef_environment">>, <<"json_class">>, <<"chef_type">>,
-         <<"normal">>, <<"default">>, <<"override">>, <<"automatic">>, <<"run_list">>]).
+         <<"normal">>, <<"default">>, <<"override">>, <<"automatic">>, <<"run_list">>,
+         <<"policy_name">>, <<"policy_group">> ]).
 
 -define(create_if_missing_fields,
         [{<<"chef_environment">>, <<"_default">>},

--- a/src/oc_erchef/apps/chef_objects/test/chef_node_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_node_tests.erl
@@ -362,6 +362,8 @@ basic_node_index() ->
     {[{<<"name">>, <<"a_node">>},
       {<<"chef_type">>, <<"node">>},
       {<<"chef_environment">>, <<"prod">>},
+      {<<"policy_group">>, undefined},
+      {<<"policy_name">>, undefined},
       {<<"recipe">>, [<<"web">>]},
       {<<"role">>, [<<"prod">>]},
       {<<"run_list">>, [<<"recipe[web]">>, <<"role[prod]">>]}

--- a/src/oc_erchef/include/chef_types.hrl
+++ b/src/oc_erchef/include/chef_types.hrl
@@ -173,6 +173,8 @@
           'org_id',           % organization guid
           'name',             % node name
           'environment',      % environment
+          'policy_name',      % name of policyfile used by this node
+          'policy_group',     % name of policy group this node is in
           'last_updated_by',  % authz guid of last actor to update object
           'created_at',       % time created at
           'updated_at',       % time created at

--- a/src/oc_erchef/schema/deploy/node_policy_name_policy_group.sql
+++ b/src/oc_erchef/schema/deploy/node_policy_name_policy_group.sql
@@ -1,0 +1,11 @@
+-- Deploy node_policy_name_policy_group
+
+BEGIN;
+
+ALTER TABLE nodes ADD COLUMN policy_group VARCHAR(255);
+ALTER TABLE nodes ADD COLUMN policy_name VARCHAR(255);
+
+CREATE INDEX nodes_policy_group ON nodes(org_id, policy_group);
+CREATE INDEX nodes_policy_name ON nodes(org_id, policy_name);
+
+COMMIT;

--- a/src/oc_erchef/schema/revert/node_policy_name_policy_group.sql
+++ b/src/oc_erchef/schema/revert/node_policy_name_policy_group.sql
@@ -1,0 +1,11 @@
+-- Revert node_policy_name_policy_group
+
+BEGIN;
+
+DROP INDEX IF EXISTS nodes_policy_group;
+DROP INDEX IF EXISTS nodes_policy_name;
+
+ALTER TABLE nodes DROP COLUMN policy_group;
+ALTER TABLE nodes DROP COLUMN policy_name;
+
+COMMIT;

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -74,3 +74,5 @@ policy_revisions_policy_groups_association 2015-03-05T20:57:56Z Daniel DeLeo <dd
 
 cbv_type 2015-04-23T08:33:00Z Steven Danna <steve@chef.io> # Add cbv type for new bulk_fetch_cookbook_versions query
 @cbv-type 2015-04-23T08:34:00Z Steven Danna <steve@chef.io> # Add cbv type for new bulk_fetch_cookbook_versions query
+
+node_policy_name_policy_group 2015-09-04T01:15:03Z Daniel DeLeo <ddeleo@lorentz.local># Add policy_name and policy_group fields to node

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -76,3 +76,4 @@ cbv_type 2015-04-23T08:33:00Z Steven Danna <steve@chef.io> # Add cbv type for ne
 @cbv-type 2015-04-23T08:34:00Z Steven Danna <steve@chef.io> # Add cbv type for new bulk_fetch_cookbook_versions query
 
 node_policy_name_policy_group 2015-09-04T01:15:03Z Daniel DeLeo <ddeleo@lorentz.local># Add policy_name and policy_group fields to node
+@node-policyfile-fields 2015-09-05T01:47:34Z Daniel DeLeo <ddeleo@lorentz.local># Add policyfile fields to node

--- a/src/oc_erchef/schema/t/test_nodes_policy_name_policy_group.sql
+++ b/src/oc_erchef/schema/t/test_nodes_policy_name_policy_group.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION test_nodes_pname_pgroup()
+RETURNS SETOF TEXT
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY SELECT has_table('nodes');
+
+  -- Columns
+
+  RETURN QUERY SELECT col_type_is('nodes', 'policy_group', 'character varying(255)');
+  RETURN QUERY SELECT col_type_is('nodes', 'policy_name', 'character varying(255)');
+
+  -- Indexes
+
+  RETURN QUERY SELECT chef_pgtap.has_index('nodes', 'nodes_policy_group', ARRAY['org_id', 'policy_group']);
+  RETURN QUERY SELECT chef_pgtap.has_index('nodes', 'nodes_policy_name', ARRAY['org_id', 'policy_name']);
+
+END;
+$$;

--- a/src/oc_erchef/schema/verify/node_policy_name_policy_group.sql
+++ b/src/oc_erchef/schema/verify/node_policy_name_policy_group.sql
@@ -1,0 +1,10 @@
+-- Verify node_policy_name_policy_group
+
+BEGIN;
+
+SELECT id, authz_id, org_id, name, environment, policy_group, policy_name,
+last_updated_by, created_at, updated_at, serialized_object
+FROM nodes
+WHERE FALSE;
+
+ROLLBACK;


### PR DESCRIPTION
Integrate node objects and policyfile attributes by updating node create/update to accept `policy_group` and `policy_name`

These things are dependent but will be done later to keep patch size small:
* add endpoint `GET /policies/:policy_name/nodes`
* add endpoint `GET /policy_groups/:policy_group/nodes`
