### PR TITLE
Mp/parameterize search provider

### DIFF
--- a/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
+++ b/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
@@ -8,7 +8,7 @@ query <- star_star / (expression / space)* %{
 star_star <- "*:*" ~;
 
 expression <- operation / group / field_phrase / field / field_range / term / string %{
-           [chef_solr:transform_query_safe(iolist_to_binary(Node))]
+           [chef_solr:transform_query_safe(get(search_module), iolist_to_binary(Node))]
 %};
 
 term <- keyword valid_letter+ / !keyword valid_letter+ %{
@@ -16,12 +16,12 @@ term <- keyword valid_letter+ / !keyword valid_letter+ %{
 %};
 
 field <- name:field_name ":" arg:(fuzzy_op / term / group / string) %{
-    [<<"content:">>, convert_term(?gv(name, Node)), chef_solr:kv_sep(), ?gv(arg, Node)]
+    [<<"content:">>, convert_term(?gv(name, Node)), chef_solr:kv_sep(get(search_module)), ?gv(arg, Node)]
 %};
 
 field_phrase <- name:field_name ':' '"' str:(term (space term)*) '"' %{
     P = convert_phrase(?gv(str, Node)),
-    [<<"content:\"">>, ?gv(name, Node), chef_solr:kv_sep(), P, <<"\"">>]
+    [<<"content:\"">>, ?gv(name, Node), chef_solr:kv_sep(get(search_module)), P, <<"\"">>]
 %};
 
 field_range <- field_name ":" (("[" range_entry " TO " range_entry "]") /
@@ -108,37 +108,37 @@ special_char <- '[' / ']' / '\\' / '"' / [!(){}^~*?:] ~;
 
 -spec convert_term(iolist()) -> binary().
 convert_term(Term) ->
-  chef_solr:transform_query_term(iolist_to_binary(Term)).
+  chef_solr:transform_query_term(get(search_module), iolist_to_binary(Term)).
 
 -spec convert_phrase(iolist()) -> binary().
 convert_phrase(Phrase) ->
-  chef_solr:transform_query_phrase(iolist_to_binary(Phrase)).
+  chef_solr:transform_query_phrase(get(search_module), iolist_to_binary(Phrase)).
 
 -spec convert_char(iolist()) -> binary().
 convert_char(Char) ->
-  chef_solr:transform_query_all(iolist_to_binary(Char)).
+  chef_solr:transform_query_all(get(search_module), iolist_to_binary(Char)).
 
 
 -spec convert_range_expression(binary(), binary(), binary(), binary(), binary()) -> iolist().
 convert_range_expression(FieldName, _, <<"*">>, <<"*">>, _) ->
-    [<<"content:">>, FieldName, chef_solr:kv_sep(), <<"*">>];
+    [<<"content:">>, FieldName, chef_solr:kv_sep(get(search_module)), <<"*">>];
 
 convert_range_expression(FieldName, Open, Start, <<"*">>, Close) ->
     [<<"content:">>,
-     Open, FieldName, chef_solr:kv_sep(), Start,
+     Open, FieldName, chef_solr:kv_sep(get(search_module)), Start,
      <<" TO ">>,
-     FieldName, chef_solr:kv_sep(), <<"\\ufff0">>, Close];
+     FieldName, chef_solr:kv_sep(get(search_module)), <<"\\ufff0">>, Close];
 
 convert_range_expression(FieldName, Open, <<"*">>, End, Close) ->
     [<<"content:">>,
-     Open, FieldName, chef_solr:kv_sep(),
+     Open, FieldName, chef_solr:kv_sep(get(search_module)),
      <<" TO ">>,
-     FieldName, chef_solr:kv_sep(), End, Close];
+     FieldName, chef_solr:kv_sep(get(search_module)), End, Close];
 
 convert_range_expression(FieldName, Open, Start, End, Close) ->
     [<<"content:">>,
-     Open, FieldName, chef_solr:kv_sep(), Start,
+     Open, FieldName, chef_solr:kv_sep(get(search_module)), Start,
      <<" TO ">>,
-     FieldName, chef_solr:kv_sep(), End, Close].
+     FieldName, chef_solr:kv_sep(get(search_module)), End, Close].
 
 %}

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -26,23 +26,24 @@
 -export([
          %% Static Data Accessors
          search_provider/0,
-         id_field/0,
-         database_field/0,
-         kv_sep/0,
-         type_field/0,
-         update_url/0,
+         search_module/0,
+         id_field/1,
+         database_field/1,
+         kv_sep/1,
+         type_field/1,
+         update_url/1,
          %% Query Building
          add_org_guid_to_query/2,
          make_query_from_params/4,
-         transform_query_all/1,
-         transform_query_safe/1,
-         transform_query_term/1,
-         transform_query_phrase/1,
+         transform_query_all/2,
+         transform_query_safe/2,
+         transform_query_term/2,
+         transform_query_phrase/2,
          %% Document Buidling
          transform_data/1,
          %% Operations
          search/1,
-         update/1,
+         update/2,
          commit/0,
          ping/0,
          delete_search_db/1,
@@ -52,43 +53,55 @@
         ]).
 
 -include("chef_solr.hrl").
