### PR TITLE
Fix bug where requestor membership of public_key_read_access was not being properly tested for keys access.

### DIFF
--- a/oc-chef-pedant/lib/pedant/platform.rb
+++ b/oc-chef-pedant/lib/pedant/platform.rb
@@ -427,6 +427,14 @@ module Pedant
       alter_group(orgname, groupname, :remove, :user, user.name, actor)
     end
 
+    def add_client_to_group(orgname, client, groupname, actor=nil)
+      alter_group(orgname, groupname, :add, :client, client.name, actor)
+    end
+
+    def remove_client_from_group(orgname, client, groupname, actor=nil)
+      alter_group(orgname, groupname, :remove, :client, client.name, actor)
+    end
+
     def add_group_to_group(orgname, object_name, groupname, actor=nil)
       alter_group(orgname, groupname, :add, :group, object_name, actor)
     end
@@ -440,7 +448,7 @@ module Pedant
       # to suffice
       actor ||= superuser
 
-      type_map = { :user => :users, :group => :groups }
+      type_map = { :user => :users, :group => :groups, :client => :clients }
 
       group_url = "#{@server}/organizations/#{orgname}/groups/#{groupname}"
       r = get(group_url, actor)
@@ -450,7 +458,8 @@ module Pedant
         :groupname => groupname,
         :actors => {
           :users => group["actors"],
-          :groups => group["groups"]
+          :groups => group["groups"],
+          :clients => group["clients"]
         }
       }
 

--- a/oc-chef-pedant/spec/api/keys/client_keys_spec.rb
+++ b/oc-chef-pedant/spec/api/keys/client_keys_spec.rb
@@ -774,6 +774,143 @@ describe "Client keys endpoint", :keys, :client_keys do
             get_client_key(org_name, org_client_name, current_requestor, 'key1').should look_like(:status => 401)
           end
         end
