### PR TITLE
[chef-server-ctl] Fix several bugs in chef-server-ctl backup

### DIFF
--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -15,14 +15,10 @@
 # limitations under the License.
 #
 name 'chef_backup-gem'
-default_version '0.0.1.dev.4'
+default_version '0.0.1'
 
 dependency 'ruby'
 dependency 'rubygems'
-# rsync dependency must be met by pre-installation on the server,
-# Because of rsync's GPLv3 licensing, we can't include it in the shipped
-# chef-server without further evaluation.
-#dependency 'rsync'
 
 build do
   gem "install chef_backup -n #{install_dir}/embedded/bin --no-rdoc --no-ri -v #{version}"

--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +15,14 @@
 # limitations under the License.
 #
 name 'chef_backup-gem'
-default_version '0.0.1'
+default_version 'master'
+source git: "https://github.com/chef/chef_backup.git"
 
 dependency 'ruby'
 dependency 'rubygems'
 
 build do
-  gem "install chef_backup -n #{install_dir}/embedded/bin --no-rdoc --no-ri -v #{version}"
+  env = with_standard_compiler_flags(with_embedded_path)
+  gem "build chef_backup.gemspec", env: env
+  gem "install chef_backup*.gem -n #{install_dir}/embedded/bin --no-rdoc --no-ri", env: env
 end

--- a/omnibus/files/private-chef-ctl-commands/backup.rb
+++ b/omnibus/files/private-chef-ctl-commands/backup.rb
@@ -22,8 +22,12 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
       options.pg_options = pg_options
     end
 
-    opts.on('-c', '--config-only', 'Backup only the config on the frontends. No data will be backedup.') do
+    opts.on('-c', '--config-only', 'Only backup configuration, no data') do
       options.config_only = true
+    end
+
+    opts.on('-t', '--timeout [string]', 'Set the Maximum amount of time to wait for shell commands') do |shell_out_timeout|
+      options.shell_out_timeout = shell_out_timeout
     end
 
     opts.on('-h', '--help', 'Show this message') do
@@ -64,6 +68,10 @@ add_command_under_category 'restore', 'general', 'Restore the Chef Server from b
 
     opts.on('--pg-options [string]', 'Additional options to pass to postgress during backups') do |pg_options|
       options.pg_options = pg_options
+    end
+
+    opts.on('-t', '--timeout [string]', 'Maximum amount of time to wait for shell commands') do |shell_out_timeout|
+      options.shell_out_timeout = shell_out_timeout
     end
 
     opts.on('-h', '--help', 'Show this message') do

--- a/omnibus/files/private-chef-ctl-commands/backup.rb
+++ b/omnibus/files/private-chef-ctl-commands/backup.rb
@@ -4,10 +4,8 @@ require 'optparse'
 require 'ostruct'
 
 add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
-  unless running_config
-    log('You must reconfigure the Chef Server before a backup can be performed', :error)
-    exit(1)
-  end
+  ensure_configured!
+  ensure_rsync!
 
   options = OpenStruct.new
   options.agree_to_go_offline = false
@@ -19,6 +17,10 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
       options.agree_to_go_offline = true
     end
 
+    opts.on('--pg-options [string]', 'Additional options to pass to postgress during backups') do |pg_options|
+      options.pg_options = pg_options
+    end
+
     opts.on('-h', '--help', 'Show this message') do
       puts opts
       exit
@@ -28,7 +30,7 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
   Chef::Mixin::DeepMerge.deep_merge!(stringify_keys(options.to_h), running_config['private_chef']['backup'])
 
   begin
-    ChefBackup::Runner.new(running_config).backup
+    with_temp_dir { ChefBackup::Runner.new(running_config).backup }
   rescue => e
     log(e.message, :error)
     exit(1)
@@ -38,6 +40,8 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
 end
 
 add_command_under_category 'restore', 'general', 'Restore the Chef Server from backup', 2 do
+  ensure_rsync!
+
   options = OpenStruct.new
   options.agree_to_cleanse = nil
   options.restore_dir = nil
@@ -53,13 +57,17 @@ add_command_under_category 'restore', 'general', 'Restore the Chef Server from b
       options.agree_to_cleanse = 'yes'
     end
 
+    opts.on('--pg-options [string]', 'Additional options to pass to postgress during backups') do |pg_options|
+      options.pg_options = pg_options
+    end
+
     opts.on('-h', '--help', 'Show this message') do
       puts opts
       exit
     end
   end.parse!(ARGV)
 
-  unless ARGV.length >= 3
+  unless ARGV.length >= 4
     log('Invalid command', :error)
     log('USAGE: chef-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]', :error)
     exit(1)
@@ -69,13 +77,36 @@ add_command_under_category 'restore', 'general', 'Restore the Chef Server from b
   config['restore_param'] = normalize_arg(ARGV[3])
 
   begin
-    ChefBackup::Runner.new(config).restore
+    with_temp_dir { ChefBackup::Runner.new(config).restore }
   rescue => e
     log(e.message, :error)
     exit(1)
   end
 
   exit(0)
+end
+
+def ensure_rsync!
+  log('Locating rsync..')
+  unless system('which rsync')
+    log('rsync must be installed in order to run this command', :error)
+    exit(1)
+  end
+end
+
+def ensure_configured!
+  unless running_config
+    log('You must reconfigure the Chef Server before a backup can be performed', :error)
+    exit(1)
+  end
+end
+
+def with_temp_dir
+  Dir.mktmpdir do |dir|
+    Dir.chdir(dir) do
+      yield
+    end
+  end
 end
 
 def stringify_keys(hash)

--- a/omnibus/files/private-chef-ctl-commands/backup.rb
+++ b/omnibus/files/private-chef-ctl-commands/backup.rb
@@ -9,6 +9,7 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
 
   options = OpenStruct.new
   options.agree_to_go_offline = false
+  options.config_only = false
 
   OptionParser.new do |opts|
     opts.banner = 'Usage: chef-server-ctl backup [options]'
@@ -19,6 +20,10 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
 
     opts.on('--pg-options [string]', 'Additional options to pass to postgress during backups') do |pg_options|
       options.pg_options = pg_options
+    end
+
+    opts.on('-c', '--config-only', 'Backup only the config on the frontends. No data will be backedup.') do
+      options.config_only = true
     end
 
     opts.on('-h', '--help', 'Show this message') do


### PR DESCRIPTION
* Bump chef_backup dependency
* Allow passing pg_options to backup/restore database operations
* Add early exit if rsync is not installed
* Add early exit if commands not run as root
* Use a temporary working directory when executing commands