### PR TITLE
Added event reporting to a file for insights

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -93,6 +93,11 @@ default['private_chef']['opscode-solr']['data_dir'] = "/var/opt/opscode/opscode-
 ####
 default['private_chef']['server-api-version'] = 0
 
+####
+# Inisghts
+####
+default['private_chef']['insights']['enable'] = false
+default['private_chef']['insights']['log_dir'] = '/var/log/insights'
 
 ####
 # RabbitMQ

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -7,10 +7,12 @@
 opscode_erchef_dir = node['private_chef']['opscode-erchef']['dir']
 opscode_erchef_log_dir = node['private_chef']['opscode-erchef']['log_directory']
 opscode_erchef_sasl_log_dir = File.join(opscode_erchef_log_dir, "sasl")
+insights_log_dir = node['private_chef']['insights']['log_dir']
 [
   opscode_erchef_dir,
   opscode_erchef_log_dir,
-  opscode_erchef_sasl_log_dir
+  opscode_erchef_sasl_log_dir,
+  insights_log_dir
 ].each do |dir_name|
   directory dir_name do
     owner OmnibusHelper.new(node).ownership['owner']

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -75,6 +75,8 @@
               {authz_fanout, <%= node['private_chef']['opscode-erchef']['authz_fanout'] %>},
 
               {enable_actions, <%= node['private_chef']['dark_launch']['actions'] %>},
+              {enable_insights, <%= node['private_chef']['insights']['enable']%>},
+              {insights_log, "<%= node['private_chef']['insights']['log_dir'] %>"},
               <% if @ldap_enabled -%>
               {ldap, [{host, "<%= @helper.normalize_host(node['private_chef']['ldap']['host']) || "localhost" %>"},
                       {port, <%= node['private_chef']['ldap']['port'] || (@ssl_enabled ? 636 : 389) %> },
@@ -145,7 +147,7 @@
                           ]}
             ]},
 
