### PR TITLE
Use mixlib-installs’ built-in platform detection during add-on install

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_wrapper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_wrapper.rb
@@ -53,10 +53,7 @@ if OmnibusHelper.new(node).remote_install_addons?
       channel: :stable,
       product_name: pkg.split(/(chef-|opscode-)(.*)/).last,
       product_version: :latest,
-      platform: node['platform'],
-      platform_version: node['platform_version'],
-      architecture: node['kernel']['machine'],
-    ).artifact_info
+    ).detect_platform.artifact_info
 
     pkg_file = File.join(addon_path, File.basename(artifact_info.url))
 


### PR DESCRIPTION
This will ensure `rhel` or `centos` is translated into `el` and only the `MAJOR` portion of the platform version is used when queuing for add-on artifacts.

With out this fix `chef-server-ctl install` fails on EL.

### Testing:
- [x] Wilson ad-hoc build: http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/122/downstreambuildview/
- [x] Ubuntu 14.04 Remote Install add-on: https://gist.github.com/schisamo/923f1f9323b1229707d0a3adffa03ba6
- [x] EL 7 Remote Install add-on: https://gist.github.com/schisamo/06c873767fec3df0e14247a112faf05a


/cc @chef/chef-server-maintainers @chef/engineering-services @mmzyk 