### PR TITLE
[ET-221] Move SAML/LDAP check into pre-flight

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_auth_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_auth_validator.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "preflight_checks"
+
+class AuthPreflightValidator < PreflightValidator
+  def initialize(node)
+    super
+    @user_ldap = PrivateChef['ldap']
+  end
+
+  def run!
+    # Sanity check: for any configuration we should expect that
+    # both LDAP and SAML auth cannot be enabled simultaneously
+    # across Chef Server and Chef Manage
+    validate_sane_state
+  end
+
+  private
+
+  def validate_sane_state
+    # used for checking if LDAP and SAML are both enabled
+    chef_manage = { "chef_manage" => {} }
+    if ::File.exists?("/var/opt/chef-manage/etc/chef-manage-running.json")
+      chef_manage = JSON.parse(IO.read("/var/opt/chef-manage/etc/chef-manage-running.json"))
+    end
+
+    # Do a sanity check to make sure both SAML and LDAP are not enabled at the same time
+    ldap_enabled = !(@user_ldap.nil? || @user_ldap.empty?)
+    saml_enabled = chef_manage["chef-manage"] && chef_manage["chef-manage"]['saml'] && chef_manage["chef-manage"]['saml']['enabled']
+
+    if ldap_enabled && saml_enabled
+      fail_with err_AUTH001_failed_validation
+    end
+  end
+
+  def err_AUTH001_failed_validation
+<<EOM
+AUTH001: Your configuration indicates that you are attempting to
+         enable both LDAP and SAML authentication. Only one of these
+         authentication types can be enabled across Chef Server and
+         Chef Manage simultaneously.
+EOM
+  end
+
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -136,6 +136,7 @@ class PreflightChecks
         BootstrapPreflightValidator.new(node).run!
         PostgresqlPreflightValidator.new(node).run!
       end
+      AuthPreflightValidator.new(node).run!
       SolrPreflightValidator.new(node).run!
       BookshelfPreflightValidator.new(node).run!
     rescue PreflightValidationFailed => e

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -37,13 +37,6 @@ if File.exists?("/etc/opscode/chef-server-running.json")
   node.consume_attributes({"previous_run" => old_config['private_chef']})
 end
 
-# used for checking if LDAP and SAML are both enabled
-chef_manage = { "chef_manage" => {} }
-if ::File.exists?("/var/opt/chef-manage/etc/chef-manage-running.json")
-  chef_manage = JSON.parse(IO.read("/var/opt/chef-manage/etc/chef-manage-running.json"))
-end
-node.consume_attributes({"chef_manage" => chef_manage["chef-manage"]})
-
 if File.exists?("/etc/opscode/chef-server.json") &&
     !(File.exist?("/etc/opscode/private-chef.rb") || File.exist?("/etc/opscode/chef-server.rb"))
   Chef::Log.fatal("Configuration via /etc/opscode/chef-server.json is not supported. Please use /etc/opscode/chef-server.rb")

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -52,15 +52,6 @@ if OmnibusHelper.has_been_bootstrapped? or
   node.set['private_chef']['bootstrap']['enable'] = false
 end
 
-# Do a sanity check to make sure both SAML and LDAP are not enabled at the same time
-ldap_enabled = !(node['private_chef']['ldap'].nil? || node['private_chef']['ldap'].empty?)
-saml_enabled = node['chef_manage'] && node['chef_manage']['saml'] && node['chef_manage']['saml']['enabled']
-
-if ldap_enabled && saml_enabled
-  Chef::Log.fatal("Both SAML and LDAP auth are enabled at the same time - please enable only one of those auth types.")
-  exit!(1)
-end
-
 # Create the Chef User
 include_recipe "private-chef::users"
 


### PR DESCRIPTION
This change moves the check for SAML/LDAP into the pre-flight checks.
It adds a new AuthPreflightValidator class.