### PR TITLE
Lock port compiler to 0.3.0 

### DIFF
--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -54,6 +54,8 @@
     ]}
 ]}.
 
+{plugins, [{pc, "0.3.0"}]}.
+
 {xref_checks,
  [exports_not_used,
   undefined_function_calls]}.

--- a/src/chef-mover/rebar.config
+++ b/src/chef-mover/rebar.config
@@ -59,9 +59,7 @@
              {compile, "make bundle VERSION"}
 ]}.
 
-{plugins, [
-    { pc, {git, "https://github.com/blt/port_compiler.git", {branch, "master"}}}
-]}.
+{plugins, [{pc, "0.3.0"}]}.
 
 {overrides, [
     {override, jiffy, [

--- a/src/oc_bifrost/rebar.config
+++ b/src/oc_bifrost/rebar.config
@@ -65,6 +65,8 @@
     ]}
 ]}.
 
+{plugins, [{pc, "0.3.0"}]}.
+
 {ct_opts, [{ct_hooks, [cth_readable_shell]}]}.
 
 {relx, [

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -81,6 +81,7 @@
 ]}.
 
 {plugins, [
+            {pc, "0.3.0"},
             {rebar3_neotoma_plugin, ".*",
               {git, "https://github.com/tsloughter/rebar3_neotoma_plugin", {branch, "master"}}}
         ]}.


### PR DESCRIPTION
An update to the port compiler on hex caused an incompatibility with the
version of rebar we had vendored. Here we lock the pc plugin to avoid
the problem.

We should try to move to a newer rebar3 and update the port compiler
once rebar3 does a release.