### PR TITLE
ChangeLog-Entry: [dvm] add support for dotfiles external to the repository

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -90,6 +90,7 @@ def define_chef_server(config, attributes)
       json = simple_deep_merge(json, { "provisioning" => { "opscode-reporting-config" => pg } })
     end
 
+    dotfiles_path = attributes["vm"]["dotfile_path"] || "dotfiles"
     config.vm.synced_folder File.absolute_path(File.join(Dir.pwd, "../")), "/host",
       type: "rsync",
       rsync__args: ["--verbose", "--archive", "--delete", "-z", "--no-owner", "--no-group" ],
@@ -97,6 +98,8 @@ def define_chef_server(config, attributes)
     # We're also going to do a share of the slower vboxsf style, allowing us to auto-checkout dependencies
     # and have them be properly synced to a place that we can use them.
     config.vm.synced_folder installer_path, "/installers"
+    config.vm.synced_folder File.expand_path(dotfiles_path), "/dotfiles"
+
     config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
     config.vm.provision "shell", inline: install_hack(installer)
     config.vm.provision "chef_solo" do |chef|

--- a/dev/cookbooks/dev/recipes/user-env.rb
+++ b/dev/cookbooks/dev/recipes/user-env.rb
@@ -66,7 +66,7 @@ end
 ruby_block "dotfiles" do
   block do
     require "fileutils"
-    copyfiles = Dir.glob("/vagrant/dotfiles/.*").reject { |name| name =~ /.*\.$/ }
+    copyfiles = Dir.glob("/dotfiles/.*").reject { |name| name =~ /.*\.$/ }
     FileUtils.cp(copyfiles, "/home/vagrant")
   end
 end

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -29,7 +29,9 @@ vm:
   memory: 4096
   packages: [ ntp, curl, wget, htop, uuid-dev, tmux, vim, iotop ]
   omnibus-autoload: [] # see config.yml for details and to add components
-
+  # Override this in config.yml to set a custom path for your dotfiles
+  # that's external to this repository.
+  dotfile_path: dotfiles
   # TODO whitelist as well?
   # Note that we can't exclude .git from top-level projects, and by extension from anything,
   # otherwise rebar commands begin to fail.

--- a/dev/dotfiles/README
+++ b/dev/dotfiles/README
@@ -4,3 +4,12 @@ allowing you to modify shell and application dotfiles to suit your needs.
 Take care that if you provide a custom .bashrc, that you set up your PATH as:
 
 export PATH=/opt/opscode/embedded/bin:$PATH
+
+You can also choose to specify a custom dotfiles location, so that it's not tied to this repository
+(allowing you to safely nuke the repo and not lose your dotfiles)
+
+To do this, edit or create config.yml and add the following:
+
+    vm:
+      dotfile_host_path=/path/to/your/dotfiles
+


### PR DESCRIPTION
Add a dvm config setting to allow dotfiles to live outside of the chef-server repo, so that they survive repo purges... 