### PR TITLE
Remove chef-sync from the known add on packages for the install command

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -51,7 +51,7 @@ default['private_chef']['fips_enabled'] = false
 default['private_chef']['addons']['install'] = false
 default['private_chef']['addons']['path'] = nil
 default['private_chef']['addons']['packages'] =
-  %w{opscode-reporting opscode-manage opscode-analytics opscode-push-jobs-server chef-ha chef-sync}
+  %w{opscode-reporting opscode-manage opscode-analytics opscode-push-jobs-server chef-ha}
 default['private_chef']['addons']['ubuntu_supported_codenames'] =
   %w{lucid precise trusty}
 default['private_chef']['addons']['ubuntu_distribution'] =

--- a/omnibus/files/private-chef-ctl-commands/install.rb
+++ b/omnibus/files/private-chef-ctl-commands/install.rb
@@ -3,7 +3,6 @@
 
 KNOWN_ADDONS = %w(
   chef-ha
-  chef-sync
   chef-manage
   opscode-push-jobs-server
   opscode-reporting


### PR DESCRIPTION
chef-sync is no longer being offered as a product to new users and should
be removed as an option to prevent unintended user confusion.

It has already been removed as an option on the doc site and from the downloads site.