### PR TITLE
Add logic to support configure yum repos for Amazon Linux (#741)

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_repository.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_repository.rb
@@ -26,7 +26,12 @@ when 'debian'
 
 when 'rhel'
 
-  major_version = node['platform_version'].split('.').first
+  major_version = if node['platform'] == 'amazon' then
+                    '7' # Hard-code to EL7 for Amazon Linux.  the platform_version on AL
+                        # looks like '2015.09' which doesn't then make a valid yum repo path
+                    else
+                      node['platform_version'].split('.').first
+                    end
 
   gpg_key_path = File.join(node['private_chef']['install_path'], "/embedded/keys/packages-chef-io-public.key")
 


### PR DESCRIPTION
We need to hard-code AL to use EL7 repositories

ChangeLog-Entry: [omnibus] [chef-server/741] Support chef-server-ctl install on Amazon Linux