### PR TITLE
[IPO-204] Send actions to the Data Collector before sending stats_her…

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -752,6 +752,7 @@ finish_request(Req, #base_state{reqid = ReqId,
                                 server_api_version = APIVersion,
                                 darklaunch = Darklaunch}=State) ->
     try
+        log_action(Req, State),
         Code = wrq:response_code(Req),
         PerfTuples = stats_hero:snapshot(ReqId, agg),
         UserId = wrq:get_req_header("x-ops-userid", Req),
@@ -763,7 +764,6 @@ finish_request(Req, #base_state{reqid = ReqId,
         AnnotatedReq = maybe_annotate_org_specific(OrgName, Darklaunch, Req1),
         stats_hero:report_metrics(ReqId, Code),
         stats_hero:stop_worker(ReqId),
-        log_action(Req, State),
         case Code of
             500 ->
                 % Sanitize response body

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_data_collector_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_data_collector_tests.erl
@@ -47,7 +47,9 @@ oc_chef_data_collector_failed_actions_test_() ->
     ErrorCodes = [500, 400, 401, 402, 403, 404],
     MockedModules = [wrq, data_collector_http],
     {foreach,
-     fun() -> oc_chef_wm_test_utils:setup(MockedModules) end,
+     fun() -> oc_chef_wm_test_utils:setup(MockedModules),
+              chef_index_test_utils:start_stats_hero()
+     end,
      fun(_) -> oc_chef_wm_test_utils:cleanup(MockedModules) end,
      [{"skips notifying" ++ integer_to_list(ErrorCode) ++ "errors",
        fun() ->


### PR DESCRIPTION
This commit will send actions to the Data Collector/Analytics before the stats_hero worker sends it's data for the request. This allows us to gather additional stats_hero data during data collection that would otherwise be lost.