### PR TITLE
svlogd can't write with /var/log at 0700

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -145,6 +145,11 @@ directory "/var/opt/opscode" do
   action :create
 end
 
+directory "/var/log" do
+  mode "0755"
+  action :create
+end
+
 directory "/var/log/opscode" do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']


### PR DESCRIPTION
Some customers set /var/log 's mode to 0700, which breaks Chef Server 12.3.1+ initial reconfigure.

/var/log/opscode is either not present or unwritable even if present and the reconfigure fails.