### PR TITLE
Fixing upgrade instructions in package postinstall script

### DIFF
--- a/omnibus/package-scripts/chef-server/postinst
+++ b/omnibus/package-scripts/chef-server/postinst
@@ -48,7 +48,7 @@ if [ -e /etc/opscode/chef-server-running.json ]; then
   echo "(Add the '--no-op' option to see what would be removed by"
   echo "this command)"
   echo
-  echo "For verbose upgrade instructions please see:"
+  echo "For detailed upgrade instructions please see:"
   echo "https://docs.chef.io/upgrade_server.html"
 fi
 

--- a/omnibus/package-scripts/chef-server/postinst
+++ b/omnibus/package-scripts/chef-server/postinst
@@ -33,6 +33,11 @@ if [ -e /etc/opscode/chef-server-running.json ]; then
   echo
   echo -e "\033[1;31mchef-server-ctl upgrade\033[0m"
   echo
+  echo "After the upgrade command completes, your Chef services will"
+  echo "remain in a down state. To bring them back up run:"
+  echo
+  echo -e "\033[1;31mchef-server-ctl start\033[0m"
+  echo
   echo "Then, to remove configuration files, logs, directories,"
   echo "users, etc. that were used by internal services that"
   echo "have been removed from this version of Chef Server,"
@@ -42,6 +47,9 @@ if [ -e /etc/opscode/chef-server-running.json ]; then
   echo
   echo "(Add the '--no-op' option to see what would be removed by"
   echo "this command)"
+  echo
+  echo "For verbose upgrade instructions please see:"
+  echo "https://docs.chef.io/upgrade_server.html"
 fi
 
 exit 0


### PR DESCRIPTION
Fixing #646

Simply adding some information via echo to tell the user they need to run chef-server-ctl start after the upgrade command completes.

Currently if you follow our post-install packages instructions explicitly you end up with a chef-server with all of its services down. Adding an explicit chef-server-ctl start and a link to our verbose docs upgrade instructions corrects the situation.