### PR TITLE
[omnibus] bypass_bootstrap? should ensure both creds exist

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
@@ -50,7 +50,6 @@ class BootstrapPreflightValidator < PreflightValidator
       end
     end
 
-
     # TODO:
     # If the pivotal key file exists locally:
     #  - fetch pivotal public key(s) from opscode_chef keys view + users
@@ -75,13 +74,21 @@ class BootstrapPreflightValidator < PreflightValidator
   # backend components, allow data bootstrapping to be bypassed when
   # no chef-server-running.json is present but a secrets file is present.
   def bypass_bootstrap?
-    first_run? && secrets_exists? && PrivateChef["use_chef_backend"]
+    first_run? && all_creds_exist? && PrivateChef["postgresql"]["external"]
   end
 
   private
 
+  def all_creds_exist?
+    pivotal_key_exists? && secrets_exists?
+  end
+
+  def pivotal_key_exists?
+    File.exist? "/etc/opscode/pivotal.pem"
+  end
+
   def validate_sane_state
-    if File.exists? "/etc/opscode/pivotal.pem"
+    if pivotal_key_exists?
       unless secrets_exists?
         fail_with err_BOOT006_pivotal_with_no_secrets
       end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
@@ -1,0 +1,99 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../../libraries/preflight_bootstrap_validator.rb'
+require_relative '../../libraries/private_chef.rb'
+require_relative '../../libraries/helper.rb'
+
+
+describe BootstrapPreflightValidator do
+  let(:subject) { BootstrapPreflightValidator.new(node_object) }
+
+  describe "#bypass_bootstrap?" do
+    context "when a previous run exists" do
+      let(:node_object) do { "private_chef" => {},
+                             "previous_run" => {"some" => "has"}}
+      end
+
+      # We end up skipping the bootstrap in most cases here because if
+      # a previous run exists we likely have a bootstrap sentinal file
+      # so OmnibusHelper.has_been_bootstrapped? will be true and that
+      # function is used in conjunction with this when determinging
+      # whether to run the bootstrap recipe.
+      it "counter-intuitively returns false" do
+        expect(subject.bypass_bootstrap?).to eq(false)
+      end
+    end
+
+    context "when no previous run exists" do
+      let(:node_object) do
+        { "private_chef" => {} }
+      end
+
+      context "when the secrets file doesn't exist" do
+        before do
+          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(true)
+          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
+        end
+
+        it "returns false" do
+          expect(subject.bypass_bootstrap?).to eq(false)
+        end
+      end
+
+      context "when the pivotal.pem file doesn't exist" do
+        before do
+          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
+          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+        end
+
+        it "returns false" do
+          expect(subject.bypass_bootstrap?).to eq(false)
+        end
+      end
+
+      context "when both private-chef-secrets.json and pivotal.pem exist" do
+        before do
+          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(true)
+          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+          allow(Veil::CredentialCollection::ChefSecretsFile).to receive(:from_file)
+                                                                 .with("/etc/opscode/private-chef-secrets.json")
+                                                                 .and_return(double("SecretsFile", size: 10))
+        end
+
+
+        context "when postgresql is running externally" do
+          before do
+            allow(PrivateChef).to receive(:[]).with('postgresql').and_return({"external" => true})
+          end
+
+          it "returns true" do
+            expect(subject.bypass_bootstrap?).to eq(true)
+          end
+        end
+
+        context "when postgresql is running locally" do
+          before do
+            allow(PrivateChef).to receive(:[]).with('postgresql').and_return({"external" => false})
+          end
+
+          it "returns false" do
+            expect(subject.bypass_bootstrap?).to eq(false)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In addition to its use in the validator bypass_bootstrap? is called in
recipes/default.rb to determine whether or not we should run the
bootstrap cookbook.  The call to bypass_bootstrap? in recipes/default.rb
happens /after/ the private-chef-secrets.json file is written to disk.
Thus, this check was leading us to bypass the bootstrap even in cases
when this was the first node running reconfigure against an external
postgresql.

Additionally, given the current complexity of the bootstrap procedure, I
don't think we should actively use the `use_chef_backend` option for
anything but the "HAProxy routing enabled" bits until we ship the code
related to that feature.

Overall, I'm not thrilled with this solution. I've started to do some
code review of the bootstrap situation generally and will have a follow
up PR with some documentation on what I've found.