### PR TITLE
Modify postgres preflight checks to have correct assumptions

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -28,6 +28,14 @@ class PreflightValidator
     end
   end
 
+  def first_run?
+    previous_run.nil?
+  end
+
+  def secrets_exists?
+    PrivateChef.existing_secrets.length > 0
+  end
+
   def backend?
     #
     # When these preflight checks are run, the chef-server.rb has been ingested into

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_postgres_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_postgres_validator_spec.rb
@@ -1,0 +1,110 @@
+require_relative '../../libraries/helper.rb'
+require_relative '../../libraries/preflight_checks.rb'
+require_relative '../../libraries/preflight_postgres_validator.rb'
+
+describe PostgresqlPreflightValidator do
+  let(:node) { { 'private_chef' => {'opscode-erchef' => { 'sql_user' => 'blah' }, 'oc_bifrost' => { 'sql_user' => 'blah' }, 'oc_id' => { 'sql_user' => 'blah' }} } }
+  let(:first_run_response) { false }
+  let(:secrets_exists_response) { false }
+  let(:postgres_validator) {
+    validator = PostgresqlPreflightValidator.new(node)
+
+    # This lets us control the result of external_bootstrap_done?
+    # by including let(:external_bootstrap_return) { true | false }
+    # within each test or context.
+    allow(validator)
+      .to receive(:first_run?)
+      .and_return(first_run_response)
+
+    allow(validator)
+      .to receive(:secrets_exists?)
+      .and_return(secrets_exists_response)
+
+    allow(validator)
+      .to receive(:backend_verify_database_access)
+
+    allow(validator)
+      .to receive(:backend_verify_postgres_version)
+
+    allow(validator)
+      .to receive(:connect_as)
+      .and_yield(Object.new)
+
+    validator
+  }
+
+  context "#backend_validation" do
+    context "when determining what it should validate" do
+      describe "when this is the first run and secrets exist" do
+        let (:first_run_response) { true }
+        let (:secrets_exists_response) { true }
+        it "does not check for existing databases or roles" do
+          expect(postgres_validator).to_not receive(:backend_verify_named_db_not_present)
+          expect(postgres_validator).to_not receive(:backend_verify_cs_roles_not_present)
+          postgres_validator.backend_validation
+        end
+      end
+
+      describe "when this is not the first run and secrets exist" do
+        let (:first_run_response) { false }
+        let (:secrets_exists_response) { true }
+        it "does check for existing databases and roles" do
+          expect(postgres_validator).to_not receive(:backend_verify_named_db_not_present)
+          expect(postgres_validator).to_not receive(:backend_verify_cs_roles_not_present)
+          postgres_validator.backend_validation
+        end
+      end
+
+      describe "when this is the first run and no secrets exist" do
+        let (:first_run_response) { true }
+        let (:secrets_exists_response) { false }
+        it "does check for existing databases and roles" do
+          expect(postgres_validator)
+            .to receive(:backend_verify_cs_roles_not_present)
+              .at_least(:once)
+          expect(postgres_validator)
+            .to receive(:backend_verify_named_db_not_present)
+              .at_least(:once)
+          postgres_validator.backend_validation
+        end
+      end
+
+      describe "when this is not the first run and no secrets exist" do
+        let (:first_run_response) { false }
+        let (:secrets_exists_response) { false }
+        it "does not check for existing databases or roles" do
+          expect(postgres_validator).to_not receive(:backend_verify_named_db_not_present)
+          expect(postgres_validator).to_not receive(:backend_verify_cs_roles_not_present)
+          postgres_validator.backend_validation
+        end
+      end
+    end
+  end
+
+  context "#backend_verify_named_db_not_present" do
+    it "throws an error if the database does exist" do
+      allow(postgres_validator).to receive(:named_db_exists?).and_return true
+      expect {postgres_validator.backend_verify_named_db_not_present(Object.new, "any_database")}
+        .to raise_error PreflightValidationFailed, /CSPG016/
+    end
+
+    it "does not throw an error if the database does not exist" do
+      allow(postgres_validator).to receive(:named_db_exists?).and_return false
+      expect {postgres_validator.backend_verify_named_db_not_present(Object.new, "any_database")}
+        .not_to raise_error
+    end
+  end
+
+  context "#backend_verify_cs_roles_not_present" do
+    it "throws an error if the role does exist" do
+      expect(postgres_validator).to receive(:named_role_exists?)
+      allow(postgres_validator).to receive(:named_role_exists?).and_return true
+      expect {postgres_validator.backend_verify_cs_roles_not_present(Object.new)}.to raise_error PreflightValidationFailed, /CSPG017/
+    end
+
+    it "does not throw an error if the role does not exist" do
+      allow(postgres_validator).to receive(:named_role_exists?).and_return false
+      expect {postgres_validator.backend_verify_cs_roles_not_present(Object.new)}.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
- We now look for combination of previous run and secrets when
  deciding whether or not to check for existing databases and roles.
  Previously, we looked only for the presence of a previous run which
  was wrong because front end nodes won't always have a
  chef-server-running.json copied over, but they should always have
  private-chef-secrets.json in place prior to the initial reconfigure.

- Added first_run? and secrets_exist? to PreflightValidator to make
  logic and testing more clear.

- Added preflight_postgres_validator_spec.rb
  - Added test for existing errors CSPG016 and CSPG017
  - Added tests of backend_validation for previous_run and secrets

- Fixes #599