### PR TITLE
Add chef-server-ctl require-credential-rotation command

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 89b3385eee74bf19d8d68ddb8b6f240d9bd28d70
+  revision: 91797cdae99ca91cb87af877ceb4953610d45152
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: b62510242eceae2f52f2701f6ee0c4ef48ae8b4a
+  revision: ea5273b9cc3e3de32b93ae959ba76cc148613d60
   specs:
     omnibus (5.4.0)
       aws-sdk (~> 2)
@@ -24,12 +24,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.3.3)
-      aws-sdk-resources (= 2.3.3)
-    aws-sdk-core (2.3.3)
+    aws-sdk (2.3.5)
+      aws-sdk-resources (= 2.3.5)
+    aws-sdk-core (2.3.5)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.3)
-      aws-sdk-core (= 2.3.3)
+    aws-sdk-resources (2.3.5)
+      aws-sdk-core (= 2.3.5)
     berkshelf (4.3.0)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -150,7 +150,7 @@ GEM
     nio4r (1.2.1)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.15.1)
+    ohai (8.16.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -204,7 +204,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    ruby-progressbar (1.8.0)
+    ruby-progressbar (1.8.1)
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
@@ -246,4 +246,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.12.3
+   1.12.4

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -32,7 +32,7 @@ override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
 override :ruby, version: "2.1.4"
 override :rubygems, version: "2.4.5"
-override :'omnibus-ctl', version: "0.4.2"
+override :'omnibus-ctl', version: "master"
 override :bundler, version: "1.10.6"
 # creates required build directories
 dependency "preparation"

--- a/omnibus/files/private-chef-ctl-commands/Gemfile.lock
+++ b/omnibus/files/private-chef-ctl-commands/Gemfile.lock
@@ -39,10 +39,10 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus-ctl.git
-  revision: 3f61f2e1af8b261743aad8dd767c1d4b0173a4d6
+  revision: a0ccf08af008c5fd248a5dcc5af9ff1c48f2a1a9
   branch: master
   specs:
-    omnibus-ctl (0.3.4)
+    omnibus-ctl (0.5.0)
 
 PATH
   remote: ../veil
@@ -158,4 +158,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.11.2
+   1.12.4

--- a/omnibus/files/private-chef-ctl-commands/chef-server-ctl
+++ b/omnibus/files/private-chef-ctl-commands/chef-server-ctl
@@ -216,6 +216,17 @@ EOM
         "/admin/ping?wt=json"
       end
     end
+
+    # Override reconfigure to skip license checking
+    def reconfigure(*args)
+      status = run_chef("#{base_path}/embedded/cookbooks/dna.json")
+      if status.success?
+        log "#{display_name} Reconfigured!"
+        exit! 0
+      else
+        exit! 1
+      end
+    end
   end
 end
 

--- a/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
+++ b/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
@@ -194,15 +194,18 @@ add_command_under_category "require-credential-rotation", "credential-rotation",
       add_global_pre_hook "require_credential_rotation" do
         # Allow running "chef-server-ctl rotate-shared-secrets"
         # "chef-server-ctl" is a wapper that runs "omnibus-ctl opscode $command"
-        # so we'll look for our command and opscode in the args
+        # so we'll look for that in ARGV
 
-        return true if ARGV.include?("opscode") && ARGV.include?("rotate-shared-secrets")
+        return true if ARGV == %w{omnibus-ctl opscode rotate-shared-secrets}
 
         raise("You must rotate the Chef Server credentials to enable the Chef Server. "\
               "Please run 'sudo chef-server-ctl rotate-shared-secrets'")
       end
     EOF
   end
+
+  log("The Chef Server has been disabled until credentials have been rotated. "\
+      "Run 'sudo chef-server-ctl rotate-shared-secrets' to rotate them.")
 
   exit(0)
 end

--- a/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
+++ b/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
@@ -156,7 +156,10 @@ end
 # and you want to make sure that the Chef Server doesn't start up until all
 # secrets have been rotated. It's important to note that credential rotation
 # does not rotate the pivotal, user or client keys, or remove any Chef Server
-# policy or cookbooks that have been uploaded.
+# policy or cookbooks that have been uploaded. When the user rotates the shared
+# credentials the chef-client reconfigure run will re-enable/link the services,
+# restart the Chef Server and remove the sentinel file that enables the
+# pre-hook.
 add_command_under_category "require-credential-rotation", "credential-rotation", "Disable the Chef Server and require credential rotation", 2 do
   @agree_to_disable = false
   @ui = HighLine.new

--- a/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
+++ b/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
@@ -3,6 +3,11 @@ require "time"
 require "optparse"
 require "highline"
 
+# rotate-credentials will generate new credential values for all credentials for
+# a given service by incrementing the value and creating a new hash value.
+# Because the shared secrets are known on all nodes in the cluster the user can
+# choose between copying the secrets file to each node in the cluster and
+# reconfiguring or by running this command on all nodes.
 add_command_under_category "rotate-credentials", "credential-rotation", "Rotate Chef Server credentials for a given service", 2 do
   ensure_configured!
 
@@ -55,6 +60,11 @@ add_command_under_category "rotate-credentials", "credential-rotation", "Rotate 
   end
 end
 
+# rotate-all-credentials will generate new credential values for all service
+# credentials by incrementing the version and creating a new hash value. Because
+# the shared secrets are known on all nodes in the cluster the user can choose
+# between copying the secrets file to each node in the cluster and reconfiguring
+# or by running this command on all nodes.
 add_command_under_category "rotate-all-credentials", "credential-rotation", "Rotate all Chef Server service credentials", 2 do
   ensure_configured!
 
@@ -91,6 +101,10 @@ add_command_under_category "rotate-all-credentials", "credential-rotation", "Rot
   end
 end
 
+# rotate-shared-secrets will create a new shared secret and salt and generate
+# new service credentials for all services. It will then do a chef run to apply
+# the new credentials. As the shared secret and salt is securely and randomly
+# generated the user must copy the secrets file to all nodes in the cluster.
 add_command_under_category "rotate-shared-secrets", "credential-rotation", "Rotate the Chef Server shared secrets and all service credentials", 2 do
   ensure_configured!
 
@@ -136,6 +150,13 @@ add_command_under_category "show-service-credentials", "credential-rotation", "S
   exit(0)
 end
 
+# require-credential-rotation is designed to put the Chef Server in a state
+# where it's offline and requires complete credential rotation to restart.
+# This sort of thing is useful if you're creating public Chef Server images
+# and you want to make sure that the Chef Server doesn't start up until all
+# secrets have been rotated. It's important to note that credential rotation
+# does not rotate the pivotal, user or client keys, or remove any Chef Server
+# policy or cookbooks that have been uploaded.
 add_command_under_category "require-credential-rotation", "credential-rotation", "Disable the Chef Server and require credential rotation", 2 do
   @agree_to_disable = false
   @ui = HighLine.new

--- a/omnibus/files/private-chef-ctl-commands/spec/helpers/omnibus_ctl_helper.rb
+++ b/omnibus/files/private-chef-ctl-commands/spec/helpers/omnibus_ctl_helper.rb
@@ -1,4 +1,4 @@
-require 'omnibus-ctl'
+require "omnibus-ctl"
 
 class OmnibusCtlHelper
   attr_accessor :ctl
@@ -23,5 +23,13 @@ class OmnibusCtlHelper
       ARGV << arg
     end
     @ctl.run([command])
+  end
+
+  def run_global_pre_hooks(args = [])
+    ARGV.clear
+    args.each do |arg|
+      ARGV << arg
+    end
+    @ctl.run_global_pre_hooks
   end
 end

--- a/omnibus/files/private-chef-ctl-commands/spec/key_control_spec.rb
+++ b/omnibus/files/private-chef-ctl-commands/spec/key_control_spec.rb
@@ -25,7 +25,8 @@ describe "chef-server-ctl *key(s)*" do
 
   # marco for testing mandatory args
   def mandatory_argument_should_exist(command, arg_name, arg_list, arg_number)
-    expect { @helper.run_test_omnibus_command(command, arg_list) }.to raise_error(SystemExit, Regexp.new(KeyCtlHelper.new.argument_missing_msg(arg_name, arg_number)))
+    expect { @helper.run_test_omnibus_command(command, arg_list) }
+      .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
   end
 
   let(:public_key) {
@@ -55,7 +56,8 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
   shared_examples_for "a key command with option parsing" do
     context "when an invalid argument is passed" do
       it "should return a proper error" do
-        expect { @helper.run_test_omnibus_command(command, ["--wrong"]) }.to raise_error(SystemExit, KeyCtlHelper.new.invalid_arg_msg("--wrong"))
+        expect { @helper.run_test_omnibus_command(command, ["--wrong"]) }
+          .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
       end
     end
   end
@@ -63,7 +65,8 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
   shared_examples_for "a key command with options that require input" do
     context "when a valid argument is missing valid input" do
       it "should return a proper error" do
-        expect { @helper.run_test_omnibus_command(command, [valid_arg_missing_input]) }.to raise_error(SystemExit, KeyCtlHelper.new.missing_valid_input_msg(valid_arg_missing_input))
+        expect { @helper.run_test_omnibus_command(command, [valid_arg_missing_input]) }
+          .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
       end
     end
   end
@@ -71,7 +74,8 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
   shared_examples_for "a key command with multiple options that require input" do
     context "when a command that requires input is passed another command" do
       it "should return a proper error" do
-        expect { @helper.run_test_omnibus_command(command, arguments) }.to raise_error(SystemExit, KeyCtlHelper.new.missing_input_msg(argument_followed_by_invalid_input))
+        expect { @helper.run_test_omnibus_command(command, arguments) }
+          .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
       end
     end
   end
@@ -220,17 +224,20 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
       context "when --key-name isn't passed" do
         context "when --public-key-path points to a key with an invalid header" do
           it "should exit_failure and print the proper message" do
-            expect { @helper.run_test_omnibus_command(command, base_arguments.concat(["-p", not_a_key_path])) }.to raise_error(SystemExit, KeyCtlHelper.new.not_a_public_key_msg)
+            expect { @helper.run_test_omnibus_command(command, base_arguments.concat(["-p", not_a_key_path])) }
+              .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
           end
         end
         context "when --public-key-path points to a file that doesn't exist" do
           it "should exit_failure and print the proper message" do
-            expect { @helper.run_test_omnibus_command(command, base_arguments.concat(["-p", "/dev/null/not_there"])) }.to raise_error(SystemExit, KeyCtlHelper.new.public_key_path_msg)
+            expect { @helper.run_test_omnibus_command(command, base_arguments.concat(["-p", "/dev/null/not_there"])) }
+              .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
           end
         end
         context "when --public-key-path is not passed" do
           it "should exit_failure and print the proper message" do
-            expect { @helper.run_test_omnibus_command(command, base_arguments) }.to raise_error(SystemExit, KeyCtlHelper.new.pass_key_name_if_public_key_missing)
+            expect { @helper.run_test_omnibus_command(command, base_arguments) }
+              .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
           end
         end
       end
@@ -273,9 +280,9 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
 
     context "when an invalid date is passed" do
       it "should fail with the proper error message" do
-        expect {
-          @helper.run_test_omnibus_command("add-user-key",["username", "-p", public_key_path, "-e", "invalid-date"])
-        }.to raise_error(SystemExit, Regexp.new(KeyCtlHelper.new.invalid_date_msg))
+        expect do
+          @helper.run_test_omnibus_command("add-user-key", ["username", "-p", public_key_path, "-e", "invalid-date"])
+        end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
       end
     end
 
@@ -317,9 +324,9 @@ Tfuc9dUYsFjptWYrV6pfEQ+bgo1OGBXORBFcFL+2D7u9JYquKrMgosznHoEkQNLo
 
     context "when an invalid date is passed" do
       it "should fail with the proper error message" do
-        expect {
+        expect do
           @helper.run_test_omnibus_command("add-client-key",["testclient", "testorg", "-p", public_key_path,"-e", "invalid-date"])
-        }.to raise_error(SystemExit, Regexp.new(KeyCtlHelper.new.invalid_date_msg))
+        end.to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
       end
     end
 

--- a/omnibus/files/private-chef-ctl-commands/spec/rotate_credentials_spec.rb
+++ b/omnibus/files/private-chef-ctl-commands/spec/rotate_credentials_spec.rb
@@ -1,0 +1,153 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "omnibus_ctl_helper"
+
+describe "chef-server-ctl rotate credentials" do
+  subject do
+    OmnibusCtlHelper.new(["./rotate_credentials.rb"])
+  end
+
+  let(:veil_creds) do
+    double("ChefSecretsFile",
+           rotate: true,
+           rotate_credentials: true,
+           rotate_hasher: true,
+           save: true)
+  end
+
+  before do
+    allow(subject.ctl).to receive(:ensure_configured!).and_return(true)
+    allow(subject.ctl).to receive(:backup_secrets_file).and_return("/tmp/backup.json")
+    allow(subject.ctl).to receive(:restore_secrets_file).and_return(true)
+    allow(subject.ctl).to receive(:remove_backup_file).and_return(true)
+    allow(subject.ctl).to receive(:run_chef).and_return(double("ProcessStatus", success?: true))
+    allow(Veil::CredentialCollection::ChefSecretsFile).to receive(:from_file).and_return(veil_creds)
+  end
+
+  shared_examples "rotation command" do
+    it "exits with 1 when the chef run fails" do
+      allow(subject.ctl).to receive(:run_chef).and_return(double("ProcessStatus", success?: false))
+      expect { subject.run_test_omnibus_command(command, params) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+
+    it "exits with 0 when the chef run succeeds" do
+      expect { subject.run_test_omnibus_command(command, params) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "backs up the secrets file" do
+      expect(subject.ctl).to receive(:backup_secrets_file)
+      expect { subject.run_test_omnibus_command(command, params) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "restores the old file if rotation fails" do
+      %i{rotate rotate_credentials rotate_hasher}.each do |rotation_command|
+        allow(veil_creds).to receive(rotation_command).and_raise
+      end
+
+      expect(subject.ctl).to receive(:restore_secrets_file)
+      expect { subject.run_test_omnibus_command(command, params) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+  end
+
+  context "rotate-credentials" do
+    let(:command) { "rotate-credentials" }
+    let(:params) { ["opscode-solr4"] }
+
+    it_behaves_like "rotation command"
+  end
+
+  context "rotate-all-credentials" do
+    let(:command) { "rotate-all-credentials" }
+    let(:params) { [] }
+
+    it_behaves_like "rotation command"
+  end
+
+  context "rotate-shared-secrets" do
+    let(:command) { "rotate-shared-secrets" }
+    let(:params) { [] }
+
+    it_behaves_like "rotation command"
+  end
+
+  context "require-credential-rotation" do
+    let(:ui) { HighLine.new }
+    let(:prehook_file_path) { "/tmp/prehook" }
+    let(:prehook_file) { StringIO.new }
+
+    before do
+      allow(HighLine).to receive(:new).and_return(ui)
+      allow(subject.ctl).to receive(:run_sv_command).with("stop").and_return(true)
+      allow(subject.ctl).to receive(:get_all_services).and_return([])
+      allow(subject.ctl).to receive(:run_sv_command).with("stop")
+      allow(subject.ctl)
+        .to receive(:credential_prehook_file_path)
+        .and_return(prehook_file_path)
+      allow(File).to receive(:open).with(prehook_file_path, "a+").and_yield(prehook_file)
+    end
+
+    it "bypasses cofirmation if passed --yes" do
+      expect(ui).to_not receive(:ask)
+
+      expect { subject.run_test_omnibus_command("require-credential-rotation", %w{--yes}) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "prompts the user for confirmation" do
+      allow(ui).to receive(:ask).and_return("yes")
+      expect(ui).to receive(:ask).with(/confirm/)
+
+      expect { subject.run_test_omnibus_command("require-credential-rotation", []) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "exits if the user does not agree" do
+      allow(ui).to receive(:ask).and_return("no")
+      expect(ui).to receive(:ask).with(/confirm/)
+
+      expect { subject.run_test_omnibus_command("require-credential-rotation", []) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+
+    it "stops all services" do
+      expect(subject.ctl).to receive(:run_sv_command).with("stop")
+      expect { subject.run_test_omnibus_command("require-credential-rotation", %w{--yes}) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "disables all services" do
+      allow(subject.ctl)
+        .to receive(:get_all_services)
+        .and_return(%w{postgresql oc_erchef})
+      allow(subject.ctl).to receive(:service_enabled?).and_return(true)
+      allow(File).to receive(:unlink).with(/postgresq/).and_return(true)
+      allow(File).to receive(:unlink).with(/oc_erchef/).and_return(true)
+      expect { subject.run_test_omnibus_command("require-credential-rotation", %w{--yes}) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it "writes the pre-hook lock" do
+      expect(prehook_file).to receive(:write).with(/require_credential_rotation/)
+      expect { subject.run_test_omnibus_command("require-credential-rotation", %w{--yes}) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+  end
+end


### PR DESCRIPTION
# Requiring Chef Server credential rotation

As as Marketplace developer, I want a way to generate a Chef Server
image that requires credential rotation before starting services so that my Chef
Server does not start up insecurely.

## Current Problems

1. There's no way for us to force a credential rotation before the Chef Server's
  services start up.
1. There's no way to force a credential rotation before a `chef-server-ctl reconfigure`
1. There's no way to force a credential rotation before a `chef-server-ctl start`

## Solution

We solve the current problems by:

* Writing a `chef-server-ctl require-credential-rotation` command that:
  * Stops all Chef Server services
  * Disables all Chef Server services
  * Write a special prehook that will prevent service and reconfigure commands from running until rotation command has run.

OmnibusCtl prehook system: https://github.com/chef/omnibus-ctl/pull/43