### PR TITLE
Standardize license information based on omnibus best practices.

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: efcc4217164df7d756f5e1a24a422aa874816cf3
+  revision: 8d92d016355e25af6525876c6ea6930c8fd35b2d
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: a33d9cb41fc5284498a3805e8bf3dede14161a47
+  revision: afdd6ede314242dfd0c9a0dcbc86a65037f2f118
   specs:
     omnibus (5.2.0)
       aws-sdk (~> 2)
@@ -23,12 +23,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.2.26)
-      aws-sdk-resources (= 2.2.26)
-    aws-sdk-core (2.2.26)
+    aws-sdk (2.2.27)
+      aws-sdk-resources (= 2.2.27)
+    aws-sdk-core (2.2.27)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.26)
-      aws-sdk-core (= 2.2.26)
+    aws-sdk-resources (2.2.27)
+      aws-sdk-core (= 2.2.27)
     berkshelf (4.2.3)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0)

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -17,7 +17,7 @@
 name "chef-server"
 maintainer "Chef Software, Inc."
 homepage   "https://www.chef.io"
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 package_name    "chef-server-core"

--- a/omnibus/config/software/bookshelf.rb
+++ b/omnibus/config/software/bookshelf.rb
@@ -17,7 +17,7 @@
 name "bookshelf"
 source path: "#{project.files_path}/../../src/bookshelf", options: {:exclude => ["_build"]}
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE.md"
 
 dependency "erlang"

--- a/omnibus/config/software/chef-ha-plugin-config.rb
+++ b/omnibus/config/software/chef-ha-plugin-config.rb
@@ -18,7 +18,7 @@ name "chef-ha-plugin-config"
 description "generates chef-server-plugin.rb"
 default_version "0.0.1"
 
-license "Apache 2.0"
+license :project_license
 
 build do
   block do

--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -18,7 +18,7 @@ name 'chef_backup-gem'
 default_version 'master'
 source git: "https://github.com/chef/chef_backup.git"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "https://github.com/chef/chef_backup/blob/master/LICENSE"
 
 dependency 'ruby'

--- a/omnibus/config/software/ctl-man.rb
+++ b/omnibus/config/software/ctl-man.rb
@@ -18,7 +18,7 @@
 name "ctl-man"
 default_version "7b25fa4de4d6663dafe2cbe853ada29eee67a6a6"
 
-license "Apache 2.0"
+license :project_license
 
 dependency "private-chef-ctl"
 

--- a/omnibus/config/software/gpg-key.rb
+++ b/omnibus/config/software/gpg-key.rb
@@ -23,7 +23,7 @@
 name "gpg-key"
 default_version "1.0.1"
 
-license "Apache 2.0"
+license :project_license
 
 version "1.0.1" do
   source md5: "369efc3a19b9118cdf51c7e87a34f266"

--- a/omnibus/config/software/knife-ec-backup-gem.rb
+++ b/omnibus/config/software/knife-ec-backup-gem.rb
@@ -17,7 +17,7 @@
 name "knife-ec-backup"
 default_version "2.0.6"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "https://github.com/chef/knife-ec-backup/blob/master/LICENSE"
 
 dependency "pg-gem"

--- a/omnibus/config/software/knife-opc-gem.rb
+++ b/omnibus/config/software/knife-opc-gem.rb
@@ -17,7 +17,7 @@
 name "knife-opc"
 default_version "master"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "https://github.com/chef/knife-opc/blob/master/LICENSE"
 
 source git: "git://github.com/opscode/knife-opc.git"

--- a/omnibus/config/software/oc-chef-pedant.rb
+++ b/omnibus/config/software/oc-chef-pedant.rb
@@ -17,7 +17,7 @@
 name "oc-chef-pedant"
 source path: "#{project.files_path}/../../oc-chef-pedant"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "ruby"

--- a/omnibus/config/software/oc_bifrost.rb
+++ b/omnibus/config/software/oc_bifrost.rb
@@ -17,7 +17,7 @@
 name "oc_bifrost"
 source path: "#{project.files_path}/../../src/oc_bifrost", options: {:exclude => ["_build"]}
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "erlang"

--- a/omnibus/config/software/oc_erchef.rb
+++ b/omnibus/config/software/oc_erchef.rb
@@ -17,7 +17,7 @@
 name "oc_erchef"
 source path: "#{project.files_path}/../../src/oc_erchef", options: {:exclude => ["_build"]}
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "erlang"

--- a/omnibus/config/software/oc_id.rb
+++ b/omnibus/config/software/oc_id.rb
@@ -18,7 +18,7 @@ name "oc_id"
 
 source path: "#{project.files_path}/../../src/oc-id"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "postgresql92" # for libpq

--- a/omnibus/config/software/opscode-solr4.rb
+++ b/omnibus/config/software/opscode-solr4.rb
@@ -17,7 +17,7 @@
 name "opscode-solr4"
 default_version "4.10.4"
 
-license "Apache 2.0"
+license "Apache-2.0"
 license_file "LICENSE.txt"
 
 source url: "http://archive.apache.org/dist/lucene/solr/#{version}/solr-#{version}.tgz",

--- a/omnibus/config/software/perl_pg_driver.rb
+++ b/omnibus/config/software/perl_pg_driver.rb
@@ -17,7 +17,7 @@
 name "perl_pg_driver"
 default_version "3.3.0"
 
-license "Artistic"
+license "Artistic-2.0"
 license_file "LICENSES/artistic.txt"
 
 dependency "perl"

--- a/omnibus/config/software/postgresql92.rb
+++ b/omnibus/config/software/postgresql92.rb
@@ -17,7 +17,7 @@
 name "postgresql92"
 default_version "9.2.15"
 
-license "Postgresql"
+license "PostgreSQL"
 license_file "COPYRIGHT"
 
 source url: "https://ftp.postgresql.org/pub/source/v9.2.15/postgresql-9.2.15.tar.bz2",


### PR DESCRIPTION
This PR uses the omnibus certified licensing information in order not to have any warnings in the build logs. See https://github.com/chef/omnibus/pull/638 and https://github.com/chef/omnibus-software/pull/624 for more information. 

- [x] Pick up the latest omnibus & omnibus software.

/cc: @chef/chef-server-maintainers, @jamesc