### PR TITLE
Pick up latest omnibus/omnibus-software

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,18 +1,19 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 3e392f27c2a7d49a2aded125d825d54ac191ea1a
+  revision: 8d611676c4458fa679cbc48e2111892ae7986cbf
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: e75b1bff54814036684fe091dc9a2f72087f5378
+  revision: e73722f46fbd5f302d9e1541aaae0b2f8be2110e
   specs:
-    omnibus (5.2.0)
+    omnibus (5.3.0)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
+      ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.0)
       mixlib-versioning
       ohai (~> 8.0)
@@ -23,12 +24,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.2.28)
-      aws-sdk-resources (= 2.2.28)
-    aws-sdk-core (2.2.28)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.28)
-      aws-sdk-core (= 2.2.28)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
     berkshelf (4.3.0)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -118,8 +119,10 @@ GEM
     hitimes (1.2.3)
     httpclient (2.7.1)
     ipaddress (0.8.3)
-    jmespath (1.1.3)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     json (1.8.3)
+    json_pure (1.8.3)
     libyajl2 (1.2.0)
     minitar (0.5.4)
     mixlib-authentication (1.4.0)
@@ -147,7 +150,7 @@ GEM
     nio4r (1.2.1)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.12.1)
+    ohai (8.14.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -156,7 +159,7 @@ GEM
       mixlib-config (~> 2.0)
       mixlib-log
       mixlib-shellout (~> 2.0)
-      plist
+      plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     plist (3.1.0)

--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -40,19 +40,19 @@ build do
         r << 'recipe[private-chef::default]'
       end
 
-      f.write JSON.fast_generate(
+      f.write FFI_Yajl::Encoder.encode(
         run_list: run_list
       )
     end
     File.open("#{install_dir}/embedded/cookbooks/show-config.json", "w") do |f|
-      f.write JSON.fast_generate(
+      f.write FFI_Yajl::Encoder.encode(
         run_list: [
           'recipe[private-chef::show_config]'
         ]
       )
     end
     File.open("#{install_dir}/embedded/cookbooks/post_upgrade_cleanup.json", "w") do |f|
-      f.write JSON.fast_generate(
+      f.write FFI_Yajl::Encoder.encode(
         run_list: [
           'recipe[private-chef::post_11_upgrade_cleanup]',
           'recipe[private-chef::post_12_upgrade_cleanup]'


### PR DESCRIPTION
We are after an updated Omnibus with chef/omnibus#656 and chef/omnibus#664. This adds the following fields to the generated `*.metadata.json` files:

* `license`
* `license_content`
* `version_manifest`

We’ll begin surfacing this extended data on downloads.chef.io.

### Testing

Wilson ad-hoc build: http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/134/downstreambuildview/

/cc @chef/engineering-services @chef/chef-server-maintainers