### PR TITLE
Fix build of `chef_backup`

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -32,6 +32,7 @@ override :berkshelf2, version: "2.0.18"
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
 override :ruby, version: "2.1.4"
+override :rubygems, version: "2.4.5"
 override :'omnibus-ctl', version: "0.4.2"
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
Build of `chef_backup` is failing on master in Ci with:

```
The following shell command exited with status 1:

    $ /opt/opscode/embedded/bin/gem install chef_backup -n /opt/opscode/embedded/bin --no-rdoc --no-ri -v 0.0.1.dev.4

Output:

    (nothing)

Error:

    ERROR:  While executing gem ... (Gem::DependencyError)
    Unable to resolve dependencies: chef requires chef-config (= 12.4.1)
```

I'm not sure of the exact cause of this but it's related to rubygems versions and upgrading fixes it. I cherry-picked this commit from @joedevivo, resulting in a successful Ci build http://wilson.ci.chef.co/job/chef-server-12-build/1435/ (internal to Chef Software folks).

@chef/lob 