### PR TITLE
Adding support for configuring nginx's stub_status module.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -374,6 +374,12 @@ default['private_chef']['nginx']['x_forwarded_proto'] = 'https'
 default['private_chef']['nginx']['server_name'] = node['fqdn']
 default['private_chef']['nginx']['url'] = "https://#{node['fqdn']}"
 default['private_chef']['nginx']['proxy_connect_timeout'] = 1
+# Support for the stub_status module
+default['private_chef']['nginx']['enable_stub_status'] = true
+default['private_chef']['nginx']['stub_status']['listen_host'] = "127.0.0.1"
+default['private_chef']['nginx']['stub_status']['listen_port'] = "9999"
+default['private_chef']['nginx']['stub_status']['location'] = "/nginx_status"
+default['private_chef']['nginx']['stub_status']['allow_list'] = ["127.0.0.1"]
 # Based off of the Mozilla recommended cipher suite
 # https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_Ciphersuite
 #

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -48,6 +48,21 @@ http {
     config.set_default_org(<%= @helper.default_orgname %>)
   ';
 
+  <%- if node['private_chef']['nginx']['enable_stub_status'] -%>
+  # Listen for local requests to the stub_status module.
+  server {
+    listen <%= node['private_chef']['nginx']['stub_status']['listen_host'] %>:<%= node['private_chef']['nginx']['stub_status']['listen_port'] %>;
+    location <%= node['private_chef']['nginx']['stub_status']['location'] %> {
+      stub_status on;
+      access_log   off;
+      <%- node['private_chef']['nginx']['stub_status']['allow_list'].each do |allowed| -%>
+      allow <%= allowed %>;
+      <%- end -%>
+      deny all;
+    }
+  }
+  <%- end -%>
+
   <%- node['private_chef']['lb']['upstream'].each do |uname, servers| -%>
   upstream <%= uname.sub(/-/, '_') %> {
     <%- servers.each do |server| -%>


### PR DESCRIPTION
- nginx is compiled with stub_status; make it the default to enable it on 127.0.0.1:9999.
- Sensible defaults are defined in `attributes/default.rb`.