### PR TITLE
Increase default nginx server_names_hash_bucket_size to 128 from 64

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -473,6 +473,7 @@ default['private_chef']['nginx']['gzip_types'] = [ "text/plain", "text/css", "ap
 default['private_chef']['nginx']['keepalive_timeout'] = 65
 default['private_chef']['nginx']['client_max_body_size'] = '250m'
 default['private_chef']['nginx']['cache_max_size'] = '5000m'
+default['private_chef']['nginx']['server_names_hash_bucket_size'] = 128
 default['private_chef']['nginx']['enable_ipv6'] = false
 
 ###
@@ -600,7 +601,7 @@ default['private_chef']['bookshelf']['secret_access_key'] = "generated-by-defaul
 # Default: set to Host: header. Override to hardcode a url, "http://..."
 default['private_chef']['bookshelf']['external_url'] = :host_header
 default['private_chef']['bookshelf']['storage_type'] = :filesystem
-# This retries connections that are rejected because pooler queue is maxed out. 
+# This retries connections that are rejected because pooler queue is maxed out.
 default['private_chef']['bookshelf']['sql_retry_count'] = 0
 # Intervals are in milliseconds
 default['private_chef']['bookshelf']['sql_retry_delay'] = 10

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -8,6 +8,8 @@ events {
   worker_connections <%= @worker_connections %>;
 }
 
+server_names_hash_bucket_size <%= @server_names_hash_bucket_size %>;
+
 http {
 <% if node['private_chef']['nginx']['log_x_forwarded_for'] -%>
   log_format opscode '$http_x_forwarded_for - $remote_user [$time_local]  '


### PR DESCRIPTION
This is needed on standalone/combined installs on EC2 where the
combination of several long DNS names can take you over the default
hash_bucket_size.

ChangeLog-Entry: [omnibus] [chef-server/743] Increase default nginx
server_names_hash_bucket_size to 128 from 64

Fixes https://github.com/chef/chef-server/issues/743

How to repro on EC2:
1. Set the api_fqdn for chef-server.rb to the external FQDN
2. Set the fqdn in manage.rb to another name, e.g. a CNAME to that FQDN

Do reconfigure on manage and chef-server.  nginx will start throwing the errors if bucket_size is 64.