### PR TITLE
Bug fix: treat a successful PG conn and auth as a preflight success

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 class PostgresqlPreflightValidator < PreflightValidator
 
   def initialize(node)
@@ -96,6 +95,12 @@ class PostgresqlPreflightValidator < PreflightValidator
         fail_with err_CSPG010_postgres_not_available
       when /.*password authentication failed.*/
         # This is what we want to see.
+      when /role .* does not exist/
+        # This indicates we were successfully able to connect to Postgres
+        # AND we authenticated! This is likely because the pg_hba is set
+        # to trust our connection. Such an example would be configuring
+        # Chef Server to use an "external" Postgres, such as Delivery's,
+        # when running on the same host.
       when /.*no pg_hba.conf entry.*/
         # This is also possible, depending on if they've set up pg_hba
         # by host or user or both. This is OK, since it confirms that we're


### PR DESCRIPTION
Currently, if the PostgreSQL preflight check is able to connect to the
DB *and* authenticate (due to a pg_hba trust entry, for example) but is
unable to find the not-expected-to-be-there database name in question,
it treats the preflight connection check as a failure.

An example of such a condition would be configuring Chef Server and
Delivery on the same node and configuring Chef Server to use Delivery's
database. Delivery's pg_hba.conf trusts local connections, so a
`chef-server-ctl reconfigure` will fail the preflight checks because
it connects to the DB but fails to find the fake database.

This change treats a successful connection and auth as a success during
pre-flight and also adds tests for the `#connectivity_validation` method
which previously had none.