### PR TITLE
Add ci/run_tests.sh to drive the CI process

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -evx
+
+chef-server-ctl test -J $WORKSPACE/pedant.xml --all


### PR DESCRIPTION
opscode-ci will get a parallel change to run this instead
of running `chef-server-ctl test -J $WORKSPACE/pedant.xml --all`
directly. This gives us per-checkin control of the test set and
procedure.