--define(PROVIDER_FUNC(FuncName),
-        begin
-            Mod = list_to_atom(atom_to_list(search_provider()) ++ "_provider"),
-            Mod:FuncName()
-        end).
 
--define(PROVIDER_FUNC(FuncName, Args),
-        begin
-            Mod = list_to_atom(atom_to_list(search_provider()) ++ "_provider"),
-            apply(Mod, FuncName, Args)
-        end).
+
+provider_call(FuncName) ->
+    (search_module()):FuncName().
+
+provider_call(FuncName, Arg1) ->
+    (search_module()):FuncName(Arg1).
+
+provider_call(FuncName, Arg1, Arg2) ->
+    (search_module()):FuncName(Arg1, Arg2).
+
 
 search_provider() ->
     envy:get(chef_index, search_provider, solr, envy:one_of([solr, cloudsearch])).
 
--spec id_field() -> binary().
-id_field() ->
-    ?PROVIDER_FUNC(id_field).
+search_module() ->
+    search_module(search_provider()).
 
--spec database_field() -> binary().
-database_field() ->
-    ?PROVIDER_FUNC(database_field).
+search_module(solr) ->
+    solr_provider;
+search_module(cloudsearch) ->
+    cloudsearch_provider.
 
--spec type_field() -> binary().
-type_field() ->
-    ?PROVIDER_FUNC(type_field).
 
--spec ping_url() -> string().
-ping_url() ->
-    ?PROVIDER_FUNC(ping_url).
+-spec id_field(atom()) -> binary().
+id_field(SearchModule) ->
+    SearchModule:id_field().
 
--spec update_url() -> string().
-update_url() ->
-    ?PROVIDER_FUNC(update_url).
+-spec database_field(atom()) -> binary().
+database_field(SearchModule) ->
+    SearchModule:database_field().
 
-kv_sep() ->
-    ?PROVIDER_FUNC(kv_sep).
+
+-spec type_field(atom()) -> binary().
+type_field(SearchModule) ->
+    SearchModule:type_field().
+
+
+-spec ping_url(atom()) -> string().
+ping_url(SearchModule) ->
+    SearchModule:ping_url().
+
+-spec update_url(atom()) -> string().
+update_url(SearchModule) ->
+    SearchModule:update_url().
+
+-spec kv_sep(atom()) -> binary().
+kv_sep(SearchModule) ->
+    SearchModule:kv_sep().
 
 %% Query Building functions
 %%
@@ -104,13 +117,16 @@ kv_sep() ->
                              string()) -> #chef_solr_query{}.
 make_query_from_params(ObjType, QueryString, Start, Rows) ->
     % TODO: super awesome error messages
