### PR TITLE
FLOW-67: ACL endpoints for policies and policy groups

### DIFF
--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
@@ -90,6 +90,20 @@ fetch_id(role, DbContext, Name, OrgId) ->
         #chef_role{authz_id = AuthzId} ->
             AuthzId
     end;
+fetch_id(policy, DbContext, Name, OrgId) ->
+    case chef_db:fetch(#oc_chef_policy{org_id = OrgId, name = Name}, DbContext) of
+        not_found ->
+            not_found;
+        #oc_chef_policy{authz_id = AuthzId} ->
+            AuthzId
+    end;
+fetch_id(policy_group, DbContext, Name, OrgId) ->
+    case chef_db:fetch(#oc_chef_policy_group{org_id = OrgId, name = Name}, DbContext) of
+        not_found ->
+            not_found;
+        #oc_chef_policy_group{authz_id = AuthzId} ->
+            AuthzId
+    end;
 fetch_id(group, #context{server_api_version = ApiVersion, reqid = ReqId}, Name, OrgId) ->
     % Yes, this is ugly, but functionally it's identical to the internal logic
     % of a regular group fetch, minus expanding the group members and such.
@@ -244,6 +258,10 @@ acl_path(client, AuthzId) ->
 acl_path(user, AuthzId) ->
     acl_path(actor, AuthzId);
 acl_path(organization, AuthzId) ->
+    acl_path(object, AuthzId);
+acl_path(policy, AuthzId) ->
+    acl_path(object, AuthzId);
+acl_path(policy_group, AuthzId) ->
     acl_path(object, AuthzId);
 acl_path(Type, AuthzId) ->
     "/" ++ type_to_resource(Type) ++ "/" ++ binary_to_list(AuthzId) ++ "/acl".

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -25,6 +25,10 @@
 % This must be before cookbooks section, otherwise "_acl" gets interpreted as a version
 {["organizations", organization_id, "cookbooks", cookbook_name, "_acl"],
  oc_chef_wm_acl, [{acl_object_type, cookbook}]}.
+{["organizations", organization_id, "policies", policy_name, "_acl"],
+ oc_chef_wm_acl, [{acl_object_type, policy}]}.
+{["organizations", organization_id, "policy_groups", policy_group_name, "_acl"],
+ oc_chef_wm_acl, [{acl_object_type, policy_group}]}.
 
 {["users", user_name, "_acl", acl_permission],
  oc_chef_wm_acl_permission, [{acl_object_type, user}]}.
@@ -46,6 +50,10 @@
   acl_permission], oc_chef_wm_acl_permission, [{acl_object_type, environment}]}.
 {["organizations", organization_id, "cookbooks", cookbook_name, "_acl", acl_permission],
  oc_chef_wm_acl_permission, [{acl_object_type, cookbook}]}.
+{["organizations", organization_id, "policies", policy_name, "_acl", acl_permission],
+ oc_chef_wm_acl_permission, [{acl_object_type, policy}]}.
+{["organizations", organization_id, "policy_groups", policy_group_name, "_acl", acl_permission],
+ oc_chef_wm_acl_permission, [{acl_object_type, policy_group}]}.
 
 {["organizations", organization_id, "cookbooks"], chef_wm_cookbooks, []}.
 %% 'qualifier' will be things like "_latest", "_recipes"

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -114,7 +114,7 @@ environment_not_found_message(EnvName) ->
 -spec not_found_message( node | role | data_bag | data_bag_item1 |
                          data_bag_item2 | client | data_bag_missing_for_item_post |
                          environment | sandbox | sandboxes | cookbook |
-                         cookbook_version | user | invitation,
+                         cookbook_version | user | invitation | policy | policy_group,
                          bin_or_string() | {bin_or_string(), bin_or_string()} ) -> ejson().
 not_found_message(node, Name) ->
     error_message_envelope(iolist_to_binary(["node '", Name, "' not found"]));
@@ -154,6 +154,8 @@ not_found_message(invitation, Id) ->
     {[{<<"error">>, iolist_to_binary(["Cannot find association request: ", Id])}]};
 not_found_message(key, {OwnerName, KeyName}) ->
     {[{<<"error">>, iolist_to_binary(["There is no key named ", KeyName, " associated with ", OwnerName, "."])}]};
+not_found_message(policy, Name) ->
+    error_message_envelope(iolist_to_binary(["policy '", Name, "' not found"]));
 not_found_message(policy_group, Name) ->
     error_message_envelope(iolist_to_binary(["policy_group '", Name, "' not found"])).
 
@@ -217,7 +219,8 @@ set_location_of_created_resource(Uri, Req0) when is_binary(Uri) ->
 %% the spec will be updated
 -spec object_name(cookbook | node | role | data_bag | data_bag_item |
                   environment | principal | sandbox | client | user |
-                  group | container | organization | invitation | key,
+                  group | container | organization | invitation | key |
+                  policy | policy_group,
                   Request :: #wm_reqdata{}) -> binary() | undefined.
 object_name(node, Req) ->
     extract_from_path(node_name, Req);
@@ -248,7 +251,11 @@ object_name(organization, Req) ->
 object_name(invitation, Req) ->
     extract_from_path(invitation_id, Req);
 object_name(key, Req) ->
-    extract_from_path(key_name, Req).
+    extract_from_path(key_name, Req);
+object_name(policy, Req) ->
+    extract_from_path(policy_name, Req);
+object_name(policy_group, Req) ->
+    extract_from_path(policy_group_name, Req).
 
 
 


### PR DESCRIPTION
This PR adds:

FLOW-155: ACL access for policies and policy groups (both read and write) to oc_erchef
FLOW-156: pedant test coverage for the endpoints
