### PR TITLE
Use enterprise cookbook version that supports systemd on ubuntu 16.04

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/Berksfile
+++ b/omnibus/files/private-chef-cookbooks/private-chef/Berksfile
@@ -2,7 +2,7 @@ site :opscode
 
 metadata
 
-cookbook 'enterprise', :git => 'https://github.com/chef-cookbooks/enterprise-chef-common', :tag => '0.10.0'
+cookbook 'enterprise', :git => 'https://github.com/chef-cookbooks/enterprise-chef-common', :tag => '0.10.1'
 cookbook 'chef-ha-drbd', :path => '../chef-ha-drbd'
 cookbook 'apt', '~> 2.0'
 cookbook 'yum', '~> 3.0'


### PR DESCRIPTION
Successful pipeline run on ubuntu 16.04 in a dev jenkins environment:  http://10.194.10.88/job/chef-server-12-trigger-ad_hoc/10/downstreambuildview/