### PR TITLE
Revert changes to sqitch plan files to avoid upgrade breakage

### DIFF
--- a/src/oc_bifrost/schema/sqitch.plan
+++ b/src/oc_bifrost/schema/sqitch.plan
@@ -2,24 +2,24 @@
 %project=bifrost
 %uri=https://github.com/opscode/oc_bifrost
 
-base 2013-06-24T11:10:23Z Christopher Maier <cm@chef.io> # The initial base install of the bifrost schema
-forbid_group_cycles [base] 2013-06-24T13:04:05Z Christopher Maier <cm@chef.io> # Add forbid_group_cycles function and accompanying trigger
-id_resolution_functions [base] 2013-06-24T13:10:28Z Christopher Maier <cm@chef.io> # Add several accessory functions for resolving database IDs
-groups_for_actor [base] 2013-06-24T13:14:17Z Christopher Maier <cm@chef.io> # Add groups_for_actor function
-actor_has_permission_on [base id_resolution_functions] 2013-06-24T13:18:21Z Christopher Maier <cm@chef.io> # add actor_has_permission_on function
-create_and_add_permissions [base id_resolution_functions] 2013-06-24T13:21:01Z Christopher Maier <cm@chef.io> # add create_and_add_permissions function
-clear_acl [base id_resolution_functions] 2013-06-24T13:23:19Z Christopher Maier <cm@chef.io> # add clear_acl function
-update_acl [base id_resolution_functions] 2013-06-24T13:32:28Z Christopher Maier <cm@chef.io> # add update_acl function
-debug_schema 2013-06-24T13:34:20Z Christopher Maier <cm@chef.io> # add debug schema
-debug_object_acl_view [debug_schema base] 2013-06-24T13:36:09Z Christopher Maier <cm@chef.io> # add object_acl view in debug schema
-@1.1.6 2013-06-25T15:05:55Z Christopher Maier <cm@chef.io> # Base schema back-ported to sqitch
+base 2013-06-24T11:10:23Z Christopher Maier <cm@opscode.com> # The initial base install of the bifrost schema
+forbid_group_cycles [base] 2013-06-24T13:04:05Z Christopher Maier <cm@opscode.com> # Add forbid_group_cycles function and accompanying trigger
+id_resolution_functions [base] 2013-06-24T13:10:28Z Christopher Maier <cm@opscode.com> # Add several accessory functions for resolving database IDs
+groups_for_actor [base] 2013-06-24T13:14:17Z Christopher Maier <cm@opscode.com> # Add groups_for_actor function
+actor_has_permission_on [base id_resolution_functions] 2013-06-24T13:18:21Z Christopher Maier <cm@opscode.com> # add actor_has_permission_on function
+create_and_add_permissions [base id_resolution_functions] 2013-06-24T13:21:01Z Christopher Maier <cm@opscode.com> # add create_and_add_permissions function
+clear_acl [base id_resolution_functions] 2013-06-24T13:23:19Z Christopher Maier <cm@opscode.com> # add clear_acl function
+update_acl [base id_resolution_functions] 2013-06-24T13:32:28Z Christopher Maier <cm@opscode.com> # add update_acl function
+debug_schema 2013-06-24T13:34:20Z Christopher Maier <cm@opscode.com> # add debug schema
+debug_object_acl_view [debug_schema base] 2013-06-24T13:36:09Z Christopher Maier <cm@opscode.com> # add object_acl view in debug schema
+@1.1.6 2013-06-25T15:05:55Z Christopher Maier <cm@opscode.com> # Base schema back-ported to sqitch
 
