### PR TITLE
dvm fixes to fix unhelpful error messages and enable successful loading of bifrost

### DIFF
--- a/dev/dvm/bin/dvm
+++ b/dev/dvm/bin/dvm
@@ -11,6 +11,6 @@ require "dvm"
 
 begin
   DVM::Application.start(ARGV)
-rescue DVM::DVMArgumentError => e
+rescue Exception => e
   say HighLine.color(e.message, :red)
 end

--- a/dev/dvm/bin/dvm
+++ b/dev/dvm/bin/dvm
@@ -11,6 +11,6 @@ require "dvm"
 
 begin
   DVM::Application.start(ARGV)
-rescue Exception => e
+rescue DVM::DVMArgumentError => e
   say HighLine.color(e.message, :red)
 end

--- a/dev/dvm/lib/dvm.rb
+++ b/dev/dvm/lib/dvm.rb
@@ -1,3 +1,7 @@
+module DVM
+  class DVMArgumentError < RuntimeError; end
+end
+
 require_relative "dvm/tools"
 require_relative "dvm/project"
 require_relative "dvm/application"

--- a/src/oc_bifrost/Makefile
+++ b/src/oc_bifrost/Makefile
@@ -53,7 +53,6 @@ omnibus: $(REBAR3) distclean
 	$(REBAR3) do compile, release
 
 ## For dvm
-DVM_HOOK = bundle
 dvm_file = $(wildcard /vagrant/dvm.mk)
 ifeq ($(dvm_file),/vagrant/dvm.mk)
 	include /vagrant/dvm.mk


### PR DESCRIPTION
Thanks to @marcparadise for help with these.   3 specific fixes that got me unstuck:

1. `dev/dvm/bin/dvm`:   The rescue was masking the underlying failure -  loosen up what we rescue in order to always show the underlying failure
2. `dev/dvm/lib/dvm.rb`:  a class definition went missing which was masking the `raise` messages with an unhelpful message
3.  `src/oc_bifrost/Makefile`:  remove an errant `bundle` target from `oc_bifrost` so that it can be successfully loaded