### PR TITLE
Cloudsearch Support

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/search_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/search_util.rb
@@ -629,8 +629,7 @@ module Pedant
       let(:search_success_response) do
         {
           :status => 200,
-          :body_exact => {
-            "total" => search_result_items.size,
+          :body => {
             "start" => 0, # TODO: Test paging
             "rows" => search_result_items
           }
@@ -725,8 +724,7 @@ module Pedant
           get(api_url("/search/#{options[:type]}?q=#{options[:query]}"),user) do |response|
             response.should look_like({
                                         :status => 200,
-                                        :body_exact => {
-                                          "total" => results.count,
+                                        :body => {
                                           "start" => 0,
                                           "rows" => results
                                         }
@@ -741,7 +739,6 @@ module Pedant
           response = get(search_url, admin_user)
           response.should look_like({:status => 200, :body => { 'start' => 0 }})
           response = parse(response)
-          response['total'].should == response['rows'].size
           response['rows']
         end
       end

--- a/oc-chef-pedant/spec/api/search/search_spec.rb
+++ b/oc-chef-pedant/spec/api/search/search_spec.rb
@@ -142,7 +142,6 @@ describe 'Search API endpoint', :search do
           with_search_polling do
             response = get(search_url, requestor)
             result = parse(response)
-            expect(result["total"]).to eq(1)
             expect(result["rows"].first).to eq(node)
           end
         end
@@ -152,7 +151,6 @@ describe 'Search API endpoint', :search do
           with_search_polling do
             response = get(search_url, requestor)
             result = parse(response)
-            expect(result["total"]).to eq(1)
             expect(result["rows"].first).to eq(node)
           end
         end
@@ -660,8 +658,7 @@ describe 'Search API endpoint', :search do
               }
               # TODO this seems wrong, sine we're discarding the actual expected result...
               want_results = 10.times.map { |i| want_result }
-              response.should look_like({:status => 200,
-                                          :body => {'total' => 10}})
+              response.should look_like({:status => 200 })
               got = parse(response)['rows']
               got_digits = got.map { |o| o['data']['goal'] }.sort
               got_digits.should == (0..9).to_a
@@ -713,11 +710,11 @@ describe 'Search API endpoint', :search do
             post(api_url("/search/node?q=name:#{node_name}"), admin_user,
                  :payload => payload) do |response|
               response.should look_like({:status => 200,
-                                          :body => {'total' => 1,
-                                            "rows" => [{ 'url' => api_url("/nodes/#{node_name}"),
-                                                         'data' => {
-                                                           'we_found_default' => true
-                                                         }}]}})
+                                          :body => {
+                                           "rows" => [{ 'url' => api_url("/nodes/#{node_name}"),
+                                                        'data' => {
+                                                          'we_found_default' => true
+                                                        }}]}})
             end
           end
         end
@@ -730,11 +727,11 @@ describe 'Search API endpoint', :search do
             post(api_url("/search/node?q=name:#{node_name}"), admin_user,
                  :payload => payload) do |response|
               response.should look_like({:status => 200,
-                                          :body => {'total' => 1,
-                                            "rows" => [{ 'url' => api_url("/nodes/#{node_name}"),
-                                                         'data' => {
-                                                           'we_found_normal' => true
-                                                         }}]}})
+                                         :body => {
+                                           "rows" => [{ 'url' => api_url("/nodes/#{node_name}"),
+                                                        'data' => {
+                                                          'we_found_normal' => true
+                                                        }}]}})
             end
           end
         end
@@ -747,17 +744,14 @@ describe 'Search API endpoint', :search do
             post(api_url("/search/node?q=name:#{node_name}"), admin_user,
                  :payload => payload) do |response|
               response.should look_like({:status => 200,
-                                          :body => {'total' => 1,
-                                            "rows" => [{ 'url' => api_url("/nodes/#{node_name}"),
-                                                         'data' => {
-                                                           'goal' => 'found_it_normal'
-                                                         }}]}})
+                                         :body => {
+                                           "rows" => [{ 'url' => api_url("/nodes/#{node_name}"),
+                                                        'data' => {
+                                                          'goal' => 'found_it_normal'
+                                                        }}]}})
             end
           end
         end
-
-
-
       end # context
     end
   end

--- a/oc-chef-pedant/spec/api/search/word_break_spec.rb
+++ b/oc-chef-pedant/spec/api/search/word_break_spec.rb
@@ -1,0 +1,79 @@
+require 'pedant/rspec/search_util'
+require 'pedant/rspec/node_util'
+
+describe 'Search API endpoint', :search do
+
+  include Pedant::RSpec::SearchUtil
+  include Pedant::RSpec::NodeUtil
+
+  # TODO: until we rename requestors
+  shared(:admin_requestor){admin_user}
+  shared(:requestor){admin_requestor}
+
+  context "word break handling", :focus do
+    let(:request_method){:GET}
+    let(:request_url){api_url("/search/node")}
+    SPECIAL_CHARS = '!"$%&()*+,-:;<=>?@[\]%_`{|}~\'\\'
+    QUERY_CHARS = '[]\\"!(){}^~*?:'
+
+    # We're going to cycle a lot of tests here, so let's create just one item to meet all the data conditions
+    # we want to validate.
+    before :all do
+      # confirm 201 status as a sanity check
+      n = new_node("search_supernode").tap do |node|
+        SPECIAL_CHARS.each_char do |c|
+          node["default"]["attrtest#{SPECIAL_CHARS.index(c)}"] = "hello#{c}world"
+          node["default"]["key#{SPECIAL_CHARS.index(c)}name"] = "dlrow#{c}olleh"
+        end
+      end
+      add_node(admin_requestor, n).should look_like({:status => 201 })
+
+      # Just force this once- all subsequent searches here will be against the same object.
+      force_solr_commit
+    end
+
+    after :all do
+      delete_node(admin_requestor, "search_supernode")
+    end
+
+    def wb_node_found_result
+      { status: 200, body: { "rows" => [{ "name" => "search_supernode" }] } }
+    end
+    def wb_node_not_found_result
+      { status: 200, body: { "rows" => [] } }
+    end
+    def wb_special_char(c)
+    end
+
+    SPECIAL_CHARS.each_char do |char|
+      describe "when using attribute values containing the special character '#{char}'" do
+          attrname = "attrtest#{SPECIAL_CHARS.index(char)}"
+          c = if QUERY_CHARS.include? char
+                "\\#{char}"
+              else
+               char
+              end
+
+          [ [ "an exact match on name and value", "#{attrname}:hello#{c}world", :uses_char, true],
+            [ "a wildcard match on attribute name with exact value", "*:hello#{c}world", :uses_char, true ],
+            [ "a wildcard in attribute value around the special char", "#{attrname}:*#{c}*", :uses_char, true],
+            [ "a wildcard in attribute value before the special char", "#{attrname}:*#{c}", :uses_char, false],
+            [ "a wildcard in attribute value after the special char", "#{attrname}:#{c}*", :uses_char, false],
+            [ "an exact search for a partial match of the first word", "#{attrname}:hello", :does_not_use_char, false],
+            [ "an exact search for a partial match of the second word", "#{attrname}:world",:does_not_use_char, false],
+          ].each do | description, query, usage, find_expected|
+            # We can only query on valid characters to use in a query - so
+            # anything that uses the special char isn't valid. If it doesn't use it
+            # let it through.
+            if usage == :does_not_use_char or (usage == :uses_char and QUERY_CHARS.include?(char))
+              it "and #{description}, should #{find_expected ? "find" : "not find"} the node" do
+                expected = find_expected ? wb_node_found_result : wb_node_not_found_result
+                expect(search_result("node", query)).to look_like expected
+              end
+
+            end
+          end
+        end
+    end
+  end
+end

--- a/oc-chef-pedant/spec/api/search/word_break_spec.rb
+++ b/oc-chef-pedant/spec/api/search/word_break_spec.rb
@@ -14,7 +14,7 @@ describe 'Search API endpoint', :search do
     let(:request_method){:GET}
     let(:request_url){api_url("/search/node")}
     SPECIAL_CHARS = '!"$%&()*+,-:;<=>?@[\]%_`{|}~\'\\'
-    QUERY_CHARS = '[]\\"!(){}^~*?:'
+    PERMITTED_QUERY_CHARS = '[]\\"!(){}^~*?:'
 
     # We're going to cycle a lot of tests here, so let's create just one item to meet all the data conditions
     # we want to validate.
@@ -23,12 +23,24 @@ describe 'Search API endpoint', :search do
       n = new_node("search_supernode").tap do |node|
         SPECIAL_CHARS.each_char do |c|
           node["default"]["attrtest#{SPECIAL_CHARS.index(c)}"] = "hello#{c}world"
-          node["default"]["key#{SPECIAL_CHARS.index(c)}name"] = "dlrow#{c}olleh"
+          node["default"]["key#{SPECIAL_CHARS.index(c)}abc"] = "dlrow olleh"
+        end
+      end
+      add_node(admin_requestor, n).should look_like({:status => 201 })
+      n = new_node("search_workbreak_node").tap do |node|
+        SPECIAL_CHARS.each_char do |c|
+          node["default"]["key1"] = "a quick brown fox"
+          node["default"]["key2"] = 3.14
+          node["default"]["key3"] = "one-two-one-two-three-four"
+          node["default"]["a.key"] = "a.value"
         end
       end
       add_node(admin_requestor, n).should look_like({:status => 201 })
 
-      # Just force this once- all subsequent searches here will be against the same object.
+
+      # Just force this once- all subsequent searches here
+      # will be against the same object so we don't need to
+      # recommit for every test.
       force_solr_commit
     end
 
@@ -42,38 +54,60 @@ describe 'Search API endpoint', :search do
     def wb_node_not_found_result
       { status: 200, body: { "rows" => [] } }
     end
-    def wb_special_char(c)
-    end
 
     SPECIAL_CHARS.each_char do |char|
-      describe "when using attribute values containing the special character '#{char}'" do
-          attrname = "attrtest#{SPECIAL_CHARS.index(char)}"
-          c = if QUERY_CHARS.include? char
-                "\\#{char}"
-              else
-               char
-              end
+      describe "when searching for an attribute value containing the special character '#{char}'" do
+        c = PERMITTED_QUERY_CHARS.include?(char) ? "\\#{char}" : char
+        attrname = "attrtest#{SPECIAL_CHARS.index(char)}"
+        [ [ "an exact match on name and value", "#{attrname}:hello#{c}world", :uses_char, true],
+          [ "a wildcard match on attribute name with exact value", "*:hello#{c}world", :uses_char, true ],
+          [ "a wildcard in attribute value around the special char", "#{attrname}:*#{c}*", :uses_char, true],
+          [ "a wildcard in attribute value before the special char with trailing match", "#{attrname}:*#{c}", :uses_char, false],
+          [ "a wildcard in attribute value before the special char with no trailing match", "#{attrname}:*#{c}world", :uses_char, true],
+          [ "a wildcard in attribute value after the special char with prefixing match", "#{attrname}:hello#{c}*", :uses_char, true],
+          [ "a wildcard in attribute value after the special char with no prefixing match", "#{attrname}:#{c}*", :uses_char, false],
+          [ "an exact search for a partial match of the first word", "#{attrname}:hello", :does_not_use_char, false],
+          [ "an exact search for a partial match of the second word", "#{attrname}:world",:does_not_use_char, false],
+          [ "a search for attribute value as a string without the special character", "#{attrname}:*\"hello world\"*",:does_not_use_char, false],
+        ].each do | description, query, usage, find_expected|
+          # We can only query on valid characters to use in a query - so
+          # anything that uses the special char may not be valid. If it doesn't use it
+          # let it through.
+          if usage == :does_not_use_char or (usage == :uses_char and PERMITTED_QUERY_CHARS.include?(char))
+            it "with #{description}, should #{find_expected ? "find" : "not find"} the node" do
+              expected = find_expected ? wb_node_found_result : wb_node_not_found_result
+              expect(search_result("node", query)).to look_like expected
+            end
 
-          [ [ "an exact match on name and value", "#{attrname}:hello#{c}world", :uses_char, true],
-            [ "a wildcard match on attribute name with exact value", "*:hello#{c}world", :uses_char, true ],
-            [ "a wildcard in attribute value around the special char", "#{attrname}:*#{c}*", :uses_char, true],
-            [ "a wildcard in attribute value before the special char", "#{attrname}:*#{c}", :uses_char, false],
-            [ "a wildcard in attribute value after the special char", "#{attrname}:#{c}*", :uses_char, false],
-            [ "an exact search for a partial match of the first word", "#{attrname}:hello", :does_not_use_char, false],
-            [ "an exact search for a partial match of the second word", "#{attrname}:world",:does_not_use_char, false],
-          ].each do | description, query, usage, find_expected|
-            # We can only query on valid characters to use in a query - so
-            # anything that uses the special char isn't valid. If it doesn't use it
-            # let it through.
-            if usage == :does_not_use_char or (usage == :uses_char and QUERY_CHARS.include?(char))
-              it "and #{description}, should #{find_expected ? "find" : "not find"} the node" do
-                expected = find_expected ? wb_node_found_result : wb_node_not_found_result
-                expect(search_result("node", query)).to look_like expected
-              end
+          end
+        end
+      end
 