-actor_has_bulk_permission_on 2013-06-25T15:28:59Z Christopher Maier <cm@chef.io> # Add actor_has_bulk_permission_on function, enabling the bulk authorization endpoint
-@1.2.0 2013-06-25T15:41:51Z Christopher Maier <cm@chef.io> # Bulk authorization endpoint
-@1.2.1 2013-06-25T18:19:42Z Christopher Maier <cm@chef.io> # Placeholder version to keep in sync with code version
-@1.2.2 2013-06-25T18:19:47Z Christopher Maier <cm@chef.io> # Placeholder version to keep in sync with code version
-update_acl [update_acl@1.2.0] 2013-06-25T18:34:24Z Christopher Maier <cm@chef.io># Address potential bug
-@1.3.0 2013-06-28T18:44:53Z Christopher Maier <cm@chef.io> # fixed update_acl 'bug'
-@1.3.1 2013-07-24T16:15:09Z Christopher Maier <cm@chef.io> # Placeholder version bump
+actor_has_bulk_permission_on 2013-06-25T15:28:59Z Christopher Maier <cm@opscode.com> # Add actor_has_bulk_permission_on function, enabling the bulk authorization endpoint
+@1.2.0 2013-06-25T15:41:51Z Christopher Maier <cm@opscode.com> # Bulk authorization endpoint
+@1.2.1 2013-06-25T18:19:42Z Christopher Maier <cm@opscode.com> # Placeholder version to keep in sync with code version
+@1.2.2 2013-06-25T18:19:47Z Christopher Maier <cm@opscode.com> # Placeholder version to keep in sync with code version
+update_acl [update_acl@1.2.0] 2013-06-25T18:34:24Z Christopher Maier <cm@opscode.com># Address potential bug
+@1.3.0 2013-06-28T18:44:53Z Christopher Maier <cm@opscode.com> # fixed update_acl 'bug'
+@1.3.1 2013-07-24T16:15:09Z Christopher Maier <cm@opscode.com> # Placeholder version bump
 update_acl [update_acl@1.3.0] 2015-08-04T15:16:05Z Marc Paradise <marc@chef.io># modify update_acl to use a pg_advisor_xact_lock
 @1.3.2 2015-08-04T15:22:01Z Marc Paradise <marc@chef.io> # concurrency fix for update_acl

--- a/src/oc_erchef/schema/baseline/sqitch.plan
+++ b/src/oc_erchef/schema/baseline/sqitch.plan
@@ -2,31 +2,31 @@
 %project=oss_chef
 %uri=https://github.com/opscode/chef-server-schema
 
