### PR TITLE
update minimal cookbook versions query to force query plan

### DIFF
--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -363,19 +363,31 @@
 %% Used in implementation of environemnts/ENVNAME/cookbook_versions endpoint.
 %%
 %% Depends on the cbv type existing in the schema
+%%
+%% This query uses two CTEs (inputs and min_cve) to force the query planner
+%% to first join cookbook_versions (min, maj, patch) with cookbooks (id, name)
+%% before filtering with inputs.
+%%
+%% Without the min_cv CTE, the query planner would choose to join inputs with
+%% cookbook_versions before filtering by name. In the worst case scenario (all
+%% cookbooks have the same version number), the inputs and cookbook_versions
+%% join behaved like a cartesian product of all the inputs and the cookbook versions.
 {bulk_fetch_minimal_cookbook_versions,
- <<"WITH inputs AS ( select * from unnest($2::cbv[]) )
-  SELECT v.frozen, v.meta_deps, v.metadata, v.serialized_object,
-         c.authz_id, c.org_id, c.name
+ <<"WITH inputs AS ( SELECT * FROM unnest($2::cbv[]) ),
+         min_cv AS ( SELECT v.frozen, v.meta_deps, v.metadata, v.serialized_object,
+                            v.major, v.minor, v.patch, c.authz_id, c.org_id, c.name
+                       FROM cookbooks as c,
+                            cookbook_versions as v
+                      WHERE c.org_id = $1
+                        AND c.id = v.cookbook_id )
+  SELECT min_cv.frozen, min_cv.meta_deps, min_cv.metadata, min_cv.serialized_object,
+         min_cv.authz_id, min_cv.org_id, min_cv.name
     FROM inputs,
-         cookbooks as c,
-         cookbook_versions as v
-   WHERE c.org_id = $1
-     AND inputs.name = c.name
-     AND v.cookbook_id = c.id
-     AND v.major = inputs.major
-     AND v.minor = inputs.minor
-     AND v.patch = inputs.patch">>}.
+         min_cv
+   WHERE inputs.name = min_cv.name
+     AND inputs.major = min_cv.major
+     AND inputs.minor = min_cv.minor
+     AND inputs.patch = min_cv.patch">>}.
 
 %% Used in implementation of environments/ENVIRONMENT/recipes endpoint
 %%


### PR DESCRIPTION
This query uses two CTEs (inputs and min_cve) to force the query planner
to first join cookbook_versions (min, maj, patch) with cookbooks (id, name)
before filtering with inputs.

Without the min_cv CTE, the query planner would choose to join inputs with
cookbook_versions before filtering by name. In the worst case scenario (all
cookbooks have the same version number), the inputs and cookbook_versions
join behaved like a cartesian product of all the inputs and the cookbook versions.

/cc @chef/lob