### PR TITLE
Dt/user by email

### DIFF
--- a/oc-chef-pedant/spec/api/authenticate_user_spec.rb
+++ b/oc-chef-pedant/spec/api/authenticate_user_spec.rb
@@ -153,6 +153,37 @@ describe 'authenticate_user', :users do
       end
     end
 
+    context 'with correct (email) credentials', :smoke do
+      let(:body) { { 'username' => username + '@opscode.com', 'password' => password } }
+
+      it 'superuser user returns 200 ("OK")' do
+        post(request_url, superuser, :payload => body).should look_like({
+            :status => 200,
+            :body_exact => response_body
+          })
+      end
+
+      it 'admin/different user returns 403 ("Forbidden")', :authorization do
+        # This doubles as a test of a non-superuser checking a different user
+        post(request_url, platform.admin_user, :payload => body).should look_like({
+            :status => 403
+          })
+      end
+
+      it 'non-admin/same user returns 403 ("Forbidden")', :authorization do
+        # This doubles as a test of a the same non-superuser checking themselves
+        post(request_url, platform.non_admin_user, :payload => body).should look_like({
+            :status => 403
+          })
+      end
+
+      it 'invalid user returns 401 ("Unauthorized")', :authorization do
+        post(request_url, invalid_user, :payload => body).should look_like({
+            :status => 401
+          })
+      end
+    end
+
     context 'and user has external authentication enabled' do
       context 'but local bypass parameter is used' do
         let(:password) { "badger badger" }

--- a/oc-chef-pedant/spec/api/user_spec.rb
+++ b/oc-chef-pedant/spec/api/user_spec.rb
@@ -1116,6 +1116,43 @@ EOF
           end
         end
 
+        context "using email in request" do
+          let(:request_body) do
+            {
+              "username" => username,
+              "email" => "#{username}@opscode.com",
+              "first_name" => "Ren Kai",
+              "last_name" => "de Boers",
+              "display_name" => username,
+              "password" => "badger badger"
+            }
+          end
+
+          let(:modified_user) do
+            {
+              "username" => username,
+              "email" => "#{username}@opscode.com",
+              "first_name" => "Ren Kai",
+              "last_name" => "de Boers",
+              "display_name" => username,
+              "public_key" => public_key_regex
+            }
+          end
+
+          let(:request_url) { "#{platform.server}/users/#{request_body['email']}" }
+
+          it "can modify user" do
+            put(request_url, platform.superuser,
+              :payload => request_body).should look_like({
+                :status => 200
+              })
+            get(request_url, platform.superuser).should look_like({
+                :status => 200,
+                :body => modified_user
+              })
+          end
+        end
+
         context "with spaces in names" do
           let(:request_body) do
             {

--- a/oc-chef-pedant/spec/api/user_spec.rb
+++ b/oc-chef-pedant/spec/api/user_spec.rb
@@ -645,6 +645,17 @@ describe "users", :users do
         end
       end
 
+      context "when using email instead of username" do
+        let(:request_url) { "#{platform.server}/users/#{user_body['email']}" }
+
+        it "can get user" do
+          get(request_url, platform.superuser).should look_like({
+              :status => 200,
+              :body_exact => user_body
+            })
+        end
+      end
+
       context "when user doesn't exist" do
         let(:username) { "bogus" }
         it "returns 404" do

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -489,7 +489,7 @@
       recovery_authentication_enabled, serialized_object
       FROM users u
  LEFT JOIN keys k ON u.id = k.id AND key_name = 'default'
-     WHERE username = $1">>}.
+     WHERE username = $1 OR email = $1">>}.
 
 {find_user_by_username,
   <<"SELECT u.id, authz_id, username, email,
@@ -497,7 +497,7 @@
       u.updated_at, external_authentication_uid,
       recovery_authentication_enabled, serialized_object
       FROM users u
-     WHERE username = $1">>}.
+     WHERE username = $1 OR email = $1">>}.
 
 {find_user_by_external_authentication_uid_v0,
   <<"SELECT u.id, authz_id, username, email, k.public_key, k.key_version pubkey_version,
@@ -515,8 +515,6 @@
       recovery_authentication_enabled, serialized_object
       FROM users u
      WHERE external_authentication_uid = $1">>}.
-
-
 
 {delete_user_by_id,
   <<"DELETE FROM users WHERE id = $1">>}.


### PR DESCRIPTION
This is mainly intended for the authenticate user endpoint, i.e., we want to be able to login via email address, not just username.

This has the side effect of making the /users/:name endpoint (where :name = email address) work as well.  Pro: this makes password resets possible in manage using either username or email address.  Possible con: this makes any user lookup with email address work, including (probably) a knife lookup.

The question is: do we care about that, or does it open any holes we might be worried about?  If so, we should do this another way (i.e., a distinct lookup for the authenticate_user endpoint, and another way of looking up users by email for password resets).