-osc_users 2013-09-04T13:54:01Z Christopher Maier <cm@chef.io> # Open Source users table
-nodes 2013-09-04T14:07:22Z Christopher Maier <cm@chef.io> # Nodes table
-clients 2013-09-04T14:46:05Z Christopher Maier <cm@chef.io> # Clients table
-roles 2013-09-04T15:03:17Z Christopher Maier <cm@chef.io> # Roles table
-data_bags 2013-09-04T15:09:09Z Christopher Maier <cm@chef.io> # Data bags table
-data_bag_items [data_bags] 2013-09-04T15:21:33Z Christopher Maier <cm@chef.io> # Data bag items table
-environments 2013-09-04T15:46:43Z Christopher Maier <cm@chef.io> # Environments table
-checksums 2013-09-04T17:44:45Z Christopher Maier <cm@chef.io> # Checksums table
-sandboxed_checksums 2013-09-04T17:52:21Z Christopher Maier <cm@chef.io> # Sandboxed checksums table
-cookbooks 2013-09-04T18:31:20Z Christopher Maier <cm@chef.io> # Cookbooks table
-cookbook_versions [cookbooks] 2013-09-04T18:40:34Z Christopher Maier <cm@chef.io> # Cookbook versions table
-cookbook_version_checksums [cookbook_versions checksums] 2013-09-04T19:01:53Z Christopher Maier <cm@chef.io> # Cookbook version checksums table
-cookbook_versions_by_rank [cookbook_versions cookbooks] 2013-09-04T19:19:14Z Christopher Maier <cm@chef.io> # Add cookbook_versions_by_rank view
-cookbook_version_dependencies [cookbook_versions cookbooks] 2013-09-04T19:26:20Z Christopher Maier <cm@chef.io> # Add cookbook_version_dependencies view
-joined_cookbook_version [cookbook_versions cookbooks] 2013-09-04T21:02:02Z Christopher Maier <cm@chef.io> # Add joined_cookbook_version view
-@1.0.0 2013-09-04T21:58:35Z Christopher Maier <cm@chef.io> # Use Sqitch for schema management
+osc_users 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # Open Source users table
+nodes 2013-09-04T14:07:22Z Christopher Maier <cm@opscode.com> # Nodes table
+clients 2013-09-04T14:46:05Z Christopher Maier <cm@opscode.com> # Clients table
+roles 2013-09-04T15:03:17Z Christopher Maier <cm@opscode.com> # Roles table
+data_bags 2013-09-04T15:09:09Z Christopher Maier <cm@opscode.com> # Data bags table
+data_bag_items [data_bags] 2013-09-04T15:21:33Z Christopher Maier <cm@opscode.com> # Data bag items table
+environments 2013-09-04T15:46:43Z Christopher Maier <cm@opscode.com> # Environments table
+checksums 2013-09-04T17:44:45Z Christopher Maier <cm@opscode.com> # Checksums table
+sandboxed_checksums 2013-09-04T17:52:21Z Christopher Maier <cm@opscode.com> # Sandboxed checksums table
+cookbooks 2013-09-04T18:31:20Z Christopher Maier <cm@opscode.com> # Cookbooks table
+cookbook_versions [cookbooks] 2013-09-04T18:40:34Z Christopher Maier <cm@opscode.com> # Cookbook versions table
+cookbook_version_checksums [cookbook_versions checksums] 2013-09-04T19:01:53Z Christopher Maier <cm@opscode.com> # Cookbook version checksums table
+cookbook_versions_by_rank [cookbook_versions cookbooks] 2013-09-04T19:19:14Z Christopher Maier <cm@opscode.com> # Add cookbook_versions_by_rank view
+cookbook_version_dependencies [cookbook_versions cookbooks] 2013-09-04T19:26:20Z Christopher Maier <cm@opscode.com> # Add cookbook_version_dependencies view
+joined_cookbook_version [cookbook_versions cookbooks] 2013-09-04T21:02:02Z Christopher Maier <cm@opscode.com> # Add joined_cookbook_version view
+@1.0.0 2013-09-04T21:58:35Z Christopher Maier <cm@opscode.com> # Use Sqitch for schema management
 
-cookbook_version_checksums_by_org_id_checksum_index [cookbook_version_checksums] 2013-09-05T18:59:21Z Christopher Maier <cm@chef.io> # Add org_id / checksum index to cookbook_version_checksums table
-@1.0.1 2013-09-05T19:03:52Z Christopher Maier <cm@chef.io> # Add org_id / checksum index to cookbook_version_checksums table
+cookbook_version_checksums_by_org_id_checksum_index [cookbook_version_checksums] 2013-09-05T18:59:21Z Christopher Maier <cm@opscode.com> # Add org_id / checksum index to cookbook_version_checksums table
+@1.0.1 2013-09-05T19:03:52Z Christopher Maier <cm@opscode.com> # Add org_id / checksum index to cookbook_version_checksums table
 
-node_external_storage [nodes] 2013-09-05T21:30:08Z Christopher Maier <cm@chef.io> # Ensure node.serialized_object storage is external
-@1.0.2 2013-09-05T19:04:52Z Christopher Maier <cm@chef.io> # Ensure node.serialized_object storage is external
+node_external_storage [nodes] 2013-09-05T21:30:08Z Christopher Maier <cm@opscode.com> # Ensure node.serialized_object storage is external
+@1.0.2 2013-09-05T19:04:52Z Christopher Maier <cm@opscode.com> # Ensure node.serialized_object storage is external
 
