### PR TITLE
Fixing pedant/bookshelf when nginx on non-standard port

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -619,6 +619,7 @@ default['private_chef']['bookshelf']['log_directory'] = "/var/log/opscode/booksh
 default['private_chef']['bookshelf']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['bookshelf']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['bookshelf']['vip'] = node['private_chef']['lb']['api_fqdn']
+default['private_chef']['bookshelf']['vip_port'] = 443
 default['private_chef']['bookshelf']['listen'] = '127.0.0.1'
 default['private_chef']['bookshelf']['port'] = 4321
 default['private_chef']['bookshelf']['stream_download'] = true

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -63,6 +63,16 @@ class OmnibusHelper
     end
   end
 
+  def bookshelf_s3_url
+    # Using URI#to_s to strip ":443" for https and ":80" for http
+    URI("#{node['private_chef']['nginx']['x_forwarded_proto']}://#{vip_for_uri('bookshelf')}:#{node['private_chef']['bookshelf']['vip_port']}").to_s
+  end
+
+  def nginx_ssl_url
+    # Using URI#to_s to strip ":443" for https and ":80" for http
+    URI("#{node['private_chef']['nginx']['url']}:#{node['private_chef']['nginx']['ssl_port']}").to_s
+  end
+
   def db_connection_uri
     db_protocol = "postgres"
     db_user     = node['private_chef']['opscode-erchef']['sql_user']

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
@@ -45,7 +45,7 @@ template pedant_config do
   mode  "0755"
   variables({
     :actions_enabled => node['private_chef']['dark_launch']['actions'],
-    :api_url  => node['private_chef']['nginx']['url'],
+    :api_url  => OmnibusHelper.new(node).nginx_ssl_url,
     :solr_url => OmnibusHelper.new(node).solr_root,
     :opscode_account_internal_url => node['private_chef']['lb_internal']['vip'],
     :opscode_account_internal_port => node['private_chef']['lb_internal']['account_port'],

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../libraries/helper.rb'
+
+describe OmnibusHelper do
+  describe '#bookshelf_s3_url' do
+    let(:node) do
+      {
+        'private_chef' => {
+          'nginx' => {
+            'x_forwarded_proto' => 'https'
+          },
+          'bookshelf' => {
+            'vip_port' => 8443
+          }
+        }
+      }
+    end
+
+    it 'returns a properly formatted URL' do
+      helper = described_class.new(node)
+      allow(helper).to receive(:vip_for_uri).with('bookshelf').and_return('bookshelf-vip')
+      expect(helper.bookshelf_s3_url).to eq('https://bookshelf-vip:8443')
+    end
+  end
+
+  describe '#nginx_ssl_url' do
+    let(:node) do
+      {
+        'private_chef' => {
+          'nginx' => {
+            'url' => 'https://nginx-url',
+            'ssl_port' => 8443
+          }
+        }
+      }
+    end
+
+    it 'returns a properly formatted URL' do
+      helper = described_class.new(node)
+      expect(helper.nginx_ssl_url).to eq('https://nginx-url:8443')
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -218,7 +218,7 @@
                   %% chef server can talk to bookshelf.
                   {s3_url, "http://<%= node['private_chef']['bookshelf']['listen'] %>:<%= node['private_chef']['bookshelf']['port'] %>"},
                   <% else -%>
-                  {s3_url, "<%= node['private_chef']['nginx']['x_forwarded_proto'] %>://<%= @helper.vip_for_uri('bookshelf') %>"},
+                  {s3_url, "<%= @helper.bookshelf_s3_url %>"},
                   <% end %>
                   {s3_external_url, <%= @helper.erl_atom_or_string(node['private_chef']['bookshelf']['external_url']) %>},
                   {s3_platform_bucket_name, "<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>"},


### PR DESCRIPTION
This change addresses three primary issues:
 * bookshelf breaks when a custom SSL port is used for nginx
 * the bookshelf VIP port itself cannot be customized
 * pedant tests fail when a customer SSL port is used for nginx

When a user configures `nginx['ssl_port']` to be something other than 443, Pedant tests fail because the `nginx['url']` attribute assumes port 443 by default. That attribute is rendered in the `pedant_config.rb` file, so Pedant fails when you change the port from the standard 443. This change will correctly set `nginx['url']` with the ssl_port as well.

Additionally, the `s3_url` used in opscode-erchef for internal access to the bookshelf store assumes that the bookshelf vip is always listening on port 443. If you are using the bookshelf service and you have changed your config to have nginx listen on a port other than 443, cookbook-related tasks that use bookshelf will fail. This change introduces a new attribute (`vip_port`) that defaults to 443, and a helper method to properly render the s3_url in the erchef config with a port number if the user elects to change from the default port.