### PR TITLE
[bookshelf/omnibus] Convert storage_type to a string consistently

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -670,7 +670,7 @@ default['private_chef']['bookshelf']['port'] = 4321
 default['private_chef']['bookshelf']['stream_download'] = true
 # Default: set to Host: header. Override to hardcode a url, "http://..."
 default['private_chef']['bookshelf']['external_url'] = :host_header
-default['private_chef']['bookshelf']['storage_type'] = :filesystem
+default['private_chef']['bookshelf']['storage_type'] = 'filesystem'
 # This retries connections that are rejected because pooler queue is maxed out.
 default['private_chef']['bookshelf']['sql_retry_count'] = 0
 # Intervals are in milliseconds

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bookshelf_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bookshelf_validator.rb
@@ -38,11 +38,11 @@ class BookshelfPreflightValidator < PreflightValidator
       true
     else
       previous_value = previous_run['bookshelf']['storage_type']
-      current_value = user_attrs['storage_type'] || :filesystem
+      current_value = user_attrs['storage_type'] || 'filesystem'
 
-      if previous_value.nil? && current_value.to_s == 'filesystem' # case (2)
+      if previous_value.nil? && current_value == 'filesystem' # case (2)
         true
-      elsif previous_value.nil? && current_value.to_s != "filesystem" # case (3)
+      elsif previous_value.nil? && current_value != "filesystem" # case (3)
         fail_with <<EOM
 
 Bookshelf's storage_type was previously the default of 'filesystem';
@@ -52,11 +52,11 @@ bookshelf storage_type post-installation.
 
 Please set
 
-bookshelf['storage_type'] = :filesystem
+bookshelf['storage_type'] = 'filesystem'
 
 in /etc/opscode/chef-server.rb or leave it unset.
 EOM
-      elsif previous_value.to_s == current_value.to_s # case (5)
+      elsif previous_value == current_value # case (5)
         true
       else # everything else is invalid, including case 4 above
         fail_with <<EOM
@@ -67,7 +67,7 @@ At this time it is not possible to change the bookshelf storage_type post-instal
 
 Please set
 
-bookshelf['storage_type'] = :#{previous_value}
+bookshelf['storage_type'] = '#{previous_value}'
 
 in /etc/opscode/chef-server.rb
 EOM

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -36,7 +36,7 @@ class PostgresqlPreflightValidator < PreflightValidator
   end
 
   def bookshelf_in_sql?
-    @cs_pg_attr['bookshelf'] && @cs_pg_attr['bookshelf']['storage_type'].to_s == "sql"
+    @cs_pg_attr['bookshelf'] && @cs_pg_attr['bookshelf']['storage_type'] == "sql"
   end
 
   def databases_to_check

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -132,6 +132,12 @@ module PrivateChef
       end
     end
 
+    # Mutate PrivateChef to account for common cases of user-provided
+    # types not being what we want
+    def transform_to_consistent_types
+      PrivateChef['bookshelf']['storage_type'] = PrivateChef['bookshelf']['storage_type'].to_s
+    end
+
     VALID_EXTENSION_CONFIGS = %i{server_config_required config_values gen_backend gen_frontend gen_secrets gen_api_fqdn} unless defined?(VALID_EXTENSION_CONFIGS)
     def register_extension(name, extension)
       bad_keys = extension.keys - VALID_EXTENSION_CONFIGS
@@ -796,6 +802,7 @@ EOF
 
       # Transition Solr memory and JVM settings from OSC11 to Chef 12.
       import_legacy_service_config("opscode_solr", "opscode_solr4", ["heap_size", "new_size", "java_opts"])
+      transform_to_consistent_types
 
       PrivateChef["nginx"]["enable_ipv6"] ||= PrivateChef["use_ipv6"]
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql-external.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql-external.rb
@@ -20,5 +20,5 @@ if is_data_master? and node['private_chef']['postgresql']['external']
   include_recipe "private-chef::erchef_database"
   include_recipe "private-chef::bifrost_database"
   include_recipe "private-chef::oc_id_database"
-  include_recipe "private-chef::bookshelf_database" if node["private_chef"]["bookshelf"]["storage_type"].to_s == "sql"
+  include_recipe "private-chef::bookshelf_database" if node["private_chef"]["bookshelf"]["storage_type"] == "sql"
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -165,5 +165,5 @@ ERR
   include_recipe "private-chef::erchef_database"
   include_recipe "private-chef::bifrost_database"
   include_recipe "private-chef::oc_id_database"
-  include_recipe "private-chef::bookshelf_database" if node["private_chef"]["bookshelf"]["storage_type"].to_s == "sql"
+  include_recipe "private-chef::bookshelf_database" if node["private_chef"]["bookshelf"]["storage_type"] == "sql"
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bookshelf_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bookshelf_validator_spec.rb
@@ -47,11 +47,6 @@ describe BookshelfPreflightValidator do
         expect(subject.verify_storage_type_unchanged).to eq(true)
       end
 
-      it "succeeds if set to :filesystem" do
-        expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({'storage_type' => :filesystem})
-        expect(subject.verify_storage_type_unchanged).to eq(true)
-      end
-
       it "succeeds if not set" do
         expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({})
         expect(subject.verify_storage_type_unchanged).to eq(true)
@@ -79,11 +74,6 @@ describe BookshelfPreflightValidator do
 
       it "succceds if set to the same value as before" do
         expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({'storage_type' => 'sql'})
-        expect(subject.verify_storage_type_unchanged).to eq(true)
-      end
-
-      it "succceds if set to the same value as before but as a symbol" do
-        expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({'storage_type' => :sql})
         expect(subject.verify_storage_type_unchanged).to eq(true)
       end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -102,6 +102,18 @@ EOF
     end
   end
 
+  context "when given types that need to be converted" do
+    let(:config) { <<-EOF
+bookshelf['storage_type'] = :filesystem
+EOF
+    }
+
+    it "coverts bookshelf storage_type to a string" do
+      rendered_config = config_for("api.chef.io")
+      expect(rendered_config["private_chef"]["bookshelf"]["storage_type"]).to eq("filesystem")
+    end
+  end
+
   context "in a standalone topology" do
     let(:config) { <<-EOF
 topology "standalone"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -80,7 +80,7 @@
               {port, <%= @port %>},
               {storage_type, <%= @storage_type %>},
               {disk_store, "<%= @data_dir %>"},
-<% if @storage_type.to_s == "sql" -%>
+<% if @storage_type == "sql" -%>
               {sql_retry_count, <%= @sql_retry_count -%>},
               {sql_retry_delay, <%= @sql_retry_delay -%>},
               {abandoned_upload_cleanup_interval, <%= @abandoned_upload_cleanup_interval -%>},
@@ -89,7 +89,7 @@
               {stream_download, <%= @stream_download %>},
               {log_dir, "<%= @log_directory %>"}
              ]},
-<% if @storage_type.to_s == "sql" -%>
+<% if @storage_type == "sql" -%>
  {sqerl, [
            {db_driver_mod, sqerl_pgsql_client},
            {config_cb, {chef_secrets_sqerl, config, [{<<"bookshelf">>, <<"sql_password">>}]}},


### PR DESCRIPTION
A new function, transform_to_consistent_types, now converts the
bookshelf storage_type config value to a string when parsing the
user-provided configuration. Internally, we now assume that it is always
a string.
