### PR TITLE
Fix repo for manderson26->markan git change

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,7 +26,7 @@ The core chef REST API server, packaging/installation,  and its primary dependen
 ### Lieutenants
 
 * [Marc Paradise](http://github.com/marcparadise)
-* [Mark Anderson](http://github.com/manderson26)
+* [Mark Anderson](http://github.com/markan)
 * [Tyler Cloke](http://github.com/tylercloke)
 
 ### Maintainers

--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -28,7 +28,7 @@
         {sqerl, ".*",
          {git, "https://github.com/chef/sqerl", {branch, "master"}}},
         {envy, ".*",
-         {git, "https://github.com/manderson26/envy", {branch, "master"}}},
+         {git, "https://github.com/markan/envy", {branch, "master"}}},
         {sync, ".*",
          {git, "https://github.com/rustyio/sync", {branch, "master"}}},
         {eper, ".*",

--- a/src/bookshelf/rebar.lock
+++ b/src/bookshelf/rebar.lock
@@ -1,5 +1,5 @@
 [{<<"envy">>,
-  {git,"https://github.com/manderson26/envy",
+  {git,"https://github.com/markan/envy",
        {ref,"8ba233bae37d87c319f3b4c5ae6973576986b36c"}},
   0},
  {<<"eper">>,

--- a/src/bookshelf/stest/rebar.config
+++ b/src/bookshelf/stest/rebar.config
@@ -5,7 +5,7 @@
 {deps,
  [
   {mini_s3, ".*",
-         {git, "git://github.com/manderson26/mini_s3.git",
+         {git, "git://github.com/markan/mini_s3.git",
           {branch, "ma/fix_for_V18"}}}
   ]}.
 

--- a/src/chef-mover/_checkouts/oc_erchef/rebar.config
+++ b/src/chef-mover/_checkouts/oc_erchef/rebar.config
@@ -17,7 +17,7 @@
                      {git,"git://github.com/opscode/opscoderl_wm.git",
                           "64db62e070da58cf7bb0caebde7a3f11c2e3cbbb"}},
        {envy,".*",
-             {git,"git://github.com/manderson26/envy.git",
+             {git,"git://github.com/markan/envy.git",
                   "d62cb227b9000ee866c8bcc724ddf68d87621dea"}},
        {chef_authn,".*",
                    {git,"git://github.com/opscode/chef_authn.git",

--- a/src/chef-mover/rebar.lock
+++ b/src/chef-mover/rebar.lock
@@ -47,7 +47,7 @@
        {ref,"2a78a82f9fb240cac5a33ee4dc13702539463ad6"}},
   2},
  {<<"envy">>,
-  {git,"https://github.com/manderson26/envy",
+  {git,"https://github.com/markan/envy",
        {ref,"8ba233bae37d87c319f3b4c5ae6973576986b36c"}},
   1},
  {<<"eper">>,

--- a/src/oc_bifrost/rebar.lock
+++ b/src/oc_bifrost/rebar.lock
@@ -7,7 +7,7 @@
        {ref,"132a9a3c0662a2377eaf7ebee694a496a0957160"}},
   0},
  {<<"envy">>,
-  {git,"git://github.com/manderson26/envy.git",
+  {git,"git://github.com/markan/envy.git",
        {ref,"8ba233bae37d87c319f3b4c5ae6973576986b36c"}},
   1},
  {<<"eper">>,

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -32,7 +32,7 @@
         {ej, ".*",
          {git, "https://github.com/seth/ej", {branch, "master"}}},
         {envy, ".*",
-         {git, "https://github.com/manderson26/envy", {branch, "master"}}},
+         {git, "https://github.com/markan/envy", {branch, "master"}}},
         {jiffy, ".*",
          {git, "https://github.com/davisp/jiffy", {tag, "0.14.1"}}},
         {ibrowse, ".*",

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -31,7 +31,7 @@
        {ref,"132a9a3c0662a2377eaf7ebee694a496a0957160"}},
   0},
  {<<"envy">>,
-  {git,"https://github.com/manderson26/envy",
+  {git,"https://github.com/markan/envy",
        {ref,"954c87adcfea892db462f56059eb8bc2857ab50b"}},
   0},
  {<<"eper">>,


### PR DESCRIPTION
The github handle manderson26 is now markan. The repo currently is forwarded, but might as well get this changed before the forwarding expires. 