### PR TITLE
[ET-202] Check for SAML enablement during reconfigure

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -37,6 +37,13 @@ if File.exists?("/etc/opscode/chef-server-running.json")
   node.consume_attributes({"previous_run" => old_config['private_chef']})
 end
 
+# used for checking if LDAP and SAML are both enabled
+chef_manage = { "chef_manage" => {} }
+if ::File.exists?("/var/opt/chef-manage/etc/chef-manage-running.json")
+  chef_manage = JSON.parse(IO.read("/var/opt/chef-manage/etc/chef-manage-running.json"))
+end
+node.consume_attributes({"chef_manage" => chef_manage["chef-manage"]})
+
 if File.exists?("/etc/opscode/chef-server.json") &&
     !(File.exist?("/etc/opscode/private-chef.rb") || File.exist?("/etc/opscode/chef-server.rb"))
   Chef::Log.fatal("Configuration via /etc/opscode/chef-server.json is not supported. Please use /etc/opscode/chef-server.rb")

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -52,6 +52,14 @@ if OmnibusHelper.has_been_bootstrapped? or
   node.set['private_chef']['bootstrap']['enable'] = false
 end
 
+# Do a sanity check to make sure both SAML and LDAP are not enabled at the same time
+ldap_enabled = !(node['private_chef']['ldap'].nil? || node['private_chef']['ldap'].empty?)
+saml_enabled = node['chef_manage']['saml'] && node['chef_manage']['saml']['enabled']
+
+if ldap_enabled && saml_enabled
+  Chef::Log.fatal("Both SAML and LDAP auth are enabled at the same time - please enable only one of those auth types.")
+  exit!(1)
+end
 
 # Create the Chef User
 include_recipe "private-chef::users"


### PR DESCRIPTION
This change adds a sanity check to make sure we don't try and enable LDAP at the same time that SAML is enabled. It maps to the same sanity check we do during chef-manage-ctl reconfigure.

@chef/chef-server-maintainers 