### PR TITLE
[chef-server-ctl] Cleanse bookshelf database when storage_type is sql

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/chef-server-ctl
+++ b/omnibus/files/private-chef-ctl-commands/chef-server-ctl
@@ -13,8 +13,8 @@ module Omnibus
       d = [%w{oc_bifrost bifrost},
            %w{opscode-erchef opscode_chef},
            %w{oc_id oc_id}]
-      if running_service_config('bookshelf')['storage_mode'] == 'sql'
-        d << [%w{bookshelf bookshelf}]
+      if running_service_config('bookshelf')['storage_type'] == 'sql'
+        d << %w{bookshelf bookshelf}
       end
       d
     end


### PR DESCRIPTION
The key is storage_type, not storage_mode.