### PR TITLE
Add validation tag to header validation test

### DIFF
--- a/oc-chef-pedant/spec/api/header_spec.rb
+++ b/oc-chef-pedant/spec/api/header_spec.rb
@@ -24,7 +24,7 @@ describe "Headers", :headers do
         })
     end
 
-    it "Rejects Low Version" do
+    it "Rejects Low Version", :validation do
       get(request_url, requestor, :headers => low_version_headers).should look_like({
           :status => 400
         })


### PR DESCRIPTION
...so Chef Zero can skip them because it doesn't implement checking for things that are 400s.

@chef/chef-server-maintainers 