### PR TITLE
[dvm] simplify sync

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -3,6 +3,7 @@
 
 
 require "yaml"
+load "dvmtools.rb"
 CS_VM_ADDRESS="192.168.33.100"
 DB_VM_ADDRESS="192.168.33.150"
 DB_SUPERUSER="bofh"
@@ -69,7 +70,7 @@ def define_chef_server(config, attributes)
     config.vm.synced_folder File.absolute_path(File.join(Dir.pwd, "../")), "/host",
       type: "rsync",
       rsync__args: ["--verbose", "--archive", "--delete", "-z", "--no-owner", "--no-group" ],
-      rsync__exclude: attributes["vm"]["sync-exclude"]
+      rsync__exclude: attributes["vm"]['sync']['exclude-files']
     # We're also going to do a share of the slower vboxsf style, allowing us to auto-checkout dependencies
     # and have them be properly synced to a place that we can use them.
     config.vm.synced_folder installer_path, "/installers"
@@ -120,16 +121,6 @@ end
 # what it needs to load up and install chef-server
 ##############
 
-
-def load_settings
-  attributes = YAML.load_file("defaults.yml")
-  begin
-    custom_attributes = YAML.load_file("config.yml")
-    attributes = simple_deep_merge(attributes, custom_attributes)
-  rescue
-  end
-  attributes
-end
 
 def prepare
   action = ARGV[0]
@@ -287,16 +278,3 @@ def base_path
   File.absolute_path(File.join(Dir.pwd, "../"))
 end
 
-def simple_deep_merge(source_hash, new_hash)
-  source_hash.merge(new_hash) do |key, old, new|
-    if new.respond_to?(:blank) && new.blank?
-      old
-    elsif (old.kind_of?(Hash) and new.kind_of?(Hash))
-        simple_deep_merge(old, new)
-    elsif (old.kind_of?(Array) and new.kind_of?(Array))
-        old.concat(new).uniq
-    else
-       new
-    end
-  end
-end

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -22,35 +22,42 @@ vm:
   # TODO whitelist as well?
   # Note that we can't exclude .git from top-level projects, and by extension from anything,
   # otherwise rebar commands begin to fail.
-  sync-exclude:
-    - pkg/
-    - deps/
-    - rel/
-    - _rel/
-    - _build/
-    - chef-mover/rel/mover/
-    - ebin/
-    - .eunit/
-    - .kitchen/
-    - .bundle/
-    - vendor/bundle/
-    - "*_SUITE_data/"
-    - "*.deb"
-    - "*.rpm"
-    - "*.vmdk"
-    - "*.plt"
-    - "*.beam"
-    - "*.o"
-    - "*.so"
-    - "*.d"
-    - logs/
-    - /dev/
-    - .concrete/
-    - relx # we don't want to pull in a mac relx to our linux vm
-    - rspec.failures
-    - VERSION
-    - partybus/config.rb
-    - oc-reporting-pedant/Gemfile.lock # friggin ugh
+  sync:
+  # In local tests, it is about a 1.1 seconds per sync,
+  # with up to about 15 seconds for a large sync (400mb single file)
+  # CPU usage on the host is minimal, but for large syncs does increase
+  # significantly on the guest.
+     interval: 5
+     show-syncing-message: true
+     exclude-files:
+       - pkg/
+       - deps/
+       - rel/
+       - _rel/
+       - _build/
+       - chef-mover/rel/mover/
+       - ebin/
+       - .eunit/
+       - .kitchen/
+       - .bundle/
+       - vendor/bundle/
+       - "*_SUITE_data/"
+       - "*.deb"
+       - "*.rpm"
+       - "*.vmdk"
+       - "*.plt"
+       - "*.beam"
+       - "*.o"
+       - "*.so"
+       - "*.d"
+       - logs/
+       - /dev/
+       - .concrete/
+       - relx # we don't want to pull in a mac relx to our linux vm
+       - rspec.failures
+       - VERSION
+       - partybus/config.rb
+       - oc-reporting-pedant/Gemfile.lock # friggin ugh
 
   cover:
     base_output_path: /vagrant/testdata/cover # maps to dev/testdata/cover

