### PR TITLE
Bumping private-chef's enterprise cookbook dependency to 0.10.0

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/Berksfile
+++ b/omnibus/files/private-chef-cookbooks/private-chef/Berksfile
@@ -2,7 +2,7 @@ site :opscode
 
 metadata
 
-cookbook 'enterprise', :git => 'https://github.com/opscode-cookbooks/enterprise-chef-common', :tag => '0.5.1'
+cookbook 'enterprise', :git => 'https://github.com/chef-cookbooks/enterprise-chef-common', :tag => '0.10.0'
 cookbook 'chef-ha-drbd', :path => '../chef-ha-drbd'
 cookbook 'apt', '~> 2.0'
 cookbook 'yum', '~> 3.0'


### PR DESCRIPTION
We need to bump our enterprise dependency to pull in downstream fixes.

Wilson build: http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/50/