### PR TITLE
Replace _'s in data and queries in cloudsearch mode

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
@@ -23,25 +23,28 @@ class SolrPreflightValidator < PreflightValidator
   end
 
   def run!
-    warn_unchanged_external_flag
+    warn_changed_external_flag
     verify_external_url
     verify_erchef_config
   end
 
-  def warn_unchanged_external_flag
+  def warn_changed_external_flag
     if OmnibusHelper.has_been_bootstrapped? && backend?  && previous_run
-      if cs_solr_attr.has_key?('external') && (cs_solr_attr['external'] != previous_run['opscode-solr4']['external'])
+      if external_flag_changed?
         Chef::Log.warn <<-EOM
 
-The value of opscode_solr4['external'] has been changed.  Search
+The value of opscode_solr4['external'] has been changed. Search
 results against the new external search index may be incorrect. Please
 run `chef-server-ctl reindex --all` to ensure correct results
 
 EOM
       end
-    else
-      return true
     end
+  end
+
+  def external_flag_changed?
+    cs_solr_attr.has_key?('external') &&
+      (cs_solr_attr['external'] != previous_run['opscode-solr4']['external'])
   end
 
   def verify_external_url
@@ -77,6 +80,7 @@ EOM
     when 'solr'
     else
       fail_with <<-EOM
