### PR TITLE
Make org creation optional in APIv1 spec

### DIFF
--- a/oc-chef-pedant/spec/api/versioned_behaviors/server_api_v1_spec.rb
+++ b/oc-chef-pedant/spec/api/versioned_behaviors/server_api_v1_spec.rb
@@ -7,7 +7,15 @@ describe "Server API v1 Behaviors", :api_v1 do
   context "[v1+]" do
     shared(:pubkey_regex) { /^(-----BEGIN (RSA )?PUBLIC KEY)/ }
     shared(:privkey_regex) { /^(-----BEGIN (RSA )?PRIVATE KEY)/ }
-    shared(:org_name) { @org_name ||= unique_name("api-v1-org")}
+
+    shared(:org_name) do
+      if Pedant.config[:org][:create_me]
+        unique_name("api-v1-org")
+      else
+        Pedant.config[:org][:name]
+      end
+    end
+
     shared(:org_client_url){ "#{platform.server}/organizations/#{org_name}/clients" }
     shared(:user_url){ "#{platform.server}/users" }
     shared(:client_name) { unique_name("api-v1-client") }
@@ -15,7 +23,6 @@ describe "Server API v1 Behaviors", :api_v1 do
     shared(:named_client_url) { "#{org_client_url}/#{client_name}" }
     shared(:named_user_url) { "#{user_url}/#{user_name}" }
     shared(:valid_pubkey) { @valid_pubkey ||= platform.gen_rsa_key("client-v1-test")[:public]}
-    shared(:org) { $org }
     shared(:default_client_payload) {
       {
           "name" => client_name,
@@ -38,11 +45,16 @@ describe "Server API v1 Behaviors", :api_v1 do
       # Note that a client is created by the server during org creation,
       # so we'll want to set our api version from the start.
       platform.use_max_server_api_version
-      $org = platform.create_org(org_name)
+
+      if Pedant.config[:org][:create_me]
+        platform.create_org(org_name)
+      end
     end
 
     after(:all) do
-      platform.delete_org(org_name)
+      if Pedant.config[:org][:create_me]
+        platform.delete_org(org_name)
+      end
       platform.reset_server_api_version
     end
     context "org creation", :organizations do


### PR DESCRIPTION
This makes pedant fail when running against servers that don't have multi-org (Chef Zero in ChefFS mode).