### PR TITLE
Upgrade Posgtresql to 9.2.15.

### DIFF
--- a/omnibus/config/software/postgresql92.rb
+++ b/omnibus/config/software/postgresql92.rb
@@ -1,5 +1,5 @@
-#
-# Copyright 2012-2014 Chef Software, Inc.
+#1
+# Copyright 2012-2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
 #
 
 name "postgresql92"
-default_version "9.2.14"
+default_version "9.2.15"
 
-source url: "http://ftp.postgresql.org/pub/source/v9.2.14/postgresql-9.2.14.tar.bz2",
-       md5: "ce2e50565983a14995f5dbcd3c35b627"
+source url: "https://ftp.postgresql.org/pub/source/v9.2.15/postgresql-9.2.15.tar.bz2",
+       md5: "235b4fc09eff4569a7972be65c449ecc"
 
 dependency "zlib"
 dependency "openssl"
@@ -26,7 +26,7 @@ dependency "libedit"
 dependency "ncurses"
 dependency "libossp-uuid"
 
-relative_path "postgresql-9.2.14"
+relative_path "postgresql-9.2.15"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
This mitigates CVE-2016-0773.

As a side note, is there any reason not to update this in omnibus-software and then just reference the correct version? I didn't see anything in the files which would compile them differently.