### PR TITLE
Use HAProxy to route Postgresql and ElasticSearch connections

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -52,6 +52,7 @@ dependency "postgresql92"
 dependency "rabbitmq"
 dependency "redis" # dynamic routing controls
 dependency "opscode-solr4"
+dependency "haproxy"
 dependency "opscode-expander"
 dependency "pg-gem" # used by private-chef-ctl reconfigure
 

--- a/omnibus/config/software/haproxy.rb
+++ b/omnibus/config/software/haproxy.rb
@@ -1,0 +1,71 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name "haproxy"
+default_version "1.6.4"
+
+dependency "zlib"
+dependency "pcre"
+dependency "openssl"
+
+license "GPLv2"
+license_file "LICENSE"
+
+# HTTPS is available but certificate validation fails on OS X
+source url: "http://www.haproxy.org/download/1.6/src/haproxy-#{version}.tar.gz",
+       sha256: "e5fa3c604f1fe9ecb6974ccda6705c105ebee14b3a913069fb08f00e860cd230"
+
+relative_path "haproxy-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  #
+  # Many of these are the same environment variables that debian sets
+  # PREFIX and TARGET are mandatory to get it building under omnibus.
+  #
+  build_options = {
+   "PREFIX" => "#{install_dir}/embedded",
+   # Use libpcre for regex, libpcre > 8.32 required
+   # for JIT
+   "USE_PCRE" => "1",
+   "USE_PCRE_JIT" => "1",
+   "USE_ZLIB" => "1",
+   "USE_OPENSSL" => "1",
+  }
+  # Required to resolve hostnames to IPv6 addresses
+  # off-by-default because of prolems on older glibc's
+  # TODO(ssd): Should we turn this off on RHEL5?
+  build_options['USE_GETADDRINFO'] = "1"
+  if intel?
+    build_options["USE_REGPARM"] = "1"
+  end
+  build_options['TARGET'] = if ohai["kernel"] && ohai["kernel"]["name"] == "Linux"
+                              version = Gem::Version.new(String(ohai["kernel"]["release"]).split("-").first)
+                              case
+                              when version >= Gem::Version.new("2.6.28")
+                                "linux2628"
+                              when version >= Gem::Version.new("2.6")
+                                "linux26"
+                              else
+                                "linux24e"
+                              end
+                            else
+                              "generic"
+                            end
+  build_args = ""
+  build_options.each { |k,v| build_args << " #{k}=#{v}"}
+  make "haproxy #{build_args}", env: env
+  make "install #{build_args}", env: env
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -93,6 +93,26 @@ default['private_chef']['opscode-solr']['data_dir'] = "/var/opt/opscode/opscode-
 ####
 default['private_chef']['server-api-version'] = 0
 