--- a/dev/dvmtools.rb
+++ b/dev/dvmtools.rb
@@ -1,0 +1,23 @@
+
+def load_settings
+  attributes = YAML.load_file("defaults.yml")
+  begin
+    custom_attributes = YAML.load_file("config.yml")
+    attributes = simple_deep_merge(attributes, custom_attributes)
+  rescue
+  end
+  attributes
+end
+def simple_deep_merge(source_hash, new_hash)
+  source_hash.merge(new_hash) do |key, old, new|
+    if new.respond_to?(:blank) && new.blank?
+      old
+    elsif (old.kind_of?(Hash) and new.kind_of?(Hash))
+        simple_deep_merge(old, new)
+    elsif (old.kind_of?(Array) and new.kind_of?(Array))
+        old.concat(new).uniq
+    else
+       new
+    end
+  end
+end

--- a/dev/sync
+++ b/dev/sync
@@ -3,39 +3,37 @@
 
 require "yaml"
 require "io/console"
-
-# TODO allow this to be configured and refresh per load
-# In local tests, it is about a 1.1 seconds per sync,
-# with up to about 15 seconds for a large sync (400mb single file)
-# CPU usage on the host is minimal, but for large syncs does increase
-# significantly on the guest.
-INTERVAL = 5
+load "dvmtools.rb"
 
 # Everything we do has to fit in above STATUS_ROW
 # At some point I should make this dynamic...
-STATUS_ROW = 11
+STATUS_ROW = 5
 CSI = "\e["
-
-
 init
 interrupted = false
+interval_remaining = 1
 while true do
-  # TODO add capture of keystrokes from term as well, avoid 'ctrl+c' requirement
-  # and just include the options menu on the top level
+  # reload the config for each sync so that we pick up changes
+  # TODO - merge in custom settings...
+  config = load_settings['vm']['sync']
   # TODO how to safely stop any interrupt from passing through to child process
   # before we intercept?
   begin
-    # Removing this - having it regularly flickering up and calling attention
-    # to itself has proven annoying...
-    #@screen.set_status("Syncing...")
-    r = do_sync
-    # Prevent scrolling and resizing from doing ugly things...
-    @screen.clear
-    @screen.say_at(1, 1, banner)
-    output = parse_results(r)
-    interrupted = false
-    refresh_stats(output)
-    sleep(INTERVAL)
+    interval_remaining = interval_remaining - 1
+    if interval_remaining == 0
+      r = do_sync(config)
+      interval_remaining = config['interval'] + 1
+      # Prevent scrolling and resizing from doing ugly things...
+      @screen.clear
+      @screen.say_at(1, 1, banner)
+      output = parse_results(r)
+      interrupted = false
+      refresh_stats(output)
+    else
+      refresh_sync(config, "#{interval_remaining} seconds")
+      sleep(1)
+    end
+
   rescue Interrupt => e
     @screen.clear
     if interrupted
@@ -47,15 +45,8 @@ while true do
       case result
       when ?q, "\u0003"
         quit
-      when ?s
-        suspend
-      when ?h
-        halt
-      when ?d
-        nuke
       else
-        @screen.clear
-        @screen.say_at 1, 1, banner
+        @screen.show_banner
         interrupted = false
       end
     end
