### PR TITLE
Use case-insensitive search for user lookup by external_auth_id

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -666,6 +666,9 @@ default['private_chef']['ldap'] = nil
 # default['private_chef']['ldap']['base_dn'] = "OU=Employees,OU=Domain users,DC=example,DC=com"
 # default['private_chef']['ldap']['timeout'] = 60000
 # default['private_chef']['ldap']['port'] = 389
+## Nearly every attribute in the standard LDAP schema that users likely set login_attr
+## to is case sensitive.
+# default['private_chef']['ldap']['case_sensitive_login_attribute'] = false
 #
 # default['private_chef']['ldap']['enable_ssl'] = false
 # default['private_chef']['ldap']['enable_tls'] = false

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -84,6 +84,7 @@
                       {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
                       {group_dn, "<%= node['private_chef']['ldap']['group_dn'] || "" %>" },
                       {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },
+                      {case_sensitive_login_attribute, <%= node['private_chef']['ldap']['case_sensitive_login_attribute'] || false %>},
                       {encryption, <%= @ldap_encryption_type %>}
               ]},
               <% else -%>

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -508,7 +508,7 @@
       recovery_authentication_enabled, serialized_object
       FROM users u
  LEFT JOIN keys k ON u.id = k.id AND key_name = 'default'
-     WHERE external_authentication_uid = $1">>}.
+     WHERE lower(external_authentication_uid) = lower($1)">>}.
 
 {find_user_by_external_authentication_uid,
   <<"SELECT u.id, authz_id, username, email,
@@ -516,9 +516,24 @@
       u.updated_at, external_authentication_uid,
       recovery_authentication_enabled, serialized_object
       FROM users u
+     WHERE lower(external_authentication_uid) = lower($1)">>}.
+
+{find_user_by_sensitive_external_authentication_uid_v0,
+  <<"SELECT u.id, authz_id, username, email, k.public_key, k.key_version pubkey_version,
+      hashed_password, salt, hash_type, u.last_updated_by, u.created_at,
+      u.updated_at, external_authentication_uid,
+      recovery_authentication_enabled, serialized_object
+      FROM users u
+ LEFT JOIN keys k ON u.id = k.id AND key_name = 'default'
      WHERE external_authentication_uid = $1">>}.
 
-
+{find_user_by_sensitive_external_authentication_uid,
+  <<"SELECT u.id, authz_id, username, email,
+      hashed_password, salt, hash_type, u.last_updated_by, u.created_at,
+      u.updated_at, external_authentication_uid,
+      recovery_authentication_enabled, serialized_object
+      FROM users u
+     WHERE external_authentication_uid = $1">>}.
 
 {delete_user_by_id,
   <<"DELETE FROM users WHERE id = $1">>}.

--- a/src/oc_erchef/apps/chef_objects/src/chef_user.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_user.erl
@@ -466,14 +466,26 @@ bulk_get_query(_ObjectRec) ->
 is_indexed(_ObjectRec) ->
     false.
 
-fetch(#chef_user{server_api_version = ?API_v0, username = undefined, external_authentication_uid = AuthUid} = Record, CallbackFun) ->
-    fetch_user(find_user_by_external_authentication_uid_v0, Record, AuthUid, CallbackFun);
-fetch(#chef_user{username = undefined, external_authentication_uid = AuthUid} = Record, CallbackFun) ->
-    fetch_user(find_user_by_external_authentication_uid, Record, AuthUid, CallbackFun);
+fetch(#chef_user{server_api_version = ApiVersion,
+                 username = undefined, external_authentication_uid = AuthUid} = Record, CallbackFun) ->
+    fetch_user(external_auth_id_query(ApiVersion, case_sensitivity()), Record, AuthUid, CallbackFun);
 fetch(#chef_user{server_api_version = ?API_v0, username = UserName} = Record, CallbackFun) ->
     fetch_user(find_user_by_username_v0, Record, UserName, CallbackFun);
 fetch(#chef_user{username = UserName} = Record, CallbackFun) ->
     fetch_user(find_user_by_username, Record, UserName, CallbackFun).
+
+case_sensitivity() ->
+    LdapConfig = envy:get(oc_chef_wm, ldap, [], list),
+    proplists:get_value(case_sensitive_login_attribute, LdapConfig, false).
+
+external_auth_id_query(?API_v0, true) ->
+    find_user_by_sensitive_external_authentication_uid_v0;
+external_auth_id_query(?API_v0, _NotSensitive) ->
+    find_user_by_external_authentication_uid_v0;
+external_auth_id_query(_Not0, true) ->
+    find_user_by_sensitive_external_authentication_uid;
+external_auth_id_query(_Not0, _NotSensitive) ->
+    find_user_by_external_authentication_uid.
 
 fetch_user(Query, Record, KeyValue, CallbackFun) ->
     CallbackFun({Query, [KeyValue],

--- a/src/oc_erchef/apps/chef_objects/src/chef_user.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_user.erl
@@ -468,13 +468,13 @@ is_indexed(_ObjectRec) ->
 
 fetch(#chef_user{server_api_version = ApiVersion,
                  username = undefined, external_authentication_uid = AuthUid} = Record, CallbackFun) ->
-    fetch_user(external_auth_id_query(ApiVersion, case_sensitivity()), Record, AuthUid, CallbackFun);
+    fetch_user(external_auth_id_query(ApiVersion, ldap_case_sensitivity()), Record, AuthUid, CallbackFun);
 fetch(#chef_user{server_api_version = ?API_v0, username = UserName} = Record, CallbackFun) ->
     fetch_user(find_user_by_username_v0, Record, UserName, CallbackFun);
 fetch(#chef_user{username = UserName} = Record, CallbackFun) ->
     fetch_user(find_user_by_username, Record, UserName, CallbackFun).
 
-case_sensitivity() ->
+ldap_case_sensitivity() ->
     LdapConfig = envy:get(oc_chef_wm, ldap, [], list),
     proplists:get_value(case_sensitive_login_attribute, LdapConfig, false).
 


### PR DESCRIPTION
Almost all of the typical values of ldap['login_attribute'] are case
insensitive according to the LDAP schema. However, we previously used a
case-sensitive lookup when trying to find an existing user record.

This commit changes the default lookup to be case insensitive but
provides a user-controllable override for the rare case where users are
setting a case-sensitive login_attribute.

## Review Notes

If we were doing this from scratch, I think the *correct* method of linking LDAP accounts to user records would be to store a canonicalized form of the distinguished name as returned by the LDAP server.  Unfortunately, we have live installations with existing data.

I've made case-sensitivity a configurable with a default of false.  Most fields that people will use for login_attribute are case insensitive; but it is possible that some users want to use a case sensitive field here.  Unfortunately, because of the way chef_db/chef_sql/chef_object are tied together, changing queries based on config either requires adding a new field to the record, or querying the config all the way from chef_user.  I opted for the latter as that change seemed to have the smaller surface area.

I looked at the prospect of doing something smarter here such as some sort of data migration combined with a canonicalization of what we store here are the problems I kept running into:

- Data migrations that transform the existing data in the external_authentication_uid column will probably eliminate our ability to use a case-sensitive field for login_attribute.

- Data migrations that change external_authentication_uid to store something such as Distinguished Name require talking to a 3rd party data service, which seems really brittle for large installations.

- Querying the LDAP server for the schema of the login_attribute and changing what we do based on that might be possible but it seems that the exact way to do this might differ between LDAP servers and require our bind user to have permissions that we don't currently require.
 