+      describe "when searching for attribute an attribute key containing the special character '#{char}'" do
+        c = PERMITTED_QUERY_CHARS.include?(char) ? "\\#{char}" : char
+        attrval = "dlrow olleh"
+        [ [ "an exact match on name and value", "key#{c}abc:#{attrval}", :uses_char, true],
+          [ "a wildcard match on key name with exact value", "*:#{attrval}", :uses_char, true ],
+          [ "a wildcard in attribute key around the special char", "*#{c}*:#{attrval}", :uses_char, true],
+          [ "a wildcard in attribute key before the special char with trailing match", "*#{c}abc:#{attrval}", :uses_char, true],
+          [ "a wildcard in attribute key before the special char with no trailing match", "*#{c}:#{attrval}", :uses_char, false],
+          [ "a wildcard in attribute key after the special char with no prefixing match", "#{c}*:#{attrval}", :uses_char, false],
+          [ "a wildcard in attribute key after the special char with prefixing match", "key#{c}*:#{attrval}", :uses_char, true],
+          [ "an exact search for a partial match of the first word", "key:#{attrval}", :does_not_use_char, false],
+          [ "an exact search for a partial match of the second word", "abc:#{attrval}",:does_not_use_char, false],
+          [ "a search for attribute key as a string without the special character", "*\"key abc\"*:*",:does_not_use_char, false],
+        ].each do | description, query, usage, find_expected|
+          # We can only query on valid characters to use in a query - so
+          # anything that uses the special char isn't valid. If it doesn't use it
+          # let it through.
+          if usage == :does_not_use_char or (usage == :uses_char and PERMITTED_QUERY_CHARS.include?(char))
+            it "with #{description}, should #{find_expected ? "find" : "not find"} the node" do
+              expected = find_expected ? wb_node_found_result : wb_node_not_found_result
+              expect(search_result("node", query)).to look_like expected
             end
           end
         end
+      end
     end
   end
 end

--- a/oc-chef-pedant/spec/api/search/word_break_spec.rb
+++ b/oc-chef-pedant/spec/api/search/word_break_spec.rb
@@ -27,21 +27,10 @@ describe 'Search API endpoint', :search do
         end
       end
       add_node(admin_requestor, n).should look_like({:status => 201 })
-      n = new_node("search_workbreak_node").tap do |node|
-        SPECIAL_CHARS.each_char do |c|
-          node["default"]["key1"] = "a quick brown fox"
-          node["default"]["key2"] = 3.14
-          node["default"]["key3"] = "one-two-one-two-three-four"
-          node["default"]["a.key"] = "a.value"
-        end
+
+      with_search_polling do
+        expect(search("nodes", "name:search_supernode").length).to eq(1)
       end
-      add_node(admin_requestor, n).should look_like({:status => 201 })
-
-
-      # Just force this once- all subsequent searches here
-      # will be against the same object so we don't need to
-      # recommit for every test.
-      force_solr_commit
     end
 
     after :all do
@@ -51,6 +40,7 @@ describe 'Search API endpoint', :search do
     def wb_node_found_result
       { status: 200, body: { "rows" => [{ "name" => "search_supernode" }] } }
     end
+
     def wb_node_not_found_result
       { status: 200, body: { "rows" => [] } }
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -143,6 +143,7 @@ default['private_chef']['opscode-solr4']['enable'] = true
 # Set this to point at a solr/cloudsearch installation
 # not controlled by chef-server
 #
+default['private_chef']['opscode-solr4']['external'] = false
 default['private_chef']['opscode-solr4']['external_url'] = nil
 default['private_chef']['opscode-solr4']['ha'] = false
 default['private_chef']['opscode-solr4']['dir'] = "/var/opt/opscode/opscode-solr4"

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -139,6 +139,11 @@ default['private_chef']['jetty']['log_directory'] = "/var/opt/opscode/opscode-so
 # Chef Solr 4
 ####
 default['private_chef']['opscode-solr4']['enable'] = true
+#
+# Set this to point at a solr/cloudsearch installation
+# not controlled by chef-server
+#
+default['private_chef']['opscode-solr4']['external_url'] = nil
 default['private_chef']['opscode-solr4']['ha'] = false
 default['private_chef']['opscode-solr4']['dir'] = "/var/opt/opscode/opscode-solr4"
 default['private_chef']['opscode-solr4']['data_dir'] = "/var/opt/opscode/opscode-solr4/data"

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -44,6 +44,14 @@ class OmnibusHelper
     normalize_host(node['private_chef'][service]['vip'])
   end
 
+  def solr_url()
+    if node['private_chef']['opscode-solr4']['external_url']
+      node['private_chef']['opscode-solr4']['external_url']
+    else
+      "http://#{vip_for_uri('opscode-solr4')}:#{node['private_chef']['opscode-solr4']['port']}/solr"
+    end
+  end
+
   def db_connection_uri
     db_protocol = "postgres"
     db_user     = node['private_chef']['opscode-erchef']['sql_user']
@@ -163,4 +171,3 @@ class OmnibusHelper
     end
   end
 end
-

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -1,4 +1,5 @@
 require 'mixlib/shellout'
+require 'uri'
 
 class OmnibusHelper
   attr_reader :node
@@ -44,8 +45,18 @@ class OmnibusHelper
     normalize_host(node['private_chef'][service]['vip'])
   end
 
-  def solr_url()
-    if node['private_chef']['opscode-solr4']['external_url']
+  # Returns scheme://host:port without any path
+  def solr_root
+    url = URI.parse(solr_url)
+    host = url.scheme + "://" + url.host
+    if url.port
+      host += ":" + url.port.to_s
+    end
+    host
+  end
+
+  def solr_url
+    if node['private_chef']['opscode-solr4']['external']
       node['private_chef']['opscode-solr4']['external_url']
     else
       "http://#{vip_for_uri('opscode-solr4')}:#{node['private_chef']['opscode-solr4']['port']}/solr"

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -72,6 +72,7 @@ class PreflightChecks
   def run!
     begin
       PostgresqlPreflightValidator.new(node).run!
+      SolrPreflightValidator.new(node).run!
     rescue PreflightValidationFailed => e
       # use of exit! prevents exit handlers from running, ensuring the last thing
       # the customer sees is the descriptive error we've provided.

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
@@ -29,14 +29,13 @@ class SolrPreflightValidator < PreflightValidator
   end
 
   def warn_changed_external_flag
-    if OmnibusHelper.has_been_bootstrapped? && backend?  && previous_run
+    if OmnibusHelper.has_been_bootstrapped? && backend? && previous_run
       if external_flag_changed?
         Chef::Log.warn <<-EOM
 
-The value of opscode_solr4['external'] has been changed. Search
-results against the new external search index may be incorrect. Please
-run `chef-server-ctl reindex --all` to ensure correct results
-
+CSSOLR001: The value of opscode_solr4['external'] has been changed. Search
+           results against the new external search index may be incorrect. Please
+           run `chef-server-ctl reindex --all` to ensure correct results
 EOM
       end
     end
@@ -51,10 +50,9 @@ EOM
     if cs_solr_attr['external'] & (! cs_solr_attr['external_url'])
       fail_with <<EOM
 
-No external url specified for Solr depsite opscode_solr4['external']
-being set to true. To use an external solr instance, please set
-opscode_solr4['external_url'] to the external solr endpoint.
-
+CSSOLR002: No external url specified for Solr depsite opscode_solr4['external']
+           being set to true. To use an external solr instance, please set
+           opscode_solr4['external_url'] to the external solr endpoint.
 EOM
     end
   end
@@ -67,25 +65,24 @@ EOM
       if ! ['batch', 'inline'].include?(@cs_erchef_attr['search_queue_mode'])
         fail_with <<-EOM
 
-The cloudsearch search provider is only supported by the batch or
-inline queue modes. To use the cloudsearch search provider, please
-also set:
+CSSOLR003: The cloudsearch search provider is only supported by the batch or
+           inline queue modes. To use the cloudsearch search provider, please
+           also set:
 
-opscode_erchef['search_queue_mode'] = 'batch'
+           opscode_erchef['search_queue_mode'] = 'batch'
 
-in /etc/opscode/chef-server.rb
-
+           in /etc/opscode/chef-server.rb
 EOM
       end
     when 'solr'
     else
       fail_with <<-EOM
 