+####
+# HAProxy
+#
+# HAProxy is only used when use_chef_backend is true. All Postgresql
+# and Elasticsearch requests are routed to it and then forwarded to
+# the current chef-backend leader.
+####
+default['private_chef']['haproxy']['enable'] = true
+default['private_chef']['haproxy']['ha'] = false
+default['private_chef']['haproxy']['dir'] = "/var/opt/opscode/haproxy"
+default['private_chef']['haproxy']['log_directory'] = "/var/log/opscode/haproxy"
+default['private_chef']['haproxy']['log_rotation']['file_maxbytes'] = 104857600
+default['private_chef']['haproxy']['log_rotation']['num_to_keep'] = 10
+default['private_chef']['haproxy']['listen'] = '0.0.0.0'
+default['private_chef']['haproxy']['local_postgresql_port'] = 5432
+default['private_chef']['haproxy']['remote_postgresql_port'] = 5432
+default['private_chef']['haproxy']['local_elasticsearch_port'] = 9200
+default['private_chef']['haproxy']['remote_elasticsearch_port'] = 9200
+default['private_chef']['haproxy']['leaderl_healthcheck_port'] = 7331
+default['private_chef']['haproxy']['etcd_port'] = 2379
 
 ####
 # RabbitMQ

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_backend.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_backend.rb
@@ -1,0 +1,28 @@
+require 'json'
+require 'uri'
+require 'chef/http'
+
+module ChefBackend
+  ETCD_MEMBERS_URL = "/v2/members"
+  def self.configured_members(node)
+    ret = {}
+    node['private_chef']['chef_backend_members'].each_with_index do |member, i|
+      ret["backend#{i}"] = member
+    end
+    ret
+  end
+
+  def self.etcd_members(ip, port)
+    ret = {}
+    raw_members = JSON.parse(etcd_get(ETCD_MEMBERS_URL, ip, port))["members"]
+    raw_members.each do |m|
+      ret[m["name"]] = URI.parse(m["peerURLs"].first).host
+    end
+    ret
+  end
+
+  def self.etcd_get(url, ip, port)
+    client = Chef::HTTP.new("http://#{ip}:#{port}")
+    client.get(url)
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/haproxy.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/haproxy.rb
@@ -1,0 +1,55 @@
+class HAProxyStatus
+
+  attr_accessor :socket
+  def initialize(sock)
+    @socket = sock
+  end
+
+  def server_stats
+    stats(" -1 4 -1")
+  end
+
+  def stats(args=nil)
+    socket.puts("show stat#{args}")
+    parse_stats_table(read_until_end(socket))
+  end
+
+  private
+  def read_until_end(socket)
+    ret = []
+    while line = socket.gets
+      ret << line
+    end
+    ret
+  end
+
+  def parse_stats_table(table)
+    return [] if table.empty?
+    header, *data = table
+    header = transform_header(header)
+    data.map do |line|
+      parse_status_line(line, header)
+    end.compact
+  end
+
+  def transform_header(line)
+    columns = line.split(",").map(&:strip)
+    columns[0] = columns[0].gsub("# ", "")
+    columns
+  end
+
+  # Incomplete parser for the output of show stats;
+  #
+  # Currently only returns the pxname, svname, status
+  #
+  def parse_status_line(line, header)
+    split_line = line.split(",").map(&:strip)
+    if split_line.first == "" && split_line.length == 1 # Empty line
+      nil
+    else
+      { pxname: split_line[header.index("pxname")],
+        svname: split_line[header.index("svname")],
+        status: split_line[header.index("status")] }
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -125,11 +125,11 @@ class PreflightChecks
   # the defaults set in the recipe.
   def run!
     begin
-      BootstrapPreflightValidator.new(node).run!
       # When Chef Backend is configured, this is too early to verify
       # postgresql accessibility since we need to configure HAProxy
       # first
       if ! PrivateChef['use_chef_backend']
+        BootstrapPreflightValidator.new(node).run!
         PostgresqlPreflightValidator.new(node).run!
       end
       SolrPreflightValidator.new(node).run!

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -126,7 +126,12 @@ class PreflightChecks
   def run!
     begin
       BootstrapPreflightValidator.new(node).run!
-      PostgresqlPreflightValidator.new(node).run!
+      # When Chef Backend is configured, this is too early to verify
+      # postgresql accessibility since we need to configure HAProxy
+      # first
+      if ! PrivateChef['use_chef_backend']
+        PostgresqlPreflightValidator.new(node).run!
+      end
       SolrPreflightValidator.new(node).run!
       BookshelfPreflightValidator.new(node).run!
     rescue PreflightValidationFailed => e

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -23,6 +23,9 @@ module PrivateChef
   # Set this for default org mode
   default_orgname nil
 
+  use_chef_backend false
+  chef_backend_members []
+
   addons Mash.new
   rabbitmq Mash.new
   external_rabbitmq Mash.new
@@ -212,6 +215,8 @@ module PrivateChef
         "ldap",
         "user",
         "ha",
+        "use_chef_backend",
+        "chef_backend_members",
         "disabled_plugins",
         "enabled_plugins",
         "license",
@@ -224,7 +229,9 @@ module PrivateChef
       (default_keys | keys_from_extensions).each do |key|
         # @todo: Just pick a naming convention and adhere to it
         # consistently
-        rkey = if key =~ /^oc_/ || key == "redis_lb"
+        rkey = if key =~ /^oc_/ || key == "redis_lb" ||
+                  key == "use_chef_backend" ||
+                  key == "chef_backend_members"
                  key # leave oc_* keys as is
                else
                  key.gsub('_', '-')

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -121,6 +121,10 @@ include_recipe "private-chef::sysctl-updates"
 # Run plugins first, mostly for ha
 include_recipe "private-chef::plugin_chef_run"
 