-    FilterQuery = make_fq_type(ObjType),
+    SearchProvider = search_provider(),
+    SearchModule = search_module(SearchProvider),
+    FilterQuery = make_fq_type(SearchModule, ObjType),
     %% 'sort' param is ignored and hardcoded because indexing
     %% scheme doesn't support sorting since there is only one field.
-    Sort = binary_to_list(id_field()) ++ " asc",
-    #chef_solr_query{query_string = check_query(QueryString),
+    Sort = binary_to_list(id_field(SearchModule)) ++ " asc",
+    #chef_solr_query{query_string = check_query(SearchModule, QueryString),
                      filter_query = FilterQuery,
-                     search_provider = search_provider(),
+                     search_provider = SearchProvider,
+                     search_module = SearchModule,
                      start = decode({nonneg_int, "start"}, Start, 0),
                      rows = decode({nonneg_int, "rows"}, Rows, 1000),
                      sort = Sort,
@@ -118,17 +134,16 @@ make_query_from_params(ObjType, QueryString, Start, Rows) ->
 
 -spec add_org_guid_to_query(#chef_solr_query{}, binary())
                            -> #chef_solr_query{}.
-add_org_guid_to_query(Query = #chef_solr_query{filter_query = FilterQuery},
+add_org_guid_to_query(Query = #chef_solr_query{filter_query = FilterQuery, search_module = Mod},
                       OrgGuid) ->
-    Query#chef_solr_query{filter_query = ?PROVIDER_FUNC(add_org_guid_to_fq,
-                                                        [OrgGuid, FilterQuery])}.
+    Query#chef_solr_query{filter_query = Mod:add_org_guid_to_fq(OrgGuid, FilterQuery)}.
 
 
 %% Document Building Helpers
 %% These helpers are called by chef_index_expand to build
 %% XML documents appropriate for the given provider.
 transform_data(Data) ->
-    ?PROVIDER_FUNC(transform_data, [Data]).
+    provider_call(transform_data, Data).
 
 %% Search/Solr Operations
 %%
