### PR TITLE
Use omnibus-ctl version that supports license acceptance.

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -32,7 +32,7 @@ override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
 override :ruby, version: "2.1.4"
 override :rubygems, version: "2.4.5"
-override :'omnibus-ctl', version: "0.4.2"
+override :'omnibus-ctl', version: "sersut/license-accept"
 override :bundler, version: "1.10.6"
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
This is a minor change in chef-server but a major change in omnibus-ctl. 

https://github.com/chef/omnibus-ctl/pull/42

Will update this PR with a real version number once omnibus-ctl PR is merged and released but I wanted to share this here to see if it is going to raise any alarm bells. 

Note that once this is in, all existing automation calling reconfigure will break and users will need to add `--accept-license` to fix. We have got product's :+1: on this. You can read [this](https://docs.google.com/a/opscode.com/document/d/1GqI4Ofr4udY5QM3HgJPVFX_BZUnzk8et06ZsVZeCYM4/edit?usp=sharing) for more information on the future. 

/cc: @chef/server-team