### PR TITLE
Updated Copyright and URL

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/404.html
+++ b/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/404.html
@@ -10,7 +10,7 @@
 <body>
   <div class="header-block">
     <div id="header">
-      <strong class="logo"><a href="http://www.chef.io">Chef</a></strong>
+      <strong class="logo"><a href="https://www.chef.io">Chef</a></strong>
     </div>
   </div>
   <div id="wrapper">

--- a/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/404.html
+++ b/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/404.html
@@ -28,7 +28,7 @@
       <div class="mybox">
       </div>
       <div class="footer-bottom">
-        <span>&copy; 2010&thinsp;&ndash;&thinsp;2014 Chef Software, Inc. All Rights Reserved</span>
+        <span>&copy; 2010&thinsp;&ndash;&thinsp;2016 Chef Software, Inc. All Rights Reserved</span>
       </div>
     </div>
   </div>

--- a/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/index.html
+++ b/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/index.html
@@ -10,7 +10,7 @@
 <body>
   <div class="header-block">
     <div id="header">
-      <strong class="logo"><a href="http://chef.io">Chef</a></strong>
+      <strong class="logo"><a href="https://chef.io">Chef</a></strong>
     </div>
   </div>
   <div id="wrapper">

--- a/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/index.html
+++ b/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/index.html
@@ -52,7 +52,7 @@
       <div class="mybox">
       </div>
       <div class="footer-bottom">
-        <span>&copy; 2010&thinsp;&ndash;&thinsp;2015 Chef Software, Inc. All Rights Reserved</span>
+        <span>&copy; 2010&thinsp;&ndash;&thinsp;2016 Chef Software, Inc. All Rights Reserved</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- It's 2016 now, so...updated that
- Our main site is chef.io now, not getchef.com