-purge_sequel 2013-09-05T21:00:09Z Christopher Maier <cm@chef.io> # Remove Sequel metadata
-@1.0.3 2013-09-05T19:05:52Z Christopher Maier <cm@chef.io> # Purge Sequel metadata
+purge_sequel 2013-09-05T21:00:09Z Christopher Maier <cm@opscode.com> # Remove Sequel metadata
+@1.0.3 2013-09-05T19:05:52Z Christopher Maier <cm@opscode.com> # Purge Sequel metadata
 
-cookbook_versions_cookbook_id_index [cookbook_versions] 2013-10-09T15:06:07Z Oliver Ferrigni <oliver@chef.io># Add index cookbook_versions(cookbook_id)
-@1.0.4 2013-10-10T18:36:12Z Oliver Ferrigni <oliver@chef.io># Tagging with 1.0.4 for index creation
+cookbook_versions_cookbook_id_index [cookbook_versions] 2013-10-09T15:06:07Z Oliver Ferrigni <oliver@opscode.com># Add index cookbook_versions(cookbook_id)
+@1.0.4 2013-10-10T18:36:12Z Oliver Ferrigni <oliver@opscode.com># Tagging with 1.0.4 for index creation

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -2,45 +2,45 @@
 %project=enterprise_chef
 %uri=https://github.com/opscode/enterprise-chef-server-schema
 
-drop_osc_users [oss_chef:osc_users] 2013-09-05T19:22:00Z Christopher Maier <cm@chef.io> # Remove osc_users table
-users [drop_osc_users] 2013-09-04T13:54:01Z Christopher Maier <cm@chef.io> # users table
-opc_customers 2013-09-04T16:05:27Z Christopher Maier <cm@chef.io> # OPC customers table
-opc_users [users opc_customers] 2013-09-04T16:15:19Z Christopher Maier <cm@chef.io> # OPC users table
-reporting_schema_info 2013-09-04T21:07:31Z Christopher Maier <cm@chef.io> # Add reporting_schema_info table
-widen_uuid_fields [oss_chef:roles oss_chef:clients oss_chef:data_bags oss_chef:data_bag_items oss_chef:environments] 2013-09-05T20:25:39Z Christopher Maier <cm@chef.io> # Widen UUID fields used by Solr
-delete_migrated_couch_data [oss_chef:cookbook_version_checksums oss_chef:checksums oss_chef:cookbook_versions oss_chef:cookbooks oss_chef:environments oss_chef:roles oss_chef:clients oss_chef:data_bag_items oss_chef:data_bags] 2013-09-04T21:18:40Z Christopher Maier <cm@chef.io> # Add delete_migrated_couch_data stored procedure
-org_migration_state 2013-09-04T21:27:50Z Christopher Maier <cm@chef.io> # Add org_migration_state table
-@2.0.0 2013-09-04T21:58:35Z Christopher Maier <cm@chef.io> # Use Sqitch for schema management
-@2.0.1 2013-09-23T09:52:31Z Christopher Maier <cm@chef.io> # Placeholder version to keep in sync with repo tag
+drop_osc_users [oss_chef:osc_users] 2013-09-05T19:22:00Z Christopher Maier <cm@opscode.com> # Remove osc_users table
+users [drop_osc_users] 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # users table
+opc_customers 2013-09-04T16:05:27Z Christopher Maier <cm@opscode.com> # OPC customers table
+opc_users [users opc_customers] 2013-09-04T16:15:19Z Christopher Maier <cm@opscode.com> # OPC users table
+reporting_schema_info 2013-09-04T21:07:31Z Christopher Maier <cm@opscode.com> # Add reporting_schema_info table
+widen_uuid_fields [oss_chef:roles oss_chef:clients oss_chef:data_bags oss_chef:data_bag_items oss_chef:environments] 2013-09-05T20:25:39Z Christopher Maier <cm@opscode.com> # Widen UUID fields used by Solr
+delete_migrated_couch_data [oss_chef:cookbook_version_checksums oss_chef:checksums oss_chef:cookbook_versions oss_chef:cookbooks oss_chef:environments oss_chef:roles oss_chef:clients oss_chef:data_bag_items oss_chef:data_bags] 2013-09-04T21:18:40Z Christopher Maier <cm@opscode.com> # Add delete_migrated_couch_data stored procedure
+org_migration_state 2013-09-04T21:27:50Z Christopher Maier <cm@opscode.com> # Add org_migration_state table
+@2.0.0 2013-09-04T21:58:35Z Christopher Maier <cm@opscode.com> # Use Sqitch for schema management
+@2.0.1 2013-09-23T09:52:31Z Christopher Maier <cm@opscode.com> # Placeholder version to keep in sync with repo tag
 
