### PR TITLE
Avoid proxies when talking to local chef-server

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
@@ -1,5 +1,6 @@
 node_name "pivotal"
 chef_server_url "<%= @prefix %>://<%= @vip %>"
 chef_server_root "<%= @prefix %>://<%= @vip %>"
+no_proxy "<%= node['private_chef']['lb']['vip'] %>"
 client_key "/etc/opscode/pivotal.pem"
 ssl_verify_mode :verify_none


### PR DESCRIPTION
This configuration file is used by chef-server-ctl to talk to the API
locally. Proxy configs in the users environment often cause problems
because the LB VIP is almost always 127.0.0.1, which causes the proxy to
try to connect to itself rather than back to the chef-server.