@@ -71,6 +62,11 @@ end
 BEGIN {
   def init
     @num_syncs = 0
+    @screen = Screen.new
+    @screen.show_banner
+    refresh_stats(transferred: 0, walltime: 0)
+    refresh_sync({"show-syncing-message" => true} , "Soon.")
+    @screen.set_status 'Loading SSH config...'
     @all_stats = { walltime: 0.0,  transferred: 0, created: 0, deleted: 0, bytes: 0, time: 0.0}
     # Determine our ssh args up front, so we won't need to do this on every sync.
     ssh_info = {}
@@ -78,33 +74,24 @@ BEGIN {
       k, v = line.split(" ")
       ssh_info[k.strip] = v.strip
     end
+    @screen.clear_status
     @username = ssh_info["User"]
     @host = ssh_info["HostName"]
     @rsh = "ssh -p #{ssh_info["Port"]} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q -i #{ssh_info["IdentityFile"]}"
-    @screen = Screen.new
-    @screen.clear
-    @screen.say_at(1, 1, banner)
-
-
   end
 
-  def do_sync
+  def refresh_sync(config, message)
+    return unless config['show-syncing-message']
+    @screen.say_at(4, 10, "#{@screen.colortext(:purple, "Next Sync", true)}: #{@screen.colortext(:blue, message)}")
+  end
+  def do_sync(config)
+
+    # use  minimal text change to avoid drawing the eye to movement on the screen
+    # if someone doens't want to be actively looking...
+    refresh_sync(config, "0 seconds...")
     start = Time.now
-    # reload the config for each sync so that we pick up changes
-    config = YAML.load_file("defaults.yml")
-    excludes = Array(config["vm"]["sync-exclude"]).map(&:to_s)
-
-    begin
-      userconfig = YAML.load_file("config.yml")
-      userexclude = Array(userconfig["vm"]["sync-exclude"].map(&:to_s)) if userconfig.is_a? Hash and userconfig["vm"]
-      if userexclude
-        excludes += userexclude
-      end
-    rescue # config.yml may not exist
-    end
-
+    excludes = Array(config['exclude-files']).map(&:to_s)
     excludes += ['.vagrant/']
-    excludes += Array(config["vm"]["sync-exclude"]).map(&:to_s)
     excludes.uniq!
     args = ["--stats", "--archive", "--delete", "-z",
             "--no-owner", "--no-group", "--rsync-path /usr/bin/rsync", "-k" ]
@@ -116,63 +103,24 @@ BEGIN {
     [ Time.now - start, r.split("\n") ]
   end
 
-  def suspend
-    @screen.set_status "Suspending the VM, please wait..."
-    `vagrant suspend`
+  # Honestly, does anyone care?
+  def refresh_stats(output)
     @screen.clear_status
-    @screen.say_at 6, 5, "VM suspended."
-    @screen.say_at 7, 5, "To resume the VM and syncing, just run: "
-    @screen.say_at 8, 8, "#{@screen.color(:magenta)}vagrant up && ./sync#{@screen.endcolor}."
-    exit 0
+    color = @screen.color(:purple, true)
+    ec = @screen.endcolor
+    @screen.say_at(3, 2,  "#{color}Files Transferred:#{ec} #{output[:transferred]}                ")
+    @num_syncs += 1
   end
 
   def quit
-    @screen.say_at 6, 5, "The VM will remain running, though sync is now terminated."
-    @screen.say_at 7, 5, "To resume syncing, just run:"
-    @screen.say_at 8, 8, "#{@screen.color(:magenta)}./sync#{@screen.endcolor}."
+    @screen.say_at 4, 1, "File sync is now terminated."
+    @screen.say_at 5, 1, "The VM will remain running."
+    @screen.say_at 6, 1, "To resume syncing, just run:"
+    @screen.say_at 7, 4, "#{@screen.colortext(:purple, "./sync")}"
     exit 0
   end
 
-  def nuke
-    @screen.set_status "Destroying the VM(s), please wait..."
-    `vagrant destroy -f`
-    @screen.clear_status
-    @screen.say_at 6, 5, "VM destroyed."
-    @screen.say_at 7, 5, "To start the VM fresh and resume syncing, just run: "
-    @screen.say_at 8, 8, "#{@screen.color(:magenta)}vagrant up#{@screen.endcolor} && #{@screen.color(:magenta)}./sync#{@screen.endcolor}."
-    exit 0
-  end
 
-  def halt
-    @screen.set_status "Halting the VM, please wait..."
-    `vagrant halt`
-    @screen.clear_status
-    @screen.say_at 6, 5, "VM halted."
-    @screen.say_at 7, 5, "To start the VM and resume syncing, just run: "
-    @screen.say_at 8, 8, "#{@screen.color(:magenta)}vagrant up#{@screen.endcolor} && #{@screen.color(:magenta)}./sync#{@screen.endcolor}."
-    exit 0
-  end
-
-  def refresh_stats(output)
-    @screen.clear_status
-    @num_syncs += 1
-    color = @screen.color(:magenta)
-    ec = @screen.endcolor
-    @screen.say_at(6, 15,  "#{color}Last Sync:#{ec} #{Time.new.to_s}")
-    @screen.say_at(7, 7,  "#{color}Files Transferred:#{ec} #{output[:transferred]}                ")
-    if output[:bytes]
-      if output[:bytes] > 1024
-        @screen.say_at(8, 19, "#{color}   KB:#{ec} #{(output[:bytes].to_f/1024.0).round(2)}               ")
-      else
-        @screen.say_at(8, 19, "#{color}Bytes:#{ec} #{output[:bytes]}                ")
-      end
-    end
-    @screen.say_at(7, 40,  "#{color}Transfer Time:#{ec} #{output[:time]}s")
-    @screen.say_at(8, 43, "#{color}Clock Time:#{ec} #{sprintf('%0.1f', output[:walltime])}")
-    color = @screen.color(:blue, true)
-    @screen.say_at(10, 8, "#{color}Total Clock Time:#{ec} #{sprintf('%0.1f', @all_stats[:walltime])}s")
-    @screen.say_at(10, 38, "#{color}Number of Syncs:#{ec} #{@num_syncs}")
-  end
 
   def parse_results(results)
     walltime, results = results
@@ -203,11 +151,15 @@ BEGIN {
     attr_reader :rows, :cols
     def initialize()
       @rows, @cols = $stdin.winsize
-      @colors =  { black: 0, red: 1, green: 2, yellow: 3, blue: 4, magenta: 5, cyan: 6, white: 7 }
+      @colors =  { black: 0, red: 1, green: 2, brown: 3, blue: 4, purple: 5, cyan: 6, grey: 7 }
     end
 
     def clear_status
       set_status("")
+    end
+    def show_banner
+      clear
+      say_at(1, 1, banner)
     end
 
 
@@ -226,11 +178,14 @@ BEGIN {
     def endcolor
       "#{CSI}0m"
     end
+    def colortext(c, text, bright = false)
+      "#{color(c, bright)}#{text}#{endcolor}"
+    end
     def color(color, bright = false)
-      "#{CSI}#{30+@colors[color]}#{bright ? ';1' : ''}m"
+      "#{CSI}#{30+@colors[color]}#{bright ? ';1' : ';0'}m"
     end
     def bgcolor(color, bright = false)
-      "#{CSI}#{40+@colors[color]}#{bright ? ';1' : ''}m"
+      "#{CSI}#{40+@colors[color]}#{bright ? ';1' : ';0'}m"
     end
     def say_at(row, col, message)
       move_to(row, col)
@@ -252,20 +207,14 @@ BEGIN {
 
   def pause_message
 <<-EOM
-    Syncing paused. Options:
-        (q) terminate and leave the VM running
-        (h) terminate and halt the VM
-        (s) terminate and suspend
-        (d) destroy the VM(s)
-        Any other key to continue syncing
+Syncing paused. Type 'q' or Ctrl+C
+again to stop sync. Type any other
+key to continue.
 EOM
   end
   def banner
 <<-EOM
-This will remain running to keep files in sync between host and guest.
-Any modifications you make on the host are automatically loaded into the VM.
-
-Hit Ctrl+C to pause sync checks and be presented with options at any time.
+       Ctrl+C to pause sync.
 
 EOM
   end


### PR DESCRIPTION
* make the status output show just what we care about -
  how much got synced, and how long until the next sync.
* removed support for managing the VM itself from within
  the sync command.
* moved common functions from Vagrantfile and sync
  into new file dvmtools.rb.
* add a sync section to config.yml with file blacklist
  new located under it. New option for sync interval,
  and to disable the visual indicator for currently syncing.

ChangeLog-Entry: [dvm] updated the sync tool with more configuration
options and more succinct output.