### PR TITLE
ChangeLog-Entry: [oc_erchef] queue monitor doesn't affect overall_sta…

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -131,6 +131,8 @@ default['private_chef']['rabbitmq']['analytics_max_length'] = 10000
 default['private_chef']['rabbitmq']['queue_length_monitor_vhost'] = "/analytics"
 default['private_chef']['rabbitmq']['queue_length_monitor_queue'] = "alaska"
 default['private_chef']['rabbitmq']['queue_length_monitor_enabled'] = true
+# does a full queue set overall_status to fail at \_status
+default['private_chef']['rabbitmq']['queue_at_capacity_affects_overall_status'] = false
 
 ####
 # RabbitMQ Queue Monitor

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -138,7 +138,8 @@
                                 {queue_length_monitor_millis, <%= @node['private_chef']['rabbitmq']['queue_length_monitor_millis'] %>},
                                 {queue_length_monitor_timeout_millis, <%= @node['private_chef']['rabbitmq']['queue_length_monitor_timeout_millis'] %>},
                                 {drop_on_full_capacity, <%=  @node['private_chef']['rabbitmq']['drop_on_full_capacity']  %>},
-                                {prevent_erchef_startup_on_full_capacity, <%= @node['private_chef']['rabbitmq']['prevent_erchef_startup_on_full_capacity'] %>}
+                                {prevent_erchef_startup_on_full_capacity, <%= @node['private_chef']['rabbitmq']['prevent_erchef_startup_on_full_capacity'] %>},
+                                {queue_at_capacity_affects_overall_status, <%= @node['private_chef']['rabbitmq']['queue_at_capacity_affects_overall_status'] %>}
                                ]}
                           ]}
             ]},

--- a/src/oc_erchef/apps/oc_chef_wm/itest/chef_wm_actions_queue_monitoring_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/chef_wm_actions_queue_monitoring_SUITE.erl
@@ -262,7 +262,8 @@ default_rabbit_config(Config) ->
             {queue_length_monitor_millis, 30000 },
             {queue_length_monitor_timeout_millis, 5000 },
             {drop_on_full_capacity, true },
-            {prevent_erchef_startup_on_full_capacity, false}
+            {prevent_erchef_startup_on_full_capacity, false},
+            {queue_at_capacity_affects_overall_status, false}
         ]}
     ].
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
@@ -103,7 +103,7 @@ queue_at_capacity_affects_overall_status() ->
     chef_wm_rabbitmq_management:get_rabbit_queue_monitor_setting(queue_at_capacity_affects_overall_status, false).
 
 
--spec log_failure(fail | pong, [{binary(), <<_:32>>}], tuple()) -> ok.
+-spec log_failure(fail | pong, [{binary(), <<_:32>>}], list()) -> ok.
 log_failure(fail, Pings, []) ->
     % queue monitor isn't active
     FailureData = {{status, fail}, {upstreams, {Pings}}},

--- a/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_actions_queue_monitoring_statem.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_actions_queue_monitoring_statem.erl
@@ -68,7 +68,8 @@ default_rabbit_config() ->
             {queue_length_monitor_queue, alaska },
             {queue_length_monitor_millis, 30000 },
             {queue_length_monitor_timeout_millis, 5000 },
-            {drop_on_full_capacity, true }
+            {drop_on_full_capacity, true },
+            {queue_at_capacity_affects_overall_status, false}
         ]}
     ].
 

--- a/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_actions_queue_monitoring_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_actions_queue_monitoring_tests.erl
@@ -167,7 +167,8 @@ default_config() ->
             {queue_length_monitor_queue, alaska },
             {queue_length_monitor_millis, 30000 },
             {queue_length_monitor_timeout_millis, 5000 },
-            {drop_on_full_capacity, true }
+            {drop_on_full_capacity, true },
+            {queue_at_capacity_affects_overall_status, false}
         ]}
     ].
 


### PR DESCRIPTION
…tus by default

add queue_at_capacity_affects_overall_status boolean attribute

cc @chef/lob @irvingpop 