### PR TITLE
[travis] Fixup GECODE_PATH in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
   global:
     - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
     - USE_OMNIBUS_FILES=0
-    - CHEFDK_GECODE_PATH=/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.0.2/lib/dep-selector-libgecode/vendored-gecode
+    - CHEFDK_GECODE_PATH=/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.2.0/lib/dep-selector-libgecode/vendored-gecode
     - PATH=~/perl5/bin:$PATH
     - LUALIB=~/.luarocks/lib/lua/5.2
   matrix:


### PR DESCRIPTION
The latest version of ChefDK shipped with a new version of
dep-selector-libgecode that lives at a new path.