### PR TITLE
[omnibus] Add rb-readline to the build

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -42,6 +42,7 @@ dependency "private-chef-scripts" # assorted scripts used by installed instance
 dependency "private-chef-ctl" # additional project-specific private-chef-ctl subcommands
 dependency "ctl-man" # install man page
 dependency "openresty"
+dependency "rb-readline"
 dependency "redis-gem" # gem for interacting with redis
 dependency "openresty-lpeg"  # lua-based routing
 dependency "runit"


### PR DESCRIPTION
Omnibus-software no longer compiles ruby with readline support because
of various compatibility issues. Adding rb-readline ensures that irb
and other irb or pry-based REPLs have readline support.