### PR TITLE
Use configured port everywhere we talk to postgres

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -22,7 +22,7 @@ class EcPostgres
     require 'pg'
     postgres = node['private_chef']['postgresql']
     as_user(postgres['username']) do
-      connection = ::PGconn.open('dbname' => database)
+      connection = ::PGconn.open('dbname' => database, :port => postgres['port'])
       begin
         yield connection
       ensure

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -128,7 +128,9 @@ if is_data_master?
     block do
       connectable = false
       2.times do |i|
-        `echo 'SELECT * FROM pg_database;' | su - opscode-pgsql -c '/opt/opscode/embedded/bin/psql -U opscode-pgsql postgres -t -A'`
+        # Note that we have to include the port even for a local pipe, because the port number
+        # is included in the pipe default.
+        `echo 'SELECT * FROM pg_database;' | su - opscode-pgsql -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']}  -U  opscode-pgsql postgres -t -A'`
 	if $?.exitstatus != 0
           Chef::Log.fatal("Could not connect to database, retrying in 10 seconds.")
           sleep 10

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bootstrap-config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bootstrap-config.rb.erb
@@ -2,6 +2,7 @@ output_directory: '/tmp/opscode-platform-test'
 
 db_driver: "postgres"
 db_host: '<%= node['private_chef']['postgresql']['vip'] %>'
+db_port: '<%= node['private_chef']['postgresql']['port'] %>'
 db_user: '<%= node['private_chef']['opscode-erchef']['sql_user'] %>'
 db_password: '<%= node['private_chef']['opscode-erchef']['sql_password'] %>'
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -198,7 +198,7 @@
            {ip_mode, [ <%=PrivateChef['use_ipv6'] ? "ipv6,ipv4" : "ipv4" %> ] },
            %% Database connection parameters
            {db_host, "<%= node['private_chef']['postgresql']['vip'] %>"},
-           {db_port, 5432},
+           {db_port, <%= node['private_chef']['postgresql']['port'] %>},
            {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
            {db_pass, "<%= node['private_chef']['opscode-erchef']['sql_password'] %>"},
            {db_name, "opscode_chef" },

--- a/src/chef-server-bootstrap/bin/bootstrap-platform
+++ b/src/chef-server-bootstrap/bin/bootstrap-platform
@@ -38,7 +38,7 @@ class BootstrapPlatform
   def bootstrap
     config = YAML.load_file(@config_file)
 
-    db = Sequel.connect("#{config['db_driver']}://#{config['db_user']}:#{config['db_password']}@#{config['db_host']}/opscode_chef")
+    db = Sequel.connect("#{config['db_driver']}://#{config['db_user']}:#{config['db_password']}@#{config['db_host']}:#{config['db_port']}/opscode_chef")
 
     #################################
     # create superuser authz object #


### PR DESCRIPTION

Fixes #459  and allows a custom port to be specified in chef-server postgresql settings. 