### PR TITLE
Add option to set rspec seed value

### DIFF
--- a/oc-chef-pedant/lib/pedant/command_line.rb
+++ b/oc-chef-pedant/lib/pedant/command_line.rb
@@ -19,7 +19,7 @@ module Pedant
 
   class CommandLine < Struct.new(:junit_file, :config_file, :log_file, :include_internal, :only_internal,
                                  :run_all, :exclude_internal_orgs, :only_internal_orgs, :verify_error_messages,
-                                 :bell_on_completion, :rerun, :use_default_org, :ssl_version, :server_api_version)
+                                 :bell_on_completion, :rerun, :seed, :use_default_org, :ssl_version, :server_api_version)
 
     def initialize(argv)
       @argv = argv.dup
@@ -111,6 +111,11 @@ module Pedant
       opts.on("--rerun", "Run tests that failed the last time") do
         self.rerun = true
       end
+
+      opts.on("--seed SEED", "Use SEED for random ordering") do |seed|
+        self.seed = seed
+      end
+
       opts.on("--ssl-version VERSION", "Specify SSL version to use when connecting to an ssl-enabled endpoint. Defaults to TLSv1 if not specified") do |v|
         self.ssl_version = f.split(/ /).first.to_sym
       end

--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -74,6 +74,10 @@ module Pedant
         args.concat(self[:tags].map { |tag| ['-t', tag.to_s] } )
       end
 
+      if self[:seed]
+        args.concat([ '--seed', self[:seed] ])
+      end
+
       args.concat(rspec_formatting_args)
 
       # Load up the failures file if we're re-running


### PR DESCRIPTION
Rspec by default runs tests in a random order, which normally is
good. However sometimes bugs manifest themselves as state leftover from
prior tests, and it's hard to sort those out when the order changes
every time.

Add a --seed flag to pedant to set the rspec seed value.