-The specified search provider (#{provider}) is not currently supported.
-Please choose from one of the following search providers:
+CSSOLR004: The specified search provider (#{provider}) is not currently supported.
+           Please choose from one of the following search providers:
 
-solr
-cloudsearch
+           solr
+           cloudsearch
 EOM
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
@@ -23,25 +23,28 @@ class SolrPreflightValidator < PreflightValidator
   end
 
   def run!
-    warn_unchanged_external_flag
+    warn_changed_external_flag
     verify_external_url
     verify_erchef_config
   end
 
-  def warn_unchanged_external_flag
+  def warn_changed_external_flag
     if OmnibusHelper.has_been_bootstrapped? && backend?  && previous_run
-      if cs_solr_attr.has_key?('external') && (cs_solr_attr['external'] != previous_run['opscode-solr4']['external'])
+      if external_flag_changed?
         Chef::Log.warn <<-EOM
 
-The value of opscode_solr4['external'] has been changed.  Search
+The value of opscode_solr4['external'] has been changed. Search
 results against the new external search index may be incorrect. Please
 run `chef-server-ctl reindex --all` to ensure correct results
 
 EOM
       end
-    else
-      return true
     end
+  end
+
+  def external_flag_changed?
+    cs_solr_attr.has_key?('external') &&
+      (cs_solr_attr['external'] != previous_run['opscode-solr4']['external'])
   end
 
   def verify_external_url
@@ -77,6 +80,7 @@ EOM
     when 'solr'
     else
       fail_with <<-EOM
+
 The specified search provider (#{provider}) is not currently supported.
 Please choose from one of the following search providers:
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
@@ -1,0 +1,88 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+class SolrPreflightValidator < PreflightValidator
+  attr_reader :cs_solr_attr, :node_solr_attr, :cs_erchef_attr
+
+  def initialize(node)
+    super
+    @cs_solr_attr = PrivateChef['opscode_solr4']
+    @node_solr_attr = node['private_chef']['opscode-solr4']
+    @cs_erchef_attr = PrivateChef['opscode_erchef']
+  end
+
+  def run!
+    warn_unchanged_external_flag
+    verify_external_url
+    verify_erchef_config
+  end
+
+  def warn_unchanged_external_flag
+    if OmnibusHelper.has_been_bootstrapped? && backend?  && previous_run
+      if cs_solr_attr.has_key?('external') && (cs_solr_attr['external'] != previous_run['opscode-solr4']['external'])
+        Chef::Log.warn <<-EOM
+
+The value of opscode_solr4['external'] has been changed.  Search
+results against the new external search index may be incorrect. Please
+run `chef-server-ctl reindex --all` to ensure correct results
+
+EOM
+      end
+    else
+      return true
+    end
+  end
+
+  def verify_external_url
+    if cs_solr_attr['external'] & (! cs_solr_attr['external_url'])
+      fail_with <<EOM
+
+No external url specified for Solr depsite opscode_solr4['external']
+being set to true. To use an external solr instance, please set
+opscode_solr4['external_url'] to the external solr endpoint.
+
+EOM
+    end
+  end
+
+  def verify_erchef_config
+    provider = @cs_erchef_attr['search_provider']
+    return true if provider.nil? #default provider
+    case provider
+    when 'cloudsearch'
+      if ! ['batch', 'inline'].include?(@cs_erchef_attr['search_queue_mode'])
+        fail_with <<-EOM
+
+The cloudsearch search provider is only supported by the batch or
+inline queue modes. To use the cloudsearch search provider, please
+also set:
+
+opscode_erchef['search_queue_mode'] = 'batch'
+
+in /etc/opscode/chef-server.rb
+
+EOM
+      end
+    when 'solr'
+    else
+      fail_with <<-EOM
+The specified search provider (#{provider}) is not currently supported.
+Please choose from one of the following search providers:
+
+solr
+cloudsearch
+EOM
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
@@ -1,0 +1,18 @@
+# Author:: Steven Danna
+# Copyright:: Copyright (c) 2015 Chef Software, Inc
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Chef::Log.warn("External Solr Support does not include configuring the Solr/Cloudsearch schema.")

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/expander.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/expander.rb.erb
@@ -1,11 +1,11 @@
 log_location       STDOUT
 
-solr_url  "http://<%= node['private_chef']['opscode-solr4']['vip'] %>:<%= node['private_chef']['opscode-solr4']['port'] %>"
+solr_url  "<%= OmnibusHelper.new(node).solr_root %>"
 amqp_host '<%= node['private_chef']['rabbitmq']['vip'] %>'
 amqp_port <%= node['private_chef']['rabbitmq']['node_port'] %>
 amqp_user '<%= node['private_chef']['rabbitmq']['user'] %>'
 amqp_pass '<%= node['private_chef']['rabbitmq']['password'] %>'
-<% if @reindexer == true %> 
+<% if @reindexer == true %>
 amqp_vhost '<%= node['private_chef']['rabbitmq']['reindexer_vhost'] %>'
 ps_tag '-reindexer'
 <% else %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -160,7 +160,7 @@
                 {search_queue_mode, <%= node['private_chef']['opscode-erchef']['search_queue_mode'] %>},
                 {search_batch_max_size, <%= node['private_chef']['opscode-erchef']['search_batch_max_size'] %>},
                 {search_batch_max_wait, <%= node['private_chef']['opscode-erchef']['search_batch_max_wait'] %>},
-                {solr_service, [{root_url, "http://<%= @helper.vip_for_uri('opscode-solr4') %>:<%= node['private_chef']['opscode-solr4']['port'] %>/solr"},
+                {solr_service, [{root_url, "<%= @helper.solr_url() %>"},
                                 {timeout, <%= @solr_timeout %>},
                                 {init_count, <%= @solr_http_init_count %>},
                                 {max_count, <%= @solr_http_max_count %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -61,7 +61,7 @@ default_orgname <%= @default_orgname ? "\"#{@default_orgname}\"" : "nil" %>
 # testing location, you should not specify a value for this parameter.
 # The tests will still run, albeit slower, as they will now need to
 # poll for a period to ensure they are querying committed results.
-<% if node['private_chef']['search_provider'] == "solr" %>
+<% if node['private_chef']['opscode-erchef']['search_provider'] == "solr" %>
 search_server "<%= @solr_url %>"
 <% else %>
 # search_server "<%= @solr_url %>"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -61,7 +61,11 @@ default_orgname <%= @default_orgname ? "\"#{@default_orgname}\"" : "nil" %>
 # testing location, you should not specify a value for this parameter.
 # The tests will still run, albeit slower, as they will now need to
 # poll for a period to ensure they are querying committed results.
+<% if node['private_chef']['search_provider'] == "solr" %>
 search_server "<%= @solr_url %>"
+<% else %>
+# search_server "<%= @solr_url %>"
+<% end %>
 
 # Some tests expect access erchef server directly, instead of routing through
 # LB.

--- a/omnibus/files/private-chef-ctl-commands/chef-server-ctl
+++ b/omnibus/files/private-chef-ctl-commands/chef-server-ctl
@@ -182,6 +182,31 @@ CLEANSE002: Note that Chef Server data was not removed from your
 EOM
     end
 
+    # External Solr/Cloudsearch Commands
+    def external_status_opscode_solr4(_detail_level)
+      solr = external_services['opscode-solr4']['external_url']
+      begin
+        Chef::HTTP.new(solr).get(solr_status_url)
+        puts "run: opscode-solr4: connected OK to #{solr}"
+      rescue StandardError => e
+        puts "down: opscode-solr4: failed to connect to #{solr}: #{e.message.split("\n")[0]}"
+      end
+    end
+
+    def external_cleanse_opscode_solr4(perform_delete)
+      log <<-EOM
+Cleansing data in a remote Sol4 instance is not currently supported.
+EOM
+    end
+
+    def solr_status_url
+      case running_service_config('opscode-erchef')['search_provider']
+      when "cloudsearch"
+        "/search"
+      else
+        "/admin/ping?wt=json"
+      end
+    end
   end
 end
 

--- a/src/oc_erchef/apps/chef_index/c_src/cs_escape.c
+++ b/src/oc_erchef/apps/chef_index/c_src/cs_escape.c
@@ -1,0 +1,224 @@
+/* Copyright 2015 Chef Software, Inc.
+ *
+ * This file is provided to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * cs_escape: Does text-replacement on select ASCII punctionation
+ * to avoid problems with CloudSearch's word-splitting rules.
+ *
+ */
+#include <string.h>
+#include <stdbool.h>
+#include "erl_nif.h"
+
+// The first 32 ASCII/UTF8 Characters are control characters.  We
+// don't expect to see them so we don't define replacements for them,
+// shortening the array.
+#define replacement_for(n) replacements[n - 33]
+
+static const char *replacements[] = {
+  "__EX__", // !
+  "__DQ__", // "
+  "__HS__", // #
+  "__DL__", // $
+  "__PC__", // %
+  "__AM__", // &
+  "'", // ' No replacement
+  "__OP__", // (
+  "__CP__", // )
+  "__ST__", // *
+  "__PL__", // +
+  "__CM__", // ,
+  "__DS__", // -
+  ".", // . No replacement
+  "__FS__", // Foward Slash
+  "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", // No replacement
+  ":", // :
+  "__SC__", // ;
+  "__LT__", // <
+  "__EQ__", // =
+  "__GT__", // >
+  "__QS__", // ?
+  "__AT__", // @
+  "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K",
+  "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V",
+  "W", "X", "Y", "Z", // No replacements
+  "__OB__", // [
+  "__BS__", // Back Slash
+  "__CB__", // ]
+  "__CA__", // ^
+  "_", // _
+  "__BT__", // `
+  "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k",
+  "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v",
+  "w", "x", "y", "z", // No replacements
+  "__OC__", // {
+  "__PI__", // |
+  "__CC__", // }
+  "__TL__" // ~
+};
+
+// 0x21- 0x2f is ! through /
+// 0x3a - 0x40 is : through @
+// 0x5b - 0x60 is [ through `
+// 0x7b - 0x7e is { through ~
+static inline bool has_replacement(unsigned char n) {
+  return ((n >= 0x21 && n <= 0x2f) || \
+          (n >= 0x3a && n <= 0x40) || \
+          (n >= 0x5b && n <= 0x60) || \
+          (n >= 0x7b && n <= 0x7e));
+}
+
+static inline bool is_cs_safe(unsigned char n) {
+  return (n == 0x23 || n == 0x24 || n == 0x25 || \
+          n == 0x2c || n == 0x2f || n == 0x3b || \
+          n == 0x3c || n == 0x3d || n == 0x3e ||
+          n == 0x40 || n == 0x60);
+}
+
+static inline bool is_cs_term_safe(unsigned char n) {
+  return (n == 0x2b || n == 0x2d || is_cs_safe(n));
+}
+
+static inline bool is_cs_phrase_safe(unsigned char n) {
+  return (n == 0x2b || n == 0x2d || \
+          n == 0x2a || n == 0x3f || \
+          is_cs_safe(n));
+}
+
+static size_t do_replace(unsigned char *buf, int n) {
+  size_t len = strlen(replacement_for(n));
+  memcpy(buf, replacement_for(n), len);
+  return len;
+}
+
+unsigned char * cs_escape_if(unsigned char * string, size_t len, size_t * res_size, bool (*condPtr)(unsigned char)) {
+  long i;
+  size_t s_len = len;
+  unsigned char * rv;
+  // Below we assgin tmp_rv = rv and tmp_string = string to avoid
+  // incrementing the original pointers in the copy loop
+  unsigned char * tmp_rv;
+  unsigned char * tmp_string;
+
+  for (i = len-1; i >=0; --i) {
+    int n = string[i];
+    if (condPtr(n)) {
+      s_len += (strlen(replacements[n-33]) - 1);
+    }
+  }
+
+  *res_size = s_len;
+  // The caller is expected to call enif_free
+  rv = enif_alloc(s_len);
+  tmp_rv = rv;
+
+  for (tmp_string = string, i = len - 1; i >= 0; --i, tmp_string++) {
+    if (condPtr(*tmp_string)) {
+      tmp_rv += do_replace(tmp_rv, *tmp_string);
+    } else {
+      *tmp_rv = *tmp_string;
+      tmp_rv++;
+    }
+  }
+
+  return rv;
+}
+
+unsigned char * cs_escape(unsigned char * string, size_t len, size_t * res_size) {
+  return cs_escape_if(string, len, res_size, &has_replacement);
+}
+
+unsigned char * cs_escape_safe(unsigned char * string, size_t len, size_t * res_size) {
+  return cs_escape_if(string, len, res_size, &is_cs_safe);
+}
+
+unsigned char * cs_escape_term_safe(unsigned char * string, size_t len, size_t * res_size) {
+  return cs_escape_if(string, len, res_size, &is_cs_term_safe);
+}
+
+unsigned char * cs_escape_phrase_safe(unsigned char * string, size_t len, size_t * res_size) {
+  return cs_escape_if(string, len, res_size, &is_cs_phrase_safe);
+}
+
+typedef unsigned char * (*cs_escape_func)(unsigned char * string, size_t len, size_t * res_size);
+
+unsigned char * escape_nif_gen(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[], cs_escape_func funcPtr) {
+  unsigned char * result_binary, * dest_binary;
+  ErlNifBinary input_binary;
+  ERL_NIF_TERM retval;
+  size_t res_size = 0;
+
+  if (!enif_inspect_binary(env, argv[0], &input_binary))
+    return enif_make_badarg(env);
+
+  result_binary = funcPtr(input_binary.data, input_binary.size, &res_size);
+  dest_binary = enif_make_new_binary(env, res_size, &retval);
+  memcpy(dest_binary, result_binary, res_size);
+  enif_free(result_binary);
+  return retval;
+}
+
+
+unsigned char * escape_nif(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[]) {
+  return escape_nif_gen(env, argc, argv, &cs_escape);
+}
+
+unsigned char * escape_safe_nif(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[]) {
+  return escape_nif_gen(env, argc, argv, &cs_escape_safe);
+}
+
+unsigned char * escape_term_safe_nif(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[]) {
+  return escape_nif_gen(env, argc, argv, &cs_escape_term_safe);
+}
+
+unsigned char * escape_phrase_safe_nif(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[]) {
+  return escape_nif_gen(env, argc, argv, &cs_escape_phrase_safe);
+}
+
+
+/* Nif Boiler Plate */
+
+static ErlNifFunc nif_funcs[] = {
+  {"escape", 1, escape_nif},
+  {"escape_safe", 1, escape_safe_nif},
+  {"escape_term_safe", 1, escape_term_safe_nif},
+  {"escape_phrase_safe", 1, escape_phrase_safe_nif}
+};
+
+static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info);
+static int reload(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info);
+static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info);
+static void unload(ErlNifEnv* env, void* priv_data);
+
+static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info)
+{
+    return 0;
+}
+
+static int reload(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+{
+    return 0;
+}
+
+static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info)
+{
+    return 0;
+}
+
+static void unload(ErlNifEnv* env, void* priv_data)
+{
+}
+
+ERL_NIF_INIT(cs_escape, nif_funcs, load, reload, upgrade, unload)

--- a/src/oc_erchef/apps/chef_index/rebar.config
+++ b/src/oc_erchef/apps/chef_index/rebar.config
@@ -5,8 +5,12 @@
             {git, "https://github.com/tsloughter/rebar3_neotoma_plugin", {branch, "master"}}}
           ]}.
 
+{port_specs, [{"priv/cs_escape.so", ["c_src/*.c"]}]}.
+
 {provider_hooks, [
                   {pre, [
-                         {compile, {neotoma, compile}}
+                         {compile, {neotoma, compile}},
+                         {compile, {pc, compile}},
+                         {clean, {pc, clean}}
                         ]
                   }]}.

--- a/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
@@ -86,7 +86,6 @@ wrap_cloudsearch(Docs) ->
 wrap(Docs, #chef_idx_batch_state{search_provider = solr}) ->
     wrap_solr(Docs);
 wrap(Docs, #chef_idx_batch_state{search_provider = cloudsearch}) ->
-    lager:warning("Not implemented yet."),
     wrap_cloudsearch(Docs).
 
 -spec wrapper_size(#chef_idx_batch_state{}) -> non_neg_integer().

--- a/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
@@ -143,7 +143,7 @@ flush(State = #chef_idx_batch_state{item_queue = Queue,
     {PidsToReply, Timestamps, DocsToAdd} = lists:unzip3(Queue),
     Doc = wrap(DocsToAdd, State),
     Self = self(),
-    spawn_link(
+    spawn(
       fun() ->
               lager:debug("Batch posting to solr ~p documents (~p bytes)", [length(DocsToAdd), CurrentSize+WrapperSize]),
               Now = os:timestamp(),

--- a/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
@@ -147,7 +147,7 @@ flush(State = #chef_idx_batch_state{item_queue = Queue,
       fun() ->
               lager:debug("Batch posting to solr ~p documents (~p bytes)", [length(DocsToAdd), CurrentSize+WrapperSize]),
               Now = os:timestamp(),
-              Res = chef_index_expand:post_to_solr(Doc),
+              Res = chef_solr:update(Doc),
               Now1 = os:timestamp(),
               TotalDocs = length(Timestamps),
               {BeforeDiff, AfterDiff} =

--- a/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
@@ -139,6 +139,7 @@ flush(State = #chef_idx_batch_state{item_queue = []}) ->
     State;
 flush(State = #chef_idx_batch_state{item_queue = Queue,
                                     current_size = CurrentSize,
+                                    search_provider = Provider,
                                     wrapper_size = WrapperSize}) ->
     {PidsToReply, Timestamps, DocsToAdd} = lists:unzip3(Queue),
     Doc = wrap(DocsToAdd, State),
@@ -147,7 +148,7 @@ flush(State = #chef_idx_batch_state{item_queue = Queue,
       fun() ->
               lager:debug("Batch posting to solr ~p documents (~p bytes)", [length(DocsToAdd), CurrentSize+WrapperSize]),
               Now = os:timestamp(),
-              Res = chef_solr:update(Doc),
+              Res = chef_solr:update(chef_solr:search_module(Provider), Doc),
               Now1 = os:timestamp(),
               TotalDocs = length(Timestamps),
               {BeforeDiff, AfterDiff} =

--- a/src/oc_erchef/apps/chef_index/src/chef_index_expand.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_expand.erl
@@ -153,6 +153,8 @@ meta_fields(#chef_idx_expand_doc{id = Id, database = Database, type=Type}) ->
 
 get_object_type({ObjectType, _}) ->
     get_object_type(ObjectType);
+get_object_type(ObjectType) when is_binary(ObjectType) ->
+    <<"data_bag_item">>;
 get_object_type(ObjectType) ->
     list_to_binary(atom_to_list(ObjectType)).
 
@@ -170,8 +172,7 @@ doc_end(cloudsearch) ->
 
 %% @doc If we have a `data_bag_item' object, return a Solr field
 %% `data_bag', otherwise empty list.
-
-maybe_data_bag_field({_, DataBagName}) ->
+maybe_data_bag_field(DataBagName) when is_binary(DataBagName) ->
     ?FIELD(<<"data_bag">>, xml_text_escape(DataBagName));
 maybe_data_bag_field(_) ->
     [].
@@ -249,9 +250,9 @@ add_kv_pair([K|_]=Keys, Value, Acc) ->
 %% text escaping `K' and `V' and building an iolist with the
 %% appropriate separator.
 encode_pair(K, V) ->
-    [xml_text_escape(chef_solr:transform_data(K)),
+    [xml_text_escape(chef_solr:transform_data(iolist_to_binary(K))),
      chef_solr:kv_sep(),
-     xml_text_escape(chef_solr:transform_data(V)),
+     xml_text_escape(chef_solr:transform_data(iolist_to_binary(V))),
      <<" ">>].
 
 %% @doc Return an iolist such that `Sep' is added between each element

--- a/src/oc_erchef/apps/chef_index/src/chef_index_expand.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_expand.erl
@@ -97,10 +97,10 @@ add_block(ToAdd, cloudsearch) ->
 
 %% @doc Send a single document to solr directly.
 send_item(Doc) ->
-    chef_solr:update(update_payload([Doc], [])).
+    chef_solr:update(chef_solr:search_module(), update_payload([Doc], [])).
 
 send_delete(Doc) ->
-    chef_solr:update(update_payload([], [Doc])).
+    chef_solr:update(chef_solr:search_module(), update_payload([], [Doc])).
 
 %% @doc Create a chef_idx_expand_doc given Chef object attributes
 %% `Type', `ID', `DatabaseName', and `Item'.

--- a/src/oc_erchef/apps/chef_index/src/chef_index_http.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_http.erl
@@ -6,7 +6,7 @@
          delete_pool/0
         ]).
 
--define(HEADERS, [{"Content-Type", "text/xml"}]).
+-define(HEADERS, [{"Content-Type", "application/xml"}]).
 
 request(Path, Method, Body) ->
     SolrConfig = envy:get(chef_index, solr_service, list),

--- a/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
+++ b/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
@@ -8,7 +8,7 @@ query <- star_star / (expression / space)* %{
 star_star <- "*:*" ~;
 
 expression <- operation / group / field_phrase / field / field_range / term / string %{
-           [chef_solr:transform_query_safe(iolist_to_binary(Node))]
+           [chef_solr:transform_query_safe(get(search_module), iolist_to_binary(Node))]
 %};
 
 term <- keyword valid_letter+ / !keyword valid_letter+ %{
@@ -16,12 +16,12 @@ term <- keyword valid_letter+ / !keyword valid_letter+ %{
 %};
 
 field <- name:field_name ":" arg:(fuzzy_op / term / group / string) %{
-    [<<"content:">>, convert_term(?gv(name, Node)), chef_solr:kv_sep(), ?gv(arg, Node)]
+    [<<"content:">>, convert_term(?gv(name, Node)), chef_solr:kv_sep(get(search_module)), ?gv(arg, Node)]
 %};
 
 field_phrase <- name:field_name ':' '"' str:(term (space term)*) '"' %{
     P = convert_phrase(?gv(str, Node)),
-    [<<"content:\"">>, ?gv(name, Node), chef_solr:kv_sep(), P, <<"\"">>]
+    [<<"content:\"">>, ?gv(name, Node), chef_solr:kv_sep(get(search_module)), P, <<"\"">>]
 %};
 
 field_range <- field_name ":" (("[" range_entry " TO " range_entry "]") /
@@ -108,37 +108,37 @@ special_char <- '[' / ']' / '\\' / '"' / [!(){}^~*?:] ~;
 
 -spec convert_term(iolist()) -> binary().
 convert_term(Term) ->
-  chef_solr:transform_query_term(iolist_to_binary(Term)).
+  chef_solr:transform_query_term(get(search_module), iolist_to_binary(Term)).
 
 -spec convert_phrase(iolist()) -> binary().
 convert_phrase(Phrase) ->
-  chef_solr:transform_query_phrase(iolist_to_binary(Phrase)).
+  chef_solr:transform_query_phrase(get(search_module), iolist_to_binary(Phrase)).
 
 -spec convert_char(iolist()) -> binary().
 convert_char(Char) ->
-  chef_solr:transform_query_all(iolist_to_binary(Char)).
+  chef_solr:transform_query_all(get(search_module), iolist_to_binary(Char)).
 
 
 -spec convert_range_expression(binary(), binary(), binary(), binary(), binary()) -> iolist().
 convert_range_expression(FieldName, _, <<"*">>, <<"*">>, _) ->
-    [<<"content:">>, FieldName, chef_solr:kv_sep(), <<"*">>];
+    [<<"content:">>, FieldName, chef_solr:kv_sep(get(search_module)), <<"*">>];
 
 convert_range_expression(FieldName, Open, Start, <<"*">>, Close) ->
     [<<"content:">>,
-     Open, FieldName, chef_solr:kv_sep(), Start,
+     Open, FieldName, chef_solr:kv_sep(get(search_module)), Start,
      <<" TO ">>,
-     FieldName, chef_solr:kv_sep(), <<"\\ufff0">>, Close];
+     FieldName, chef_solr:kv_sep(get(search_module)), <<"\\ufff0">>, Close];
 
 convert_range_expression(FieldName, Open, <<"*">>, End, Close) ->
     [<<"content:">>,
-     Open, FieldName, chef_solr:kv_sep(),
+     Open, FieldName, chef_solr:kv_sep(get(search_module)),
      <<" TO ">>,
-     FieldName, chef_solr:kv_sep(), End, Close];
+     FieldName, chef_solr:kv_sep(get(search_module)), End, Close];
 
 convert_range_expression(FieldName, Open, Start, End, Close) ->
     [<<"content:">>,
-     Open, FieldName, chef_solr:kv_sep(), Start,
+     Open, FieldName, chef_solr:kv_sep(get(search_module)), Start,
      <<" TO ">>,
-     FieldName, chef_solr:kv_sep(), End, Close].
+     FieldName, chef_solr:kv_sep(get(search_module)), End, Close].
 
 %}

--- a/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
+++ b/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
@@ -7,17 +7,21 @@ query <- star_star / (expression / space)* %{
 
 star_star <- "*:*" ~;
 
-expression <- operation / group / field_phrase / field / field_range / term / string ~;
+expression <- operation / group / field_phrase / field / field_range / term / string %{
+           [chef_solr:transform_query_safe(iolist_to_binary(Node))]
+%};
 
-term <- keyword valid_letter+ / !keyword valid_letter+ ~;
+term <- keyword valid_letter+ / !keyword valid_letter+ %{
+     [convert_term(Node)]
+%};
 
 field <- name:field_name ":" arg:(fuzzy_op / term / group / string) %{
-    [<<"content:">>, ?gv(name, Node), <<"__=__">>, ?gv(arg, Node)]
+    [<<"content:">>, convert_term(?gv(name, Node)), chef_solr:kv_sep(), ?gv(arg, Node)]
 %};
 
 field_phrase <- name:field_name ':' '"' str:(term (space term)*) '"' %{
-    P = ?gv(str, Node),
-    [<<"content:\"">>, ?gv(name, Node), <<"__=__">>, P, <<"\"">>]
+    P = convert_phrase(?gv(str, Node)),
+    [<<"content:\"">>, ?gv(name, Node), chef_solr:kv_sep(), P, <<"\"">>]
 %};
 
 field_range <- field_name ":" (("[" range_entry " TO " range_entry "]") /
@@ -54,14 +58,19 @@ fuzzy_op <- (term / string) '~' fuzzy_param? ~;
 
 fuzzy_param <- [0-9]+ ('.' [0-9])? ~;
 
-string <- '"' (term (space term)*) '"' ~;
+string <- '"' phr:(term (space term)*) '"' %{
+       [<<"\"">>, convert_phrase(?gv(phr, Node)), <<"\"">>]
+%};
 
 keyword <- "AND" / "OR" / "NOT" ~;
 
+valid_letter <- start_letter+ ([a-zA-Z0-9*?@_+./-] / escaped_special)* ~;
 
-valid_letter <- start_letter+ ([a-zA-Z0-9*?@_+./-] / '\\' special_char)* ~;
+start_letter <- [a-zA-Z0-9_.*/] / escaped_special ~;
 
-start_letter <- [a-zA-Z0-9_.*/] / '\\' special_char ~;
+escaped_special <- '\\' chr:special_char %{
+    [<<"\\">>, convert_char(?gv(chr, Node))]
+%};
 
 space <- [ \t]+ ~;
 
@@ -97,26 +106,39 @@ special_char <- '[' / ']' / '\\' / '"' / [!(){}^~*?:] ~;
 -define(not_op, 'NOT').
 -define(not_bang_op, '!').
 
+-spec convert_term(iolist()) -> binary().
+convert_term(Term) ->
+  chef_solr:transform_query_term(iolist_to_binary(Term)).
+
+-spec convert_phrase(iolist()) -> binary().
+convert_phrase(Phrase) ->
+  chef_solr:transform_query_phrase(iolist_to_binary(Phrase)).
+
+-spec convert_char(iolist()) -> binary().
+convert_char(Char) ->
+  chef_solr:transform_query_all(iolist_to_binary(Char)).
+
+
 -spec convert_range_expression(binary(), binary(), binary(), binary(), binary()) -> iolist().
 convert_range_expression(FieldName, _, <<"*">>, <<"*">>, _) ->
-    [<<"content:">>, FieldName, <<"__=__*">>];
+    [<<"content:">>, FieldName, chef_solr:kv_sep(), <<"*">>];
 
 convert_range_expression(FieldName, Open, Start, <<"*">>, Close) ->
     [<<"content:">>,
-     Open, FieldName, <<"__=__">>, Start,
+     Open, FieldName, chef_solr:kv_sep(), Start,
      <<" TO ">>,
-     FieldName, <<"__=__\\ufff0">>, Close];
+     FieldName, chef_solr:kv_sep(), <<"\\ufff0">>, Close];
 
 convert_range_expression(FieldName, Open, <<"*">>, End, Close) ->
     [<<"content:">>,
-     Open, FieldName, <<"__=__">>,
+     Open, FieldName, chef_solr:kv_sep(),
      <<" TO ">>,
-     FieldName, <<"__=__">>, End, Close];
+     FieldName, chef_solr:kv_sep(), End, Close];
 
 convert_range_expression(FieldName, Open, Start, End, Close) ->
     [<<"content:">>,
-     Open, FieldName, <<"__=__">>, Start,
+     Open, FieldName, chef_solr:kv_sep(), Start,
      <<" TO ">>,
-     FieldName, <<"__=__">>, End, Close].
+     FieldName, chef_solr:kv_sep(), End, Close].
 
 %}

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -191,7 +191,7 @@ delete_search_db_by_type(OrgId, Type) ->
 %%
 %% Body is really a string(), but Dialyzer can only determine it is a list of bytes due to
 %% the implementation of search_db_from_orgid/1
--spec update(Body :: [byte(),...]) -> ok | {error, term()}.
+-spec update(iolist() | binary()) -> ok | {error, term()}.
 update(Body) when is_list(Body) ->
     update(iolist_to_binary(Body));
 update(Body) ->

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -192,6 +192,8 @@ delete_search_db_by_type(OrgId, Type) ->
 %% Body is really a string(), but Dialyzer can only determine it is a list of bytes due to
 %% the implementation of search_db_from_orgid/1
 -spec update(Body :: [byte(),...]) -> ok | {error, term()}.
+update(Body) when is_list(Body) ->
+    update(iolist_to_binary(Body));
 update(Body) ->
     try
         %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -24,17 +24,76 @@
 -module(chef_solr).
 
 -export([
+         %% Static Data Accessors
+         search_provider/0,
+         id_field/0,
+         database_field/0,
+         kv_sep/0,
+         type_field/0,
+         update_url/0,
+         %% Query Building
          add_org_guid_to_query/2,
+         make_query_from_params/4,
+         %% Document Buidling
+         transform_data/1,
+         %% Operations
+         search/1,
+         update/1,
+         commit/0,
+         ping/0,
          delete_search_db/1,
          delete_search_db_by_type/2,
-         make_query_from_params/4,
-         ping/0,
-         search/1,
-         solr_commit/0
+         %% Helpers used by providers
+         db_from_orgid/1
         ]).
 
 -include("chef_solr.hrl").
+-define(PROVIDER_FUNC(FuncName),
+        begin
+            Mod = list_to_atom(atom_to_list(search_provider()) ++ "_provider"),
+            Mod:FuncName()
+        end).
 
+-define(PROVIDER_FUNC(FuncName, Args),
+        begin
+            Mod = list_to_atom(atom_to_list(search_provider()) ++ "_provider"),
+            apply(Mod, FuncName, Args)
+        end).
+
+search_provider() ->
+    envy:get(chef_index, search_provider, solr, envy:one_of([solr, cloudsearch])).
+
+-spec id_field() -> binary().
+id_field() ->
+    ?PROVIDER_FUNC(id_field).
+
+-spec database_field() -> binary().
+database_field() ->
+    ?PROVIDER_FUNC(database_field).
+
+-spec type_field() -> binary().
+type_field() ->
+    ?PROVIDER_FUNC(type_field).
+
+-spec ping_url() -> string().
+ping_url() ->
+    ?PROVIDER_FUNC(ping_url).
+
+-spec update_url() -> string().
+update_url() ->
+    ?PROVIDER_FUNC(update_url).
+
+kv_sep() ->
+    ?PROVIDER_FUNC(kv_sep).
+
+%% Query Building functions
+%%
+%% Callers of search can use make_query_from_params/4 and add_org_guid_to_query/2 to
+%% construct a chef_solr_query object suitable for consumption by search/1.
+%%
+%% Query constructions is split into 2 parts since we typically want to validate the
+%% user-provided search query before we have the OrgId in the webmachine module that calls
+%% this function (chef_wm_search in the oc_chef_wm app).
 -spec make_query_from_params(binary()|string(),
                              string() | binary() | undefined,
                              string(),
@@ -44,22 +103,32 @@ make_query_from_params(ObjType, QueryString, Start, Rows) ->
     FilterQuery = make_fq_type(ObjType),
     %% 'sort' param is ignored and hardcoded because indexing
     %% scheme doesn't support sorting since there is only one field.
-    Sort = "X_CHEF_id_CHEF_X asc",
+    Sort = binary_to_list(id_field()) ++ " asc",
     #chef_solr_query{query_string = check_query(QueryString),
                      filter_query = FilterQuery,
+                     search_provider = search_provider(),
                      start = decode({nonneg_int, "start"}, Start, 0),
                      rows = decode({nonneg_int, "rows"}, Rows, 1000),
                      sort = Sort,
                      index = index_type(ObjType)}.
 
--spec add_org_guid_to_query(#chef_solr_query{}, binary()) ->
-                                   #chef_solr_query{}.
+-spec add_org_guid_to_query(#chef_solr_query{}, binary())
+                           -> #chef_solr_query{}.
 add_org_guid_to_query(Query = #chef_solr_query{filter_query = FilterQuery},
                       OrgGuid) ->
-    Query#chef_solr_query{filter_query = "+" ++
-                              search_db_from_orgid(OrgGuid) ++
-                              " " ++ FilterQuery}.
+    Query#chef_solr_query{filter_query = ?PROVIDER_FUNC(add_org_guid_to_fq,
+                                                        [OrgGuid, FilterQuery])}.
 
+
+%% Document Building Helpers
+%% These helpers are called by chef_index_expand to build
+%% XML documents appropriate for the given provider.
+transform_data(Data) ->
+    ?PROVIDER_FUNC(transform_data, [Data]).
+
+%% Search/Solr Operations
+%%
+%%
 -spec search(#chef_solr_query{}) ->
                     {ok, non_neg_integer(), non_neg_integer(), [binary()]} |
                     {error, {solr_400, string()}} |
@@ -70,13 +139,7 @@ search(#chef_solr_query{} = Query) ->
     {ok, Code, _Head, Body} = chef_index_http:request(Url, get, []),
     case Code of
         "200" ->
-            SolrData = jiffy:decode(Body),
-            Response = ej:get({<<"response">>}, SolrData),
-            Start = ej:get({<<"start">>}, Response),
-            NumFound = ej:get({<<"numFound">>}, Response),
-            DocList = ej:get({<<"docs">>}, Response),
-            Ids = [ ej:get({<<"X_CHEF_id_CHEF_X">>}, Doc) || Doc <- DocList ],
-            {ok, Start, NumFound, Ids};
+            handle_successful_search(Body);
         %% We only have the transformed query at this point, so for the following two error
         %% conditions, we just send along the full query URL. This is for logging only and
         %% should NOT be sent back to the client. Note that a 400 from solr can occur when
@@ -88,11 +151,16 @@ search(#chef_solr_query{} = Query) ->
             {error, {solr_500, Url}}
     end.
 
+-spec handle_successful_search(binary() | string()) -> {ok, non_neg_integer(), non_neg_integer(), [binary()]}.
+handle_successful_search(Body) ->
+    SolrData = jiffy:decode(Body),
+    ?PROVIDER_FUNC(handle_successful_search, [SolrData]).
+
 -spec ping() -> pong | pang.
 ping() ->
     try
         %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash
-        case chef_index_http:request("/admin/ping?wt=json", get, []) of
+        case chef_index_http:request(ping_url(), get, []) of
             %% FIXME: verify that solr returns non-200 if something is wrong and not "status":"ERROR".
             {ok, "200", _Head, _Body} -> pong;
             _Error -> pang
@@ -107,33 +175,44 @@ ping() ->
 %% @doc Delete all search index entries for a given organization.
 -spec delete_search_db(OrgId :: binary()) -> ok.
 delete_search_db(OrgId) ->
-    DeleteQuery = "<?xml version='1.0' encoding='UTF-8'?><delete><query>" ++
-        search_db_from_orgid(OrgId) ++
-        "</query></delete>",
-    ok = solr_update(DeleteQuery),
-    ok = solr_commit(),
-    ok.
+    ?PROVIDER_FUNC(delete_search_db, [OrgId]).
 
 %% @doc Delete all search index entries for a given
 %% organization and type.  Types are generally binaries or strings elsewhere in this
 %% module. We should think about converting the other APIs in this file to use atoms
 %% instead.
-%% Note: This omits solr_commit because of the high cost of that call in production.
-%% Some users will want to call the commit directly.
 %% @end
 -spec delete_search_db_by_type(OrgId :: binary(), Type :: atom()) -> ok.
-delete_search_db_by_type(OrgId, Type)
-  when Type == client orelse Type == data_bag_item orelse
-       Type == environment orelse Type == node orelse
-       Type == role ->
-    DeleteQuery = "<?xml version='1.0' encoding='UTF-8'?><delete><query>" ++
-        search_db_from_orgid(OrgId) ++ " AND " ++
-        search_type_constraint(Type) ++
-        "</query></delete>",
-    solr_update(DeleteQuery).
+delete_search_db_by_type(OrgId, Type) ->
+    ?PROVIDER_FUNC(delete_search_db_by_type, [OrgId, Type]).
 
+%% @doc Sends `Body` to the Solr server's "/update" endpoint.
+%% @end
+%%
+%% Body is really a string(), but Dialyzer can only determine it is a list of bytes due to
+%% the implementation of search_db_from_orgid/1
+-spec update(Body :: [byte(),...]) -> ok | {error, term()}.
+update(Body) ->
+    try
+        %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash
+        case chef_index_http:request(update_url(), post, Body) of
+            %% FIXME: verify that solr returns non-200 if something is wrong and not "status":"ERROR".
+            {ok, "200", _Head, _Body} -> ok;
+            Error -> {error, Error}
+        end
+    catch
+        How:Why ->
+            error_logger:error_report({chef_solr, update, How, Why}),
+            {error, Why}
+    end.
 
-%% Internal functions
+%% @doc Sends a "commit" message directly to Solr
+%% This is exposed for the users of delete_search_db_by_type
+-spec commit() -> ok | {error, term()}.
+commit() ->
+    ?PROVIDER_FUNC(commit).
+
+%% Helpers
 
 %% @doc Generates the name of the organization's search database from its ID
 %% @end
@@ -141,41 +220,33 @@ delete_search_db_by_type(OrgId, Type)
 %% Note: this really returns a string(), but Dialyzer is convinced it's a byte list (which
 %% it is, technically).  In order for it to be recognized as a printable string, though,
 %% we'd have to use io_lib:format
--spec search_db_from_orgid(OrgId :: binary()) -> DBName :: [byte(),...].
-search_db_from_orgid(OrgId) ->
-    "X_CHEF_database_CHEF_X:chef_" ++ binary_to_list(OrgId).
-
-%% @doc Generates a constraint for chef_type
-%% @end
--spec search_type_constraint(Type :: atom()) -> TypeConstraint :: [byte(),...].
-search_type_constraint(Type) ->
-    "X_CHEF_type_CHEF_X:" ++ atom_to_list(Type).
+db_from_orgid(OrgId) ->
+    "chef_" ++ binary_to_list(OrgId).
 
 
-% /solr/select?
-    % fq=%2BX_CHEF_type_CHEF_X%3Anode+%2BX_CHEF_database_CHEF_X%3Achef_288da1c090ff45c987346d2829257256
-    % &indent=off
-    % &q=content%3Aattr1__%3D__v%2A
+%% Internal Functions
+
+%% Construct a solr query URL
+%% Calls assert_org_id_filter and search_url_fmt from provider
+%% The search_url_fmt should accept all standard search args.
 -spec make_solr_query_url(#chef_solr_query{}) -> string().
-make_solr_query_url(#chef_solr_query{
-                       query_string = Query,
-                       %% ensure we filter on an org ID
-                       filter_query = FilterQuery = "+X_CHEF_database_CHEF_X:chef_" ++ _Rest,
-                       start = Start,
-                       rows = Rows,
-                       sort = Sort}) ->
-    Url = "/select?"
-        "fq=~s"
-        "&indent=off"
-        "&q=~s"
-        "&start=~B"
-        "&rows=~B"
-        "&wt=json"
-        "&sort=~s",
-    lists:flatten(io_lib:format(Url, [ibrowse_lib:url_encode(FilterQuery),
-                                      ibrowse_lib:url_encode(Query),
-                                      Start, Rows,
-                                      ibrowse_lib:url_encode(Sort)])).
+make_solr_query_url(Query = #chef_solr_query{filter_query = FilterQuery}) ->
+    %% ensure we filter on an org ID
+    ?PROVIDER_FUNC(assert_org_id_filter, [FilterQuery]),
+    Url = ?PROVIDER_FUNC(search_url_fmt),
+    Args = search_url_args(Query),
+    lists:flatten(io_lib:format(Url, Args)).
+
+search_url_args(#chef_solr_query{
+                   query_string = Query,
+                   filter_query = FilterQuery,
+                   start = Start,
+                   rows = Rows,
+                   sort = Sort}) ->
+    [ibrowse_lib:url_encode(FilterQuery),
+     ibrowse_lib:url_encode(Query),
+     Start, Rows,
+     ibrowse_lib:url_encode(Sort)].
 
 make_fq_type(ObjType) when is_binary(ObjType) ->
     make_fq_type(binary_to_list(ObjType));
@@ -183,9 +254,9 @@ make_fq_type(ObjType) when ObjType =:= "node";
                            ObjType =:= "role";
                            ObjType =:= "client";
                            ObjType =:= "environment" ->
-    "+X_CHEF_type_CHEF_X:" ++ ObjType;
+    ?PROVIDER_FUNC(make_standard_fq, [ObjType]);
 make_fq_type(ObjType) ->
-    "+X_CHEF_type_CHEF_X:data_bag_item +data_bag:" ++ ObjType.
+    ?PROVIDER_FUNC(make_data_bag_fq, [ObjType]).
 
 index_type(Type) when is_binary(Type) ->
     index_type(binary_to_list(Type));
@@ -218,7 +289,7 @@ transform_query(RawQuery) when is_list(RawQuery) ->
 transform_query(RawQuery) ->
     case chef_lucene:parse(RawQuery) of
         Query when is_binary(Query) ->
-            binary_to_list(Query);
+            binary_to_list(?PROVIDER_FUNC(transform_query, [Query]));
         _ ->
             throw({bad_query, RawQuery})
     end.
@@ -242,36 +313,3 @@ validate_non_neg(Key, Int, OrigValue) when Int < 0 ->
     throw({bad_param, {Key, OrigValue}});
 validate_non_neg(_Key, Int, _OrigValue) ->
     Int.
-
-%%------------------------------------------------------------------------------
-%% Direct Solr Server Interaction
-%%
-%% To drop all entries for a given org's search "database", we need to bypass the indexer
-%% queue and interact directly with the Solr server.  These functions facilitate that.
-%%------------------------------------------------------------------------------
-
-%% @doc Sends `Body` to the Solr server's "/update" endpoint.
-%% @end
-%%
-%% Body is really a string(), but Dialyzer can only determine it is a list of bytes due to
-%% the implementation of search_db_from_orgid/1
--spec solr_update(Body :: [byte(),...]) -> ok | {error, term()}.
-solr_update(Body) ->
-    try
-        %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash
-        case chef_index_http:request("/update", post, Body) of
-            %% FIXME: verify that solr returns non-200 if something is wrong and not "status":"ERROR".
-            {ok, "200", _Head, _Body} -> ok;
-            Error -> {error, Error}
-        end
-    catch
-        How:Why ->
-            error_logger:error_report({chef_solr, update, How, Why}),
-            {error, Why}
-    end.
-
-%% @doc Sends a "commit" message directly to Solr
-%% This is exposed for the users of delete_search_db_by_type
--spec solr_commit() -> ok | {error, term()}.
-solr_commit() ->
-    solr_update("<?xml version='1.0' encoding='UTF-8'?><commit/>").

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -34,6 +34,10 @@
          %% Query Building
          add_org_guid_to_query/2,
          make_query_from_params/4,
+         transform_query_all/1,
+         transform_query_safe/1,
+         transform_query_term/1,
+         transform_query_phrase/1,
          %% Document Buidling
          transform_data/1,
          %% Operations
@@ -286,12 +290,24 @@ check_query(RawQuery) ->
             transform_query(http_uri:decode(Query))
     end.
 
+transform_query_all(Data) ->
+    ?PROVIDER_FUNC(transform_query_all, [Data]).
+
+transform_query_safe(Data) ->
+    ?PROVIDER_FUNC(transform_query_safe, [Data]).
+
+transform_query_term(Data) ->
+    ?PROVIDER_FUNC(transform_query_term, [Data]).
+
+transform_query_phrase(Data) ->
+    ?PROVIDER_FUNC(transform_query_phrase, [Data]).
+
 transform_query(RawQuery) when is_list(RawQuery) ->
     transform_query(list_to_binary(RawQuery));
 transform_query(RawQuery) ->
     case chef_lucene:parse(RawQuery) of
         Query when is_binary(Query) ->
-            binary_to_list(?PROVIDER_FUNC(transform_query, [Query]));
+            binary_to_list(Query);
         _ ->
             throw({bad_query, RawQuery})
     end.

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -27,6 +27,7 @@
          %% Static Data Accessors
          search_provider/0,
          search_module/0,
+         search_module/1,
          id_field/1,
          database_field/1,
          kv_sep/1,

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -26,23 +26,24 @@
 -export([
          %% Static Data Accessors
          search_provider/0,
-         id_field/0,
-         database_field/0,
-         kv_sep/0,
-         type_field/0,
-         update_url/0,
+         search_module/0,
+         id_field/1,
+         database_field/1,
+         kv_sep/1,
+         type_field/1,
+         update_url/1,
          %% Query Building
          add_org_guid_to_query/2,
          make_query_from_params/4,
-         transform_query_all/1,
-         transform_query_safe/1,
-         transform_query_term/1,
-         transform_query_phrase/1,
+         transform_query_all/2,
+         transform_query_safe/2,
+         transform_query_term/2,
+         transform_query_phrase/2,
          %% Document Buidling
          transform_data/1,
          %% Operations
          search/1,
-         update/1,
+         update/2,
          commit/0,
          ping/0,
          delete_search_db/1,
@@ -52,43 +53,55 @@
         ]).
 
 -include("chef_solr.hrl").
--define(PROVIDER_FUNC(FuncName),
-        begin
-            Mod = list_to_atom(atom_to_list(search_provider()) ++ "_provider"),
-            Mod:FuncName()
-        end).
 
--define(PROVIDER_FUNC(FuncName, Args),
-        begin
-            Mod = list_to_atom(atom_to_list(search_provider()) ++ "_provider"),
-            apply(Mod, FuncName, Args)
-        end).
+
+provider_call(FuncName) ->
+    (search_module()):FuncName().
+
+provider_call(FuncName, Arg1) ->
+    (search_module()):FuncName(Arg1).
+
+provider_call(FuncName, Arg1, Arg2) ->
+    (search_module()):FuncName(Arg1, Arg2).
+
 
 search_provider() ->
     envy:get(chef_index, search_provider, solr, envy:one_of([solr, cloudsearch])).
 
--spec id_field() -> binary().
-id_field() ->
-    ?PROVIDER_FUNC(id_field).
+search_module() ->
+    search_module(search_provider()).
 
--spec database_field() -> binary().
-database_field() ->
-    ?PROVIDER_FUNC(database_field).
+search_module(solr) ->
+    solr_provider;
+search_module(cloudsearch) ->
+    cloudsearch_provider.
 
--spec type_field() -> binary().
-type_field() ->
-    ?PROVIDER_FUNC(type_field).
 
--spec ping_url() -> string().
-ping_url() ->
-    ?PROVIDER_FUNC(ping_url).
+-spec id_field(atom()) -> binary().
+id_field(SearchModule) ->
+    SearchModule:id_field().
 
--spec update_url() -> string().
-update_url() ->
-    ?PROVIDER_FUNC(update_url).
+-spec database_field(atom()) -> binary().
+database_field(SearchModule) ->
+    SearchModule:database_field().
 
-kv_sep() ->
-    ?PROVIDER_FUNC(kv_sep).
+
+-spec type_field(atom()) -> binary().
+type_field(SearchModule) ->
+    SearchModule:type_field().
+
+
+-spec ping_url(atom()) -> string().
+ping_url(SearchModule) ->
+    SearchModule:ping_url().
+
+-spec update_url(atom()) -> string().
+update_url(SearchModule) ->
+    SearchModule:update_url().
+
+-spec kv_sep(atom()) -> binary().
+kv_sep(SearchModule) ->
+    SearchModule:kv_sep().
 
 %% Query Building functions
 %%
@@ -104,13 +117,16 @@ kv_sep() ->
                              string()) -> #chef_solr_query{}.
 make_query_from_params(ObjType, QueryString, Start, Rows) ->
     % TODO: super awesome error messages
-    FilterQuery = make_fq_type(ObjType),
+    SearchProvider = search_provider(),
+    SearchModule = search_module(SearchProvider),
+    FilterQuery = make_fq_type(SearchModule, ObjType),
     %% 'sort' param is ignored and hardcoded because indexing
     %% scheme doesn't support sorting since there is only one field.
-    Sort = binary_to_list(id_field()) ++ " asc",
-    #chef_solr_query{query_string = check_query(QueryString),
+    Sort = binary_to_list(id_field(SearchModule)) ++ " asc",
+    #chef_solr_query{query_string = check_query(SearchModule, QueryString),
                      filter_query = FilterQuery,
-                     search_provider = search_provider(),
+                     search_provider = SearchProvider,
+                     search_module = SearchModule,
                      start = decode({nonneg_int, "start"}, Start, 0),
                      rows = decode({nonneg_int, "rows"}, Rows, 1000),
                      sort = Sort,
@@ -118,17 +134,16 @@ make_query_from_params(ObjType, QueryString, Start, Rows) ->
 
 -spec add_org_guid_to_query(#chef_solr_query{}, binary())
                            -> #chef_solr_query{}.
-add_org_guid_to_query(Query = #chef_solr_query{filter_query = FilterQuery},
+add_org_guid_to_query(Query = #chef_solr_query{filter_query = FilterQuery, search_module = Mod},
                       OrgGuid) ->
-    Query#chef_solr_query{filter_query = ?PROVIDER_FUNC(add_org_guid_to_fq,
-                                                        [OrgGuid, FilterQuery])}.
+    Query#chef_solr_query{filter_query = Mod:add_org_guid_to_fq(OrgGuid, FilterQuery)}.
 
 
 %% Document Building Helpers
 %% These helpers are called by chef_index_expand to build
 %% XML documents appropriate for the given provider.
 transform_data(Data) ->
-    ?PROVIDER_FUNC(transform_data, [Data]).
+    provider_call(transform_data, Data).
 
 %% Search/Solr Operations
 %%
@@ -158,13 +173,13 @@ search(#chef_solr_query{} = Query) ->
 -spec handle_successful_search(binary() | string()) -> {ok, non_neg_integer(), non_neg_integer(), [binary()]}.
 handle_successful_search(Body) ->
     SolrData = jiffy:decode(Body),
-    ?PROVIDER_FUNC(handle_successful_search, [SolrData]).
+    provider_call(handle_successful_search, SolrData).
 
 -spec ping() -> pong | pang.
 ping() ->
     try
         %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash
-        case chef_index_http:request(ping_url(), get, []) of
+        case chef_index_http:request(ping_url(search_module()), get, []) of
             %% FIXME: verify that solr returns non-200 if something is wrong and not "status":"ERROR".
             {ok, "200", _Head, _Body} -> pong;
             _Error -> pang
@@ -179,7 +194,7 @@ ping() ->
 %% @doc Delete all search index entries for a given organization.
 -spec delete_search_db(OrgId :: binary()) -> ok.
 delete_search_db(OrgId) ->
-    ?PROVIDER_FUNC(delete_search_db, [OrgId]).
+    provider_call(delete_search_db, OrgId).
 
 %% @doc Delete all search index entries for a given
 %% organization and type.  Types are generally binaries or strings elsewhere in this
@@ -188,20 +203,21 @@ delete_search_db(OrgId) ->
 %% @end
 -spec delete_search_db_by_type(OrgId :: binary(), Type :: atom()) -> ok.
 delete_search_db_by_type(OrgId, Type) ->
-    ?PROVIDER_FUNC(delete_search_db_by_type, [OrgId, Type]).
+    provider_call(delete_search_db_by_type, OrgId, Type).
 
 %% @doc Sends `Body` to the Solr server's "/update" endpoint.
 %% @end
 %%
 %% Body is really a string(), but Dialyzer can only determine it is a list of bytes due to
 %% the implementation of search_db_from_orgid/1
--spec update(iolist() | binary()) -> ok | {error, term()}.
-update(Body) when is_list(Body) ->
-    update(iolist_to_binary(Body));
-update(Body) ->
+%% For that matter, `update` is really 'post to provider'.
+-spec update(atom(), iolist() | binary()) -> ok | {error, term()}.
+update(Mod, Body) when is_list(Body) ->
+    update(Mod, iolist_to_binary(Body));
+update(Mod, Body) ->
     try
         %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash
-        case chef_index_http:request(update_url(), post, Body) of
+        case chef_index_http:request(update_url(Mod), post, Body) of
             %% FIXME: verify that solr returns non-200 if something is wrong and not "status":"ERROR".
             {ok, "200", _Head, _Body} -> ok;
             Error -> {error, Error}
@@ -216,7 +232,7 @@ update(Body) ->
 %% This is exposed for the users of delete_search_db_by_type
 -spec commit() -> ok | {error, term()}.
 commit() ->
-    ?PROVIDER_FUNC(commit).
+    provider_call(commit).
 
 %% Helpers
 
@@ -236,10 +252,10 @@ db_from_orgid(OrgId) ->
 %% Calls assert_org_id_filter and search_url_fmt from provider
 %% The search_url_fmt should accept all standard search args.
 -spec make_solr_query_url(#chef_solr_query{}) -> string().
-make_solr_query_url(Query = #chef_solr_query{filter_query = FilterQuery}) ->
+make_solr_query_url(Query = #chef_solr_query{search_module = SearchModule, filter_query = FilterQuery}) ->
     %% ensure we filter on an org ID
-    ?PROVIDER_FUNC(assert_org_id_filter, [FilterQuery]),
-    Url = ?PROVIDER_FUNC(search_url_fmt),
+    SearchModule:assert_org_id_filter(FilterQuery),
+    Url = SearchModule:search_url_fmt(),
     Args = search_url_args(Query),
     lists:flatten(io_lib:format(Url, Args)).
 
@@ -254,15 +270,16 @@ search_url_args(#chef_solr_query{
      Start, Rows,
      ibrowse_lib:url_encode(Sort)].
 
-make_fq_type(ObjType) when is_binary(ObjType) ->
-    make_fq_type(binary_to_list(ObjType));
-make_fq_type(ObjType) when ObjType =:= "node";
-                           ObjType =:= "role";
-                           ObjType =:= "client";
-                           ObjType =:= "environment" ->
-    ?PROVIDER_FUNC(make_standard_fq, [ObjType]);
-make_fq_type(ObjType) ->
-    ?PROVIDER_FUNC(make_data_bag_fq, [ObjType]).
+make_fq_type(SearchModule, ObjType) when is_binary(ObjType) ->
+    make_fq_type(SearchModule, binary_to_list(ObjType));
+make_fq_type(SearchModule, ObjType) when ObjType =:= "node";
+                       ObjType =:= "role";
+                       ObjType =:= "client";
+                       ObjType =:= "environment" ->
+
+    SearchModule:make_standard_fq(ObjType);
+make_fq_type(SearchModule, ObjType) ->
+    SearchModule:make_data_bag_fq(ObjType).
 
 index_type(Type) when is_binary(Type) ->
     index_type(binary_to_list(Type));
@@ -277,7 +294,7 @@ index_type("environment") ->
 index_type(DataBag) ->
     {'data_bag', list_to_binary(DataBag)}.
 
-check_query(RawQuery) ->
+check_query(SearchModule, RawQuery) ->
     case RawQuery of
         undefined ->
             %% Default query string if no 'q' param is present. We might
@@ -287,24 +304,28 @@ check_query(RawQuery) ->
             %% thou shalt not query with the empty string
             throw({bad_query, ""});
         Query ->
-            transform_query(http_uri:decode(Query))
+            transform_query(SearchModule, http_uri:decode(Query))
     end.
 
-transform_query_all(Data) ->
-    ?PROVIDER_FUNC(transform_query_all, [Data]).
+transform_query_all(SearchModule, Data) ->
+    SearchModule:transform_query_all(Data).
 
-transform_query_safe(Data) ->
-    ?PROVIDER_FUNC(transform_query_safe, [Data]).
+transform_query_safe(SearchModule, Data) ->
+   SearchModule:transform_query_safe(Data).
 
-transform_query_term(Data) ->
-    ?PROVIDER_FUNC(transform_query_term, [Data]).
+transform_query_term(SearchModule, Data) ->
+    SearchModule:transform_query_term(Data).
 
-transform_query_phrase(Data) ->
-    ?PROVIDER_FUNC(transform_query_phrase, [Data]).
+transform_query_phrase(SearchModule, Data) ->
+    SearchModule:transform_query_phrase(Data).
 
-transform_query(RawQuery) when is_list(RawQuery) ->
-    transform_query(list_to_binary(RawQuery));
-transform_query(RawQuery) ->
+transform_query(SearchModule, RawQuery) when is_list(RawQuery) ->
+    transform_query(SearchModule, list_to_binary(RawQuery));
+transform_query(SearchModule, RawQuery) ->
+    % Using process dictionary to make the provider module available
+    % to the generated peg code, which doesn't currently allow us to thread this
+    % through as a parameater to 'parse'.
+    put(search_module, SearchModule),
     case chef_lucene:parse(RawQuery) of
         Query when is_binary(Query) ->
             binary_to_list(Query);

--- a/src/oc_erchef/apps/chef_index/src/cloudsearch_provider.erl
+++ b/src/oc_erchef/apps/chef_index/src/cloudsearch_provider.erl
@@ -13,7 +13,10 @@
          make_standard_fq/1,
          make_data_bag_fq/1,
          search_url_fmt/0,
-         transform_query/1,
+         transform_query_all/1,
+         transform_query_safe/1,
+         transform_query_term/1,
+         transform_query_phrase/1,
          %% Document Building Helpers
          transform_data/1,
          %% Response Handling Functions
@@ -75,10 +78,19 @@ add_org_guid_to_fq(OrgGuid, FilterQuery) ->
       FilterQuery).
 
 transform_data(Data) ->
-    replace_specials(Data).
+    cs_escape:escape(Data).
 
-transform_query(Query) ->
-    substitute_sep(Query).
+transform_query_all(Data) ->
+    cs_escape:escape(Data).
+
+transform_query_safe(Data) ->
+    cs_escape:escape_safe(Data).
+
+transform_query_term(Data) ->
+    cs_escape:escape_term_safe(Data).
+
+transform_query_phrase(Data) ->
+    cs_escape:escape_phrase_safe(Data).
 
 assert_org_id_filter(FieldQuery) ->
     Start = "(and (term field=" ++ binary_to_list(database_field()) ++ " 'chef_",
@@ -110,17 +122,3 @@ sq_and(First, Second) ->
 
 sq_quote(Value) ->
     "'" ++ Value ++ "'".
-
-replace_specials(Item) ->
-    replace_equal(Item).
-
-replace_equal(Item) ->
-    New = re:replace(Item, "=", "__EQ__", [{return, binary}, global]),
-    replace_dash(New).
-
-replace_dash(Item) ->
-    re:replace(Item, "-", "__DASH__", [{return, binary}, global]).
-
-substitute_sep(Query) ->
-    New = re:replace(Query, "__=__", "__EQ__", [{return, binary}, global]),
-    replace_specials(New).

--- a/src/oc_erchef/apps/chef_index/src/cloudsearch_provider.erl
+++ b/src/oc_erchef/apps/chef_index/src/cloudsearch_provider.erl
@@ -1,0 +1,126 @@
+-module(cloudsearch_provider).
+-export([
+         %% Static Data Accessors
+         database_field/0,
+         id_field/0,
+         kv_sep/0,
+         ping_url/0,
+         type_field/0,
+         update_url/0,
+         %% Query Building Helpers
+         add_org_guid_to_fq/2,
+         assert_org_id_filter/1,
+         make_standard_fq/1,
+         make_data_bag_fq/1,
+         search_url_fmt/0,
+         transform_query/1,
+         %% Document Building Helpers
+         transform_data/1,
+         %% Response Handling Functions
+         handle_successful_search/1,
+         %% Solr Operations
+         commit/0,
+         delete_search_db/1,
+         delete_search_db_by_type/2
+        ]).
+
+id_field() ->
+    <<"x_chef_id_chef_x">>.
+
+database_field() ->
+    <<"x_chef_database_chef_x">>.
+
+type_field() ->
+    <<"x_chef_type_chef_x">>.
+
+ping_url() ->
+    "/search".
+
+update_url() ->
+    "/documents/batch".
+
+search_url_fmt() ->
+    "/search?"
+        "fq=~s"
+        "&q=~s"
+        "&q.parser=lucene"
+        "&start=~B"
+        "&size=~B"
+        "&sort=~s".
+
+kv_sep() ->
+    <<"__EQ__">>.
+
+handle_successful_search(ResponseBody) ->
+    Response = ej:get({<<"hits">>}, ResponseBody),
+    Start    = ej:get({<<"start">>}, Response),
+    NumFound = ej:get({<<"found">>}, Response),
+    DocList  = ej:get({<<"hit">>}, Response),
+    Ids = [ ej:get({id_field()}, Doc) || Doc <- unwrap_doclist(DocList) ],
+    {ok, Start, NumFound, Ids}.
+
+unwrap_doclist(DocList) ->
+    [ej:get({<<"fields">>}, Doc) || Doc <- DocList].
+
+make_standard_fq(ObjType) ->
+    sq_term(binary_to_list(type_field()), ObjType).
+
+make_data_bag_fq(ObjType) ->
+    sq_term(binary_to_list(type_field()), "data_bag_item") ++ sq_term("data_bag", ObjType).
+
+add_org_guid_to_fq(OrgGuid, FilterQuery) ->
+    sq_and(
+      sq_term(binary_to_list(database_field()),
+              chef_solr:db_from_orgid(OrgGuid)),
+      FilterQuery).
+
+transform_data(Data) ->
+    replace_specials(Data).
+
+transform_query(Query) ->
+    substitute_sep(Query).
+
+assert_org_id_filter(FieldQuery) ->
+    Start = "(and (term field=" ++ binary_to_list(database_field()) ++ " 'chef_",
+    Len = length(Start),
+    Start = string:substr(FieldQuery, 1, Len).
+
+delete_search_db(_OrgId) ->
+    lager:warning("delete_search_db not implemented"),
+    ok.
+
+delete_search_db_by_type(_OrgId, _Type) ->
+    lager:warning("delete_search_db_by_type not implemented"),
+    ok.
+
+commit() ->
+    lager:info("Commit not supported when using cloudsearch as a search provider"),
+    ok.
+
+%% Internal Functions
+
+%% Structured Query Helpers
+%%
+%% The filter queries for CloudSearch use the "structured query" format.
+sq_term(Field, Value) ->
+    "(term field=" ++ Field ++ " " ++ sq_quote(Value) ++ ")".
+
+sq_and(First, Second) ->
+    "(and " ++ First ++ Second ++ ")".
+
+sq_quote(Value) ->
+    "'" ++ Value ++ "'".
+
+replace_specials(Item) ->
+    replace_equal(Item).
+
+replace_equal(Item) ->
+    New = re:replace(Item, "=", "__EQ__", [{return, binary}, global]),
+    replace_dash(New).
+
+replace_dash(Item) ->
+    re:replace(Item, "-", "__DASH__", [{return, binary}, global]).
+
+substitute_sep(Query) ->
+    New = re:replace(Query, "__=__", "__EQ__", [{return, binary}, global]),
+    replace_specials(New).

--- a/src/oc_erchef/apps/chef_index/src/cs_escape.erl
+++ b/src/oc_erchef/apps/chef_index/src/cs_escape.erl
@@ -1,0 +1,35 @@
+-module(cs_escape).
+
+-export([escape/1,
+         escape_safe/1,
+         escape_term_safe/1,
+         escape_phrase_safe/1
+        ]).
+-on_load(init/0).
+
+init() ->
+    PrivDir = case code:priv_dir(?MODULE) of
+        {error, _} ->
+            EbinDir = filename:dirname(code:which(?MODULE)),
+            AppPath = filename:dirname(EbinDir),
+            filename:join(AppPath, "priv");
+        Path ->
+            Path
+    end,
+    ok = erlang:load_nif(filename:join(PrivDir, "cs_escape"), 0).
+
+-spec escape(binary()) -> binary().
+escape(_X) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+-spec escape_safe(binary()) -> binary().
+escape_safe(_X) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+-spec escape_term_safe(binary()) -> binary().
+escape_term_safe(_X) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+-spec escape_phrase_safe(binary()) -> binary().
+escape_phrase_safe(_X) ->
+    erlang:nif_error(nif_library_not_loaded).

--- a/src/oc_erchef/apps/chef_index/src/solr_provider.erl
+++ b/src/oc_erchef/apps/chef_index/src/solr_provider.erl
@@ -1,0 +1,113 @@
+-module(solr_provider).
+-export([
+         %% Static Data Accessors
+         database_field/0,
+         id_field/0,
+         kv_sep/0,
+         ping_url/0,
+         type_field/0,
+         update_url/0,
+         %% Query Building Helpers
+         add_org_guid_to_fq/2,
+         assert_org_id_filter/1,
+         make_standard_fq/1,
+         make_data_bag_fq/1,
+         search_url_fmt/0,
+         transform_query/1,
+         %% Document Building Helpers
+         transform_data/1,
+         %% Response Handling Functions
+         handle_successful_search/1,
+         %% Solr Operations
+         commit/0,
+         delete_search_db/1,
+         delete_search_db_by_type/2
+        ]).
+
+id_field() ->
+    <<"X_CHEF_id_CHEF_X">>.
+
+database_field() ->
+    <<"X_CHEF_database_CHEF_X">>.
+
+type_field() ->
+    <<"X_CHEF_type_CHEF_X">>.
+
+ping_url() ->
+    "/admin/ping?wt=json".
+
+update_url() ->
+    "/update".
+
+search_url_fmt() ->
+    "/select?"
+        "fq=~s"
+        "&indent=off"
+        "&q=~s"
+        "&start=~B"
+        "&rows=~B"
+        "&wt=json"
+        "&sort=~s".
+
+kv_sep() ->
+    <<"__=__">>.
+
+handle_successful_search(ResponseBody) ->
+    Response = ej:get({<<"response">>}, ResponseBody),
+    Start    = ej:get({<<"start">>}, Response),
+    NumFound = ej:get({<<"numFound">>}, Response),
+    DocList  = ej:get({<<"docs">>}, Response),
+    Ids = [ ej:get({id_field()}, Doc) || Doc <- DocList ],
+    {ok, Start, NumFound, Ids}.
+
+make_standard_fq(ObjType) ->
+    "+" ++ binary_to_list(type_field()) ++ ":" ++ ObjType.
+
+make_data_bag_fq(ObjType) ->
+    "+" ++ binary_to_list(type_field()) ++ ":data_bag_item +data_bag:" ++ ObjType.
+
+add_org_guid_to_fq(OrgGuid, FilterQuery) ->
+    "+" ++ search_db_from_orgid(OrgGuid) ++ " " ++ FilterQuery.
+
+transform_query(Query) ->
+    Query.
+
+transform_data(Data) ->
+    Data.
+
+assert_org_id_filter(FieldQuery) ->
+    Start = "+" ++ binary_to_list(database_field()) ++ ":chef_",
+    Len = length(Start),
+    Start = string:substr(FieldQuery, 1, Len).
+
+delete_search_db(OrgId) ->
+    DeleteQuery = "<?xml version='1.0' encoding='UTF-8'?><delete><query>" ++
+        search_db_from_orgid(OrgId) ++
+        "</query></delete>",
+    ok = chef_solr:update(DeleteQuery),
+    ok = commit(),
+    ok.
+
+commit() ->
+    chef_solr:update("<?xml version='1.0' encoding='UTF-8'?><commit/>").
+
+-spec delete_search_db_by_type(OrgId :: binary(), Type :: atom()) -> ok.
+delete_search_db_by_type(OrgId, Type)
+  when Type == client orelse Type == data_bag_item orelse
+       Type == environment orelse Type == node orelse
+       Type == role ->
+    DeleteQuery = "<?xml version='1.0' encoding='UTF-8'?><delete><query>" ++
+        search_db_from_orgid(OrgId) ++ " AND " ++
+        search_type_constraint(Type) ++
+        "</query></delete>",
+    chef_solr:update(DeleteQuery).
+
+-spec search_db_from_orgid(OrgId :: binary()) -> DBName :: [byte(),...].
+search_db_from_orgid(OrgId) ->
+    binary_to_list(database_field()) ++ ":" ++ chef_solr:db_from_orgid(OrgId).
+
+%% @doc Generates a constraint for chef_type
+%% @end
+-spec search_type_constraint(Type :: atom()) -> TypeConstraint :: [byte(),...].
+search_type_constraint(Type) ->
+    binary_to_list(type_field()) ++ atom_to_list(Type).

--- a/src/oc_erchef/apps/chef_index/src/solr_provider.erl
+++ b/src/oc_erchef/apps/chef_index/src/solr_provider.erl
@@ -13,8 +13,11 @@
          make_standard_fq/1,
          make_data_bag_fq/1,
          search_url_fmt/0,
-         transform_query/1,
-         %% Document Building Helpers
+         transform_query_all/1,
+         transform_query_safe/1,
+         transform_query_term/1,
+         transform_query_phrase/1,
+          %% Document Building Helpers
          transform_data/1,
          %% Response Handling Functions
          handle_successful_search/1,
@@ -69,7 +72,16 @@ make_data_bag_fq(ObjType) ->
 add_org_guid_to_fq(OrgGuid, FilterQuery) ->
     "+" ++ search_db_from_orgid(OrgGuid) ++ " " ++ FilterQuery.
 
-transform_query(Query) ->
+transform_query_all(Query) ->
+    Query.
+
+transform_query_safe(Query) ->
+    Query.
+
+transform_query_term(Query) ->
+    Query.
+
+transform_query_phrase(Query) ->
     Query.
 
 transform_data(Data) ->

--- a/src/oc_erchef/apps/chef_index/src/solr_provider.erl
+++ b/src/oc_erchef/apps/chef_index/src/solr_provider.erl
@@ -96,12 +96,12 @@ delete_search_db(OrgId) ->
     DeleteQuery = "<?xml version='1.0' encoding='UTF-8'?><delete><query>" ++
         search_db_from_orgid(OrgId) ++
         "</query></delete>",
-    ok = chef_solr:update(DeleteQuery),
+    ok = chef_solr:update(?MODULE, DeleteQuery),
     ok = commit(),
     ok.
 
 commit() ->
-    chef_solr:update("<?xml version='1.0' encoding='UTF-8'?><commit/>").
+    chef_solr:update(?MODULE, "<?xml version='1.0' encoding='UTF-8'?><commit/>").
 
 -spec delete_search_db_by_type(OrgId :: binary(), Type :: atom()) -> ok.
 delete_search_db_by_type(OrgId, Type)
@@ -112,7 +112,7 @@ delete_search_db_by_type(OrgId, Type)
         search_db_from_orgid(OrgId) ++ " AND " ++
         search_type_constraint(Type) ++
         "</query></delete>",
-    chef_solr:update(DeleteQuery).
+    chef_solr:update(?MODULE, DeleteQuery).
 
 -spec search_db_from_orgid(OrgId :: binary()) -> DBName :: [byte(),...].
 search_db_from_orgid(OrgId) ->

--- a/src/oc_erchef/apps/chef_index/test/chef_index_expand_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_expand_tests.erl
@@ -258,7 +258,7 @@ doc_construction_tests_() ->
 
 solr_api_test_() ->
     MinItem = {[{<<"key1">>, <<"value1">>},
-                {<<"key2">>, <<"value2">>}]},
+                {<<"key2">>, <<"value-2">>}]},
     {foreach,
      fun() ->
              meck:new(chef_index_http, [])
@@ -296,7 +296,7 @@ solr_api_test_() ->
 
 cloudsearch_api_test_() ->
     MinItem = {[{<<"key1">>, <<"value1">>},
-                {<<"key2">>, <<"value2">>}]},
+                {<<"key2">>, <<"value-2">>}]},
     {foreach,
      fun() ->
              application:set_env(chef_index, search_provider, cloudsearch),
@@ -354,7 +354,7 @@ send_item_xml_expect() ->
       "X_CHEF_database_CHEF_X__=__chef_db1 "
       "X_CHEF_id_CHEF_X__=__a1 "
       "X_CHEF_type_CHEF_X__=__role "
-      "key1__=__value1 key2__=__value2 </field>"
+      "key1__=__value1 key2__=__value-2 </field>"
       "</doc>"
       "</add>"
       "</update>">>.
@@ -373,7 +373,7 @@ cs_send_item_xml_expect() ->
       "<field name=\"x_chef_database_chef_x\">chef_db1</field>"
       "<field name=\"x_chef_type_chef_x\">role</field>"
       "<field name=\"content\">"
-      "key1__EQ__value1 key2__EQ__value2 "
+      "key1__EQ__value1 key2__EQ__value__DS__2 "
       "x_chef_database_chef_x__EQ__chef_db1 "
       "x_chef_id_chef_x__EQ__a1 "
       "x_chef_type_chef_x__EQ__role </field>"

--- a/src/oc_erchef/apps/chef_index/test/chef_index_test_utils.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_test_utils.erl
@@ -24,3 +24,10 @@ dumb_random_port() ->
     {ok, Port} = inet:port(Socket),
     gen_udp:close(Socket),
     Port.
+
+set_provider(solr) ->
+    application:set_env(chef_index, search_provider, solr),
+    put(search_module, solr_provider);
+set_provider(cloudsearch) ->
+    application:set_env(chef_index, search_provider, cloudsearch),
+    put(search_module, cloudsearch_provider).

--- a/src/oc_erchef/apps/chef_index/test/chef_lucene_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_lucene_tests.erl
@@ -1,0 +1,82 @@
+%% Copyright 2015 Chef Server, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_lucene_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+chef_lucene_test_() ->
+    {foreach,
+     fun() ->
+             application:set_env(chef_index, search_provider, solr)
+     end,
+     fun(_) ->
+             application:set_env(chef_index, search_provider, solr)
+     end,
+     [
+      {"it transforms an arbitrary field search into a search on the content field",
+       fun() ->
+               ?assertEqual(chef_lucene:parse(<<"foo:bar">>), <<"content:foo__=__bar">>)
+       end},
+      {"it uses the correct key-value seperator for the given search provider",
+       fun() ->
+               application:set_env(chef_index, search_provider, cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar">>), <<"content:foo__EQ__bar">>)
+       end
+      },
+      {"cloudsearch: it does not replace solr wildcard operators in a term",
+       fun() ->
+               application:set_env(chef_index, search_provider, cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"bar*">>), <<"bar*">>),
+               ?assertEqual(chef_lucene:parse(<<"bar?">>), <<"bar?">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar*">>), <<"content:foo__EQ__bar*">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar?">>), <<"content:foo__EQ__bar?">>)
+       end
+      },
+      {"cloudsearch: it replaces other wordbreaking characters in a term",
+       fun() ->
+               application:set_env(chef_index, search_provider, cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"bar-bar">>), <<"bar__DS__bar">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar-baz">>), <<"content:foo__EQ__bar__DS__baz">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar@baz">>), <<"content:foo__EQ__bar__AT__baz">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar+baz">>), <<"content:foo__EQ__bar__PL__baz">>)
+       end
+      },
+      {"cloudsearch: it does replace escaped solr wildcard operators in a term",
+       fun() ->
+               application:set_env(chef_index, search_provider, cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"bar\\*">>), <<"bar\\__ST__">>),
+               ?assertEqual(chef_lucene:parse(<<"bar\\?">>), <<"bar\\__QS__">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar\\*">>), <<"content:foo__EQ__bar\\__ST__">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar\\?">>), <<"content:foo__EQ__bar\\__QS__">>)
+       end
+      },
+      {"cloudsearch: it does NOT replace leading operators",
+       fun() ->
+               application:set_env(chef_index, search_provider, cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"-bar">>), <<"-bar">>),
+               ?assertEqual(chef_lucene:parse(<<"-foo:bar">>), <<"-content:foo__EQ__bar">>)
+       end
+      },
+      {"cloudsearch: it does NOT replace trailing operators",
+       fun() ->
+               application:set_env(chef_index, search_provider, cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"bar~">>), <<"bar~">>),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar~">>), <<"content:foo__EQ__bar~">>)
+       end
+      }
+     ]
+    }.

--- a/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
@@ -130,7 +130,7 @@ search_test_() ->
                 sort = "X_CHEF_id_CHEF_X asc",
                 start = 0,
                 rows = 1000},
-              ?assertError(function_clause, chef_solr:search(Query))
+              ?assertError({badmatch, _X}, chef_solr:search(Query))
       end},
 
      {"parse non-empty solr result",

--- a/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
@@ -36,10 +36,13 @@ make_query_from_params_test_() ->
     [
      {"properly formed",
       fun() ->
+          chef_index_test_utils:set_provider(solr),
           Query = chef_solr:make_query_from_params("node", "myquery", "2", "5"),
           Expect = #chef_solr_query{
             query_string = "myquery",
             filter_query = "+X_CHEF_type_CHEF_X:node",
+            search_provider = solr,
+            search_module = solr_provider,
             sort = "X_CHEF_id_CHEF_X asc",
             start = 2,
             rows = 5,
@@ -51,9 +54,12 @@ make_query_from_params_test_() ->
       %% TODO: currently, a missing 'q' param is mapped to "*:*". We'd
       %% like to change that to be a 400 in the future.
       fun() ->
+          chef_index_test_utils:set_provider(solr),
           Query = chef_solr:make_query_from_params("role", undefined, undefined, undefined),
           Expect = #chef_solr_query{
             query_string = "*:*",
+            search_provider = solr,
+            search_module = solr_provider,
             filter_query = "+X_CHEF_type_CHEF_X:role",
             sort = "X_CHEF_id_CHEF_X asc",
             start = 0,

--- a/src/oc_erchef/apps/chef_index/test/cs_escape_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/cs_escape_tests.erl
@@ -1,0 +1,31 @@
+%% Copyright 2015 Chef Server, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(cs_escape_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+cs_escape_test_() ->
+    [
+     {"doesn't alter data with no special characters", ?_assertEqual(cs_escape:escape(<<"FooBar">>), <<"FooBar">>)},
+     {"replaces a bunch of special characters", ?_assertEqual(cs_escape:escape(<<"Foo-()*Bar">>), <<"Foo__DS____OP____CP____ST__Bar">>)},
+     {"doesn't replace underscore", ?_assertEqual(cs_escape:escape(<<"Foo_Bar">>), <<"Foo_Bar">>)},
+     {"doesn't replace period", ?_assertEqual(cs_escape:escape(<<"Foo.Bar">>), <<"Foo.Bar">>)},
+     {"doesn't replace integers", ?_assertEqual(cs_escape:escape(<<"Foo9Bar">>), <<"Foo9Bar">>)},
+     {"doesn't replace single quotes", ?_assertEqual(cs_escape:escape(<<"Foo'Bar">>), <<"Foo'Bar">>)},
+     {"doesn't replace colon", ?_assertEqual(cs_escape:escape(<<"Foo:Bar">>), <<"Foo:Bar">>)},
+     {"throws a badarg on strings", ?_assertError(badarg, cs_escape:escape("FooBar"))}
+    ].

--- a/src/oc_erchef/include/chef_solr.hrl
+++ b/src/oc_erchef/include/chef_solr.hrl
@@ -18,6 +18,7 @@
 -record(chef_solr_query, {
           query_string :: string(),
           filter_query :: string(),
+          search_provider = solr :: 'solr' | 'cloudsearch',
           start :: integer(),
           rows :: integer(),
           sort :: string(),

--- a/src/oc_erchef/include/chef_solr.hrl
+++ b/src/oc_erchef/include/chef_solr.hrl
@@ -19,6 +19,7 @@
           query_string :: string(),
           filter_query :: string(),
           search_provider = solr :: 'solr' | 'cloudsearch',
+          search_module = solr_provider :: 'solr_provider' | 'cloudsearch_provider',
           start :: integer(),
           rows :: integer(),
           sort :: string(),


### PR DESCRIPTION
This patchset adds support for using AWS CloudSearch as the search
index used by the Chef Server. CloudSearch provides a Solr-like API that
can provide a search service similar to that provided by the Chef Server's 
managed version of Solr 4. 

When using CloudSearch as a backend, the following limitations apply:

- All searches are case-insensitive
- Search results are limited to the first 10000 results.
- The rabbitmq search indexing queue cannot be used.  Only 
  direct-from-erchef (inline or batch) modes are supported.
- CloudSearch must be correctly configured by the user with the correct
  index fields and access policies.

We hope to remove the 10000 result max in an future version of chef-client 
and chef-server.

To support CloudSearch this PR makes the following changes:

- The chef_solr module now passes through many function calls to 
   provider-specific modules that understand the particular requirements
   of the relevant API.  

- The chef_index_expand module has been altered to know how to 
  construct post bodies for both solr and cloudsearch.  The difference in 
  the post bodies include different XML payload signatures and different key-value 
  separators in the expansion.

- chef_index_expand and chef_lucene now call chef_solr:transform_* functions when
  processing data. These functions are responsible for altering the user-inputed data
  to work around CloudSearch's tokenization which is not configurable.  Specifically,
  most ASCII punctuation results in CloudSearch breaking the data into multiple terms.
  This is problematic for most Chef Node data where special characters such as '-' can
  be expected to appear in what the user considers a single searchable term.  To avoid this 
  problem,  nearly all ASCII punctuation is replaced with markers both when indexing and making
  search requests.

- A cs_escape NIF was added to speed up the data transformations mentioned above.

- A minor refactor was done to remove unnecessary code from chef_index_expand

[Latest build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/738/downstreambuildview/)