### PR TITLE
Set forward_agent = true in Vagrant ssh config

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure("2") do |config|
   # Use the official Ubuntu 14.04 box
   # Vagrant will auto resolve the url to download from Atlas
   config.vm.box = "ubuntu/trusty64"
+  config.ssh.forward_agent = true
+
   if attributes['vm']['postgresql']['start']
     config.vm.define("database") do |c|
       define_db_server(c, attributes)


### PR DESCRIPTION
Occasionally we want to clone private repositories inside the dev-vm.
The forwarded ssh-agent makes this easier since the user can add their
github ssh key to their agent and it will be available inside the VM.