### PR TITLE
Updated omnibus software pinning to pick up ppc64 friendly defs

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 91797cdae99ca91cb87af877ceb4953610d45152
+  revision: bc8c078d2ba837c45a09f4cbd9c47a623c332c60
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: ea5273b9cc3e3de32b93ae959ba76cc148613d60
+  revision: 2a597277f1a5e13901d116ef852611fe88f6b76b
   specs:
     omnibus (5.4.0)
       aws-sdk (~> 2)
@@ -24,12 +24,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.3.5)
-      aws-sdk-resources (= 2.3.5)
-    aws-sdk-core (2.3.5)
+    aws-sdk (2.3.12)
+      aws-sdk-resources (= 2.3.12)
+    aws-sdk-core (2.3.12)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.5)
-      aws-sdk-core (= 2.3.5)
+    aws-sdk-resources (2.3.12)
+      aws-sdk-core (= 2.3.12)
     berkshelf (4.3.0)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)


### PR DESCRIPTION
@chef/chef-server-maintainers 

This resolves the issues building on ppc64 in CI.