### PR TITLE
release notes for chef-server 12.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Chef Server Changelog
 
+## [12.7.0](https://github.com/chef/chef-server/tree/12.7.0) (2016-06-20)
+[Full Changelog](https://github.com/chef/chef-server/compare/12.6.0...12.7.0)
+
+**Implemented enhancements:**
+
+- Bootstrapping a Chef server should not delete databases [\#79](https://github.com/chef/chef-server/issues/79)
+
+**Fixed bugs:**
+
+- oc\_id: Rails existing process detection fails and causes high CPU utlilization. [\#403](https://github.com/chef/chef-server/issues/403)
+- Deleting a User Should Also Delete Any Pending Invites [\#80](https://github.com/chef/chef-server/issues/80)
+
+**Closed issues:**
+
+- \[chef-server-ctl\] Incorrect error messages with `user-create` [\#844](https://github.com/chef/chef-server/issues/844)
+
+**Merged pull requests:**
+
+- Fix whitespace in config [\#851](https://github.com/chef/chef-server/pull/851) ([jkeiser](https://github.com/jkeiser))
+- Update misleading filename error message [\#862](https://github.com/chef/chef-server/pull/862) ([MichaelPereira](https://github.com/MichaelPereira))
+- Add ci/run\_tests.sh to drive the CI process [\#859](https://github.com/chef/chef-server/pull/859) ([jkeiser](https://github.com/jkeiser))
+- \[ET-202\] Fix chef\_manage node attribute access [\#856](https://github.com/chef/chef-server/pull/856) ([srenatus](https://github.com/srenatus))
+- Update openresty to point to ppc64 lua location [\#855](https://github.com/chef/chef-server/pull/855) ([scotthain](https://github.com/scotthain))
+- \[ET-202\] Check for SAML enablement during reconfigure [\#854](https://github.com/chef/chef-server/pull/854) ([chefsalim](https://github.com/chefsalim))
+- Updated omnibus software pinning to pick up ppc64 friendly defs [\#853](https://github.com/chef/chef-server/pull/853) ([scotthain](https://github.com/scotthain))
+- oc\_erchef users list: allow filtering by external\_authentication\_id [\#852](https://github.com/chef/chef-server/pull/852) ([sdelano](https://github.com/sdelano))
+- use chef\_zero mode in vagrant for dvm [\#850](https://github.com/chef/chef-server/pull/850) ([sdelano](https://github.com/sdelano))
+- Use enterprise cookbook version that supports systemd on ubuntu 16.04 [\#848](https://github.com/chef/chef-server/pull/848) ([yzl](https://github.com/yzl))
+- Reset initialization\_options and vendor\_class after a chef\_run [\#841](https://github.com/chef/chef-server/pull/841) ([ryancragun](https://github.com/ryancragun))
+- Add chef-server-ctl require-credential-rotation command [\#840](https://github.com/chef/chef-server/pull/840) ([ryancragun](https://github.com/ryancragun))
+- Update to pick up latest omnibus and omnibus software [\#839](https://github.com/chef/chef-server/pull/839) ([mmzyk](https://github.com/mmzyk))
+- Remove chef-sync from the known add on packages for the install command [\#838](https://github.com/chef/chef-server/pull/838) ([mmzyk](https://github.com/mmzyk))
+- release process updates [\#836](https://github.com/chef/chef-server/pull/836) ([patrick-wright](https://github.com/patrick-wright))
+- \[omnibus\] bypass\_bootstrap? should ensure both creds exist [\#835](https://github.com/chef/chef-server/pull/835) ([stevendanna](https://github.com/stevendanna))
+- Add Ryan Cragun as a Chef Server maintainer [\#834](https://github.com/chef/chef-server/pull/834) ([ryancragun](https://github.com/ryancragun))
+- Fixing pedant/bookshelf when nginx on non-standard port [\#833](https://github.com/chef/chef-server/pull/833) ([adamleff](https://github.com/adamleff))
+- Update opscode-solr4 JAVA\_OPTS to include whitespace [\#830](https://github.com/chef/chef-server/pull/830) ([bigbam505](https://github.com/bigbam505))
+- Update chef-server release process documentation. [\#829](https://github.com/chef/chef-server/pull/829) ([rmoshier](https://github.com/rmoshier))
+- Release Process Updates [\#828](https://github.com/chef/chef-server/pull/828) ([schisamo](https://github.com/schisamo))
+- Add support for service credentials rotation [\#798](https://github.com/chef/chef-server/pull/798) ([ryancragun](https://github.com/ryancragun))
+- Updated Copyright and URL [\#771](https://github.com/chef/chef-server/pull/771) ([jjasghar](https://github.com/jjasghar))
+
+### Components
+New Components
+* veil-gem (master)
+
+Updated Components
+* config_guess (706fbe57 -> ddd7f330)
+* openssl (1.0.1s -> 1.0.1t)
+* omnibus-ctl (e75976be -> a0ccf08a)
+* sqitch (0.973 -> 0.973)
+* ohai (780f7c5f -> 17e5c748)
+* chef (b94e2ef4 -> f0caa91e)
+
+
+### Contributors
+* Brent Montague
+* Michael Pereira
+
 ## [12.6.0](https://github.com/chef/chef-server/tree/12.6.0) (2016-04-29)
 [Full Changelog](https://github.com/chef/chef-server/compare/12.5.0...12.6.0)
 

--- a/PRIOR_RELEASE_NOTES.md
+++ b/PRIOR_RELEASE_NOTES.md
@@ -2,7 +2,44 @@ This document contains historical release notes from the last minor
 release and prior.  The current release notes and subsequent patch
 releases can be found [RELEASE\_NOTES.md](RELEASE_NOTES.md).
 
-## 12.4.0
+## 12.6.0 (2016-04-30)
+
+### Chef Server
+  * Fixed false failures for postgres preflight check.
+  * Fixed bug where public\_key\_read\_access group was not properly being respected for access on org-scoped user and client public key reads.
+  * Update licensing handling to make licensing information easier to find (see [here](https://www.chef.io/blog/2016/04/26/changes-to-how-chef-products-handle-licens
+es/)).
+
+## 12.5.0 (2016-03-22)
+
+### Chef Server
+  * Added /orgs/org/users/user/keys(/key) endpoint and changed default perms on org scoped key GETs.
+		The following endpoints' GET methods can now be accessed by any requestor that is a member of the same organization:
+		/organizations/:org/clients/:client/keys
+		/organizations/:org/clients/:client/keys/:key
+		/organizations/:org/users/:user/keys
+		/organizations/:org/users/:user/keys/:key
+		The above org-scoped user keys endpoints are new and access to them can be controlled by an admin by editing memebership
+		of the public_key_read_access group.
+	* Added support for Ubuntu 14 Trusty.
+	* Bugfixes for chef-server-ctl backup.
+
+### JRE
+  * Updated to 8u74.
+
+### OpenSSL
+  * Updated to 1.0.1s to mitigate DROWN.
+
+### NodeJS
+  * Updated to 0.10.35 to mitigate CVE-2013-4450.
+
+## Ruby On Rails
+  * Updated rails to 4.2.5.2 to mitigate CVE-2016-2097 and CVE-2016-2098.
+
+## PostgreSQL
+  * Updated to 9.2.15.
+
+## 12.4.0 (2016-01-28)
 
 ### `oc-id`
   * Pulled in a new version of Rails for `oc-id` due to critical vulnerabilities found in Rails: http://weblog.rubyonrails.org/2016/1/25/Rails-5-0-0-beta1-1-4-2-5-1-4-1-14-1-3-2-22-1-and-rails-html-sanitizer-1-0-3-have-been-released/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,9 +7,26 @@ in the release. For a detailed list of changed components, refer to
 This document contains release notes for the current release and all patches.
 For prior releases, see [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
 
-## 12.6.0
+## 12.7.0
 
 ### Chef Server
-  * Fixed false failures for postgres preflight check.
-  * Fixed bug where public\_key\_read\_access group was not properly being respected for access on org-scoped user and client public key reads.
-  * Update licensing handling to make licensing information easier to find (see [here](https://www.chef.io/blog/2016/04/26/changes-to-how-chef-products-handle-licenses/)).
+  * Add support for service credential rotation via [Veil](https://github.com/chef/chef-server/blob/3ff412b5a2e6ad54cfa79bca6865e1bbca28fe5e/omnibus/files/veil/README.md), and for requiring it via the added `require-credential-rotation` command of `chef-server-ctl`.
+  * Fixed existing process detection in oc_id which caused high CPU utilization
+  * Fixed bug where deleting a user would not delete pending invites.
+  * Allow filtering users by their external_authentication_uid, allowing for SAML-authentication in Chef-Manage.
+
+### Security Updates
+
+* The update of OpenSSL 1.0.1t addresses the following:
+  * [CVE-2016-2105](https://www.openssl.org/news/vulnerabilities.html#2016-2105)
+  * [CVE-2016-2106](https://www.openssl.org/news/vulnerabilities.html#2016-2106)
+  * [CVE-2016-2107](https://www.openssl.org/news/vulnerabilities.html#2016-2107)
+  * [CVE-2016-2109](https://www.openssl.org/news/vulnerabilities.html#2016-2109)
+  * [CVE-2016-2176](https://www.openssl.org/news/vulnerabilities.html#2016-2176)
+
+### API Changes
+
+  * `GET /users` now allows filtering by `external_authentication_uid`.
+    For example, `GET /users?external_authentication_uid=jane%40doe.com` will
+    now return the users whose external_authentication_uid is `jane@doe.com`.
+    This change is available under API v0 and later.

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -24,7 +24,7 @@ package_name    "chef-server-core"
 replace         "private-chef"
 conflict        "private-chef"
 install_dir     "/opt/opscode"
-build_version   "12.6.0"
+build_version   "12.7.0"
 build_iteration 1
 
 override :berkshelf2, version: "2.0.18"


### PR DESCRIPTION
This includes the updates changelog, release notes, and moving old release notes into prior release notes. And some discussion items below.

Note that the changelog was created with a local checkout of omnibus, due to https://github.com/chef/omnibus/pull/687

Also, I'm not too happy about the changelog generator: for example [this](https://github.com/chef/chef-server/compare/sr/release-12.7.0?expand=1#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR8) sounds like much more than [the closed issue it represents](https://github.com/chef/chef-server/issues/79). But anyway, that's probably why we do release notes: to list the important, real changes there.

I tried to keep in line with prior release notes, although they are quite mixed. __I'm not sure how prominent the OpenSSL bump should be__; I've copied the [CVEs from their changelog](https://www.openssl.org/news/openssl-1.0.1-notes.html)...

Also, I think [Veil](https://github.com/chef/chef-server/pull/798) is pretty cool and should perhaps be more publicized (/cc @ryancragun). Probably not doing it justice with this one bulletpoint.