### PR TITLE
[IPO-202] Add initial Data Collector application and /_status check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ opt/
 NEW_CHANGELOG.md
 version-manifest.json
 MODIFIED_COMPONENTS_CHANGELOG.md
+/dev/nodes

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -801,3 +801,30 @@ default['private_chef']['folsom_graphite']['prefix'] = "stats_prefix"
 default['private_chef']['folsom_graphite']['send_interval'] = 10000
 # if a connection fails, how frequently do we attempt to reconnect?
 default['private_chef']['folsom_graphite']['retry_interval'] = 2000
+
+#
+# Data Collector
+#
+# data_collector configuration for erchef. These are used to configure an
+# opscoderl_httpc pool of HTTP connecton workers.
+# If a root_url and token are present the erchef will start the data_collector
+# application.
+
+# Fully qualified URL to the data collector server (e.g.: https://localhost/insights).
+# default['private_chef']['data_collector']['root_url']
+# The authentication token to pass via the header to the data collector server
+# default['private_chef']['data_collector']['token']
+# Timeout for requests to the data collector server in milliseconds.
+default['private_chef']['data_collector']['timeout'] = 30000
+# How many HTTP workers to start in the pool.
+default['private_chef']['data_collector']['http_init_count'] = 25
+# Maximum number of HTTP workers in the pool.
+default['private_chef']['data_collector']['http_max_count'] = 100
+# Maximum age of a server pool worker before terminating it.
+default['private_chef']['data_collector']['http_max_age'] = "{70, sec}"
+# How often to cull aged-out connections.
+default['private_chef']['data_collector']['http_cull_interval'] = "{1, min}"
+# Maximum age of a connection before terminating it.
+default['private_chef']['data_collector']['http_max_connection_duration'] = "{70,sec}"
+# Options for the ibrowse connections (see ibrowse).
+default['private_chef']['data_collector']['ibrowse_options'] = "[{connect_timeout, 10000}]"

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -226,13 +226,16 @@ module PrivateChef
       (default_keys | keys_from_extensions).each do |key|
         # @todo: Just pick a naming convention and adhere to it
         # consistently
-        rkey = if key =~ /^oc_/ || key == "redis_lb" ||
-                  key == "use_chef_backend" ||
-                  key == "chef_backend_members"
-                 key # leave oc_* keys as is
-               else
-                 key.gsub("_", "-")
-               end
+        rkey = if key =~ /^oc_/ || %w{
+          redis_lb
+          use_chef_backend
+          chef_backend_members
+          data_collector
+        }.include?(key)
+          key
+        else
+          key.gsub("_", "-")
+        end
         results["private_chef"][rkey] = PrivateChef[key]
       end
       results["private_chef"]["default_orgname"] = PrivateChef["default_orgname"]

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -89,6 +89,8 @@ module PrivateChef
   backup Mash.new
   backup["strategy"] = "tar"
 
+  data_collector Mash.new
+
   # - legacy config mashes -
   # these config values are here so that if any config has been previously
   # set for these projects in an older version of private-chef/chef-server.rb
@@ -215,6 +217,7 @@ module PrivateChef
         "enabled_plugins",
         "license",
         "backup",
+        "data_collector",
 
         # keys for cleanup and back-compat
         "couchdb",

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -1,6 +1,6 @@
 %% -*- mode: erlang -*-
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%% ex: ts=4 sw=4 ft=erlang et
+%% ex: ts=4 sw=4 ft=eruby.erlang et
 [
     {kernel, [{inet_dist_use_interface, {127,0,0,1}}]},
     %% SASL config
@@ -111,7 +111,14 @@
         {max_request_size, <%= node['private_chef']['opscode-erchef']['max_request_size'] %>},
         {server_version, "<%= node['private_chef']['version'] %>"},
         {health_ping_timeout, <%= node['private_chef']['opscode-erchef']['health_ping_timeout'] %>},
-        {health_ping_modules, [oc_chef_authz, chef_sql, chef_<%= node['private_chef']['opscode-erchef']['search_provider'] %>]},
+        {health_ping_modules, [
+            <% if node['private_chef']['data_collector']['root_url'] %>
+            data_collector,
+            <% end %>
+            oc_chef_authz,
+            chef_sql,
+            chef_<%= node['private_chef']['opscode-erchef']['search_provider'] %>
+        ]},
         {base_resource_url, <%= @helper.erl_atom_or_string(node['private_chef']['opscode-erchef']['base_resource_url']) %>},
         {bulk_fetch_batch_size, <%= @bulk_fetch_batch_size %>},
         {strict_search_result_acls, <%= @strict_search_result_acls %>},
@@ -241,6 +248,20 @@
         {depsolver_timeout, <%= @depsolver_timeout %>},
         {depsolver_pooler_timeout, <%= @depsolver_pooler_timeout %>}
     ]},