- 
+
   {chef_authn, [
                 {keyring, [{default, "/etc/opscode/webui_pub.pem"}]},
                 <% unless node['private_chef']['opscode-erchef']['keygen_cache_workers'] == :auto -%>

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
@@ -93,15 +93,12 @@ log_action(Req, #base_state{resource_state = ResourceState} = State) ->
 -spec  log_action0(Req :: wm_req(),
                    State :: #base_state{}) -> ok.
 log_action0(Req, #base_state{resource_state = ResourceState} = State) ->
-    ShouldSendBody = envy:get(oc_chef_wm, enable_actions_body, true, boolean),
+    ShouldSendInsights = envy:get(oc_chef_wm, enable_insights, boolean),
     {FullActionPayload, EntityType, EntitySpecificPayload} = extract_entity_info(Req, ResourceState),
-    Payload = case ShouldSendBody of
-        true -> FullActionPayload;
-        false -> []
-    end,
     Task = task(Req, State),
     MsgType = routing_key(EntityType, Task),
-    Msg = construct_payload(Payload, Task, Req, State, EntitySpecificPayload),
+    Msg = construct_payload(FullActionPayload, Task, Req, State, EntitySpecificPayload),
+    oc_chef_action_insights:ingest(ShouldSendInsights, Msg),
     publish(MsgType, Msg).
 
 %%

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action_insights.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action_insights.erl
@@ -1,0 +1,27 @@
+%% Copyright 2012-2014 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(oc_chef_action_insights).
+
+-export([ingest/2]).
+
+-spec ingest(ShouldSend :: boolean(), Data :: binary()) -> ok.
+ingest(true, Data) ->
+    InsightsLogDir = envy:get(oc_chef_wm, insights_log, string),
+    InsightsLog = filename:join(InsightsLogDir, "insights"),
+    ok = file:write_file(InsightsLog, Data, [append]);
+ingest(false, _) -> ok.

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
@@ -340,26 +340,7 @@ end_to_end_test_() ->
                           end)
      end,
      fun(_) -> oc_chef_wm_test_utils:cleanup(MockedModules) end,
-     [{"end to end client test, action create with no payload",
-       fun() -> ExpectedMsg = msg(<<"create">>),
-                meck:expect(wrq, method, fun(req) -> 'POST' end),
-                AssertPublishDataCorrect =
-                   fun(_ServerName, RoutingKey, _Message) ->
-                       ?assertEqual(<<"erchef.node.create">>, RoutingKey),
-                       ok
-                   end,
-               meck:expect(bunny_util, new_message, fun(Data) ->
-                  ?assertEqual(ExpectedMsg, chef_json:decode(Data)),
-                  msg
-               end),
-               meck:expect(bunny_util, set_delivery_mode, fun(msg, 2) -> undefined end),
-               meck:expect(bunnyc, publish, AssertPublishDataCorrect),
-               application:set_env(oc_chef_wm, enable_actions_body, false),
-               Ret = oc_chef_action:log_action(req, State),
-               ?assertEqual(ok, Ret)
-       end
-     },
-     {"end to end client test, action create with payload",
+     [{"end to end client test, action create with payload",
        fun() -> ExpectedMsg = msg_with_payload(<<"create">>),
                 meck:expect(wrq, method, fun(req) -> 'POST' end),
                 AssertPublishDataCorrect =
@@ -373,30 +354,14 @@ end_to_end_test_() ->
                 end),
                 meck:expect(bunny_util, set_delivery_mode, fun(msg, 2) -> undefined end ),
                 meck:expect(bunnyc, publish, AssertPublishDataCorrect),
-                application:set_env(oc_chef_wm, enable_actions_body, true),
+                application:set_env(oc_chef_wm, enable_insights, true),
+                meck:expect(oc_chef_action_insights, ingest, fun(true, ActualMsg) ->
+                    ?assertEqual(ExpectedMsg, chef_json:decode(ActualMsg))
+                end),
                 Ret = oc_chef_action:log_action(req, State),
                 ?assertEqual(ok, Ret)
         end
       },
-      {"end to end client test, action delete with no payload",
-       fun() -> ExpectedMsg = msg(<<"delete">>),
-                meck:expect(wrq, method, fun(req) -> 'DELETE' end),
-                AssertPublishDataCorrect =
-                   fun(_ServerName, RoutingKey, _Message) ->
-                       ?assertEqual(<<"erchef.node.delete">>, RoutingKey),
-                       ok
-                   end,
-                meck:expect(bunny_util, new_message, fun(Data) ->
-                  ?assertEqual(ExpectedMsg, chef_json:decode(Data)),
-                  msg
-                end),
-               meck:expect(bunny_util, set_delivery_mode, fun(msg, 2) -> undefined end ),
-               meck:expect(bunnyc, publish, AssertPublishDataCorrect),
-               application:set_env(oc_chef_wm, enable_actions_body, false),
-               Ret = oc_chef_action:log_action(req, State),
-               ?assertEqual(ok, Ret)
-        end
-       },
       {"end to end client test, action delete with data",
        fun() -> ExpectedMsg = msg_with_payload(<<"delete">>),
                 meck:expect(wrq, method, fun(req) -> 'DELETE' end),
@@ -410,8 +375,11 @@ end_to_end_test_() ->
                   msg
                 end),
                 meck:expect(bunny_util, set_delivery_mode, fun(msg, 2) -> undefined end ),
+                application:set_env(oc_chef_wm, enable_insights, true),
+                meck:expect(oc_chef_action_insights, ingest, fun(true, ActualMsg) ->
+                    ?assertEqual(ExpectedMsg, chef_json:decode(ActualMsg))
+                end),
                 meck:expect(bunnyc, publish, AssertPublishDataCorrect),
-                application:set_env(oc_chef_wm, enable_actions_body, true),
                 Ret = oc_chef_action:log_action(req, State),
                 ?assertEqual(ok, Ret)
         end


### PR DESCRIPTION
* This is	the first step in adding Insights eventing to chef-server for action events.
* Initially, Insights will hook into the same action eventing system as Analytics to consume the same events.
* Insights will need chef-server to persist its events to a file from which Insights will consume.