### PR TITLE
add common_name, cn ldap binding, to auth lookup fields

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authn_ldap.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authn_ldap.erl
@@ -200,6 +200,7 @@ result_to_user_ejson(LoginAttr, UserName, [{eldap_entry, CN, DataIn}|_]) ->
     LookupFields = [{"displayname", <<"display_name">>},
                     {"givenname", <<"first_name">>},
                     {"sn", <<"last_name">>},
+                    {"cn", <<"common_name">>},
                     {"c", <<"country">>},
                     {"l", <<"city">>},
                     {"mail", <<"email">>} ],

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_authn_ldap_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_authn_ldap_tests.erl
@@ -69,6 +69,7 @@ result_to_user_ejson_test_() ->
                   {"mail", ["bob@example.com"]},
                   {"givenName",["Bob"]},
                   {"displayName", ["Bobby"]},
+                  {"cn", ["Bobby Bob"]},
                   {"o",["BigCorporation"]},
                   {"objectClass", ["person","organizationalPerson","inetOrgPerson"]},
                   {"uid",["bob^bob"]}]}],
@@ -79,6 +80,7 @@ result_to_user_ejson_test_() ->
                           {"mail", ["bob@example.com"]},
                           {"givenName",["Bob"]},
                           {"displayName", ["Bobby"]},
+                          {"cn", ["Bobby Bob"]},
                           {"o",["BigCorporation"]},
                           {"objectClass", ["person","organizationalPerson","inetOrgPerson"]},
                           {"uid",["bob^bob", "bobby"]}]}],
@@ -89,6 +91,7 @@ result_to_user_ejson_test_() ->
                             {"mail", ["bob@example.com"]},
                             {"givenName",["Bob"]},
                             {"displayName", ["Bobby"]},
+                            {"cn", ["Bobby Bob"]},
                             {"o",["BigCorporation"]},
                             {"objectClass", ["person","organizationalPerson","inetOrgPerson"]},
                             {"uid",["bob^bob", "bobby"]}]}],
@@ -96,6 +99,11 @@ result_to_user_ejson_test_() ->
       fun() ->
               {_, _, {RetUser}} = oc_chef_wm_authn_ldap:result_to_user_ejson(LoginAttr,UserName,LdapUser),
               ?assertEqual(<<"Bobby">>, proplists:get_value(<<"display_name">>, RetUser))
+      end},
+     {"sets common_name in returned user from cn in the LDAP record",
+      fun() ->
+              {_, _, {RetUser}} = oc_chef_wm_authn_ldap:result_to_user_ejson(LoginAttr,UserName,LdapUser),
+              ?assertEqual(<<"Bobby Bob">>, proplists:get_value(<<"common_name">>, RetUser))
       end},
      {"sets first_name in returned user from givenName in the LDAP record",
       fun() ->


### PR DESCRIPTION
When LDAP auth is configured and the bindings do not include "displayname" this causes a UI bug in Manage. Once a user is authenticated the account is linked to a chef account. If the account doesn't exist a new account is created using a post to the /users rest api. Since display_name is mapped to "unknown" this is was gets displayed in the UI. Product's request is that we fall back to the cn (common name) binding in this case. Manage is handling the fall back logic, but we need to provide that info when the user is authenticated.

Manage PR https://github.com/chef/chef-manage/pull/830