### PR TITLE
Set rabbitmq_management listener IP to rabbitmq node_ip_address

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/rabbitmq.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/rabbitmq.config.erb
@@ -8,7 +8,7 @@
   ]},
  {rabbitmq_management,
      [{listener, [
-               {ip, "<%= node['private_chef']['rabbitmq']['vip'] %>"},
+               {ip, "<%= node['private_chef']['rabbitmq']['node_ip_address'] %>"},
                {port,     <%= node['private_chef']['rabbitmq']['management_port'] %> },
                {ssl,      true}
                % The Rabbit Management Plugin will use the global Rabbit SSL Config


### PR DESCRIPTION
Fixes https://github.com/chef/chef-server/issues/686

@irvingpop @stevendanna please let me know what else needs to be done to merge this.

ChangeLog-Entry: Set rabbitmq_management listener IP to rabbitmq node_ip_address instead of rabbitmq vip