### PR TITLE
don't monitor rabbit queue length w/ actions disabled

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -132,7 +132,8 @@
                                     "<%= node['private_chef']['rabbitmq']['management_password'] %>"}}]}
                                 ]}]},
                             {monitoring,
-                               [{queue_length_monitor_enabled, <%= @node['private_chef']['rabbitmq']['queue_length_monitor_enabled'] %>},
+                               [{queue_length_monitor_enabled, <%= @node['private_chef']['rabbitmq']['queue_length_monitor_enabled'] &&
+                                                                   @node['private_chef']['dark_launch']['actions'] %>},
                                 {queue_length_monitor_vhost, "<%= @node['private_chef']['rabbitmq']['queue_length_monitor_vhost'] %>"},
                                 {queue_length_monitor_queue, "<%= @node['private_chef']['rabbitmq']['queue_length_monitor_queue'] %>"},
                                 {queue_length_monitor_millis, <%= @node['private_chef']['rabbitmq']['queue_length_monitor_millis'] %>},


### PR DESCRIPTION
When setting `dark_launch['actions'] = false` in
`/etc/opscode/chef-server.rb`, the actions queue is never created and
the rabbitmq actions queue monitoring code returns a 500 on `/_status`
when it's unable to connect to the queue. This PR disabled the
monitoring behavior when the actions feature is disabled.