### PR TITLE
Include license information for chef-server and dependencies in omnibus packages

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -11,7 +11,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.1.0
+  require_chef_omnibus: 12.7.2
 
 platforms:
   - name: ubuntu-12.04
@@ -22,7 +22,7 @@ platforms:
     run_list: apt::default
   - name: centos-5.10
   - name: centos-6.5
-  - name: centos-7.0
+  - name: centos-7.2
     run_list:  yum-epel::default
 
 suites:

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
   forward_agent: yes
   customize:
     cpus: 4
-    memory: 4098
+    memory: 4096
   synced_folders:
     - ['..', '/home/vagrant/chef-server']
     - ['../../omnibus', '/home/vagrant/omnibus']

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,14 +1,15 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 18d954a467719e482c8268a67ba8efcad93ad509
+  revision: efcc4217164df7d756f5e1a24a422aa874816cf3
   specs:
     omnibus-software (4.0.0)
+      omnibus (>= 5.2.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 94b293b711e3372e04c22f92974d2248a9e60330
+  revision: a33d9cb41fc5284498a3805e8bf3dede14161a47
   specs:
-    omnibus (5.0.1)
+    omnibus (5.2.0)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
@@ -22,12 +23,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.2.20)
-      aws-sdk-resources (= 2.2.20)
-    aws-sdk-core (2.2.20)
+    aws-sdk (2.2.26)
+      aws-sdk-resources (= 2.2.26)
+    aws-sdk-core (2.2.26)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.20)
-      aws-sdk-core (= 2.2.20)
+    aws-sdk-resources (2.2.26)
+      aws-sdk-core (= 2.2.26)
     berkshelf (4.2.3)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0)
