### PR TITLE
[omnibus] Change pgsql's local service user and db superuser to not be hardcoded

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -129,7 +129,7 @@ if is_data_master?
       2.times do |i|
         # Note that we have to include the port even for a local pipe, because the port number
         # is included in the pipe default.
-        `echo 'SELECT * FROM pg_database;' | su - opscode-pgsql -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']}  -U  opscode-pgsql postgres -t -A'`
+        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} postgres -t -A'`
 	if $?.exitstatus != 0
           Chef::Log.fatal("Could not connect to database, retrying in 10 seconds.")
           sleep 10


### PR DESCRIPTION
If a user changes the postgres username or superuser in their server configuration they are never able to complete a reconfigure because those values are hard coded in the changed check.