+
+    <% if node['private_chef']['data_collector']['root_url'] %>
+    {data_collector, [
+        {root_url,                "<%= node['private_chef']['data_collector']['root_url'] %>"},
+        {token,                   "<%= node['private_chef']['data_collector']['token'] %>"},
+        {timeout,                 <%= node['private_chef']['data_collector']['timeout'] %>},
+        {init_count,              <%= node['private_chef']['data_collector']['http_init_count'] %>},
+        {max_count,               <%= node['private_chef']['data_collector']['http_max_count'] %>},
+        {cull_interval,           <%= node['private_chef']['data_collector']['http_cull_interval'] %>},
+        {max_age,                 <%= node['private_chef']['data_collector']['http_max_age'] %>},
+        {max_connection_duration, <%= node['private_chef']['data_collector']['http_max_connection_duration'] %>},
+        {ibrowse_options,         <%= node['private_chef']['data_collector']['ibrowse_options'] %>}
+    ]},
+    <% end %>
 
     {stats_hero, [
         %% Set sender pool size to DB max_connections to avoid contention

--- a/src/oc_erchef/apps/data_collector/.gitignore
+++ b/src/oc_erchef/apps/data_collector/.gitignore
@@ -1,0 +1,15 @@
+.eunit
+deps/
+ebin/
+ebin_dialyzer/
+TAGS
+.DS_Store
+doc/*.html
+*.beam
+/doc/edoc-info
+/doc/erlang.png
+/doc/stylesheet.css
+/deps.plt
+test/*.out
+.rebar
+log/

--- a/src/oc_erchef/apps/data_collector/Makefile
+++ b/src/oc_erchef/apps/data_collector/Makefile
@@ -1,0 +1,30 @@
+REBAR3_URL=https://s3.amazonaws.com/rebar3/rebar3
+
+# If there is a rebar in the current directory, use it
+ifeq ($(wildcard rebar3),rebar3)
+REBAR3 = $(CURDIR)/rebar3
+endif
+
+# Fallback to rebar on PATH
+REBAR3 ?= $(shell which rebar3)
+
+# And finally, prep to download rebar if all else fails
+ifeq ($(REBAR3),)
+REBAR3 = rebar3
+endif
+
+all: $(REBAR3)
+	@$(REBAR3) do clean, compile, eunit, dialyzer
+
+rel: all
+	@$(REBAR3) release
+
+distclean:
+	@rm -rf _build
+
+$(REBAR3):
+	curl -Lo rebar3 $(REBAR3_URL) || wget $(REBAR3_URL)
+	chmod a+x rebar3
+
+install: $(REBAR3) distclean
+	$(REBAR3) update

--- a/src/oc_erchef/apps/data_collector/README.md
+++ b/src/oc_erchef/apps/data_collector/README.md
@@ -1,0 +1,3 @@
+# Data Collector
+
+Data Collector is an HTTP exporter of Chef Server actions for external services.

--- a/src/oc_erchef/apps/data_collector/rebar.config
+++ b/src/oc_erchef/apps/data_collector/rebar.config
@@ -1,0 +1,23 @@
+%% -*- mode: erlang -*-
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 ft=erlang et
+{profiles, [{
+    test, [
+        {deps, [meck]},
+        {erl_opts, [export_all]}
+    ]
+}]}.
+
+{erl_opts, [
+    warnings_as_errors,
+    {parse_transform, lager_transform},
+    debug_info
+]}.
+
+{deps, [
+    {lager, ".*", {git, "https://github.com/basho/lager", {tag, "2.1.1"}}},
+    {opscoderl_httpc, ".*", {git, "https://github.com/chef/opscoderl_httpc", {branch, "master"}}},
+    {pooler, ".*", {git,"git://github.com/seth/pooler.git", {branch,"master"}}}
+]}.
+
+{cover_enabled, true}.

--- a/src/oc_erchef/apps/data_collector/rebar.lock
+++ b/src/oc_erchef/apps/data_collector/rebar.lock
@@ -1,0 +1,12 @@
+[{<<"ibrowse">>,
+  {git,"git://github.com/opscode/ibrowse.git",
+       {ref,"8f3f6a3a30730b193cc340a8885a960586dc98de"}},
+  1},
+ {<<"opscoderl_httpc">>,
+  {git,"https://github.com/chef/opscoderl_httpc",
+       {ref,"41a0cb853f4273be394eb952c9eb4eae2d3f00d4"}},
+  0},
+ {<<"pooler">>,
+  {git,"git://github.com/seth/pooler.git",
+       {ref,"521f568bf9a2ccbe7c7e0fc23f24cd06ec559b79"}},
+  0}].

--- a/src/oc_erchef/apps/data_collector/src/data_collector.app.src
+++ b/src/oc_erchef/apps/data_collector/src/data_collector.app.src
@@ -1,0 +1,35 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%%
+%% @author Ryan Cragun <ryan@chef.io>
+%% @author John Keiser <jkeiser@chef.io.
+%%
+%% Copyright 2016 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+{application, data_collector, [
+    {description, "Chef Server Data Collector"},
+    {vsn, {cmd,"cat ../../VERSION | awk '{print $0}'"}},
+    {registered, []},
+    {applications, [
+        kernel,
+        stdlib,
+        lager,
+        opscoderl_httpc
+    ]},
+    {mod, {data_collector_app, []}}
+]}.

--- a/src/oc_erchef/apps/data_collector/src/data_collector.erl
+++ b/src/oc_erchef/apps/data_collector/src/data_collector.erl
@@ -1,0 +1,52 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%%
+%% @author Ryan Cragun <ryan@chef.io>
+%% @author John Keiser <jkeiser@chef.io.
+%%
+%% Copyright 2016 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(data_collector).
+-export([
+         ping/0,
+         update/1,
+         is_enabled/0
+        ]).
+
+-spec ping() -> pong | pang.
+ping() ->
+    case data_collector_http:get("/") of
+        ok -> pong;
+        _ -> pang
+    end.
+
+-spec update(iolist() | binary()) -> ok | {error, term()}.
+update(Body) when is_list(Body) ->
+    update(iolist_to_binary(Body));
+update(Body) ->
+    %% TODO: Transform to data collector JSON
+    data_collector_http:post("/", Body).
+
+-spec is_enabled() -> boolean().
+is_enabled() ->
+    case application:get_env(data_collector, root_url) of
+        {ok, _Value} ->
+            true;
+        undefined ->
+            false
+    end.

--- a/src/oc_erchef/apps/data_collector/src/data_collector_app.erl
+++ b/src/oc_erchef/apps/data_collector/src/data_collector_app.erl
@@ -1,0 +1,36 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Ryan Cragun <ryan@chef.io>
+%% @author John Keiser <jkeiser@chef.io.
+%%
+%% Copyright 2016 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(data_collector_app).
+
+-behaviour(application).
+
+%% API
+-export([start/2,
+         stop/1
+        ]).
+
+start(_StartType, _StartArgs) ->
+    data_collector_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/src/oc_erchef/apps/data_collector/src/data_collector_http.erl
+++ b/src/oc_erchef/apps/data_collector/src/data_collector_http.erl
@@ -1,0 +1,85 @@
+-module(data_collector_http).
+
+-export([
+         request/3,
+         request/4,
+         get/1,
+         get/2,
+         get/3,
+         post/2,
+         post/3,
+         delete/2,
+         delete/3,
+         create_pool/0,
+         delete_pool/0
+        ]).
+
+-define(DEFAULT_HEADERS, [{"Content-Type", "application/json"}]).
+
+request(Path, Method, Body) ->
+    request(Path, Method, Body, ?DEFAULT_HEADERS).
+
+request(Path, Method, Body, Headers) ->
+    {ok, Timeout} = application:get_env(data_collector, timeout),
+    oc_httpc:request(?MODULE, Path, Headers, Method, Body, Timeout).
+
+%%
+%% Simple helpers for requets when you only
+%% care about success or failure.
+%%
+-spec get(list()) -> ok | {error, term()}.
+get(Path) ->
+    get(Path, [], ?DEFAULT_HEADERS).
+
+-spec get(list(), iolist() | binary()) -> ok | {error, term()}.
+get(Path, Body) ->
+    get(Path, Body, ?DEFAULT_HEADERS).
+
+-spec get(list(), iolist() | binary(), list()) -> ok | {error, term()}.
+get(Path, Body, Headers) ->
+    request_with_caught_errors(Path, get, Body, Headers).
+
+-spec post(list(), iolist() | binary()) -> ok | {error, term()}.
+post(Path, Body) ->
+    post(Path, Body, ?DEFAULT_HEADERS).
+
+-spec post(list(), iolist() | binary(), list()) -> ok | {error, term()}.
+post(Path, Body, Headers) ->
+    request_with_caught_errors(Path, post, Body, Headers).
+
+-spec delete(list(), iolist() | binary()) -> ok | {error, term()}.
+delete(Path, Body) ->
+    delete(Path, Body, ?DEFAULT_HEADERS).
+
+-spec delete(list(), iolist() | binary(), list()) -> ok | {error, term()}.
+delete(Path, Body, Headers) ->
+    request_with_caught_errors(Path, delete, Body, Headers).
+
+request_with_caught_errors(Path, Method, Body, Headers) when is_list(Body)->
+    request_with_caught_errors(Path, Method, iolist_to_binary(Body), Headers);
+request_with_caught_errors(Path, Method, Body, Headers) ->
+    try
+        case request(Path, Method, Body, Headers) of
+            {ok, [$2|_], _Head, _RespBody} -> ok;
+            Error -> {error, Error}
+        end
+    catch
+        How:Why ->
+            error_logger:error_report({?MODULE, Method, How, Why}),
+            {error, Why}
+    end.
+
+%%
+%% Pool management functions
+%%
+-spec create_pool() -> ok.
+create_pool() ->
+    lager:info("Creating Data Collector HTTP pool"),
+    oc_httpc:add_pool(?MODULE, application:get_all_env()),
+    ok.
+
+-spec delete_pool() -> ok.
+delete_pool() ->
+    lager:info("Removing Data Collector HTTP pool"),
+    oc_httpc:delete_pool(?MODULE),
+    ok.

--- a/src/oc_erchef/apps/data_collector/src/data_collector_sup.erl
+++ b/src/oc_erchef/apps/data_collector/src/data_collector_sup.erl
@@ -1,0 +1,44 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%%
+%% @author Ryan Cragun <ryan@chef.io>
+%% @author John Keiser <jkeiser@chef.io.
+%%
+%% Copyright 2016 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(data_collector_sup).
+
+-behaviour(supervisor).
+
+-export([init/1,
+         start_link/0
+        ]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    start_data_collector_pool(),
+    {ok, {{one_for_one, 10, 10}, []}}.
+
+start_data_collector_pool() ->
+    case data_collector:is_enabled() of
+         true ->
+            data_collector_http:create_pool();
+         _NotEnabled -> ok
+    end.

--- a/src/oc_erchef/apps/data_collector/test/data_collector_sup_tests.erl
+++ b/src/oc_erchef/apps/data_collector/test/data_collector_sup_tests.erl
@@ -1,0 +1,29 @@
+-module(data_collector_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+start_data_collector_no_config_test_() ->
+    data_collector_test_utils:run_tests(
+        [data_collector_http],
+        [{
+            "does not create http pool when not configured",
+            fun() ->
+                application:unset_env(data_collector, root_url),
+                ?assertMatch(ok, application:start(data_collector)),
+                ?assertMatch(ok, application:stop(data_collector))
+            end
+    }]).
+
+start_data_collector_with_config_test_() ->
+    data_collector_test_utils:run_tests(
+        [data_collector_http],
+        [{
+            "creates http pool when configured",
+            fun() ->
+                application:set_env(data_collector, root_url, "http://data_collector"),
+                meck:expect(data_collector_http, create_pool, 0, ok),
+                ?assertMatch(ok, application:start(data_collector)),
+                meck:expect(data_collector_http, delete_pool, 0, ok),
+                ?assertMatch(ok, application:stop(data_collector))
+            end
+    }]).

--- a/src/oc_erchef/apps/data_collector/test/data_collector_test_utils.erl
+++ b/src/oc_erchef/apps/data_collector/test/data_collector_test_utils.erl
@@ -1,0 +1,42 @@
+-module(data_collector_test_utils).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([setup/1,
+         cleanup/1,
+         run_tests/2
+        ]).
+
+run_tests(MockedModules, Tests) ->
+    {foreach,
+     fun() -> data_collector_test_utils:setup(MockedModules) end,
+     fun(_) -> data_collector_test_utils:cleanup(MockedModules) end,
+     Tests
+    }.
+
+setup(MockedModules) ->
+    [meck:new(M) || M <- MockedModules],
+    Env = [
+        {timeout, 3000},
+        {init_count, 2},
+        {max_count, 2},
+        {cull_interval, {1, min}},
+        {max_age, {70, sec}},
+        {max_connection_duration, {70, sec}},
+        {ibrowse_options, [{connect_timeout, 10000}]}
+    ],
+    [application:set_env(data_collector, Name, Value) || {Name, Value} <- Env],
+    lager:start(),
+    application:start(pooler),
+    application:start(ibrowse),
+    application:start(opscoderl_httpc),
+    ok.
+
+cleanup(MockedModules) ->
+    application:stop(data_collector),
+    application:stop(opscoderl_httpc),
+    application:stop(ibrowse),
+    application:stop(pooler),
+    [ ?assert(meck:validate(M)) || M <- MockedModules],
+    [ meck:unload(M) || M <- MockedModules],
+    ok.

--- a/src/oc_erchef/apps/data_collector/test/data_collector_tests.erl
+++ b/src/oc_erchef/apps/data_collector/test/data_collector_tests.erl
@@ -1,0 +1,32 @@
+-module(data_collector_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Validate that our oc_chef_wm_status:check_health() callbacks return properly
+ping_with_valid_response_test_() ->
+    data_collector_test_utils:run_tests(
+        [data_collector_http],
+        [{
+            "returns ping if the response is valid",
+            fun() ->
+                meck:expect(data_collector_http, create_pool, 0, ok),
+                meck:expect(data_collector_http, get, ["/"], ok),
+                application:set_env(data_collector, root_url, "http://data_collector"),
+                application:start(data_collector),
+                ?assertEqual(pong, data_collector:ping())
+            end
+    }]).
+
+ping_with_invalid_response_test_() ->
+    data_collector_test_utils:run_tests(
+        [data_collector_http],
+        [{
+            "returns pang if the response is invalid",
+            fun() ->
+                meck:expect(data_collector_http, create_pool, 0, ok),
+                meck:expect(data_collector_http, get, ["/"], error),
+                application:set_env(data_collector, root_url, "http://data_collector"),
+                application:start(data_collector),
+                ?assertEqual(pang, data_collector:ping())
+            end
+    }]).

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
@@ -125,9 +125,11 @@ log_failure(_,_,_) ->
 -spec spawn_health_checks() -> [{binary(), <<_:32>>}].
 spawn_health_checks() ->
     Parent = self(),
-    Workers = [ {erlang:spawn_monitor(fun() ->
-                                              check_health_worker(Mod, Parent, ping_timeout())
-                                      end), Mod} || Mod <- ping_modules() ],
+    Workers = [{
+        erlang:spawn_monitor(
+            fun() -> check_health_worker(Mod, Parent, ping_timeout()) end
+        ),
+        Mod} || Mod <- ping_modules() ],
     %% Elements of Workers are {{Pid, MonRef}, Mod} tuples
     gather_health_workers(Workers, []).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm.app.src
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm.app.src
@@ -24,7 +24,8 @@
                   syntax_tools,
                   goldrush,
                   lager,
-                  eldap
+                  eldap,
+                  data_collector
                  ]},
   {mod, {oc_chef_wm_app, []}},
   {env, []}

--- a/src/oc_erchef/src/oc_erchef.app.src
+++ b/src/oc_erchef/src/oc_erchef.app.src
@@ -32,7 +32,8 @@
                   runtime_tools,
                   tools,
                   uuid,
-                  webtool
+                  webtool,
+                  data_collector
                  ]},
   {mod, { oc_erchef_app, []}},
   {env, []}

--- a/src/oc_erchef/src/oc_erchef_app.erl
+++ b/src/oc_erchef/src/oc_erchef_app.erl
@@ -29,4 +29,3 @@ server_api_version(max) ->
     {ok, ?API_MAX_VER};
 server_api_version(deprecated) ->
     {ok, ?API_DEPRECATED_VER}.
-

--- a/src/oc_erchef/src/oc_erchef_sup.erl
+++ b/src/oc_erchef/src/oc_erchef_sup.erl
@@ -24,4 +24,3 @@ start_link() ->
 
 init([]) ->
     {ok, { {one_for_one, 5, 10}, []} }.
-


### PR DESCRIPTION
The Data Collector application is intended to export Chef Server actions
to an external Data Collector server via HTTP requests. This PR adds:

 * The initial Data Collector application which consists of a supervisor
   and an HTTP connection pool.
 * Status checks callbacks for oc_chef_wm that are used application has
   been enabled.