### PR TITLE
Don't create unused SERVICE/etc dirs for erlang services

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
@@ -6,7 +6,6 @@
 
 cookbook_migration = "/opt/opscode/embedded/bin/cookbook_migration.sh"
 
-checksum_path = node['private_chef']['opscode-chef']['checksum_path']
 data_path = node['private_chef']['bookshelf']['data_dir']
 
 template cookbook_migration do
@@ -21,12 +20,10 @@ end
 # Note that data_path will not be a subdir of bookshelf_dir in HA configurations
 #
 bookshelf_dir = node['private_chef']['bookshelf']['dir']
-bookshelf_etc_dir = File.join(bookshelf_dir, "etc")
 bookshelf_log_dir = node['private_chef']['bookshelf']['log_directory']
 bookshelf_sasl_log_dir = File.join(bookshelf_log_dir, "sasl")
 [
   bookshelf_dir,
-  bookshelf_etc_dir,
   bookshelf_log_dir,
   bookshelf_sasl_log_dir,
   data_path

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_bifrost.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_bifrost.rb
@@ -25,13 +25,11 @@ end
 
 oc_bifrost_dir = node['private_chef']['oc_bifrost']['dir']
 oc_bifrost_bin_dir = File.join(oc_bifrost_dir, "bin")
-oc_bifrost_etc_dir = File.join(oc_bifrost_dir, "etc")
 oc_bifrost_log_dir = node['private_chef']['oc_bifrost']['log_directory']
 oc_bifrost_sasl_log_dir = File.join(oc_bifrost_log_dir, "sasl")
 [
   oc_bifrost_dir,
   oc_bifrost_bin_dir,
-  oc_bifrost_etc_dir,
   oc_bifrost_log_dir,
   oc_bifrost_sasl_log_dir
 ].each do |dir_name|

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -5,12 +5,10 @@
 # All Rights Reserved
 
 opscode_erchef_dir = node['private_chef']['opscode-erchef']['dir']
-opscode_erchef_etc_dir = File.join(opscode_erchef_dir, "etc")
 opscode_erchef_log_dir = node['private_chef']['opscode-erchef']['log_directory']
 opscode_erchef_sasl_log_dir = File.join(opscode_erchef_log_dir, "sasl")
 [
   opscode_erchef_dir,
-  opscode_erchef_etc_dir,
   opscode_erchef_log_dir,
   opscode_erchef_sasl_log_dir
 ].each do |dir_name|


### PR DESCRIPTION
Nothing lives in the etc/ directories since the move to rebar3.