### PR TITLE
oc_erchef users list: allow filtering by external_authentication_id

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_users.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_users.erl
@@ -117,7 +117,11 @@ to_json(Req, State) ->
             {chef_json:encode(verbose_users_as_ejson()), Req, State};
         _ ->
             oc_chef_wm_base:list_objects_json(Req, State#base_state{resource_state =
-                                                                 #chef_user{email = wrq:get_qs_value("email", Req)} })
+                                                                        #chef_user{email =
+                                                                                       wrq:get_qs_value("email", Req),
+                                                                                   external_authentication_uid =
+                                                                                       wrq:get_qs_value("external_authentication_uid", Req)}
+                                                                   })
     end.
 
 verbose_users_as_ejson() ->


### PR DESCRIPTION
For the enablement of external authentication mechanisms that are not LDAP,
we require the ability to fetch a list of users based on their external
authentication identifier.