### PR TITLE
Ensure erchef is configured to use custom nginx ports

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -218,7 +218,7 @@
                   %% chef server can talk to bookshelf.
                   {s3_url, "http://<%= node['private_chef']['bookshelf']['listen'] %>:<%= node['private_chef']['bookshelf']['port'] %>"},
                   <% else -%>
-                  {s3_url, "<%= node['private_chef']['nginx']['x_forwarded_proto'] %>://<%= @helper.vip_for_uri('bookshelf') %>"},
+                  {s3_url, "<%= node['private_chef']['nginx']['x_forwarded_proto'] %>://<%= @helper.vip_for_uri('bookshelf') %>:<%= node['private_chef']['nginx']['x_forwarded_proto'] == 'https' ? node['private_chef']['nginx']['ssl_port'] : node['private_chef']['nginx']['non_ssl_port'] %>"},
                   <% end %>
                   {s3_external_url, <%= @helper.erl_atom_or_string(node['private_chef']['bookshelf']['external_url']) %>},
                   {s3_platform_bucket_name, "<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>"},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -90,7 +90,7 @@
                   %% chef server can talk to bookshelf.
                   {s3_url, "http://<%= node['private_chef']['bookshelf']['listen'] %>:<%= node['private_chef']['bookshelf']['port'] %>"},
                   <% else -%>
-                  {s3_url, "<%= node['private_chef']['nginx']['x_forwarded_proto'] %>://<%= @helper.vip_for_uri('bookshelf') %>"},
+                  {s3_url, "<%= node['private_chef']['nginx']['x_forwarded_proto'] %>://<%= @helper.vip_for_uri('bookshelf') %>:<%= node['private_chef']['nginx']['x_forwarded_proto'] == 'https' ? node['private_chef']['nginx']['ssl_port'] : node['private_chef']['nginx']['non_ssl_port'] %>"},
                   <% end %>
                   <% # Re-using erchef's configuration here %>
                   {s3_platform_bucket_name, "<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>"},


### PR DESCRIPTION
This pull request is intended to fix Issue #50 & is based on [a workaround](https://github.com/chef/chef-server/issues/50#issuecomment-183827124) suggested by @wduncanfraser

This pull request should cover the case where a custom nginx ssl_port is specified,
and should also handle when nginx is configured to not use SSL.

Note: I'm not 100% sure what the `opscode-chef-mover.config.erb` template is used for, but I updated it to match the `oc_erchef.config.erb` changes since the two files were very similar.