+
+        # public_key_read_access testing
+        shared_examples_for 'multiple actors READ access to the client keys endpoints depends on public_key_read_access membership' do
+          context 'when an actor is removed from the public_key_read_access group' do
+            before do
+              platform.remove_group_from_group(org_name, groupname, 'public_key_read_access')
+            end
+
+            after do
+              platform.add_group_to_group(org_name, groupname, 'public_key_read_access')
+            end
+
+            it 'the first actor can no longer list client keys, returning a 403', :authentication do
+              list_client_keys(org_name, test_client_name_1, current_requestor).should look_like(:status => 403)
+              list_client_keys(org_name, test_client_name_2, current_requestor).should look_like(:status => 403)
+            end
+
+            it 'the first actor can no longer get client keys, returning a 403', :authentication do
+              get_client_key(org_name, test_client_name_1, current_requestor, 'default').should look_like(:status => 403)
+              get_client_key(org_name, test_client_name_2, current_requestor, 'default').should look_like(:status => 403)
+            end
+
+            it 'the second actor can no longer list client keys, returning a 403', :authentication do
+              list_client_keys(org_name, test_client_name_1, other_requestor).should look_like(:status => 403)
+              list_client_keys(org_name, test_client_name_2, other_requestor).should look_like(:status => 403)
+            end
+
+            it 'the second actor can no longer get client keys, returning a 403', :authentication do
+              get_client_key(org_name, test_client_name_1, other_requestor, 'default').should look_like(:status => 403)
+              get_client_key(org_name, test_client_name_2, other_requestor, 'default').should look_like(:status => 403)
+            end
+
+            context 'when a single actor is added back into the the public_key_read_access group' do
+              before do
+                platform.send(add_method, org_name, current_requestor, 'public_key_read_access')
+              end
+
+              after do
+                platform.send(remove_method, org_name, current_requestor, 'public_key_read_access')
+              end
+
+              it 'other actors, by default, can no longer list client keys, returning a 403', :authentication do
+                list_client_keys(org_name, test_client_name_1, other_requestor).should look_like(:status => 403)
+                list_client_keys(org_name, test_client_name_2, other_requestor).should look_like(:status => 403)
+              end
+
+              it 'other actors, by default, can no longer get client keys, returning a 403', :authentication do
+                get_client_key(org_name, test_client_name_1, other_requestor, 'default').should look_like(:status => 403)
+                get_client_key(org_name, test_client_name_2, other_requestor, 'default').should look_like(:status => 403)
+              end
+
+              it 'the added actor can list client keys', :authentication do
+                list_client_keys(org_name, test_client_name_1, current_requestor).should look_like(:status => 200)
+                list_client_keys(org_name, test_client_name_2, current_requestor).should look_like(:status => 200)
+              end
+
+              it 'the added actor can get client keys', :authentication do
+                get_client_key(org_name, test_client_name_1, current_requestor, 'default').should look_like(:status => 200)
+                get_client_key(org_name, test_client_name_2, current_requestor, 'default').should look_like(:status => 200)
+              end
+            end
+          end
+        end #shared_examples_for
+
+        context 'when multiple clients exist' do
+          before(:all) do
+            @client_name_1 = "pedant_test_client_#{rand_id}"
+            @client_name_2 = "pedant_test_client_2_#{rand_id}"
+            @client_1 = platform.create_client(@client_name_1, @test_org)
+            @client_2 = platform.create_client(@client_name_2, @test_org)
+          end
+
+          after(:all) do
+            platform.delete_client(@client_1, @test_org)
+            platform.delete_client(@client_2, @test_org)
+          end
+
+          context 'when the first client is making requests with an unmodified public_key_read_access group' do
+            let(:current_requestor) { @client_1 }
+            it_should_behave_like 'successful client key get'
+          end
+
+          context 'when the second client is making requests with an unmodified public_key_read_access group' do
+            let(:current_requestor) { @client_2 }
+            it_should_behave_like 'successful client key get'
+          end
+
+          context 'when clients are added and removed from the public_key_read_access group' do
+            let(:test_client_name_1) { @client_name_1 }
+            let(:test_client_name_2) { @client_name_2 }
+            let(:current_requestor) { @client_1 }
+            let(:other_requestor) { @client_2 }
+            let(:groupname) { 'clients' }
+            let(:add_method) { :add_client_to_group }
+            let(:noun) { :client }
+            let(:remove_method) { :remove_client_from_group }
+
+            it_should_behave_like 'multiple actors READ access to the client keys endpoints depends on public_key_read_access membership'
+          end
+
+          context 'when there are multiple users associated to the org' do
+            before(:all) do
+              @user_1 = platform.create_user("pedant_test_user_#{rand_id}")
+              @user_2 = platform.create_user("pedant_test_user_2_#{rand_id}")
+              platform.associate_user_with_org(org_name, @user_1)
+              platform.associate_user_with_org(org_name, @user_2)
+            end
+
+            after(:all) do
+              platform.delete_user(@user_1)
+              platform.delete_user(@user_2)
+            end
+
+            context 'when the user client is making requests with an unmodified public_key_read_access group' do
+              let(:current_requestor) { @user_1 }
+              it_should_behave_like 'successful client key get'
+            end
+
+            context 'when the user client is making requests with an unmodified public_key_read_access group' do
+              let(:current_requestor) { @user_2 }
+              it_should_behave_like 'successful client key get'
+            end
+
+            context 'when users are added and removed from the public_key_read_access group' do
+              let(:test_client_name_1) { @client_name_1 }
+              let(:test_client_name_2) { @client_name_2 }
+              let(:current_requestor) { @user_1 }
+              let(:other_requestor) { @user_2 }
+              let(:groupname) { 'users' }
+              let(:add_method) { :add_user_to_group }
+              let(:noun) { :user }
+              let(:remove_method) { :remove_user_from_group }
+
+              it_should_behave_like 'multiple actors READ access to the client keys endpoints depends on public_key_read_access membership'
+            end
+          end
+        end
       end # context when multiple keys are present
     end # context listing key(s)
   end # context managing keys

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_keys.erl
@@ -172,8 +172,8 @@ auth_info('GET', Req, #base_state{organization_guid = undefined,
 %% For the org scoped ones, we want to check if the requestor is a member
 %% of public_key_read_access group on GET requests to give all users and clients
 %% access on all users and clients if they share an org.
-auth_info('GET', Req, #base_state{resource_state = #key_state{parent_authz_id = ActorId}} = State) ->
-    {{member_of, ActorId, {local, "public_key_read_access"}}, Req, State};
+auth_info('GET', Req, #base_state{requestor = #chef_requestor{authz_id = RequestorAuthzId}} = State) ->
+    {{member_of, RequestorAuthzId, {local, "public_key_read_access"}}, Req, State};
 %% Non GET methods
 auth_info(_Method, Req, #base_state{resource_state = #key_state{parent_authz_id = AuthzId}}= State) ->
     {{actor, AuthzId, update}, Req, State}.


### PR DESCRIPTION
Access to the org scoped user and client keys read endpoints are controlled by membership on the public_key_read_access group (which defaults to the users and clients groups); however, a bug resulted in testing membership on public_key_read_access for the member being requested instead of the requestor.

This commit fixes that bug and adds regression tests.

[Passing build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/143/downstreambuildview/)