### PR TITLE
Bump bundler install for chef-zero Travis to 1.10.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ matrix:
       # We remove Gemfile.lock because Travis does
       # "bundle install --path bundle/vendor" which breaks our ability
       # to bundle install from the chef-zero spec.
-      before_install: rm -f oc-chef-pedant/Gemfile.lock
+      before_install: gem install bundler -v 1.10.6 && rm -f oc-chef-pedant/Gemfile.lock
       before_script: cd oc-chef-pedant
       script: bundle exec rake chef_zero_spec
       env: "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero'\""


### PR DESCRIPTION
Fixes broken master.