### PR TITLE
Add trusty and remove natty add on support.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -53,7 +53,7 @@ default['private_chef']['addons']['path'] = nil
 default['private_chef']['addons']['packages'] =
   %w{opscode-reporting opscode-manage opscode-analytics opscode-push-jobs-server chef-ha chef-sync}
 default['private_chef']['addons']['ubuntu_supported_codenames'] =
-  %w{lucid natty precise}
+  %w{lucid precise trusty}
 default['private_chef']['addons']['ubuntu_distribution'] =
   node['private_chef']['addons']['ubuntu_supported_codenames'].include?(node['lsb']['codename']) ?
   node['lsb']['codename'] : 'lucid'


### PR DESCRIPTION
[Passing Build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/97/downstreambuildview/)

Tested locally on Ubuntu 14.04. 

`chef-server-ctl install chef-manage` now properly completes.