### PR TITLE
Update rubocop definition to prevent errors.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/.rubocop.yml
+++ b/omnibus/files/private-chef-cookbooks/private-chef/.rubocop.yml
@@ -26,7 +26,7 @@ MethodLength:
   Enabled: false
 SignalException:
   Enabled: false
-TrailingComma:
+TrailingCommaInLiteral:
   Enabled: false
 WordArray:
   Enabled: false


### PR DESCRIPTION
TrailingComma moved from depricated to removed and is consequently causing errors.
Updated to TrailingCommaInLiteral to match the new definition.