### PR TITLE
[expander] Set HOME in expander's runsv script

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-expander-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-expander-run.erb
@@ -3,6 +3,7 @@
 /opt/opscode/bin/wait-for-rabbit
 
 cd /opt/opscode/embedded/service/opscode-expander
+export HOME=/opt/opscode/embedded/service/opscode-expander
 
 exec 2>&1
 exec /opt/opscode/embedded/bin/chpst -P -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> /opt/opscode/embedded/bin/bundle exec /opt/opscode/embedded/service/opscode-expander/bin/opscode-expander-cluster -n <%= node['private_chef']['opscode-expander']['nodes'] %> -c <%= File.join(node["private_chef"]['opscode-expander']['dir'], "etc", "expander.rb") %>


### PR DESCRIPTION
Upstream omnibus-software no longer builds Ruby with readline. This
means that 'require "readline"' now picks up the rb-readline that oc_id
installs into our ruby environment. Bundler internally does a require on
readline during `bundle exec`. Unfortunately rb-readline fails if it is
required with HOME unset. This leads to expander failing to start.