### PR TITLE
[oc_id] Set HOME in oc_id's runsv script

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
@@ -5,5 +5,7 @@ DIR=/opt/opscode/embedded/service/oc_id
 export RAILS_ENV=production
 export PATH=/opt/opscode/embedded/bin:$PATH
 export LD_LIBRARY_PATH=/opt/opscode/embedded/lib
+export HOME=$DIR
+
 cd $DIR
 exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /opt/opscode/embedded/bin/bundle exec rails server -p <%= node['private_chef']['oc_id']['port'] %> -b <%= node['private_chef']['oc_id']['vip'] %>


### PR DESCRIPTION
Upstream omnibus-software no longer builds Ruby with readline. This
means that 'require "readline"' now picks up the rb-readline that oc_id
installs into our ruby environment. Bundler internally does a require on
readline during `bundle exec`. Unfortunately rb-readline fails if it is
required with HOME unset. This leads to oc_id failing to start.

This is similar to 5e7d19bc13edac17c045ef141ca03527b628b188