+
 The specified search provider (#{provider}) is not currently supported.
 Please choose from one of the following search providers:
 

--- a/src/oc_erchef/apps/chef_index/c_src/cs_escape.c
+++ b/src/oc_erchef/apps/chef_index/c_src/cs_escape.c
@@ -27,7 +27,7 @@
 // shortening the array.
 #define replacement_for(n) replacements[n - 33]
 
-static const char *replacements[] = {
+static const unsigned char *replacements[] = {
   "__EX__", // !
   "__DQ__", // "
   "__HS__", // #
@@ -58,7 +58,7 @@ static const char *replacements[] = {
   "__BS__", // Back Slash
   "__CB__", // ]
   "__CA__", // ^
-  "_", // _
+  "__US__", // _
   "__BT__", // `
   "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k",
   "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v",
@@ -74,27 +74,26 @@ static const char *replacements[] = {
 // 0x5b - 0x60 is [ through `
 // 0x7b - 0x7e is { through ~
 static inline bool has_replacement(unsigned char n) {
-  return ((n >= 0x21 && n <= 0x2f) || \
-          (n >= 0x3a && n <= 0x40) || \
-          (n >= 0x5b && n <= 0x60) || \
+  return ((n >= 0x21 && n <= 0x2f) ||
+          (n >= 0x3a && n <= 0x40) ||
+          (n >= 0x5b && n <= 0x60) ||
           (n >= 0x7b && n <= 0x7e));
 }
 
 static inline bool is_cs_safe(unsigned char n) {
-  return (n == 0x23 || n == 0x24 || n == 0x25 || \
-          n == 0x2c || n == 0x2f || n == 0x3b || \
+  return (n == 0x23 || n == 0x24 || n == 0x25 ||
+          n == 0x2c || n == 0x2f || n == 0x3b ||
           n == 0x3c || n == 0x3d || n == 0x3e ||
           n == 0x40 || n == 0x60);
 }
 
 static inline bool is_cs_term_safe(unsigned char n) {
-  return (n == 0x2b || n == 0x2d || is_cs_safe(n));
+  return (n == 0x2b || n == 0x2d || n == 0x5f || is_cs_safe(n));
 }
 
 static inline bool is_cs_phrase_safe(unsigned char n) {
-  return (n == 0x2b || n == 0x2d || \
-          n == 0x2a || n == 0x3f || \
-          is_cs_safe(n));
+  return (n == 0x2b || n == 0x2d ||
+          n == 0x2a || n == 0x3f || is_cs_safe(n));
 }
 
 static size_t do_replace(unsigned char *buf, int n) {

--- a/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
+++ b/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
@@ -8,15 +8,15 @@ query <- star_star / (expression / space)* %{
 star_star <- "*:*" ~;
 
 expression <- operation / group / field_phrase / field / field_range / term / string %{
-           [chef_solr:transform_query_safe(get(search_module), iolist_to_binary(Node))]
+           convert_final(Node)
 %};
 
 term <- keyword valid_letter+ / !keyword valid_letter+ %{
-     [convert_term(Node)]
+     [{term, Node}]
 %};
 
 field <- name:field_name ":" arg:(fuzzy_op / term / group / string) %{
-    [<<"content:">>, convert_term(?gv(name, Node)), chef_solr:kv_sep(get(search_module)), ?gv(arg, Node)]
+    [<<"content:">>, {term, ?gv(name, Node)}, chef_solr:kv_sep(get(search_module)), ?gv(arg, Node)]
 %};
 
 field_phrase <- name:field_name ':' '"' str:(term (space term)*) '"' %{
@@ -59,7 +59,7 @@ fuzzy_op <- (term / string) '~' fuzzy_param? ~;
 fuzzy_param <- [0-9]+ ('.' [0-9])? ~;
 
 string <- '"' phr:(term (space term)*) '"' %{
-       [<<"\"">>, convert_phrase(?gv(phr, Node)), <<"\"">>]
+       [ <<"\"">>, convert_phrase(?gv(phr, Node)), <<"\"">>]
 %};
 
 keyword <- "AND" / "OR" / "NOT" ~;
@@ -69,7 +69,7 @@ valid_letter <- start_letter+ ([a-zA-Z0-9*?@_+./-] / escaped_special)* ~;
 start_letter <- [a-zA-Z0-9_.*/] / escaped_special ~;
 
 escaped_special <- '\\' chr:special_char %{
-    [<<"\\">>, convert_char(?gv(chr, Node))]
+    [{escaped_special, ?gv(chr, Node)}]
 %};
 
 space <- [ \t]+ ~;
@@ -106,18 +106,48 @@ special_char <- '[' / ']' / '\\' / '"' / [!(){}^~*?:] ~;
 -define(not_op, 'NOT').
 -define(not_bang_op, '!').
 
+-spec convert_final(list()) -> iolist().
+convert_final(Ast) ->
+      L = lists:flatten(Ast),
+      convert_final1(L, []).
+
+convert_final1([], Acc) ->
+  chef_solr:transform_query_safe(get(search_module), iolist_to_binary(lists:reverse(Acc)));
+convert_final1([Bin|Rest], Acc) when is_binary(Bin) ->
+   convert_final1(Rest, [Bin|Acc]);
+convert_final1([{term, Content}|Rest], Acc) ->
+   convert_final1(Rest, [convert_term(Content) | Acc]).
+
 -spec convert_term(iolist()) -> binary().
 convert_term(Term) ->
-  chef_solr:transform_query_term(get(search_module), iolist_to_binary(Term)).
+  L = lists:flatten(Term),
+  convert_term1(L, [], []).
+
+convert_term1([], Accum1, Accum2) ->
+  Prev = chef_solr:transform_query_term(get(search_module), iolist_to_binary(lists:reverse(Accum1))),
+  [Accum2, Prev];
+convert_term1([Term|Rest], Accum1, Accum2) when is_binary(Term) ->
+  convert_term1(Rest, [Term|Accum1], Accum2);
+convert_term1([{escaped_special, Char}|Rest], Accum1, Accum2) ->
+  Prev = convert_char(lists:reverse(Accum1)),
+  NewAccum2 = [Accum2, Prev, <<"\\">>, convert_char(Char)],
+  convert_term1(Rest, [], NewAccum2).
 
 -spec convert_phrase(iolist()) -> binary().
 convert_phrase(Phrase) ->
-  chef_solr:transform_query_phrase(get(search_module), iolist_to_binary(Phrase)).
+  convert_phrase1(lists:flatten(Phrase), []).
+
+convert_phrase1([], Accum) ->
+  chef_solr:transform_query_phrase(get(search_module), iolist_to_binary(lists:reverse(Accum)));
+convert_phrase1([{term, Term}|Rest], Accum) ->
+  convert_phrase1(Rest, [convert_term1(lists:flatten(Term), [], [])|Accum]);
+convert_phrase1([Other|Rest], Accum) ->
+  convert_phrase1(Rest, [Other|Accum]).
+
 
 -spec convert_char(iolist()) -> binary().
 convert_char(Char) ->
   chef_solr:transform_query_all(get(search_module), iolist_to_binary(Char)).
-
 
 -spec convert_range_expression(binary(), binary(), binary(), binary(), binary()) -> iolist().
 convert_range_expression(FieldName, _, <<"*">>, <<"*">>, _) ->

--- a/src/oc_erchef/apps/chef_index/test/chef_index_expand_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_expand_tests.erl
@@ -379,9 +379,8 @@ cs_send_item_xml_expect() ->
       "<field name=\"x_chef_type_chef_x\">role</field>"
       "<field name=\"content\">"
       "key1__EQ__value1 key2__EQ__value__DS__2 "
-      "x_chef_database_chef_x__EQ__chef_db1 "
-      "x_chef_id_chef_x__EQ__a1 "
-      "x_chef_type_chef_x__EQ__role </field>"
+      "x__US__chef__US__database__US__chef__US__x__EQ__chef__US__db1 "
+      "x__US__chef__US__id__US__chef__US__x__EQ__a1 "
+      "x__US__chef__US__type__US__chef__US__x__EQ__role </field>"
       "</add>"
       "</batch>">>.
-

--- a/src/oc_erchef/apps/chef_index/test/chef_lucene_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_lucene_tests.erl
@@ -58,6 +58,12 @@ chef_lucene_cloudsearch_test_() ->
                ?assertEqual(chef_lucene:parse(<<"foo:bar+baz">>), <<"content:foo__EQ__bar__PL__baz">>)
        end
       },
+      {"cloudsearch: it replaces underscores correctly",
+       fun() ->
+               chef_index_test_utils:set_provider(cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"foo:bar_bar">>), <<"content:foo__EQ__bar__US__bar">>)
+       end
+      },
       {"cloudsearch: it does replace escaped solr wildcard operators in a term",
        fun() ->
                chef_index_test_utils:set_provider(cloudsearch),
@@ -65,6 +71,12 @@ chef_lucene_cloudsearch_test_() ->
                ?assertEqual(chef_lucene:parse(<<"bar\\?">>), <<"bar\\__QS__">>),
                ?assertEqual(chef_lucene:parse(<<"foo:bar\\*">>), <<"content:foo__EQ__bar\\__ST__">>),
                ?assertEqual(chef_lucene:parse(<<"foo:bar\\?">>), <<"content:foo__EQ__bar\\__QS__">>)
+       end
+      },
+      {"cloudsearch: it does replace solr wildcards in a phrase",
+       fun() ->
+               chef_index_test_utils:set_provider(cloudsearch),
+               ?assertEqual(chef_lucene:parse(<<"foo:\"bar*\"">>), <<"content:\"foo__EQ__bar__ST__\"">>)
        end
       },
       {"cloudsearch: it does NOT replace leading operators",
@@ -82,4 +94,3 @@ chef_lucene_cloudsearch_test_() ->
        end
       }
      ].
-

--- a/src/oc_erchef/apps/chef_index/test/cs_escape_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/cs_escape_tests.erl
@@ -22,7 +22,7 @@ cs_escape_test_() ->
     [
      {"doesn't alter data with no special characters", ?_assertEqual(cs_escape:escape(<<"FooBar">>), <<"FooBar">>)},
      {"replaces a bunch of special characters", ?_assertEqual(cs_escape:escape(<<"Foo-()*Bar">>), <<"Foo__DS____OP____CP____ST__Bar">>)},
-     {"doesn't replace underscore", ?_assertEqual(cs_escape:escape(<<"Foo_Bar">>), <<"Foo_Bar">>)},
+     {"replaces underscores that appears in original data", ?_assertEqual(cs_escape:escape(<<"A-Foo_Bar">>), <<"A__DS__Foo__US__Bar">>)},
      {"doesn't replace period", ?_assertEqual(cs_escape:escape(<<"Foo.Bar">>), <<"Foo.Bar">>)},
      {"doesn't replace integers", ?_assertEqual(cs_escape:escape(<<"Foo9Bar">>), <<"Foo9Bar">>)},
      {"doesn't replace single quotes", ?_assertEqual(cs_escape:escape(<<"Foo'Bar">>), <<"Foo'Bar">>)},


### PR DESCRIPTION
If we don't replace `_`, then it is possible that search terms like
`foo_*` would turn up data where the value was `foo-bar` because
the search "foo-bar" will be converted to `foo__DS__bar` which will
match `foo_*`.

This commit converts `_`'s to `__US__`.  In the above example, the search
query `foo_*` would be converted to `foo__US__*` which would not match
`foo__DS__bar`.

This required special handling during query parsing since we want to
ensure we only ever replace `_`'s that were in the original data.