### PR TITLE
Restrict 'other' permissions for chef-server.rb

### DIFF
--- a/omnibus/package-scripts/chef-server/postinst
+++ b/omnibus/package-scripts/chef-server/postinst
@@ -18,6 +18,8 @@ ln -sf /opt/opscode/chef-server-plugin.rb /var/opt/opscode/plugins/chef-ha-drbd.
 
 mkdir -p /etc/opscode
 touch /etc/opscode/chef-server.rb
+# chef-server.rb might contain secrets, restrict permissions of other.
+chmod o-rwx /etc/opscode/chef-server.rb
 
 # Ensure all files/directories in $INSTALLER_DIR are owned by root. This
 # has been fixed on new installs but upgrades from old installs need to


### PR DESCRIPTION
This PR removes all permissions for 'other' on /etc/opscode/chef-server.rb. This file can hold sensitive data such as the LDAP bind_password, so it should not be accessible by anyone other than owner/group (both root in this case).