### PR TITLE
Added GET /groups/:group/transitive_member/actors/:actor endpoint for checking recursive membership.

### DIFF
--- a/src/oc_bifrost/apps/bifrost/priv/dispatch.conf
+++ b/src/oc_bifrost/apps/bifrost/priv/dispatch.conf
@@ -39,6 +39,12 @@
 {["groups", id, "groups", member_id],
  bifrost_wm_group_member_resource, [{request_type, group}, {member_type, group}]}.
 
+%% Recursive Group Membership Check
+%% TODO Currently only supports actor since it uses db function groups_for_actor
+%% and a similar one doesn't exist for groups_for_group.
+{["groups", id, "transitive_member", "actors", member_id], bifrost_wm_transitive_member_resource,
+ [{request_type, group}, {member_type, actor}]}.
+
 %% GET ACLs
 {["actors", id, "acl"], bifrost_wm_acl_resource, [{request_type, actor}]}.
 {["groups", id, "acl"], bifrost_wm_acl_resource, [{request_type, group}]}.

--- a/src/oc_bifrost/apps/bifrost/priv/pgsql_statements.config
+++ b/src/oc_bifrost/apps/bifrost/priv/pgsql_statements.config
@@ -53,6 +53,14 @@
       WHERE authz_id=$1
     ) AS exists">>}.
 
+{is_actor_recursive_member_of_group,
+<<"SELECT EXISTS(
+     SELECT auth_group.id FROM auth_actor, auth_group
+     WHERE auth_actor.authz_id=$1
+     AND auth_group.authz_id=$2 AND auth_group.id IN (
+       SELECT groups_for_actor(auth_actor.id))
+     ) AS exists">>}.
+
 %% Updating ACLs
 {update_acl,
  <<"SELECT update_acl AS success

--- a/src/oc_bifrost/apps/bifrost/src/bifrost_wm_transitive_member_resource.erl
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost_wm_transitive_member_resource.erl
@@ -1,0 +1,59 @@
+-module(bifrost_wm_transitive_member_resource).
+
+-include("bifrost_wm_rest_endpoint.hrl").
+-include_lib("stats_hero/include/stats_hero.hrl").
+
+-export([to_json/2]).
+
+-spec init([any()]) -> {ok, base_state()}.
+init(Config) ->
+    bifrost_wm_base:init(?MODULE, Config).
+
+-spec allowed_methods(wm_req(), base_state()) ->  {['GET'], wm_req(), base_state()}.
+allowed_methods(Req, State) ->
+    {['GET'], Req, State}.
+
+-spec auth_info('GET') -> read.
+auth_info('GET') ->
+    read.
+
+-spec validate_request(wm_req(), base_state()) ->
+			      {{halt, 401 | 403 | 404}, wm_req(), base_state()} |
+			      {boolean(), wm_req(), base_state()}.
+validate_request(Req, State) ->
+    bifrost_wm_base:validate_requestor(Req, State).
+
+%% TODO currently only supports actor since db query depends on db function
+%% groups_for_actor and a similar db function for groups does not exist, but
+%% will leave code in for groups in case we ever want to implement.
+-spec to_json(wm_req(), base_state()) ->
+		     {{halt, 404 | 400}, wm_req(), base_state()} |
+		     {binary(), wm_req(), base_state()}.
+to_json(Req, #base_state{reqid = ReqId,
+			 authz_id = GroupAuthzId,
+			 member_id = MemberAuthzId,
+			 member_type = MemberType} = State) ->
+    try
+	%% check if member_id exists since it doesn't get checked like base_state(authz_id)
+	case ?SH_TIME(ReqId, bifrost_db, exists, (MemberType, MemberAuthzId)) of
+	    false ->
+		{{halt, 404}, Req, State};
+	    true ->
+		IsMember = is_member(ReqId, MemberType, MemberAuthzId, GroupAuthzId),
+		{bifrost_wm_util:encode({[{<<"is_member">>, IsMember}]}), Req, State}
+	end
+    catch
+	throw:{db_error, Error} ->
+            bifrost_wm_error:set_db_exception(Req, State, Error)
+    end.
+
+%% @private
+-spec is_member(request_id(), auth_type(), auth_id(), auth_id()) -> boolean().
+is_member(ReqId, MemberType, MemberAuthzId, GroupAuthzId) ->
+    %% Recursively get all groups that contain ActorAuthzId and see if GroupAuthzId is in the list.
+    case ?SH_TIME(ReqId, bifrost_db, is_recursive_member_of_group, (MemberType, MemberAuthzId, GroupAuthzId)) of
+	{error, Error} ->
+	    throw({db_error, Error});
+	Result ->
+	    Result
+    end.

--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       rspec_junit_formatter (~> 0.1.1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.11)
       i18n (~> 0.6)
@@ -45,3 +45,6 @@ PLATFORMS
 
 DEPENDENCIES
   oc-bifrost-pedant!
+
+BUNDLED WITH
+   1.10.6

--- a/src/oc_bifrost/oc-bifrost-pedant/bin/oc-bifrost-pedant
+++ b/src/oc_bifrost/oc-bifrost-pedant/bin/oc-bifrost-pedant
@@ -4,9 +4,7 @@ require 'bundler/setup' # so we don't need to type 'bundle exec' to run it
 
 require 'rspec/core'
 require 'pedant'
-#require 'pedant/opensource'
 
-#Pedant.config.platform_class = Pedant::OpenSourcePlatform
 Pedant.config.suite = "bifrost"
 Pedant.setup(ARGV)
 puts Pedant::UI.new.info_banner


### PR DESCRIPTION
This endpoint will tell you if an actor is a member of a passed group or if that actor is a member of a group is recursively a member of a passed group.

For example, if brian is a member of the group clients, and clients is a member of the group superusers,
/groups/superusers/transitive_member/actors/brian would return true.

It returns JSON like:
  {"is_member" => true or false}

The framework is laid for adding GET /groups/:group/transitive_member/groups/:group as well, but this code currently depends on a db function called groups_for_actor,
an a similar groups_for_group does not exist yet. Notes have been left in the code to this effect.

Changelog-Entry: [bifrost] Added GET /groups/:group/transitive_member/actors/:actor endpoint for checking recursively checking group membership for a given actor on a given group.

[Build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/85/downstreambuildview/)