### PR TITLE
[dvm] change dvm install package attr name

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -62,7 +62,7 @@ def define_chef_server(config, attributes)
   end
   if provisioning
     json = {
-      "packages" => attributes["vm"]["packages"],
+      "install_packages" => attributes["vm"]["packages"],
       "tz" => host_timezone,
       "omnibus-autoload" => attributes["vm"]["omnibus-autoload"]
     }.merge attributes["vm"]["node-attributes"]

--- a/dev/cookbooks/dev/recipes/system.rb
+++ b/dev/cookbooks/dev/recipes/system.rb
@@ -1,7 +1,7 @@
 ## System setup
 # Hey neat - our packages have chef from master now
 # which means we can:
-package node['packages']
+package node['install_packages']
 
 # Time and zone should match the host so that erlang's sync module plays nicely with rsync'd files.
 file "/etc/timezone" do


### PR DESCRIPTION
Ohai recently added a 'packages' top-level attribute, which
doesn't place nicely with dvm's usage of node['packages'] to
capture which additional packages to install at startup.

This change just renames the attribute to install_packages to avoid
conflict.