@@ -144,7 +145,7 @@ GEM
     nio4r (1.2.1)
     octokit (4.2.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    ohai (8.10.0)
+    ohai (8.12.1)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -153,13 +154,13 @@ GEM
       mixlib-config (~> 2.0)
       mixlib-log
       mixlib-shellout (~> 2.0)
-      rake (~> 10.1)
+      plist
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     plist (3.1.0)
     proxifier (1.0.3)
     rack (1.6.4)
-    rake (10.5.0)
+    rake (11.1.1)
     retryable (2.0.3)
     ridley (4.4.3)
       addressable
@@ -240,4 +241,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -17,6 +17,8 @@
 name "chef-server"
 maintainer "Chef Software, Inc."
 homepage   "https://www.chef.io"
+license "Apache 2.0"
+license_file "LICENSE"
 
 package_name    "chef-server-core"
 replace         "private-chef"

--- a/omnibus/config/software/bookshelf.rb
+++ b/omnibus/config/software/bookshelf.rb
@@ -17,6 +17,9 @@
 name "bookshelf"
 source path: "#{project.files_path}/../../src/bookshelf", options: {:exclude => ["_build"]}
 
+license "Apache 2.0"
+license_file "LICENSE.md"
+
 dependency "erlang"
 
 build do

--- a/omnibus/config/software/chef-ha-plugin-config.rb
+++ b/omnibus/config/software/chef-ha-plugin-config.rb
@@ -18,6 +18,8 @@ name "chef-ha-plugin-config"
 description "generates chef-server-plugin.rb"
 default_version "0.0.1"
 
+license "Apache 2.0"
+
 build do
   block do
     File.open("#{install_dir}/chef-server-plugin.rb", "w") do |f|

--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -18,6 +18,9 @@ name 'chef_backup-gem'
 default_version 'master'
 source git: "https://github.com/chef/chef_backup.git"
 
+license "Apache 2.0"
+license_file "https://github.com/chef/chef_backup/blob/master/LICENSE"
+
 dependency 'ruby'
 dependency 'rubygems'
 

--- a/omnibus/config/software/ctl-man.rb
+++ b/omnibus/config/software/ctl-man.rb
@@ -18,6 +18,8 @@
 name "ctl-man"
 default_version "7b25fa4de4d6663dafe2cbe853ada29eee67a6a6"
 
+license "Apache 2.0"
+
 dependency "private-chef-ctl"
 
 version "7b25fa4de4d6663dafe2cbe853ada29eee67a6a6" do

--- a/omnibus/config/software/gpg-key.rb
+++ b/omnibus/config/software/gpg-key.rb
@@ -23,6 +23,8 @@
 name "gpg-key"
 default_version "1.0.1"
 
+license "Apache 2.0"
+
 version "1.0.1" do
   source md5: "369efc3a19b9118cdf51c7e87a34f266"
 end

--- a/omnibus/config/software/knife-ec-backup-gem.rb
+++ b/omnibus/config/software/knife-ec-backup-gem.rb
@@ -17,6 +17,9 @@
 name "knife-ec-backup"
 default_version "2.0.6"
 
+license "Apache 2.0"
+license_file "https://github.com/chef/knife-ec-backup/blob/master/LICENSE"
+
 dependency "pg-gem"
 dependency "sequel-gem"
 

--- a/omnibus/config/software/knife-opc-gem.rb
+++ b/omnibus/config/software/knife-opc-gem.rb
@@ -17,6 +17,9 @@
 name "knife-opc"
 default_version "master"
 
+license "Apache 2.0"
+license_file "https://github.com/chef/knife-opc/blob/master/LICENSE"
+
 source git: "git://github.com/opscode/knife-opc.git"
 
 dependency "ruby"

--- a/omnibus/config/software/libossp-uuid.rb
+++ b/omnibus/config/software/libossp-uuid.rb
@@ -17,6 +17,9 @@
 name "libossp-uuid"
 default_version "1.6.2"
 
+license "MIT"
+license_file "README"
+
 source url: "ftp://ftp.ossp.org/pkg/lib/uuid/uuid-1.6.2.tar.gz",
        md5: "5db0d43a9022a6ebbbc25337ae28942f"
 

--- a/omnibus/config/software/oc-chef-pedant.rb
+++ b/omnibus/config/software/oc-chef-pedant.rb
@@ -17,6 +17,9 @@
 name "oc-chef-pedant"
 source path: "#{project.files_path}/../../oc-chef-pedant"
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 dependency "ruby"
 dependency "bundler"
 

--- a/omnibus/config/software/oc_bifrost.rb
+++ b/omnibus/config/software/oc_bifrost.rb
@@ -17,6 +17,9 @@
 name "oc_bifrost"
 source path: "#{project.files_path}/../../src/oc_bifrost", options: {:exclude => ["_build"]}
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 dependency "erlang"
 dependency "sqitch"
 

--- a/omnibus/config/software/oc_erchef.rb
+++ b/omnibus/config/software/oc_erchef.rb
@@ -17,6 +17,9 @@
 name "oc_erchef"
 source path: "#{project.files_path}/../../src/oc_erchef", options: {:exclude => ["_build"]}
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 dependency "erlang"
 dependency "gecode"
 dependency "sqitch"

--- a/omnibus/config/software/oc_id.rb
+++ b/omnibus/config/software/oc_id.rb
@@ -18,6 +18,9 @@ name "oc_id"
 
 source path: "#{project.files_path}/../../src/oc-id"
 
+license "Apache 2.0"
+license_file "LICENSE"
+
 dependency "postgresql92" # for libpq
 dependency "nodejs"
 dependency "ruby"

--- a/omnibus/config/software/openresty-lpeg.rb
+++ b/omnibus/config/software/openresty-lpeg.rb
@@ -17,6 +17,9 @@
 name "openresty-lpeg"
 default_version "0.12"
 
+license "MIT"
+license_file "lpeg.html"
+
 source url: "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-#{version}.tar.gz",
        md5: "4abb3c28cd8b6565c6a65e88f06c9162"
 

--- a/omnibus/config/software/opscode-chef-mover.rb
+++ b/omnibus/config/software/opscode-chef-mover.rb
@@ -16,6 +16,7 @@
 
 name "opscode-chef-mover"
 source path: "#{project.files_path}/../../src/chef-mover", options: {:exclude => ["_build"]}
+license :project_license
 dependency "erlang"
 
 build do

--- a/omnibus/config/software/opscode-expander.rb
+++ b/omnibus/config/software/opscode-expander.rb
@@ -17,6 +17,8 @@
 name "opscode-expander"
 source path: "#{project.files_path}/../../src/opscode-expander"
 
+license :project_license
+
 dependency "ruby"
 dependency "bundler"
 

--- a/omnibus/config/software/opscode-solr4.rb
+++ b/omnibus/config/software/opscode-solr4.rb
@@ -17,6 +17,9 @@
 name "opscode-solr4"
 default_version "4.10.4"
 
+license "Apache 2.0"
+license_file "LICENSE.txt"
+
 source url: "http://archive.apache.org/dist/lucene/solr/#{version}/solr-#{version}.tgz",
        md5: "8ae107a760b3fc1ec7358a303886ca06"
 

--- a/omnibus/config/software/partybus.rb
+++ b/omnibus/config/software/partybus.rb
@@ -18,6 +18,8 @@ name "partybus"
 
 source path: "#{Omnibus::Config.project_root}/#{name}"
 
+license :project_license
+
 dependency "bundler"
 dependency "postgresql92"
 

--- a/omnibus/config/software/perl_pg_driver.rb
+++ b/omnibus/config/software/perl_pg_driver.rb
@@ -17,6 +17,9 @@
 name "perl_pg_driver"
 default_version "3.3.0"
 
+license "Artistic"
+license_file "LICENSES/artistic.txt"
+
 dependency "perl"
 dependency "cpanminus"
 dependency "postgresql92"

--- a/omnibus/config/software/postgresql92.rb
+++ b/omnibus/config/software/postgresql92.rb
@@ -17,6 +17,9 @@
 name "postgresql92"
 default_version "9.2.15"
 
+license "Postgresql"
+license_file "COPYRIGHT"
+
 source url: "https://ftp.postgresql.org/pub/source/v9.2.15/postgresql-9.2.15.tar.bz2",
        md5: "235b4fc09eff4569a7972be65c449ecc"
 

--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -18,6 +18,8 @@ name "private-chef-cookbooks"
 
 source path: "#{project.files_path}/#{name}"
 
+license :project_license
+
 dependency "berkshelf2"
 
 build do

--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -18,6 +18,8 @@ name "private-chef-ctl"
 
 source path: "#{project.files_path}/private-chef-ctl-commands"
 
+license :project_license
+
 dependency "highline-gem"
 dependency "sequel-gem"
 dependency "omnibus-ctl"

--- a/omnibus/config/software/private-chef-scripts.rb
+++ b/omnibus/config/software/private-chef-scripts.rb
@@ -18,6 +18,8 @@ name "private-chef-scripts"
 
 source path: "#{project.files_path}/private-chef-scripts"
 
+license :project_license
+
 build do
   copy "#{project_dir}/*", "#{install_dir}/bin"
 end

--- a/omnibus/config/software/private-chef-upgrades.rb
+++ b/omnibus/config/software/private-chef-upgrades.rb
@@ -18,6 +18,8 @@ name "private-chef-upgrades"
 
 source path: "#{project.files_path}/private-chef-upgrades"
 
+license :project_license
+
 build do
   sync project_dir, "#{install_dir}/embedded/upgrades/"
 end

--- a/omnibus/config/software/rest-client-gem.rb
+++ b/omnibus/config/software/rest-client-gem.rb
@@ -17,6 +17,9 @@
 name "rest-client"
 default_version "1.8.0"
 
+license "MIT"
+license_file "https://github.com/rest-client/rest-client/blob/master/LICENSE"
+
 dependency "ruby"
 dependency "rubygems"
 


### PR DESCRIPTION
This PR goes with https://github.com/chef/omnibus-software/pull/620, https://github.com/chef/omnibus/pull/635 and it adds information about the licenses of chef-server and its dependencies to the omnibus packages. See an example output https://gist.github.com/sersut/e1012c38e55a3890232b and read more about how this feature works https://github.com/chef/omnibus/pull/635. 

With these PRs, there are 5 components that are missing license information that I will look into soon: 
- [x] opscode-chef-mover
- [x] partybus
- [x] opscode-expander
- [x] bundler
- [x] config_guess

/cc: @chef/chef-server-maintainers, @jamesc 