-containers 2013-09-23T17:46:57Z Mark Anderson <mark@chef.io> # Add containers table
-password_hash_type 2013-09-24T14:29:08Z Marc Paradise <marc@chef.io> # new enum for supported password hash types
-users_password_hash_split [users] 2013-09-24T14:42:14Z Marc Paradise <marc@chef.io># add columns to user that split out password hash and salt
+containers 2013-09-23T17:46:57Z Mark Anderson <mark@opscode.com> # Add containers table
+password_hash_type 2013-09-24T14:29:08Z Marc Paradise <marc@opscode.com> # new enum for supported password hash types
+users_password_hash_split [users] 2013-09-24T14:42:14Z Marc Paradise <marc@opscode.com># add columns to user that split out password hash and salt
 @2.1.0 2013-09-25T01:26:17Z Marc Paradise <marc@alienix># 2.1.0 - to be synced with release tag
-groups 2013-09-23T18:21:28Z Mark Anderson <mark@chef.io> # Add groups in sql
-@2.2.0 2013-09-25T05:53:40Z Mark Anderson <mark@chef.io> # Add groups in sql
-@2.2.1 2013-10-01T20:57:23Z Mark Anderson <mark@chef.io> # sync with 2.2.1 git tag
+groups 2013-09-23T18:21:28Z Mark Anderson <mark@opscode.com> # Add groups in sql
+@2.2.0 2013-09-25T05:53:40Z Mark Anderson <mark@opscode.com> # Add groups in sql
+@2.2.1 2013-10-01T20:57:23Z Mark Anderson <mark@opscode.com> # sync with 2.2.1 git tag
 
-opc_users_customer_id_index [opc_users] 2013-10-09T14:09:35Z Oliver Ferrigni <oliver@chef.io># Add index opc_users(customer_id)
-@2.2.2 2013-10-10T18:28:40Z Oliver Ferrigni <oliver@chef.io># Tag with 2.2.2
-@2.2.3 2013-10-14T20:26:26Z Oliver Ferrigni <oliver@chef.io># Makefile updates
+opc_users_customer_id_index [opc_users] 2013-10-09T14:09:35Z Oliver Ferrigni <oliver@opscode.com># Add index opc_users(customer_id)
+@2.2.2 2013-10-10T18:28:40Z Oliver Ferrigni <oliver@opscode.com># Tag with 2.2.2
+@2.2.3 2013-10-14T20:26:26Z Oliver Ferrigni <oliver@opscode.com># Makefile updates
 
-drop_reporting_schema_info [reporting_schema_info] 2014-01-08T22:04:01Z Mark Mzyk <mmzyk@chef.io> # Drop reporting_schema_info table that is not needed
-add_migration_type [org_migration_state] 2014-01-07T18:28:10Z Oliver Ferrigni <oliver@chef.io> # Add column migration type to org_migration_status
-create_composite_key_org_migration_state 2014-01-07T23:36:23Z Oliver Ferrigni <oliver@chef.io> # Adjust the primary key to be a composite key of org_id and migration type
-migrate_org_migration_status_to_migratation_type 2014-01-08T16:33:23Z Oliver Ferrigni <oliver@chef.io> # Convert to using migration_type exploding purge_successful rows into two rows
-@2.2.4 2014-01-21T22:00:55Z Oliver Ferrigni <oliver@chef.io># Tag with 2.2.4
+drop_reporting_schema_info [reporting_schema_info] 2014-01-08T22:04:01Z Mark Mzyk <mmzyk@opscode.com> # Drop reporting_schema_info table that is not needed
+add_migration_type [org_migration_state] 2014-01-07T18:28:10Z Oliver Ferrigni <oliver@getchef.com> # Add column migration type to org_migration_status
+create_composite_key_org_migration_state 2014-01-07T23:36:23Z Oliver Ferrigni <oliver@getchef.com> # Adjust the primary key to be a composite key of org_id and migration type
+migrate_org_migration_status_to_migratation_type 2014-01-08T16:33:23Z Oliver Ferrigni <oliver@getchef.com> # Convert to using migration_type exploding purge_successful rows into two rows
+@2.2.4 2014-01-21T22:00:55Z Oliver Ferrigni <oliver@getchef.com># Tag with 2.2.4
 
