### PR TITLE
Don't run eunit on mover's vendored code.

### DIFF
--- a/src/chef-mover/Makefile
+++ b/src/chef-mover/Makefile
@@ -30,7 +30,9 @@ distclean:
 install: $(REBAR3) distclean
 	$(REBAR3) update
 
-travis: all
+travis: $(REBAR3)
+	@$(REBAR3) do clean, compile
+	@$(REBAR3) eunit --app mover
 	@echo "Travis'd!"
 
 version_clean:


### PR DESCRIPTION
We don't modify this, and it's currently preserved from a fixed
version to ensure mover's back-compatibility.  Because it's a regular
source of intermittent CI failures that we can't address(because we
can't change the vendored code), this change explicitly tests
only the parts of mover that can change.

ChangeLog-Entry: [chef-mover] do not run intermittently failing tests on dependencies
that we can't change for backward-compatibility reasons.