### PR TITLE
[omnibus] Remove old access_by_lua nginx config and allow custom acce…

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -402,6 +402,7 @@ default['private_chef']['lb']['redis_connection_pool_size'] = 250
 default['private_chef']['lb']['maint_refresh_interval'] = 600
 default['private_chef']['lb']['ban_refresh_interval'] = 600
 default['private_chef']['lb']['chef_min_version'] = 10
+default['private_chef']['lb']['access_by_lua_file'] = false
 
 ###
 # Load balancer route configuration

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -93,21 +93,13 @@
     location / {
       satisfy any;
 
-      access_by_lua '
-        if ngx.var.http_x_ops_userid then
-          -- we will pass this access check since this is to be treated
-          -- as an REST API invocation.  As long as we pass, the request will
-          -- continue since we specified "satisfy any"
-          return
-        else
-          -- by exiting this way, we will force nginx to
-          -- also evaluate the subnets above because either this access
-          -- check must pass, OR the allow/deny must pass due to "satisfy any"
-          -- We are effectively saying here: "ok, this request is going to go
-          -- to manage, so apply those other access rules first."
-          ngx.exit(ngx.DECLINED)
-        end
-      ';
+      <% if @access_by_lua_file %>
+      # access_by_lua_file acts as an access phase handler and executes Lua code
+      # contained in the given file for every request.  This is disabled by
+      # default, separate from the lua dispatch routing, and intended to do
+      # initial access authentication.
+      access_by_lua_file '<%= @access_by_lua_file %>';
+      <% end %>
 
       set $mode "api";
       set $upstream "";


### PR DESCRIPTION
This removes the old `access_by_lua` entry that probably could have been removed in https://github.com/chef/chef-server/commit/f22c1f111e94751f5b1d02227390fa10fe964478

It will also allow us to set an `access_by_lua_file` location in `chef-server.rb` which is super useful for some work that we have to do for cloud marketplaces.