### PR TITLE
Gather Logs Updates

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -80,7 +80,8 @@ mkdir -p "$tmpdir"
 for i in /opt/{chef,$path}*/version-manifest.txt \
               /opt/$path/pc-version.txt \
               /etc/$path/$config_name \
-              /etc/${path}*/*-running.json \
+              /etc/{chef,$path}*/*-running.json \
+              /etc/{chef,$path}*/*.rb \
               /var/opt/$path/rabbitmq/log/*.log \
               /var/log/syslog \
               /var/log/messages; do

--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -82,7 +82,8 @@ for i in /opt/{chef,$path}*/version-manifest.txt \
               /opt/$path/pc-version.txt \
               /etc/$path/$config_name \
               /etc/{chef,$path}*/*-running.json \
-              /etc/{chef,$path}*/*.rb \
+              /var/opt/$path*/etc/*-running.json \
+              /etc/{chef,$path,opscode-manage}*/*.rb \
               /var/opt/$path/rabbitmq/log/*.log \
               /var/log/syslog \
               /var/log/messages; do

--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -26,7 +26,7 @@ then
     path='opscode'
     ctl_cmd='chef-server-ctl'
     config_name='*chef*.rb'
-    ha=$(egrep -qs 'topology[[:space:]]+.*ha' /etc/opscode/*chef*.rb)$?
+    ha=$(egrep -qs 'topology[[:space:]]+.*ha' /etc/$path/$config_name)$?
 
     if [[ ! -e "/opt/$path/bin/$ctl_cmd" ]];
     then
@@ -66,6 +66,7 @@ else
     echo "Analytics - Opscode Analytics server"
     exit 1
 fi
+config_file_path="/etc/$path/$config_name"
 
 hostname=$(hostname)
 timestamp=$(date +%F_%H.%M.%S-%Z)
@@ -243,14 +244,11 @@ fi
 if [[ $type == 'CS' ]];
 then
     fqdn="api_fqdn"
-    backend_vip="backend_vip"
-    config_file_path="/etc/opscode/chef-server.rb"
 elif [[ $type == 'Analytics' ]];
 then
     fqdn="analytics_fqdn"
-    backend_vip="backend_vip"
-    config_file_path="/etc/opscode-analytics/opscode-analytics.rb"
 fi
+backend_vip="backend_vip"
 tempname=`grep -E $fqdn $config_file_path | cut -d \" -f2`
 backend_fqdn=`grep -E $backend_vip $config_file_path | cut -d \" -f2`
 

--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -24,7 +24,7 @@ fi
 if [[ $type == 'CS' ]];
 then
     path='opscode'
-    ctl_cmd='chef-server-ctl'
+    ctl_cmd='private-chef-ctl'
     config_name='*chef*.rb'
     ha=$(egrep -qs 'topology[[:space:]]+.*ha' /etc/$path/$config_name)$?
 
@@ -36,7 +36,7 @@ then
 elif [[ $type == 'OSC' ]];
 then
     path='chef-server'
-    ctl_cmd='/opt/chef-server/bin/chef-server-ctl'
+    ctl_cmd='chef-server-ctl'
     config_name='chef-server.rb'
 
     if [[ ! -e "/opt/$path/bin/$ctl_cmd" ]];


### PR DESCRIPTION
* Lets gather the Manage config too, if found

* Use path variables, fix a related bug

    Cleaned up more static specification of config files.
    This helped fix an issue with mistakenly using chef-server.rb as the file to
    grep on EC 11.3.2 when it should have been private-chef.rb.

* Collect config and log info for chef-sync master replica

* Fix major usage of private-chef/chef-server-ctl
  We should prefer the private-chef-ctl symlink for now, so that EC 11.3.2
  still works properly

Tested on EC 11.3.2 and CS 12.0.5