### PR TITLE
Reset initialization_options and vendor_class after a chef_run

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_run_provider.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_run_provider.rb
@@ -8,10 +8,13 @@ class Chef
       action :run do
         converge_by "Running chef-run with run list #{new_resource.run_list}" do
           old_config = Chef::Config.save
+          old_initialization_options = Chef::Cookbook::FileVendor.initialization_options
+          old_vendor_class = Chef::Cookbook::FileVendor.vendor_class
           mutate_chef_config
           converge
           Chef::Config.restore(old_config)
-          Chef::Cookbook::FileVendor.instance_variable_set(:@initialization_options, Chef::Config[:cookbook_path])
+          Chef::Cookbook::FileVendor.instance_variable_set(:@initialization_options, old_initialization_options)
+          Chef::Cookbook::FileVendor.instance_variable_set(:@vendor_class, old_vendor_class)
         end
       end
 
@@ -22,8 +25,9 @@ class Chef
         if !new_resource.show_run
           Chef::Config[:force_logger] = true
         end
-        Chef::Config[:solo] = true
+        Chef::Config[:solo_legacy_mode] = true
       end
+
 
       def my_node
         @my_node ||= my_client.build_node


### PR DESCRIPTION
With the chef-client change from solo mode to zero with solo legacy mode the
chef_run resource no longer properly configured and reset the FileVendor class
variables. This causes the templates rendered in the outer chef runs to fail
when trying to download their files. This change tracks the outer run variables
and resets them after the sub runs have completed.

```
Recipe: private-chef::plugin_chef_run
  * chef_run[recipe[test::enable]] action run[2016-05-18T20:18:21+00:00] WARN: Class Chef::Provider::ChefRun does not declare 'provides :chef_run'.
[2016-05-18T20:18:21+00:00] WARN: This will no longer work in Chef 13: you must use 'provides' to use the resource's DSL.
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 1 resources
Recipe: test::enable
  * template[/tmp/works] action create
    - create new file /tmp/works
    - update content in file /tmp/works from none to 7d865e
    --- /tmp/works      2016-05-18 20:18:21.974159738 +0000
    +++ /tmp/.chef-works20160518-6651-z53916    2016-05-18 20:18:21.974159738 +0000
    @@ -1 +1,2 @@
    +bar
    - change mode from '' to '0655'
    - change owner from '' to 'root'
    - change group from '' to 'root'

    - Running chef-run with run list recipe[test::enable]
```