@@ -158,13 +173,13 @@ search(#chef_solr_query{} = Query) ->
 -spec handle_successful_search(binary() | string()) -> {ok, non_neg_integer(), non_neg_integer(), [binary()]}.
 handle_successful_search(Body) ->
     SolrData = jiffy:decode(Body),
-    ?PROVIDER_FUNC(handle_successful_search, [SolrData]).
+    provider_call(handle_successful_search, SolrData).
 
 -spec ping() -> pong | pang.
 ping() ->
     try
         %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash
-        case chef_index_http:request(ping_url(), get, []) of
+        case chef_index_http:request(ping_url(search_module()), get, []) of
             %% FIXME: verify that solr returns non-200 if something is wrong and not "status":"ERROR".
             {ok, "200", _Head, _Body} -> pong;
             _Error -> pang
@@ -179,7 +194,7 @@ ping() ->
 %% @doc Delete all search index entries for a given organization.
 -spec delete_search_db(OrgId :: binary()) -> ok.
 delete_search_db(OrgId) ->
-    ?PROVIDER_FUNC(delete_search_db, [OrgId]).
+    provider_call(delete_search_db, OrgId).
 
 %% @doc Delete all search index entries for a given
 %% organization and type.  Types are generally binaries or strings elsewhere in this
@@ -188,20 +203,21 @@ delete_search_db(OrgId) ->
 %% @end
 -spec delete_search_db_by_type(OrgId :: binary(), Type :: atom()) -> ok.
 delete_search_db_by_type(OrgId, Type) ->
-    ?PROVIDER_FUNC(delete_search_db_by_type, [OrgId, Type]).
+    provider_call(delete_search_db_by_type, OrgId, Type).
 
 %% @doc Sends `Body` to the Solr server's "/update" endpoint.
 %% @end
 %%
 %% Body is really a string(), but Dialyzer can only determine it is a list of bytes due to
 %% the implementation of search_db_from_orgid/1
--spec update(iolist() | binary()) -> ok | {error, term()}.
-update(Body) when is_list(Body) ->
-    update(iolist_to_binary(Body));
-update(Body) ->
+%% For that matter, `update` is really 'post to provider'.
+-spec update(atom(), iolist() | binary()) -> ok | {error, term()}.
+update(Mod, Body) when is_list(Body) ->
+    update(Mod, iolist_to_binary(Body));
+update(Mod, Body) ->
     try
         %% FIXME: solr will barf on doubled '/'s so SolrUrl must not end with a trailing slash
-        case chef_index_http:request(update_url(), post, Body) of
+        case chef_index_http:request(update_url(Mod), post, Body) of
             %% FIXME: verify that solr returns non-200 if something is wrong and not "status":"ERROR".
             {ok, "200", _Head, _Body} -> ok;
             Error -> {error, Error}
@@ -216,7 +232,7 @@ update(Body) ->
 %% This is exposed for the users of delete_search_db_by_type
 -spec commit() -> ok | {error, term()}.
 commit() ->
-    ?PROVIDER_FUNC(commit).
+    provider_call(commit).
 
 %% Helpers
 
@@ -236,10 +252,10 @@ db_from_orgid(OrgId) ->
 %% Calls assert_org_id_filter and search_url_fmt from provider
 %% The search_url_fmt should accept all standard search args.
 -spec make_solr_query_url(#chef_solr_query{}) -> string().
-make_solr_query_url(Query = #chef_solr_query{filter_query = FilterQuery}) ->
+make_solr_query_url(Query = #chef_solr_query{search_module = SearchModule, filter_query = FilterQuery}) ->
     %% ensure we filter on an org ID
-    ?PROVIDER_FUNC(assert_org_id_filter, [FilterQuery]),
-    Url = ?PROVIDER_FUNC(search_url_fmt),
+    SearchModule:assert_org_id_filter(FilterQuery),
+    Url = SearchModule:search_url_fmt(),
     Args = search_url_args(Query),
     lists:flatten(io_lib:format(Url, Args)).
 
@@ -254,15 +270,16 @@ search_url_args(#chef_solr_query{
      Start, Rows,
      ibrowse_lib:url_encode(Sort)].
 
-make_fq_type(ObjType) when is_binary(ObjType) ->
-    make_fq_type(binary_to_list(ObjType));
-make_fq_type(ObjType) when ObjType =:= "node";
-                           ObjType =:= "role";
-                           ObjType =:= "client";
-                           ObjType =:= "environment" ->
-    ?PROVIDER_FUNC(make_standard_fq, [ObjType]);
-make_fq_type(ObjType) ->
-    ?PROVIDER_FUNC(make_data_bag_fq, [ObjType]).
+make_fq_type(SearchModule, ObjType) when is_binary(ObjType) ->
+    make_fq_type(SearchModule, binary_to_list(ObjType));
+make_fq_type(SearchModule, ObjType) when ObjType =:= "node";
+                       ObjType =:= "role";
+                       ObjType =:= "client";
+                       ObjType =:= "environment" ->
+
+    SearchModule:make_standard_fq(ObjType);
+make_fq_type(SearchModule, ObjType) ->
+    SearchModule:make_data_bag_fq(ObjType).
 
 index_type(Type) when is_binary(Type) ->
     index_type(binary_to_list(Type));
@@ -277,7 +294,7 @@ index_type("environment") ->
 index_type(DataBag) ->
     {'data_bag', list_to_binary(DataBag)}.
 
-check_query(RawQuery) ->
+check_query(SearchModule, RawQuery) ->
     case RawQuery of
         undefined ->
             %% Default query string if no 'q' param is present. We might
@@ -287,24 +304,28 @@ check_query(RawQuery) ->
             %% thou shalt not query with the empty string
             throw({bad_query, ""});
         Query ->
-            transform_query(http_uri:decode(Query))
+            transform_query(SearchModule, http_uri:decode(Query))
     end.
 
-transform_query_all(Data) ->
-    ?PROVIDER_FUNC(transform_query_all, [Data]).
+transform_query_all(SearchModule, Data) ->
+    SearchModule:transform_query_all(Data).
 
-transform_query_safe(Data) ->
-    ?PROVIDER_FUNC(transform_query_safe, [Data]).
+transform_query_safe(SearchModule, Data) ->
+   SearchModule:transform_query_safe(Data).
 
-transform_query_term(Data) ->
-    ?PROVIDER_FUNC(transform_query_term, [Data]).
+transform_query_term(SearchModule, Data) ->
+    SearchModule:transform_query_term(Data).
 
-transform_query_phrase(Data) ->
-    ?PROVIDER_FUNC(transform_query_phrase, [Data]).
+transform_query_phrase(SearchModule, Data) ->
+    SearchModule:transform_query_phrase(Data).
 
-transform_query(RawQuery) when is_list(RawQuery) ->
-    transform_query(list_to_binary(RawQuery));
-transform_query(RawQuery) ->
+transform_query(SearchModule, RawQuery) when is_list(RawQuery) ->
+    transform_query(SearchModule, list_to_binary(RawQuery));
+transform_query(SearchModule, RawQuery) ->
+    % Using process dictionary to make the provider module available
+    % to the generated peg code, which doesn't currently allow us to thread this
+    % through as a parameater to 'parse'.
+    put(search_module, SearchModule),
     case chef_lucene:parse(RawQuery) of
         Query when is_binary(Query) ->
             binary_to_list(Query);

--- a/src/oc_erchef/apps/chef_index/src/solr_provider.erl
+++ b/src/oc_erchef/apps/chef_index/src/solr_provider.erl
@@ -96,12 +96,12 @@ delete_search_db(OrgId) ->
     DeleteQuery = "<?xml version='1.0' encoding='UTF-8'?><delete><query>" ++
         search_db_from_orgid(OrgId) ++
         "</query></delete>",
-    ok = chef_solr:update(DeleteQuery),
+    ok = chef_solr:update(?MODULE, DeleteQuery),
     ok = commit(),
     ok.
 
 commit() ->
-    chef_solr:update("<?xml version='1.0' encoding='UTF-8'?><commit/>").
+    chef_solr:update(?MODULE, "<?xml version='1.0' encoding='UTF-8'?><commit/>").
 
 -spec delete_search_db_by_type(OrgId :: binary(), Type :: atom()) -> ok.
 delete_search_db_by_type(OrgId, Type)
@@ -112,7 +112,7 @@ delete_search_db_by_type(OrgId, Type)
         search_db_from_orgid(OrgId) ++ " AND " ++
         search_type_constraint(Type) ++
         "</query></delete>",
-    chef_solr:update(DeleteQuery).
+    chef_solr:update(?MODULE, DeleteQuery).
 
 -spec search_db_from_orgid(OrgId :: binary()) -> DBName :: [byte(),...].
 search_db_from_orgid(OrgId) ->

--- a/src/oc_erchef/include/chef_solr.hrl
+++ b/src/oc_erchef/include/chef_solr.hrl
@@ -19,6 +19,7 @@
           query_string :: string(),
           filter_query :: string(),
           search_provider = solr :: 'solr' | 'cloudsearch',
+          search_module = solr_provider :: 'solr_provider' | 'cloudsearch_provider',
           start :: integer(),
           rows :: integer(),
           sort :: string(),


### PR DESCRIPTION
Please overlook branch name misspelling.
 
I left alone the externally-facing functions that are in use outside of the chef_index family. 

reindex is failing for unspecified reasons at present: 

```

Reindexing all organizations
- Enqueueing data for indexing.
Failed to enqueue data for pedant_testorg_api_13182!
Failed to enqueue data for pedant_testorg_api_4662!
Failed to enqueue data for pedant_testorg_api_5168!
Failed to enqueue data for pedant_testorg_api_6908!
Failed to enqueue data for pedant_testorg_api_24351!
root@api:~#
````\