### PR TITLE
Make the oc_chef_authz app use the chef_objects app.

### DIFF
--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.app.src
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.app.src
@@ -22,6 +22,7 @@
   {registered, []},
   {applications, [kernel,
                   stdlib,
+		  chef_objects,
                   stats_hero,
                   sqerl]},
   {mod, {oc_chef_authz_app, []}}


### PR DESCRIPTION
This ensures that chef_objects gets compiled before oc_chef_authz, so that the chef_object behaviour is available at compile time for oc_chef_authz/src/oc_chef_policy.erl.

Fixes broken build.