### PR TITLE
Remove "hosted" from page copy

### DIFF
--- a/src/oc-id/app/views/doorkeeper/authorized_applications/index.html.erb
+++ b/src/oc-id/app/views/doorkeeper/authorized_applications/index.html.erb
@@ -23,6 +23,6 @@
       </tbody>
     </table>
   <% else %>
-    <p>You have not granted any application access to your hosted Chef account.</p>
+    <p><%= t(".no_applications_message") %></p>
   <% end %>
 </div>

--- a/src/oc-id/app/views/password_resets/new.html.erb
+++ b/src/oc-id/app/views/password_resets/new.html.erb
@@ -3,7 +3,7 @@
     <h1>Forgot Your Password?</h1>
   </div>
   <div>
-    <p>Enter your hosted Chef username and we'll send you a link to reset it.</p>
+    <p><%= t(".form_caption") %></p>
     <%= form_tag({ action: 'create' }) do -%>
       <div class="row">
         <div class="medium-6 columns username-field">

--- a/src/oc-id/config/locales/en.yml
+++ b/src/oc-id/config/locales/en.yml
@@ -20,6 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  doorkeeper:
+    authorized_applications:
+      index:
+        no_applications_message: You have not granted any applications access to your Chef account.
   errors:
     passwords:
       blank: "%{label} must not be blank."
@@ -32,6 +36,9 @@ en:
       password_blank: "Password must not be blank."
       invalid_signature: "The given password reset link is expired or has an invalid signature."
       completion: "If the username you entered exists, you should receive an email shortly."
+  password_resets:
+    new:
+      form_caption: Enter your Chef username and we'll send you a link to reset it.
   profile:
     update_successful: "Profile updated successfully."
     password_changed: "Password changed."


### PR DESCRIPTION
Just call it "Chef account" and "Chef username" and put it into the i18n
config.

ChangeLog-Entry: Remove "hosted" from some text in oc-id

/cc @chef/chef-visual-interaction 