### PR TITLE
DEV: Pull in dev knife-opc branch.

### DIFF
--- a/omnibus/config/software/knife-opc-gem.rb
+++ b/omnibus/config/software/knife-opc-gem.rb
@@ -15,7 +15,7 @@
 #
 
 name "knife-opc"
-default_version "master"
+default_version "tc/force_remove_from_admins"
 
 source git: "git://github.com/opscode/knife-opc.git"
 


### PR DESCRIPTION
Fix `chef-server-ctl user-org-remove` being useless because you can't remove a user from an org if the user is in `admins`/`billing-admins`.

Depends on https://github.com/chef/knife-opc/pull/35

Fixes https://github.com/chef/chef-server/issues/157

[Build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/803/)