### PR TITLE
first round of analytics vm support

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -171,3 +171,18 @@ vm:
     start: true
     use-external: true
 ```
+
+# Chef Analytics
+
+add the following to `config.yml`:
+
+```
+analytics: true
+```
+
+Once Vagrant is done building VM's, you can access each via:
+
+```
+vagrant ssh chef-analytics
+vagrant ssh chef-server
+```

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -1,7 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby
 
-
 require "yaml"
 load "dvmtools.rb"
 CS_VM_ADDRESS="192.168.33.100"
@@ -10,44 +9,59 @@ REPORTING_DB_VM_ADDRESS="192.168.33.155"
 DB_SUPERUSER="bofh"
 DB_SUPERPASS="i1uvd3v0ps"
 
+attributes = load_settings
+
+if attributes['analytics']
+    load "analytics.rb"
+end
 
 Vagrant.configure("2") do |config|
-  attributes = load_settings
+    # Use the official Ubuntu 14.04 box
+    # Vagrant will auto resolve the url to download from Atlas
+    config.vm.box = "ubuntu/trusty64"
+    config.ssh.forward_agent = true
 
-  # Use the official Ubuntu 14.04 box
-  # Vagrant will auto resolve the url to download from Atlas
-  config.vm.box = "ubuntu/trusty64"
-  config.ssh.forward_agent = true
-
-  if attributes['vm'].has_key? 'postgresql'
-    if attributes['vm']['postgresql']['start']
-      config.vm.define("database") do |c|
-        define_db_server(c, attributes)
-      end
+    if attributes['vm'].has_key? 'postgresql'
+        if attributes['vm']['postgresql']['start']
+            config.vm.define("database") do |c|
+                define_db_server(c, attributes)
+            end
+        end
+    else
+        attributes['vm']['postgresql'] = nil
     end
-  else
-    attributes['vm']['postgresql'] = nil
-  end
 
-  if attributes['vm'].has_key? 'reporting_postgresql'
-    if attributes['vm']['reporting_postgresql']['start']
-      config.vm.define("reportingdb") do |c|
-        define_db_server_reporting(c, attributes)
-      end
+    if attributes['vm'].has_key? 'reporting_postgresql'
+        if attributes['vm']['reporting_postgresql']['start']
+            config.vm.define("reportingdb") do |c|
+                define_db_server_reporting(c, attributes)
+            end
+        end
+    else
+        attributes['vm']['reporting_postgresql'] = nil
     end
-  else
-    attributes['vm']['reporting_postgresql'] = nil
-  end
 
+    if attributes['analytics']
+      add_analytics_provisioning_atts(attributes)
+    end
 
-  config.vm.define("chef-server", primary: true) do |c|
-    define_chef_server(c, attributes)
-  end
+    config.vm.define("chef-server", primary: true) do |c|
+        define_chef_server(c, attributes)
+    end
+
+    if attributes['analytics']
+        config.vm.define("chef-analytics") do |c|
+            define_analytics_server(c)
+        end
+    end
 end
 
 
 def define_chef_server(config, attributes)
-  provisioning, installer, installer_path = prepare()
+
+  action = ARGV[0]
+  provisioning, installer, installer_path =
+        PackagePrompt.new("chef-server-core", "Chef Server", "INSTALLER", "AUTOPACKAGE").prepare(action)
   config.vm.hostname = "api.chef-server.dev"
   config.vm.network "private_network", ip: CS_VM_ADDRESS
 
@@ -116,6 +130,9 @@ def define_chef_server(config, attributes)
     # Makes more sense here than in a one-off line in the dvm recipe, which
     # has no direct connection...
     config.vm.provision "shell", inline: "chef-server-ctl reconfigure"
+    # if the box is configured for Analytics, pass the actions-source file out so
+    # analytics can use it during it's reconfigure phase
+    config.vm.provision "shell", inline: "cp /etc/opscode-analytics/actions-source.json /installers/actions-source.json || true"
   end
 end
 
@@ -168,87 +185,6 @@ end
 # what it needs to load up and install chef-server
 ##############
 
-
-def prepare
-  action = ARGV[0]
-  if action =~ /^(provision|up|reload)$/
-    installer = prompt_installer
-    raise "Please set INSTALLER to the path of a .deb package for Chef Server 12+." if installer.nil?
-    raise "#{installer} does not exist! Please fix this." unless File.file?(installer)
-    installer_path = File.dirname(File.expand_path(installer))
-    provisioning = true
-  end
-  [provisioning, installer, installer_path]
-end
-
-def prompt_installer
-  puts "Looking in #{Dir.home}/Downloads and #{base_path}/omnibus/pkg for installable chef-server-core package."
-  # TODO allow config override of location, multiple locations, search pattern, max count?
-  files = Dir.glob("#{Dir.home}/Downloads/chef-server-core*.deb") + Dir.glob("#{base_path}/omnibus/pkg/chef-server-core*.deb")
-
-  if ENV['INSTALLER']
-    if ENV['INSTALLER'] =~ /^.*chef-server-core.*deb$/ and File.file?(ENV['INSTALLER'])
-      user_installer = File.expand_path(ENV['INSTALLER'])
-    else
-      puts "INSTALLER #{ENV['INSTALLER']} is not a valid chef-server-core package. Ignoring."
-    end
-  end
-
-  if files.length == 0 and not user_installer
-    return nil
-  end
-
-  files = files.sort_by{ |f| File.mtime(f) }.last(10)
-  files.reverse!
-  files << "[INSTALLER]: #{user_installer}" if user_installer
-
-  selection = 0
-
-  # For the fantastically lazy, allow an environment variable to specify
-  # which package selection to use. Special value of '-1' or 'installer' will
-  # use the INSTALLER env var automatically (instead of just putting it in
-  # the list to choose from).
-  if ENV.has_key? 'AUTOPACKAGE'
-
-    selection = ENV['AUTOPACKAGE']
-    if (selection == 'installer' or selection == '-1') and user_installer
-      # Auto pick the INSTALLER pacckage
-      selection = files.length
-    else
-      selection = selection.to_i
-    end
-
-    if selection <= 0 or selection > files.length
-      puts "Invalid AUTOPACKAGE selection of #{selection}."
-      selection = get_selection(files)
-    else
-      puts "Using AUTOPACKAGE selection of #{files[selection - 1]}"
-    end
-
-  else
-    selection = get_selection(files)
-  end
-
-  if selection == files.length  and user_installer
-    user_installer # we munged the text on this one
-  else
-    files[selection - 1]
-  end
-
-end
-
-def get_selection(files)
-  selection = 0
-  files.each_index do |x|
-    puts " #{x+1}) #{files[x]}\n"
-  end
-  loop do
-    print "Select an image, or set the INSTALLER variable and run again: [1 - #{files.length}]: "
-    selection = $stdin.gets.chomp.to_i
-    break if selection > 0 and selection <= files.length
-  end
-  selection
-end
 
 def host_timezone
   require "time"
@@ -321,7 +257,4 @@ sudo -u postgres psql -c "CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v
 BASH
 end
 
-def base_path
-  File.absolute_path(File.join(Dir.pwd, "../"))
-end
 

--- a/dev/analytics.rb
+++ b/dev/analytics.rb
@@ -1,0 +1,87 @@
+ANALYTICS_VM_ADDRESS="192.168.33.160"
+require "yaml"
+
+def load_analytics_attributes
+    attributes = YAML.load_file("analytics_defaults.yml")
+    begin
+        custom_attributes = YAML.load_file("analytics_config.yml")
+        attributes = simple_deep_merge(attributes, custom_attributes)
+    rescue
+    end
+    attributes
+end
+
+
+def merge_analytics_settings(cs_atts)
+    attributes = YAML.load_file("cs_analytics_defaults.yml")
+    atts = simple_deep_merge(cs_atts, attributes)
+    atts
+end
+
+def add_analytics_provisioning_atts(attributes)
+    # I suppose this setting could be in a yaml file
+    # but the thought of a single entry in the file seems so lonely
+    attributes['vm']['node-attributes'] = {}
+    attributes['vm']['node-attributes']['provisioning'] = {}
+    attributes['vm']['node-attributes']['provisioning']['chef-server-config'] = {}
+    attributes['vm']['node-attributes']['provisioning']['chef-server-config']['analytics'] = true
+end
+
+def define_analytics_server(config)
+  attributes = load_analytics_attributes
+
+  action = ARGV[0]
+  provisioning, installer, installer_path =
+        PackagePrompt.new("opscode-analytics", "Chef Analytics", "ANALYTICS_INSTALLER", "ANALYTICS_AUTOPACKAGE").prepare(action)
+  config.vm.hostname = "analytics.dev"
+  config.vm.network "private_network", ip: ANALYTICS_VM_ADDRESS
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id,
+                  "--name", "chef-analytics",
+                  "--memory", attributes["vm"]["memory"],
+                  "--cpus", attributes["vm"]["cpus"],
+                  "--usb", "off",
+                  "--usbehci", "off"
+    ]
+  end
+  if provisioning
+    json = {
+      "packages" => attributes["vm"]["packages"],
+      "tz" => host_timezone,
+      "omnibus-autoload" => attributes["vm"]["omnibus-autoload"]
+    }.merge attributes["vm"]["node-attributes"]
+
+    dotfiles_path = attributes["vm"]["dotfile_path"] || "dotfiles"
+    config.vm.synced_folder File.absolute_path(File.join(Dir.pwd, "../")), "/host",
+      type: "rsync",
+      rsync__args: ["--verbose", "--archive", "--delete", "-z", "--no-owner", "--no-group" ],
+      rsync__exclude: attributes["vm"]['sync']['exclude-files']
+    # We're also going to do a share of the slower vboxsf style, allowing us to auto-checkout dependencies
+    # and have them be properly synced to a place that we can use them.
+    config.vm.synced_folder installer_path, "/installers"
+    config.vm.synced_folder File.expand_path(dotfiles_path), "/dotfiles"
+
+    config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
+    config.vm.provision "shell", inline: install_hack(installer)
+    config.vm.provision "chef_solo" do |chef|
+      chef.install = false
+      chef.binary_path = "/opt/opscode-analytics/embedded/bin"
+      chef.node_name = config.vm.hostname
+      chef.cookbooks_path = "cookbooks"
+      chef.add_recipe("provisioning::chef-analytics")
+      #chef.add_recipe("dev::system") TODO
+      #chef.add_recipe("dev::user-env") TODO
+      #chef.add_recipe("dev::dvm") TODO
+      chef.json = json || {}
+    end
+    # once the chef-server VM is provisioned, copy over actions-source.json so we
+    # know where to point the Alaska Pipeline in Analytics
+    config.vm.provision "shell", inline: "cp /installers/actions-source.json /etc/opscode-analytics/actions-source.json"
+    # Makes more sense here than in a one-off line in the dvm recipe, which
+    # has no direct connection...
+    config.vm.provision "shell", inline: "opscode-analytics-ctl reconfigure"
+  end
+end
+
+

--- a/dev/analytics_defaults.yml
+++ b/dev/analytics_defaults.yml
@@ -1,0 +1,88 @@
+# Anything in this file can be overridden in analytics_config.yml.
+#
+vm:
+  # All settings below apply only to the chef-analytics vm
+  cpus: 4
+  memory: 4096
+  packages: [ ntp, curl, wget, htop, uuid-dev, tmux, vim, iotop ]
+  omnibus-autoload: [] # see config.yml for details and to add components
+  # Override this in config.yml to set a custom path for your dotfiles
+  # that's external to this repository.
+  dotfile_path: dotfiles
+  # TODO whitelist as well?
+  # Note that we can't exclude .git from top-level projects, and by extension from anything,
+  # otherwise rebar commands begin to fail.
+  sync:
+  # In local tests, it is about a 1.1 seconds per sync,
+  # with up to about 15 seconds for a large sync (400mb single file)
+  # CPU usage on the host is minimal, but for large syncs does increase
+  # significantly on the guest.
+     interval: 5
+     show-syncing-message: true
+     exclude-files:
+       - pkg/
+       - deps/
+       - rel/
+       - _rel/
+       - _build/
+       - chef-mover/rel/mover/
+       - ebin/
+       - .eunit/
+       - .kitchen/
+       - .bundle/
+       - vendor/bundle/
+       - "*_SUITE_data/"
+       - "*.deb"
+       - "*.rpm"
+       - "*.vmdk"
+       - "*.plt"
+       - "*.beam"
+       - "*.o"
+       - "*.so"
+       - "*.d"
+       - logs/
+       - /dev/
+       - .concrete/
+       - relx # we don't want to pull in a mac relx to our linux vm
+       - rspec.failures
+       - VERSION
+       - partybus/config.rb
+       - oc-reporting-pedant/Gemfile.lock # friggin ugh
+
+  cover:
+    base_output_path: /vagrant/testdata/cover # maps to dev/testdata/cover
+  node-attributes:
+    placeholder: true
+
+projects:
+    #  omnibus:
+    #path: "omnibus"
+    #name: omnibus-analytics
+    #type: omnibus
+    #external: true
+    #components:
+    #  # dest paths are relative to /opt/opscode/embedded for these components
+    #  # source apths are relative to opscode-omnibus/files
+    #  private-chef-cookbooks:
+    #    source_path: private-chef-cookbooks/private-chef
+    #    dest_path: /opt/opscode/embedded/cookbooks/private-chef
+    #    reconfigure_on_load: true
+    #  ctl-commands:
+    #    source_path: private-chef-ctl-commands
+    #    dest_path: /opt/opscode/embedded/service/omnibus-ctl
+    #    reconfigure_on_load: false
+
+  #
+  # External Components
+  # We'll eventually allow external projects to supply their own
+  # 'dvm.yml' that we can include for project definitions, but for now...
+
+  #
+  # omnibus-ctl
+  #
+  omnibus-ctl:
+    type: ruby
+    system: true
+    external: true
+
+quickstart:

--- a/dev/cookbooks/provisioning/recipes/chef-analytics.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-analytics.rb
@@ -1,0 +1,57 @@
+# Bare minimum packages for other stuff to work:
+execute "apt-get-update" do
+  command "apt-get update"
+  ignore_failure true
+  not_if do
+    File.exists?('/var/chef/cache/apt-update-done')
+  end
+end
+
+file "/var/chef/cache/apt-update-done" do
+  action :create
+end
+
+package "build-essential"
+package "git"
+
+template "/etc/hosts" do
+  source "analytics_hosts.erb"
+  owner "root"
+  group "root"
+  action :create
+  variables({"fqdns" => ["chef-analytics.dev"]})
+end
+
+directory "/etc/opscode-analytics" do
+  owner "root"
+  group "root"
+  recursive true
+  action :create
+end
+
+# Note that we do not run reconfigure at this time
+# We will allow the dvm recipe to handle when that should occur.
+template "/etc/opscode-analytics/opscode-analytics.rb" do
+  source "opscode-analytics.rb.erb"
+  owner "root"
+  group "root"
+  action :create
+end
+
+
+# Install required external packages.
+# TODO eventually support auto-download of these packages from packagecloud
+ #node['chef-server']['installers'].each do |package_name|
+  #package package_name do
+    #source "/installers/#{package_name}"
+    #provider Chef::Provider::Package::Dpkg
+    #action :install
+    #not_if { File.exists? "/var/chef/cache/#{package_name}-installed" }
+  #end
+  #file "/var/chef/cache/#{package_name}-installed" do
+    #action :create
+  #end
+
+#end
+
+

--- a/dev/cookbooks/provisioning/templates/default/analytics_hosts.erb
+++ b/dev/cookbooks/provisioning/templates/default/analytics_hosts.erb
@@ -1,0 +1,8 @@
+127.0.0.1 localhost
+192.168.33.100  api.chef-server.dev
+
+
+::1 localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+

--- a/dev/cookbooks/provisioning/templates/default/chef-server.rb.erb
+++ b/dev/cookbooks/provisioning/templates/default/chef-server.rb.erb
@@ -4,3 +4,13 @@ topology "standalone"
 <% node['provisioning']['chef-server-config'].each_pair do |k, v| %>
 <%= k%>=<%= v%>
 <% end %>
+
+<% if node['provisioning']['chef-server-config']['analytics'] %>
+oc_id['applications'] = {
+  'analytics' => {
+    'redirect_uri' => 'https://analytics.dev/'
+  }
+}
+rabbitmq['vip'] = '192.168.33.100'
+rabbitmq['node_ip_address'] = '0.0.0.0'
+<% end %>

--- a/dev/cookbooks/provisioning/templates/default/hosts.erb
+++ b/dev/cookbooks/provisioning/templates/default/hosts.erb
@@ -2,7 +2,7 @@
 <% @fqdns.each do |fqdn| %>
 192.168.33.100  <%=fqdn.split(".")[0]%>
 <% end %>
-
+192.168.33.160 analytics.dev
 ::1 localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters

--- a/dev/cookbooks/provisioning/templates/default/opscode-analytics.rb.erb
+++ b/dev/cookbooks/provisioning/templates/default/opscode-analytics.rb.erb
@@ -1,0 +1,2 @@
+analytics_fqdn "chef-analytics.dev"
+topology "standalone"

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -1,4 +1,4 @@
-# Anything in this file can be overridden in config.yml.
+# Anything in th#is file can be overridden in config.yml.
 #
 vm:
   # Override this in config.yml if you want to bring up the
@@ -219,3 +219,7 @@ quickstart:
       - oc_bifrost
     start:
       - oc_bifrost
+
+# override this in config.yml to enable a Chef Analytics vm
+analytics: false
+

--- a/dev/dvmtools.rb
+++ b/dev/dvmtools.rb
@@ -8,6 +8,8 @@ def load_settings
   end
   attributes
 end
+
+
 def simple_deep_merge(source_hash, new_hash)
   source_hash.merge(new_hash) do |key, old, new|
     if new.respond_to?(:blank) && new.blank?
@@ -20,4 +22,100 @@ def simple_deep_merge(source_hash, new_hash)
        new
     end
   end
+end
+
+class PackagePrompt
+    attr_accessor :package_name, :package_title, :installer_var, :autopackage_var
+
+    def initialize(package_name, package_title, installer_var, autopackage_var)
+        @package_name = package_name
+        @package_title = package_title
+        @installer_var = installer_var
+        @autopackage_var = autopackage_var
+
+    end
+
+    def prepare(action)
+        if action =~ /^(provision|up|reload)$/
+            installer = prompt_installer
+            raise "Please set #{installer_var} to the path of a .deb package for #{package_title}." if installer.nil?
+            raise "#{installer} does not exist! Please fix this." unless File.file?(installer)
+            installer_path = File.dirname(File.expand_path(installer))
+            provisioning = true
+        end
+        [provisioning, installer, installer_path]
+    end
+
+    def prompt_installer
+        puts "Looking in #{Dir.home}/Downloads and #{base_path}/omnibus/pkg for installable #{@package_name} package."
+        # TODO allow config override of location, multiple locations, search pattern, max count?
+        files = Dir.glob("#{Dir.home}/Downloads/#{@package_name}*.deb") + Dir.glob("#{base_path}/omnibus/pkg/#{@package_name}*.deb")
+
+        if ENV[@installer_var]
+            if ENV[@installer_var] =~ /^.*#{@package_name}.*deb$/ and File.file?(ENV[@installer_var])
+                user_installer = File.expand_path(ENV[@installer_var])
+            else
+                puts "#{@installer_var} #{ENV[@installer_var]} is not a valid #{@package_name} package. Ignoring."
+            end
+        end
+
+        if files.length == 0 and not user_installer
+            return nil
+        end
+
+        files = files.sort_by{ |f| File.mtime(f) }.last(10)
+        files.reverse!
+        files << "[#{@installer_var}]: #{user_installer}" if user_installer
+
+        selection = 0
+
+        # For the fantastically lazy, allow an environment variable to specify
+        # which package selection to use. Special value of '-1' or 'installer' will
+        # use the INSTALLER env var automatically (instead of just putting it in
+        # the list to choose from).
+        if ENV.has_key? @autopackage_var
+
+            selection = ENV[@autopackage_var]
+            if (selection == 'installer' or selection == '-1') and user_installer
+                # Auto pick the INSTALLER pacckage
+                selection = files.length
+            else
+                selection = selection.to_i
+            end
+
+            if selection <= 0 or selection > files.length
+                puts "Invalid #{@autopackage_var} selection of #{selection}."
+                selection = get_selection(files)
+            else
+                puts "Using #{@autopackage_var} selection of #{files[selection - 1]}"
+            end
+
+        else
+            selection = get_selection(files)
+        end
+
+        if selection == files.length  and user_installer
+            user_installer # we munged the text on this one
+        else
+            files[selection - 1]
+        end
+
+    end
+
+    def get_selection(files)
+        selection = 0
+        files.each_index do |x|
+            puts " #{x+1}) #{files[x]}\n"
+        end
+        loop do
+            print "Select an image, or set the #{@installer_var} variable and run again: [1 - #{files.length}]: "
+            selection = $stdin.gets.chomp.to_i
+            break if selection > 0 and selection <= files.length
+        end
+        selection
+    end
+
+    def base_path
+        File.absolute_path(File.join(Dir.pwd, "../"))
+    end
 end


### PR DESCRIPTION
specify `analytics: true` in `config.yml` and you magically get an analytics VM that's configured to talk to your Chef Server VM. This allows you to use Chef Server, Reporting, and Analytics all with just a `vagrant up`.

This refactors the package prompt stuff upon `vagrant up` into a `PackagePrompt` class so different projects can share it.

The `chef-server.rb.erb` template is a bit wonky, as adding additional `vm.node-attributes.provisioning.chef-server-config` attributes didn't render correctly. 

TODO in future PRs: 
- NO DVM support, no projects mounted
- current Analytics release omnibus is on Chef 11, so misc tweaks to provisioning recipes
- make it easy to use the GUI