### PR TITLE
Allow opt-out of RVM/bundler busting in knife pedant tests

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/knife_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/knife_util.rb
@@ -73,17 +73,30 @@ module Pedant
         # Convenience method for creating a Mixlib::ShellOut representation
         # of a knife command in our test repository
         def shell_out(command_line)
-          # All the environment variable munging is so Bundler doesn't
-          # poison things, since we don't include a Chef gem
-          Mixlib::ShellOut.new(command_line, {
+          Mixlib::ShellOut.new(command_line,
                                  'cwd' => cwd,
-                                 'env' => {
-                                   'BUNDLE_GEMFILE' => nil,
-                                   'BUNDLE_BIN_PATH' => nil,
-                                   'GEM_PATH' => nil,
-                                   'GEM_HOME' => nil,
-                                   'RUBYOPT' => nil
-                                 }})
+                                 'env' => command_environment)
+        end
+
+        # When running pedant in a standalone configuration, Bundler will
+        # prevent `knife` from running properly because pedant doesn't have a
+        # dependency on Chef. However, unsetting all the ruby/bundler
+        # environment variables will prevent these tests from working correctly
+        # when run from a bundle that includes chef and is running under RVM.
+        # Set the `PEDANT_ALLOW_RVM` environment variable (to anything) to opt
+        # out of the bundle/rvm busting mode.
+        def command_environment
+          if ENV["PEDANT_ALLOW_RVM"]
+            {}
+          else
+            {
+              'BUNDLE_GEMFILE' => nil,
+              'BUNDLE_BIN_PATH' => nil,
+              'GEM_PATH' => nil,
+              'GEM_HOME' => nil,
+              'RUBYOPT' => nil
+            }
+          end
         end
 
         # Convenience method for actually running a knife command in our


### PR DESCRIPTION
Travis runs ruby using rvm, but the environment variable munging we're doing to run knife in the pedant tests is breaking rvm. In order to run these tests against Chef Zero, we need a way to opt-out. Since Chef Zero includes Chef in its bundle, it's also not necessary to "bundle bust" the command, so I made the opt-out disable that as well. Since my goal is to make this work on travis, the easiest path to take is to switch on an environment variable, but I could make this part of pedant's config if there's a desire to do that instead.

This seems to have fixed https://github.com/chef/chef-zero/pull/188 (there was an error on the travis side, so travis is in the process of re-running those things right now).

@chef/chef-server-maintainers 