### PR TITLE
Update opscode-solr4 JAVA_OPTS to include whitespace

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -133,7 +133,7 @@ node.default['private_chef']['opscode-solr4']['heap_size'] = solr_mem
 node.default['private_chef']['opscode-solr4']['new_size'] = new_size
 
 node.default['private_chef']['opscode-solr4']['command'] =  "java -Xmx#{solr_mem}M -Xms#{solr_mem}M"
-node.default['private_chef']['opscode-solr4']['command'] << "#{java_opts}"
+node.default['private_chef']['opscode-solr4']['command'] << " #{java_opts}" unless java_opts.empty?
 # Enable GC Logging (very useful for debugging issues) to an separate file only works with Oracle JRE
 if node['kernel']['machine'] == "x86_64"
   node.default['private_chef']['opscode-solr4']['command'] << " -Xloggc:#{File.join(solr_log_dir, "gclog.log")}"


### PR DESCRIPTION
- Allows users to specify JAVA_OPTS for solr without a prefixed space