### PR TITLE
Updating gatling-rsync configuration

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -19,6 +19,12 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.ssh.forward_agent = true
 
+  # This plugin allows for a much more efficient sync than the vanilla rsync-auto command
+  # see https://github.com/smerrill/vagrant-gatling-rsync
+  if Vagrant.has_plugin?('vagrant-gatling-rsync')
+    config.gatling.rsync_on_startup = false
+  end
+
   if attributes['vm'].has_key? 'postgresql'
     if attributes['vm']['postgresql']['start']
       config.vm.define("database") do |c|


### PR DESCRIPTION
This is to fix a change in `0.9.0` version of
`vagrant-gatling-rsync` where rsync will run by default. Here's the
changelog from the plugin:
https://github.com/smerrill/vagrant-gatling-rsync/blob/v0.9.0/CHANGELOG.md#090-june-28-2015.