### PR TITLE
Typo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 * `omnibus` [fix-warn](https://github.com/chef/chef-server/commit/1128fda0db9a38cb664b5e400feecbe2f459d611)
   * Fixes Chef 13 warning related to using 'environment' attribute to configure 'PATH'.
 * `omnibus` [RyanFrantz-master](https://github.com/chef/chef-server/commit/a50470c41d0ee9d716f860a8d6f79cc14fde5ddd)
-  * the nginx `nginx_status` endpoint is now availalbe.
+  * the nginx `nginx_status` endpoint is now available.
   * Sensibe defaults are defined in `attributes/default`.rb.
 * `omnibus` [571](https://github.com/chef/chef-server/pull/571) - CVE-2014-3628
   * Need the md5sum too...

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Chef Server Release Notes
 
-This document contains an overview of signficant customer-facing changes
+This document contains an overview of significant customer-facing changes
 in the release. For a detailed list of changed components, refer to
 [CHANGELOG.md](CHANGELOG.md).
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -38,7 +38,7 @@ release:
 - [ ] Test an upgrade from the latest release of Open Source Chef Server
 11 to the most current build from master. To do this you must:
 
-  - Install Open Souce Chef Server 11
+  - Install Open Source Chef Server 11
   - Populate data using knife
   - Install the latest build
   - Follow the upgrade instruction for that build


### PR DESCRIPTION
* Change "Changelog" to "Change Log"
* "available" was spelled wrong in the release notes
* "Source" was spelled wrong in the release process

ChangeLog-Entry: Fix typos in release notes