### PR TITLE
expand release process doc post-release steps, includes pin of Chef Client

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -127,10 +127,35 @@ based on the branch you just created.
 - [ ] Send an email to the chef and chef-dev mailing lists announcing
 the release with a link to the blog post.
 
-Chef Server is now released.
 
 ## Post Release
 
-- [ ] Bump the Chef Server version number in
-  `omnibus/config/projects/chef-server.rb` for development to the next
-  logical version number.
+Before the release can be considered complete, the following
+post-release steps must be performed;
+
+- [ ] in `omnibus/config/projects/chef-server.rb`:
+  - [ ] Bump the Chef Server version number for development to the next logical
+        version number.
+  - [ ] Update chef client to the latest stable chef-client version via
+        `override :chef`.  This may include updates to major and minor
+        versions.
+  - [ ] Update `override` versions of components that are listed
+        with `override` versions to the latest stable patch release
+        within the current major.minor version.
+- [ ] in `omnibus/config/software`, update components to latest stable
+      patch release within the current major.minor version.
+- [ ] Perform `berks update` in `omnibus/`
+- [ ] Perform `bundle update` in:
+  - [ ] `oc-chef-pedant/`
+  - [ ] `src/oc-id/`
+  - [ ] `omnibus/`
+- [ ] Perform `./rebar3 update  && ./rebar3 unlock && ./rebar3 upgrade` in:
+  - [ ] `bookshelf`
+  - [ ] `oc_erchef`
+  - [ ] `oc_bifrost`
+- [ ] Submit a post-release PR with these changes and confirm no errors
+      in the Travis CI and our internal CI pipeline.  Merge after
+      review.
+
+Chef Server is now released and ready for the next round of updates.
+


### PR DESCRIPTION
These changes to post-release process will ensure the various components
and dependencies bundled with Chef Server are kept up to date with the
latest security and bug fixes.  Making these part of the post-release process 
also ensures that the changes are in place before work on the new release begins, 
so that we work through a full release with the updates in place.

This also locks the bundled Chef Client to the currently released stable
version at the start of development for a new release.
