### PR TITLE
Update openresty to point to ppc64 lua location

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: bc8c078d2ba837c45a09f4cbd9c47a623c332c60
+  revision: 60eea7a3971d764fca2c7104a8aa46dff4261625
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
@@ -24,12 +24,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.3.12)
-      aws-sdk-resources (= 2.3.12)
-    aws-sdk-core (2.3.12)
+    aws-sdk (2.3.14)
+      aws-sdk-resources (= 2.3.14)
+    aws-sdk-core (2.3.14)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.12)
-      aws-sdk-core (= 2.3.12)
+    aws-sdk-resources (2.3.14)
+      aws-sdk-core (= 2.3.14)
     berkshelf (4.3.0)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)

--- a/omnibus/config/software/openresty-lpeg.rb
+++ b/omnibus/config/software/openresty-lpeg.rb
@@ -31,7 +31,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   if ppc64? || ppc64le?
-    make "LUADIR=#{install_dir}/embedded/lua/include", env: env
+    make "LUADIR=#{install_dir}/embedded/include", env: env
   else
     make "LUADIR=#{install_dir}/embedded/luajit/include/luajit-2.1", env: env
   end


### PR DESCRIPTION
Will be updated with a lockfile version bump commit after https://github.com/chef/omnibus-software/pull/684 gets merged.

This will get the chef-server back to green on CI: http://wilson.ci.chef.co/job/chef-server-12-test/242/

@chef/engineering-services @chef/chef-server-maintainers 