### PR TITLE
Use the correct ssl port for bookshelf and pedant when it's not default

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
@@ -30,17 +30,20 @@ class NginxErb
     end
   end
 
-  def listen_port(proto, options = {})
-    listen_port = ""
-    listen_port << case proto
-                   when "http"
-                     node['private_chef']['nginx']['non_ssl_port'].to_s || "80"
-                   when "https"
-                     node['private_chef']['nginx']['ssl_port'].to_s
-                   else
-                     proto.to_s
-                   end
+  def port_for_proto(proto)
+    case proto
+    when "http"
+      node['private_chef']['nginx']['non_ssl_port'].to_s || "80"
+    when "https"
+      node['private_chef']['nginx']['ssl_port'].to_s
+    else
+      proto.to_s
+    end
+  end
 
+
+  def listen_port(proto, options = {})
+    listen_port = port_for_proto(proto)
     if node['private_chef']['nginx']['enable_ipv6']
       # In some cases, we're serving as a front-end for a service that's already
       # listening on the same port in ipv4 - this prevents a conflict in that situation.

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -428,7 +428,12 @@ module PrivateChef
       PrivateChef["lb"]["api_fqdn"] ||= PrivateChef['api_fqdn']
       PrivateChef["lb"]["web_ui_fqdn"] ||= PrivateChef['api_fqdn']
       PrivateChef["nginx"]["server_name"] ||= PrivateChef['api_fqdn']
-      PrivateChef["nginx"]["url"] ||= "https://#{PrivateChef['api_fqdn']}"
+
+      if PrivateChef["nginx"]["ssl_port"] == 443
+          PrivateChef["nginx"]["url"] ||= "https://#{PrivateChef['api_fqdn']}"
+      else
+          PrivateChef["nginx"]["url"] ||= "https://#{PrivateChef['api_fqdn']}:#{PrivateChef["nginx"]["ssl_port"]}"
+      end
     end
 
     def gen_secrets_default(node_name)

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -1,9 +1,9 @@
 #
 # Author:: Adam Jacob (<adam@opscode.com>)
-# Copyright:: Copyright (c) 2011 Opscode, Inc.
+# Copyright:: Copyright (c) 2011-2015 Chef Software, Inc.
 #
-# All Rights Reserved
 
+helper = OmnibusHelper.new(node)
 opscode_erchef_dir = node['private_chef']['opscode-erchef']['dir']
 opscode_erchef_log_dir = node['private_chef']['opscode-erchef']['log_directory']
 opscode_erchef_sasl_log_dir = File.join(opscode_erchef_log_dir, "sasl")
@@ -13,8 +13,8 @@ opscode_erchef_sasl_log_dir = File.join(opscode_erchef_log_dir, "sasl")
   opscode_erchef_sasl_log_dir
 ].each do |dir_name|
   directory dir_name do
-    owner OmnibusHelper.new(node).ownership['owner']
-    group OmnibusHelper.new(node).ownership['group']
+    owner helper.ownership['owner']
+    group helper.ownership['group']
     mode node['private_chef']['service_dir_perms']
     recursive true
   end
@@ -24,14 +24,14 @@ link "/opt/opscode/embedded/service/opscode-erchef/log" do
   to opscode_erchef_log_dir
 end
 
-ldap_authentication_enabled = OmnibusHelper.new(node).ldap_authentication_enabled?
+ldap_authentication_enabled = helper.ldap_authentication_enabled?
  # These values are validated and managed in libraries/private_chef.rb#gen_ldap
 enable_ssl = ldap_authentication_enabled ? node['private_chef']['ldap']['enable_ssl'] : nil
 ldap_encryption_type = ldap_authentication_enabled ? node['private_chef']['ldap']['encryption_type'] : nil
 
 erchef_config = File.join(opscode_erchef_dir, "sys.config")
 
-rabbitmq = OmnibusHelper.new(node).rabbitmq_configuration
+rabbitmq = helper.rabbitmq_configuration
 
 actions_vip = rabbitmq['vip']
 actions_port = rabbitmq['node_port']
@@ -40,12 +40,15 @@ actions_password = rabbitmq['actions_password']
 actions_vhost = rabbitmq['actions_vhost']
 actions_exchange = rabbitmq['actions_exchange']
 
+s3_proto = node['private_chef']['nginx']['x_forwarded_proto']
+
 template erchef_config do
   source "oc_erchef.config.erb"
-  owner OmnibusHelper.new(node).ownership['owner']
-  group OmnibusHelper.new(node).ownership['group']
+  owner helper.ownership['owner']
+  group helper.ownership['group']
   mode "644"
-  variables(node['private_chef']['opscode-erchef'].to_hash.merge(:ldap_enabled => ldap_authentication_enabled,
+  variables(node['private_chef']['opscode-erchef'].to_hash.merge(:s3_proto => s3_proto,
+                                                                 :ldap_enabled => ldap_authentication_enabled,
                                                                  :enable_ssl =>  enable_ssl,
                                                                  :actions_vip => actions_vip,
                                                                  :actions_port => actions_port,
@@ -54,7 +57,7 @@ template erchef_config do
                                                                  :actions_vhost => actions_vhost,
                                                                  :actions_exchange => actions_exchange,
                                                                  :ldap_encryption_type => ldap_encryption_type,
-                                                                 :helper => OmnibusHelper.new(node)))
+                                                                 :helper => helper))
   notifies :run, 'execute[remove_erchef_siz_files]', :immediately
   notifies :restart, 'runit_service[opscode-erchef]' unless backend_secondary?
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -1,6 +1,6 @@
 %% -*- mode: erlang -*-
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%% ex: ts=4 sw=4 ft=erlang et
+%% ex: ts=4 sw=4 ft=eruby.erlang et
 [
  %% SASL config
  {sasl, [
@@ -144,7 +144,7 @@
                           ]}
             ]},
 
- 
+
   {chef_authn, [
                 {keyring, [{default, "/etc/opscode/webui_pub.pem"}]},
                 <% unless node['private_chef']['opscode-erchef']['keygen_cache_workers'] == :auto -%>
@@ -206,7 +206,7 @@
   {chef_objects, [
                   {s3_access_key_id, "<%= node['private_chef']['bookshelf']['access_key_id'] %>"},
                   {s3_secret_key_id, "<%= node['private_chef']['bookshelf']['secret_access_key'] %>"},
-                  {s3_url, "<%= node['private_chef']['nginx']['x_forwarded_proto'] %>://<%= @helper.vip_for_uri('bookshelf') %>"},
+                  {s3_url, "<%= "#{@s3_proto}://#{@helper.vip_for_uri('bookshelf')}:#{NginxErb.new(node).port_for_proto(@s3_proto)}"%>"},
                   {s3_external_url, <%= @helper.erl_atom_or_string(node['private_chef']['bookshelf']['external_url']) %>},
                   {s3_platform_bucket_name, "<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>"},
                   {s3_url_ttl, <%= node['private_chef']['opscode-erchef']['s3_url_ttl'] %>},


### PR DESCRIPTION
1. Update erchef's `s3_url` to properly reflect the ssl port in use
2. Similarly update pedant's `api_url`. 


Addresses #50 
