### PR TITLE
Bump nodejs to 0.10.35.

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -32,6 +32,7 @@ override :ruby, version: "2.1.4"
 override :rubygems, version: "2.4.5"
 override :'omnibus-ctl', version: "0.4.2"
 override :bundler, version: "1.10.6"
+override :nodejs, version: "0.10.35"
 # creates required build directories
 dependency "preparation"
 


### PR DESCRIPTION
Open to doing this in `omnibus-software` if people think that is a better place, but I don't know enough about where `nodejs` is all used to just blindly bump it there.