-organizations 2014-05-29T17:45:19Z Mark Anderson <mark@chef.io> # Add an organizations table
-org_user_associations 2014-05-29T20:26:29Z Mark Anderson <mark@chef.io> # Add the org user association table
-org_user_invites 2014-05-29T20:59:32Z Mark Anderson <mark@chef.io> # Add the org user invite table
-@2.2.6 2014-06-04T00:07:12Z Mark Anderson <mark@chef.io> # Tag with 2.2.6
+organizations 2014-05-29T17:45:19Z Mark Anderson <mark@getchef.com> # Add an organizations table
+org_user_associations 2014-05-29T20:26:29Z Mark Anderson <mark@getchef.com> # Add the org user association table
+org_user_invites 2014-05-29T20:59:32Z Mark Anderson <mark@getchef.com> # Add the org user invite table
+@2.2.6 2014-06-04T00:07:12Z Mark Anderson <mark@getchef.com> # Tag with 2.2.6
 
-fix_unique_constraints_and_indices_in_org_user_association 2014-07-15T17:32:22Z Tyler Cloke <tyler@chef.io> # Clean up org_user_associations table
-fix_unique_constraints_and_indices_in_org_user_invites 2014-07-16T11:01:01Z Tyler Cloke <tyler@chef.io> # Clean up org_user_invites table
-@2.3.1 2014-07-21T20:14:42Z Tyler Cloke <tyler@chef.io> # Tag with 2.3.1
-osc_password_hash_type_update [password_hash_type] 2014-08-15T15:47:45Z Mark Mzyk <mmzyk@chef.io> # Updates the password hash type to contain the OSC hash types
-@2.4.0 2014-08-21T18:15:04Z Mark Mzyk <mmzyk@chef.io> # Tag with 2.4.0
+fix_unique_constraints_and_indices_in_org_user_association 2014-07-15T17:32:22Z Tyler Cloke <tyler@getchef.com> # Clean up org_user_associations table
+fix_unique_constraints_and_indices_in_org_user_invites 2014-07-16T11:01:01Z Tyler Cloke <tyler@getchef.com> # Clean up org_user_invites table
+@2.3.1 2014-07-21T20:14:42Z Tyler Cloke <tyler@getchef.com> # Tag with 2.3.1
+osc_password_hash_type_update [password_hash_type] 2014-08-15T15:47:45Z Mark Mzyk <mmzyk@getchef.com> # Updates the password hash type to contain the OSC hash types
+@2.4.0 2014-08-21T18:15:04Z Mark Mzyk <mmzyk@getchef.com> # Tag with 2.4.0
 
 multiple_keys 2014-12-29T23:45:05Z Mark Anderson <mark@chef.io> # Add keys table to support multiple keys
 keys_drop_trigger 2015-01-03T01:25:39Z Mark Anderson <mark@chef.io># Keys table drop trigger to maintain consistency


### PR DESCRIPTION
Sqitch calculates hashes for each change based on the contents of the
plan file preceding that changes entry.  It stores that data in the
database to determine what has already been deployed. If you change the
plan file, you change the hashes, and nothing works.