+if node['private_chef']['use_chef_backend']
+  include_recipe "private-chef::haproxy"
+end
+
 # Configure Services
 [
   "rabbitmq",

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
@@ -94,3 +94,109 @@ template File.join(haproxy_dir, "haproxy.cfg") do
 end
 
 component_runit_service "haproxy"
+
+
+# On startup, all backend servers will be marked as UP.
+#
+# As the heathcheck on the non-leaders fails, they will be marked as
+# down. This usually takes 2-3 seconds, which is long enough for the
+# reconfigure to proceed to attempting to bootstrap erchef, which
+# won't work if we end up talking to a follower in read-only mode.
+#
+# Here, we wait for the HAProxy stats output to confirm that only one
+# server in each backend group (the leader) is marked as up to avoid
+# trying to bootstrap against the read-only follower.
+ruby_block "wait for haproxy status socket" do
+  block do
+    connected = false
+    10.times do
+      if ::File.exist?("/var/opt/opscode/haproxy/haproxy.sock")
+        require 'socket'
+        begin
+          UNIXSocket.new("/var/opt/opscode/haproxy/haproxy.sock")
+          connected = true
+          break
+        rescue
+          sleep 1
+        end
+      else
+        sleep 1
+      end
+    end
+
+    if !connected
+      Chef::Log.fatal("HAProxy status socket never appeared properly!")
+      Chef::Log.fatal("See /var/log/opscode/haproxy/current for more information")
+      Kernel.exit! 1
+    end
+  end
+end
+
+ruby_block "wait for backend leader to stabilize" do
+  block do
+    stable = false
+    10.times do
+      require 'socket'
+      begin
+        s = UNIXSocket.new("/var/opt/opscode/haproxy/haproxy.sock")
+        s.puts "show stat;quit"
+        _header = s.gets
+        table = []
+        up_servers = {
+          "chef_backend_elasticsearch" => [],
+          "chef_backend_postgresql" => [],
+        }
+        while line = s.gets
+          table << line
+        end
+
+        table.each do |l|
+          # show stat returns a csv formatted output. For now we do
+          # the parsing ourselves since we have simple needs.
+          split_line = l.split(",")
+          pxname = split_line[0] # Name of the service (ex: chef_backend_elasticsearch)
+          svname = split_line[1] # Name of this server or "BACKEND" or "FRONTEND"
+          state = split_line[17] # UP/DOWN/MAINT
+
+          # Ignore lines of the table not related to backend server entries
+          if svname != "BACKEND" && state == "UP" &&
+             ["chef_backend_elasticsearch", "chef_backend_postgresql"].include?(pxname)
+            up_servers[pxname] << svname
+          end
+        end
+
+        # We expect the status checks to fail on all but 1 backend
+        # (the current leader) thus we wait for that to be the case.
+        if up_servers["chef_backend_elasticsearch"].count == 1 &&
+           up_servers["chef_backend_postgresql"].count == 1
+          stable = true
+          break
+        else
+          Chef::Log.warn("HAProxy still inconsistent:")
+          Chef::Log.warn("  Postgresql servers UP:")
+          up_servers["chef_backend_postgresql"].each do |server_name|
+            Chef::Log.warn("   -#{server_name}")
+          end
+          Chef::Log.warn("  Elasticsearch servers UP:")
+          up_servers["chef_backend_elasticsearch"].each do |server_name|
+            Chef::Log.warn("   -#{server_name}")
+          end
+          Chef::Log.warn("Retrying in 2 seconds")
+          sleep 2
+        end
+      rescue StandardError => e
+        Chef::Log.warn("Error attempting to verify HAProxy State:")
+        Chef::Log.warn("   #{e}")
+        Chef::Log.warn("Retrying in 2 seconds")
+        sleep 2
+      end
+    end
+
+    if !stable
+      Chef::Log.fatal("HAProxy still showing multiple active backends")
+      Chef::Log.fatal("Please check /var/log/opscode/haproxy/current locally for problems.")
+      Chef::Log.fatal("Please check your backend cluster's status for problems.")
+      Kernel.exit! 1
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
@@ -1,0 +1,96 @@
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+haproxy_dir = node['private_chef']['haproxy']['dir']
+haproxy_log_dir = node['private_chef']['haproxy']['log_directory']
+[
+  haproxy_dir,
+  haproxy_log_dir
+].each do |dir_name|
+  directory dir_name do
+    owner OmnibusHelper.new(node).ownership['owner']
+    group OmnibusHelper.new(node).ownership['group']
+    mode node['private_chef']['service_dir_perms']
+    recursive true
+  end
+end
+
+#
+# We need to configure haproxy with the members in our Chef Backend
+# cluster. The user should have provided an array of chef-backend
+# members. We iterate through this array and try to contact the member
+# on etcd to get the most up-to-date list. If any part of that fails,
+# we fall-back to the user-configured list of hosts.
+#
+def get_chef_backend_cluster_members
+  members = nil
+  ret = {}
+  node['private_chef']['chef_backend_members'].each do |member|
+    begin
+      client = Chef::HTTP.new("http://#{member}:#{node['private_chef']['haproxy']['etcd_port']}")
+      members = JSON.parse(client.get("/v2/members"))["members"]
+      if members && !members.empty?
+        break
+      else
+        next
+      end
+    rescue
+      next
+    end
+  end
+  if members
+    members.each do |m|
+      ret[m["name"]] = URI.parse(m["peerURLs"].first).host
+    end
+    ret
+  else
+    nil
+  end
+end
+
+def configured_members
+  ret = {}
+  node['private_chef']['chef_backend_members'].each_with_index do |member, i|
+    ret["#{backend}#{i}"] = member
+  end
+  ret
+end
+
+chef_backend_members = begin
+                         Chef::Log.info("Attempting Chef Backend Member Discovery")
+                         if members = get_chef_backend_cluster_members
+                           Chef::Log.info("Using Chef Backend members discovered via etcd")
+                           members
+                         else
+                           Chef::Log.info("Member discovery failed")
+                           Chef::Log.info("Using statically configured member list")
+                           configured_members
+                         end
+                       rescue e
+                         Chef::Log.info("member discoverry failed: #{e}")
+                         Chef::Log.info("Using statically configured member list")
+                         configured_members
+                       end
+
+template File.join(haproxy_dir, "haproxy.cfg") do
+  source "haproxy.cfg.erb"
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
+  mode "600"
+  variables(node['private_chef']['haproxy'].to_hash.merge(chef_backend_members: chef_backend_members))
+  notifies :restart, 'runit_service[haproxy]'
+end
+
+component_runit_service "haproxy"

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/chef_backend_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/chef_backend_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../libraries/chef_backend.rb'
+
+describe ChefBackend do
+  describe "#configured_members" do
+    it "Returns a hash of name => IP based on the chef_backend_members config" do
+      node = {"private_chef" => {"chef_backend_members" => ["1.2.3.4", "2.3.4.5"]}}
+      expect(ChefBackend.configured_members(node)).to eq({
+                                                           "backend0" => "1.2.3.4",
+                                                           "backend1" => "2.3.4.5"
+                                                         })
+    end
+  end
+
+  describe "#etcd_members" do
+    let(:http_client) { double("Chef::HTTP") }
+    let(:members_response) do
+      <<EOF
+{"members":[{"id":"2f74e8c0e2bda03","name":"4ba4ae0a6686cf6b67590e621459f1e2","peerURLs":["http://192.168.33.216:2380"],"clientURLs":["http://192.168.33.216:2379"]},{"id":"9a7046eca5b7429b","name":"89cc3a0c2e3e51bdc5db1f97f63deb99","peerURLs":["http://192.168.33.217:2380"],"clientURLs":["http://192.168.33.217:2379"]},{"id":"c5a8c92212f542bb","name":"7caffa2c440aa682a2abbf4902d35fbd","peerURLs":["http://192.168.33.215:2380"],"clientURLs":["http://192.168.33.215:2379"]}]}
+EOF
+    end
+
+    let(:parsed_response) do
+    {
+      "4ba4ae0a6686cf6b67590e621459f1e2" => "192.168.33.216",
+      "89cc3a0c2e3e51bdc5db1f97f63deb99" => "192.168.33.217",
+      "7caffa2c440aa682a2abbf4902d35fbd" => "192.168.33.215"
+    }
+    end
+
+    it "makes a request /v2/members on the give host and port" do
+      expect(Chef::HTTP).to receive(:new).with("http://1.2.3.4:99").and_return(http_client)
+      expect(http_client).to receive(:get).with("/v2/members").and_return(members_response)
+      ChefBackend.etcd_members("1.2.3.4", 99)
+    end
+
+    it "parses the raw response, returning a hash of name => ip" do
+      expect(Chef::HTTP).to receive(:new).with("http://1.2.3.4:99").and_return(http_client)
+      expect(http_client).to receive(:get).with("/v2/members").and_return(members_response)
+      expect(ChefBackend.etcd_members("1.2.3.4", 99)).to eq(parsed_response)
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/haproxy_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/haproxy_spec.rb
@@ -1,0 +1,118 @@
+require_relative '../../libraries/haproxy.rb'
+
+#
+# FakeSocket pretends to be an HAProxy staus socket.  It understand
+# the following commands:
+#
+# - show stat
+# - show stat -1 4 -1
+#
+class FakeSocket
+  FULL_OUTPUT = <<OUTPUT
+# pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt,comp_in,comp_out,comp_byp,comp_rsp,lastsess,last_chk,last_agt,qtime,ctime,rtime,ttime,
+postgresql,FRONTEND,,,0,0,2000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,0,,,,,,,,,,,0,0,0,,,0,0,0,0,,,,,,,,
+elasticsearch,FRONTEND,,,0,0,2000,0,0,0,0,0,0,,,,,OPEN,,,,,,,,,1,3,0,,,,0,0,0,0,,,,,,,,,,,0,0,0,,,0,0,0,0,,,,,,,,
+chef_backend_postgresql,4ba4ae0a6686cf6b67590e621459f1e2,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,535,535,,1,4,1,,0,,2,0,,0,L7STS,503,0,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_postgresql,89cc3a0c2e3e51bdc5db1f97f63deb99,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,535,535,,1,4,2,,0,,2,0,,0,L7STS,503,1,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_postgresql,7caffa2c440aa682a2abbf4902d35fbd,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,535,0,,1,4,3,,0,,2,0,,0,L7OK,200,0,,,,,,,0,,,,0,0,,,,,-1,OK,,0,0,0,0,
+chef_backend_postgresql,BACKEND,0,0,0,0,200,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,535,0,,1,4,0,,0,,1,0,,0,,,,,,,,,,,,,,0,0,0,0,0,0,-1,,,0,0,0,0,
+chef_backend_elasticsearch,4ba4ae0a6686cf6b67590e621459f1e2,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,534,534,,1,5,1,,0,,2,0,,0,L7STS,503,1,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_elasticsearch,89cc3a0c2e3e51bdc5db1f97f63deb99,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,534,534,,1,5,2,,0,,2,0,,0,L7STS,503,1,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_elasticsearch,7caffa2c440aa682a2abbf4902d35fbd,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,535,0,,1,5,3,,0,,2,0,,0,L7OK,200,0,,,,,,,0,,,,0,0,,,,,-1,OK,,0,0,0,0,
+chef_backend_elasticsearch,BACKEND,0,0,0,0,200,0,0,0,0,0,,0,0,0,0,UP,1,1,0,,0,535,0,,1,5,0,,0,,1,0,,0,,,,,,,,,,,,,,0,0,0,0,0,0,-1,,,0,0,0,0,
+
+OUTPUT
+
+  SERVER_ONLY_OUTPUT = <<OUTPUT
+# pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt,comp_in,comp_out,comp_byp,comp_rsp,lastsess,last_chk,last_agt,qtime,ctime,rtime,ttime,
+chef_backend_postgresql,4ba4ae0a6686cf6b67590e621459f1e2,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,890,890,,1,4,1,,0,,2,0,,0,L7STS,503,0,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_postgresql,89cc3a0c2e3e51bdc5db1f97f63deb99,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,890,890,,1,4,2,,0,,2,0,,0,L7STS,503,0,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_postgresql,7caffa2c440aa682a2abbf4902d35fbd,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,890,0,,1,4,3,,0,,2,0,,0,L7OK,200,0,,,,,,,0,,,,0,0,,,,,-1,OK,,0,0,0,0,
+chef_backend_elasticsearch,4ba4ae0a6686cf6b67590e621459f1e2,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,889,889,,1,5,1,,0,,2,0,,0,L7STS,503,0,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_elasticsearch,89cc3a0c2e3e51bdc5db1f97f63deb99,0,0,0,0,,0,0,0,,0,,0,0,0,0,DOWN,1,1,0,1,1,889,889,,1,5,2,,0,,2,0,,0,L7STS,503,0,,,,,,,0,,,,0,0,,,,,-1,Service Unavailable,,0,0,0,0,
+chef_backend_elasticsearch,7caffa2c440aa682a2abbf4902d35fbd,0,0,0,0,,0,0,0,,0,,0,0,0,0,UP,1,1,0,0,0,890,0,,1,5,3,,0,,2,0,,0,L7OK,200,0,,,,,,,0,,,,0,0,,,,,-1,OK,,0,0,0,0,
+
+OUTPUT
+
+  def initialize
+    @output = StringIO.new
+  end
+
+  def puts(args)
+    @output = case args
+              when "show stat"
+                StringIO.new(FULL_OUTPUT)
+              when "show stat -1 4 -1"
+                StringIO.new(SERVER_ONLY_OUTPUT)
+              else
+                @output
+              end
+    args.length
+  end
+
+  def gets
+    @output.gets
+  end
+end
+
+describe HAProxyStatus do
+  let(:socket) {
+    FakeSocket.new
+  }
+  let(:subject) { HAProxyStatus.new(socket) }
+
+  describe "#stats" do
+    it "returns the parsed version of each line of data" do
+      expect(subject.stats).to eq([{:pxname=>"postgresql", :svname=>"FRONTEND", :status=>"OPEN"},
+                                   {:pxname=>"elasticsearch", :svname=>"FRONTEND", :status=>"OPEN"},
+                                   {:pxname=>"chef_backend_postgresql",
+                                    :svname=>"4ba4ae0a6686cf6b67590e621459f1e2",
+                                    :status=>"DOWN"},
+                                   {:pxname=>"chef_backend_postgresql",
+                                    :svname=>"89cc3a0c2e3e51bdc5db1f97f63deb99",
+                                    :status=>"DOWN"},
+                                   {:pxname=>"chef_backend_postgresql",
+                                    :svname=>"7caffa2c440aa682a2abbf4902d35fbd",
+                                    :status=>"UP"},
+                                   {:pxname=>"chef_backend_postgresql", :svname=>"BACKEND", :status=>"UP"},
+                                   {:pxname=>"chef_backend_elasticsearch",
+                                    :svname=>"4ba4ae0a6686cf6b67590e621459f1e2",
+                                    :status=>"DOWN"},
+                                   {:pxname=>"chef_backend_elasticsearch",
+                                    :svname=>"89cc3a0c2e3e51bdc5db1f97f63deb99",
+                                    :status=>"DOWN"},
+                                   {:pxname=>"chef_backend_elasticsearch",
+                                    :svname=>"7caffa2c440aa682a2abbf4902d35fbd",
+                                    :status=>"UP"},
+                                   {:pxname=>"chef_backend_elasticsearch", :svname=>"BACKEND", :status=>"UP"}])
+    end
+  end
+
+  describe "#server_stats" do
+    it "sends the 'show stat' with the correct arguments" do
+      expect(socket).to receive(:puts).with("show stat -1 4 -1")
+      subject.server_stats
+    end
+
+    it "returns the parsed version of each line of data" do
+      expect(subject.server_stats).to eq([{:pxname=>"chef_backend_postgresql",
+                                           :svname=>"4ba4ae0a6686cf6b67590e621459f1e2",
+                                           :status=>"DOWN"},
+                                          {:pxname=>"chef_backend_postgresql",
+                                           :svname=>"89cc3a0c2e3e51bdc5db1f97f63deb99",
+                                           :status=>"DOWN"},
+                                          {:pxname=>"chef_backend_postgresql",
+                                           :svname=>"7caffa2c440aa682a2abbf4902d35fbd",
+                                           :status=>"UP"},
+                                          {:pxname=>"chef_backend_elasticsearch",
+                                           :svname=>"4ba4ae0a6686cf6b67590e621459f1e2",
+                                           :status=>"DOWN"},
+                                          {:pxname=>"chef_backend_elasticsearch",
+                                           :svname=>"89cc3a0c2e3e51bdc5db1f97f63deb99",
+                                           :status=>"DOWN"},
+                                          {:pxname=>"chef_backend_elasticsearch",
+                                           :svname=>"7caffa2c440aa682a2abbf4902d35fbd",
+                                           :status=>"UP"}])
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
@@ -1,0 +1,23 @@
+frontend postgresql
+         bind <%= @listen %>:<%= @local_postgresql_port %>
+         mode tcp
+         default_backend chef_backend_postgresql
+
+frontend elasticsearch
+         bind <%= @listen %>:<%= @local_elasticsearch_port %>
+         mode tcp
+         default_backend chef_backend_elasticsearch
+
+backend chef_backend_postgresql
+        mode tcp
+        option httpchk GET /leader HTTP/1.1\r\nHost:localhost:<%= @leaderl_healthcheck_port %>\r\n\r\n
+        <% @chef_backend_members.each do |name, ip| -%>
+        server <%= name %> <%= ip %>:<%= @remote_postgresql_port %> check port <%= @leaderl_healthcheck_port %> rise 1 fall 1
+        <% end -%>
+
+backend chef_backend_elasticsearch
+        mode tcp
+        option httpchk GET /leader HTTP/1.1\r\nHost:localhost:<%= @leaderl_healthcheck_port %>\r\n\r\n
+        <% @chef_backend_members.each do |name, ip| -%>
+        server <%= name %> <%= ip %>:<%= @remote_elasticsearch_port %> check port <%= @leaderl_healthcheck_port %> rise 1 fall 1
+        <% end -%>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
@@ -1,3 +1,6 @@
+global
+        stats socket /var/opt/opscode/haproxy/haproxy.sock mode 600
+
 frontend postgresql
          bind <%= @listen %>:<%= @local_postgresql_port %>
          mode tcp

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
@@ -14,13 +14,15 @@ frontend elasticsearch
 backend chef_backend_postgresql
         mode tcp
         option httpchk GET /leader HTTP/1.1\r\nHost:localhost:<%= @leaderl_healthcheck_port %>\r\n\r\n
+        default-server inter 2s rise 1 fall 1
         <% @chef_backend_members.each do |name, ip| -%>
-        server <%= name %> <%= ip %>:<%= @remote_postgresql_port %> check port <%= @leaderl_healthcheck_port %> rise 1 fall 1
+        server <%= name %> <%= ip %>:<%= @remote_postgresql_port %> check port <%= @leaderl_healthcheck_port %>
         <% end -%>
 
 backend chef_backend_elasticsearch
         mode tcp
         option httpchk GET /leader HTTP/1.1\r\nHost:localhost:<%= @leaderl_healthcheck_port %>\r\n\r\n
+        default-server inter 2s rise 1 fall 1
         <% @chef_backend_members.each do |name, ip| -%>
-        server <%= name %> <%= ip %>:<%= @remote_elasticsearch_port %> check port <%= @leaderl_healthcheck_port %> rise 1 fall 1
+        server <%= name %> <%= ip %>:<%= @remote_elasticsearch_port %> check port <%= @leaderl_healthcheck_port %>
         <% end -%>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-haproxy-log-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-haproxy-log-run.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec chpst -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> \
+  svlogd -tt <%= @options[:log_directory] %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-haproxy-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-haproxy-run.erb
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+cd <%= node['private_chef']['haproxy']['dir'] %>
+exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /opt/opscode/embedded/sbin/haproxy -f haproxy.cfg


### PR DESCRIPTION
This provides two new configuration options:

   use_chef_backend
   chef_backend_members

When use_chef_backend is true, HAProxy will be enabled with a
configuration that will route requests to Postgresql and Elasticsearch
to the current Chef Backend leader.