### PR TITLE
Server Admins Part Deux

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -40,7 +40,7 @@ class ChefServerDataBootstrap
     @superuser_authz_id = create_actor_in_authz(bifrost_superuser_id)
     users_authz_id = create_container_in_authz(superuser_authz_id)
     orgs_authz_id = create_container_in_authz(superuser_authz_id)
-    create_server_admins_global_group_in_bifrost(users_authz_id)
+    create_server_admins_global_group_in_bifrost(users_authz_id, orgs_authz_id)
 
     # put pivotal in server-admins global group
     insert_authz_actor_into_group(server_admins_authz_id, superuser_authz_id)
@@ -64,13 +64,16 @@ class ChefServerDataBootstrap
   private
 
   # Create and set up permissions for the server admins group.
-  def create_server_admins_global_group_in_bifrost(users_authz_id)
-    @server_admins_authz_id = create_group_in_authz(bifrost_superuser_id)
+  def create_server_admins_global_group_in_bifrost(users_authz_id, orgs_authz_id)
+    @server_admins_authz_id = create_group_in_authz(bifrost['superuser_id'])
     %w{create read update delete}.each do |permission|
-      # grant server admins group permission on the users container,
+      # grant server admins group permission on the users and orgs container,
       # as the erchef superuser.
       grant_authz_object_permission(permission, "groups", "containers", users_authz_id,
                                     server_admins_authz_id, superuser_authz_id)
+      grant_authz_object_permission(permission, "groups", "containers", orgs_authz_id,
+                                    server_admins_authz_id, superuser_authz_id)
+
       # grant superuser actor permissions on the server admin group,
       # as the bifrost superuser
       grant_authz_object_permission(permission, "actors", "groups", server_admins_authz_id,
@@ -213,3 +216,5 @@ class ChefServerDataBootstrap
     end
   end
 end
+
+  

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -71,6 +71,8 @@ class ChefServerDataBootstrap
       # as the erchef superuser.
       grant_authz_object_permission(permission, "groups", "containers", users_authz_id,
                                     server_admins_authz_id, superuser_authz_id)
+      # NOTE: org creator ignores the org container perms anyway, so this is really only used
+      # for list and create.
       grant_authz_object_permission(permission, "groups", "containers", orgs_authz_id,
                                     server_admins_authz_id, superuser_authz_id)
 

--- a/omnibus/files/private-chef-upgrades/001/031_server_admins_add_perms_on_orgs_container.rb
+++ b/omnibus/files/private-chef-upgrades/001/031_server_admins_add_perms_on_orgs_container.rb
@@ -1,0 +1,19 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+    # Make sure API is down
+    stop_services(["nginx", "opscode-erchef"])
+
+    start_services(["oc_bifrost", "postgresql"])
+    force_restart_service("opscode-chef-mover")
+    log "Graning CRUD on the orgs container to server admins."
+
+    run_command("/opt/opscode/embedded/bin/escript " +
+                "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +
+                "mover_server_admins_add_perms_on_orgs_container_callback " +
+                "normal " +
+                "mover_transient_queue_batch_migrator")
+
+    stop_services(["opscode-chef-mover"])
+  end
+end

--- a/omnibus/files/private-chef-upgrades/001/031_server_admins_add_perms_on_orgs_container.rb
+++ b/omnibus/files/private-chef-upgrades/001/031_server_admins_add_perms_on_orgs_container.rb
@@ -6,7 +6,7 @@ define_upgrade do
 
     start_services(["oc_bifrost", "postgresql"])
     force_restart_service("opscode-chef-mover")
-    log "Graning CRUD on the orgs container to server admins."
+    log "Granting CRUD on the orgs container to server admins."
 
     run_command("/opt/opscode/embedded/bin/escript " +
                 "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +

--- a/omnibus/files/private-chef-upgrades/001/032_server_admins_existing_orgs_permissions.rb
+++ b/omnibus/files/private-chef-upgrades/001/032_server_admins_existing_orgs_permissions.rb
@@ -1,0 +1,19 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+    # Make sure API is down
+    stop_services(["nginx", "opscode-erchef"])
+
+    start_services(["oc_bifrost", "postgresql"])
+    force_restart_service("opscode-chef-mover")
+    log "Granting permission on all existing orgs to the global group server-admins"
+
+    run_command("/opt/opscode/embedded/bin/escript " +
+                "/opt/opscode/embedded/service/opscode-chef-mover/scripts/migrate " +
+                "mover_server_admins_existing_orgs_permissions_callback " +
+                "normal " +
+                "mover_transient_queue_batch_migrator")
+
+    stop_services(["opscode-chef-mover"])
+  end
+end

--- a/src/chef-mover/src/mover_actor_keys_access_group_callback.erl
+++ b/src/chef-mover/src/mover_actor_keys_access_group_callback.erl
@@ -35,10 +35,10 @@ migration_action(#org{name = OrgName, id=OrgId} = Org, _) ->
     AdminsGroupAuthzId = AdminsGroup#group.authz_id,
     ClientGroup = client_group(Org),
     case process_group(UserGroup, AccessGroupAuthzId, OrgName) of
-	{error, Error} ->
-	    Error;
-	ok ->
-	    Result = process_group(ClientGroup, AccessGroupAuthzId, OrgName),
+        {error, Error} ->
+            Error;
+        ok ->
+            Result = process_group(ClientGroup, AccessGroupAuthzId, OrgName),
             add_permissions(Result, AccessGroupAuthzId, AdminsGroupAuthzId)
     end.
 
@@ -62,19 +62,19 @@ process_group(Group, AccessGroupAuthzId, OrgName) ->
         ok ->
             ok;
         {error, failure_creating_group} ->
-            lager:warn("Failed to create keys access group for Organization ~p so cannot be migrated", [OrgName]),
+            lager:warning("Failed to create keys access group for Organization ~p so cannot be migrated", [OrgName]),
             ok;
         {error, no_user_group} ->
-            lager:warn("Organization ~p has no user group and cannot be migrated.", [OrgName]),
+            lager:warning("Organization ~p has no user group and cannot be migrated.", [OrgName]),
             ok;
         {error, no_admins_group} ->
-            lager:warn("Organization ~p has no admins group and cannot be migrated.", [OrgName]),
+            lager:warning("Organization ~p has no admins group and cannot be migrated.", [OrgName]),
             ok;
         {error, no_client_group} ->
-            lager:warn("Organization ~p has no client group and cannot be migrated.", [OrgName]),
+            lager:warning("Organization ~p has no client group and cannot be migrated.", [OrgName]),
             ok;
         {error, not_found} ->
-            lager:warn("Organization ~p is missing bifrost data for either the users or clients group and cannot be migrated.", [OrgName]),
+            lager:warning("Organization ~p is missing bifrost data for either the users or clients group and cannot be migrated.", [OrgName]),
             ok;
         {error, Error} ->
             lager:error("Organization ~p failed during group addition.", [OrgName]),

--- a/src/chef-mover/src/mover_server_admins_add_perms_on_orgs_container_callback.erl
+++ b/src/chef-mover/src/mover_server_admins_add_perms_on_orgs_container_callback.erl
@@ -1,0 +1,87 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Tyler Cloke <tyler@chef.io>
+%% @copyright 2015 Chef Software, Inc.
+%%
+%% This migration grants READ, CREATE, UPDATE, and DELETE perms to
+%% server admins on the orgs container.
+%%
+-module(mover_server_admins_add_perms_on_orgs_container_callback).
+
+-export([
+         migration_init/0,
+         migration_complete/0,
+         migration_type/0,
+         supervisor/0,
+         migration_start_worker_args/2,
+         migration_action/2,
+         next_object/0,
+         error_halts_migration/0,
+         reconfigure_object/2,
+         needs_account_dets/0
+        ]).
+
+-include("mover.hrl").
+-include("mv_oc_chef_authz.hrl").
+
+-define(GLOBAL_PLACEHOLDER_ORG_ID, <<"00000000000000000000000000000000">>).
+
+-record(container, {authz_id}).
+-record(group, {authz_id}).
+
+migration_init() ->
+    mv_oc_chef_authz_http:create_pool(),
+    mover_transient_migration_queue:initialize_queue(?MODULE, [?GLOBAL_PLACEHOLDER_ORG_ID]).
+
+migration_action(_GlobalOrgId, _AcctInfo) ->
+    BifrostSuperuserAuthzId = mv_oc_chef_authz:superuser_id(),
+    ServerAdminsAuthzId = get_server_admins_authz_id(),
+
+    %% Grant server-admins global group permissions on orgs container
+    OrgContainerAuthzId = get_org_container_authz_id(),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, OrgContainerAuthzId, read),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, OrgContainerAuthzId, create),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, OrgContainerAuthzId, update),
+    mv_oc_chef_authz:add_ace_for_entity(BifrostSuperuserAuthzId, group, ServerAdminsAuthzId, container, OrgContainerAuthzId, delete),
+    ok.
+
+get_server_admins_authz_id() ->
+    {ok, [ServerAdmin]} = sqerl:select(get_server_admins_authz_id_sql(), [], rows_as_records, [group, record_info(fields, group)]),
+    ServerAdmin#group.authz_id.
+
+get_server_admins_authz_id_sql() ->
+    erlang:iolist_to_binary([<<"SELECT authz_id FROM groups WHERE name='server-admins' and org_id='">>, ?GLOBAL_PLACEHOLDER_ORG_ID , <<"'">>]).
+
+get_org_container_authz_id() ->
+    {ok, [Container]} = sqerl:select(org_container_query(), [], rows_as_records, [container, record_info(fields, container)]),
+    Container#container.authz_id.
+
+org_container_query() ->
+    <<"SELECT authz_id FROM containers WHERE name='organizations'">>.
+
+migration_complete() ->
+    mv_oc_chef_authz_http:delete_pool().
+%%
+%% Generic mover callback functions for
+%% a transient queue migration
+%%
+needs_account_dets() ->
+    false.
+
+migration_start_worker_args(Object, AcctInfo) ->
+    [Object, AcctInfo].
+
+next_object() ->
+    mover_transient_migration_queue:next(?MODULE).
+
+migration_type() ->
+    <<"server_admins_add_perms_on_orgs_container_callback">>.
+
+supervisor() ->
+    mover_transient_worker_sup.
+
+error_halts_migration() ->
+    true.
+
+reconfigure_object(_ObjectId, _AcctInfo) ->
+    ok.

--- a/src/chef-mover/src/mover_server_admins_add_perms_on_orgs_container_callback.erl
+++ b/src/chef-mover/src/mover_server_admins_add_perms_on_orgs_container_callback.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tyler Cloke <tyler@chef.io>
-%% @copyright 2015 Chef Software, Inc.
+%% @copyright 2016 Chef Software, Inc.
 %%
 %% This migration grants READ, CREATE, UPDATE, and DELETE perms to
 %% server admins on the orgs container.

--- a/src/chef-mover/src/mover_server_admins_existing_users_read_permissions_callback.erl
+++ b/src/chef-mover/src/mover_server_admins_existing_users_read_permissions_callback.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tyler Cloke <tyler@chef.io>
-%% @copyright 2015 Chef Software, Inc.
+%% @copyright 2016 Chef Software, Inc.
 %%
 %% This migration iterates through all existing users and grants
 %% the server-admins global group READ, UPDATE, and DELETE access on them,

--- a/src/chef-mover/src/mover_server_admins_global_group_callback.erl
+++ b/src/chef-mover/src/mover_server_admins_global_group_callback.erl
@@ -106,14 +106,6 @@ chef_object_flatten_group(ObjectRec) ->
     end,
     Tail.
 
-throw_not_found(Type) ->
-    lager:error("Bifrost could not find the " ++ Type ++ " permission on the users container."),
-    throw(not_found).
-
-throw_server_error() ->
-    lager:error("There was an error communicating with bifrost."),
-    throw(server_error).
-
 create_server_admins_authz_group(SuperuserAuthzId) ->
     case mv_oc_chef_authz:create_resource(SuperuserAuthzId, group) of
         {ok, AuthzId} ->

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -50,8 +50,6 @@
 %% Query to count the number of nodes for license checks
 {count_nodes, <<"SELECT COUNT(*) FROM nodes INNER JOIN orgs ON nodes.org_id = orgs.id;">>}.
 
-{fetch
-
 {find_node_by_orgid_name,
  <<"SELECT id, authz_id, org_id, name, environment, last_updated_by,"
    " created_at, updated_at, serialized_object FROM nodes WHERE (org_id = $1"

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -50,6 +50,7 @@
 %% Query to count the number of nodes for license checks
 {count_nodes, <<"SELECT COUNT(*) FROM nodes INNER JOIN orgs ON nodes.org_id = orgs.id;">>}.
 
+{fetch
 
 {find_node_by_orgid_name,
  <<"SELECT id, authz_id, org_id, name, environment, last_updated_by,"
@@ -387,6 +388,11 @@
  <<"SELECT name, version, id
     FROM joined_cookbook_version
     WHERE org_id = $1">>}.
+
+{fetch_server_admins_authz_id,
+<<"SELECT authz_id FROM groups
+  WHERE org_id='00000000000000000000000000000000'
+  AND name='server-admins'">>}.
 
 %% Used in implementation of environemnts/ENVNAME/cookbook_versions endpoint.
 %%

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -77,6 +77,8 @@
          %% for license
          count_nodes/1,
 
+         get_server_admins_authz_id/1,
+
          is_user_in_org/3,
          create/3,
          delete/2,
@@ -568,6 +570,10 @@ list_common_orgs(User1Id, User2Id, #context{reqid=ReqId}) ->
 -spec is_user_in_org(#context{}, binary(), binary()) -> boolean() | {error, _}.
 is_user_in_org(#context{reqid = ReqId}, UserName, OrgName) ->
     ?SH_TIME(ReqId, chef_sql, is_user_in_org, (UserName, OrgName)).
+
+-spec get_server_admins_authz_id(#context{}) -> boolean() | {error, _}.
+get_server_admins_authz_id(#context{reqid = ReqId}) ->
+    ?SH_TIME(ReqId, chef_sql, get_server_admins_authz_id, ()).
 
 -spec bulk_get(#context{}, binary(), chef_type(), [binary()]) ->
                       [binary()|ej:json_object()] | {error, _}.

--- a/src/oc_erchef/apps/chef_db/src/chef_db.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.erl
@@ -571,7 +571,7 @@ list_common_orgs(User1Id, User2Id, #context{reqid=ReqId}) ->
 is_user_in_org(#context{reqid = ReqId}, UserName, OrgName) ->
     ?SH_TIME(ReqId, chef_sql, is_user_in_org, (UserName, OrgName)).
 
--spec get_server_admins_authz_id(#context{}) -> boolean() | {error, _}.
+-spec get_server_admins_authz_id(#context{}) -> binary() | {error, _}.
 get_server_admins_authz_id(#context{reqid = ReqId}) ->
     ?SH_TIME(ReqId, chef_sql, get_server_admins_authz_id, ()).
 

--- a/src/oc_erchef/apps/chef_db/src/chef_sql.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_sql.erl
@@ -51,6 +51,8 @@
 
          bulk_get_authz_ids/2,
 
+	 get_server_admins_authz_id/0,
+
          %% checksum ops
          mark_checksums_as_uploaded/2,
          non_uploaded_checksums/2,
@@ -174,6 +176,16 @@ is_user_in_org(UserName, OrgName) ->
             true;
         {error, Error} ->
             {error, Error}
+    end.
+
+-spec get_server_admins_authz_id() -> boolean() | {error, _}.
+get_server_admins_authz_id() ->
+    case sqerl:select(fetch_server_admins_authz_id,
+                      [], rows_as_scalars, [authz_id]) of
+        {ok, [AuthzId]} when is_binary(AuthzId) ->
+            AuthzId;
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %%

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
@@ -189,6 +189,7 @@ check_json_validity(Part, Ace) ->
 update_from_json(#acl_state{type = Type, authz_id = AuthzId, acl_data = Data},
                  Part, OrgId) ->
     try
+        lager:error("update_part ~p -- ~p -- ~p", [Part, Data, Type]),
         oc_chef_authz_acl:update_part(Part, Data, Type, AuthzId, OrgId)
     catch
         throw:{ambiguous_actor, Actors} ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -465,23 +465,24 @@ authorized_by_org_membership_check(Req, #base_state{organization_name = OrgName,
     case BypassesChecks of
         true -> {true, Req, State};
         _ ->
-            %% If user is a member of the global group server-admins,
-            %% we do not want to fail on org membership check, only acls.
-            case is_server_admin(DbContext, RequestorAuthzId) of
-                true -> {true, Req, State};
-                _ ->
-                    case chef_db:is_user_in_org(DbContext, UserName, OrgName) of
+            case chef_db:is_user_in_org(DbContext, UserName, OrgName) of
+                true ->
+                    {true, Req, State};
+                false ->
+                    %% If user is a member of the global group server-admins,
+                    %% we do not want to fail on org membership check, only acls.
+                    case is_server_admin(DbContext, RequestorAuthzId) of
                         true ->
                             {true, Req, State};
                         false ->
                             Msg = forbidden_message(not_member_of_org, UserName, OrgName),
                             {false, wrq:set_resp_body(chef_json:encode(Msg), Req),
-                             State#base_state{log_msg = user_not_in_org}};
-                        Error ->
-                            Msg = forbidden_message(unverified_org_membership, UserName, OrgName),
-                            {false, wrq:set_resp_body(chef_json:encode(Msg), Req),
-                             State#base_state{log_msg = {user_not_in_org_error, Error}}}
-                    end
+                             State#base_state{log_msg = user_not_in_org}}
+                    end;
+                Error ->
+                    Msg = forbidden_message(unverified_org_membership, UserName, OrgName),
+                    {false, wrq:set_resp_body(chef_json:encode(Msg), Req),
+                     State#base_state{log_msg = {user_not_in_org_error, Error}}}
             end
     end.
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -564,7 +564,7 @@ is_superuser(UserName) ->
     lists:member(UserName, Superusers).
 
 %% Tells whether this user is a member of the global group server-admin.
--spec is_server_admin(chef_db:db_context(), binary()) -> boolean().
+-spec is_server_admin(chef_db:db_context(), binary()) -> boolean() | {error, atom()}.
 is_server_admin(DbContext, RequestorAuthzId) ->
     ServerAdminsAuthzId = chef_db:get_server_admins_authz_id(DbContext),
     oc_chef_authz:is_actor_transitive_member_of_group(

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -458,22 +458,30 @@ authorized_by_org_membership_check(Req, #base_state{requestor=#chef_requestor{ty
     {true, Req, State};
 authorized_by_org_membership_check(Req, #base_state{organization_name = undefined} = State) ->
     {true, Req, State};
-authorized_by_org_membership_check(Req, #base_state{organization_name = OrgName, chef_db_context = DbContext} = State) ->
+authorized_by_org_membership_check(Req, #base_state{organization_name = OrgName,
+                                                    chef_db_context = DbContext,
+                                                    requestor = #chef_requestor{authz_id = RequestorAuthzId}} = State) ->
     {UserName, BypassesChecks} = get_user(Req, State#base_state{superuser_bypasses_checks = true}),
     case BypassesChecks of
         true -> {true, Req, State};
         _ ->
-            case chef_db:is_user_in_org(DbContext, UserName, OrgName) of
-                true ->
-                    {true, Req, State};
-                false ->
-                    Msg = forbidden_message(not_member_of_org, UserName, OrgName),
-                    {false, wrq:set_resp_body(chef_json:encode(Msg), Req),
-                     State#base_state{log_msg = user_not_in_org}};
-                Error ->
-                    Msg = forbidden_message(unverified_org_membership, UserName, OrgName),
-                    {false, wrq:set_resp_body(chef_json:encode(Msg), Req),
-                     State#base_state{log_msg = {user_not_in_org_error, Error}}}
+            %% If user is a member of the global group server-admins,
+            %% we do not want to fail on org membership check, only acls.
+            case is_server_admin(DbContext, RequestorAuthzId) of
+                true -> {true, Req, State};
+                _ ->
+                    case chef_db:is_user_in_org(DbContext, UserName, OrgName) of
+                        true ->
+                            {true, Req, State};
+                        false ->
+                            Msg = forbidden_message(not_member_of_org, UserName, OrgName),
+                            {false, wrq:set_resp_body(chef_json:encode(Msg), Req),
+                             State#base_state{log_msg = user_not_in_org}};
+                        Error ->
+                            Msg = forbidden_message(unverified_org_membership, UserName, OrgName),
+                            {false, wrq:set_resp_body(chef_json:encode(Msg), Req),
+                             State#base_state{log_msg = {user_not_in_org_error, Error}}}
+                    end
             end
     end.
 
@@ -554,6 +562,15 @@ is_superuser(Req = #wm_reqdata{}) ->
 is_superuser(UserName) ->
     Superusers = envy:get(oc_chef_wm, superusers, [], list),
     lists:member(UserName, Superusers).
+
+%% Tells whether this user is a member of the global group server-admin.
+-spec is_server_admin(chef_db:db_context(), binary()) -> boolean().
+is_server_admin(DbContext, RequestorAuthzId) ->
+    ServerAdminsAuthzId = chef_db:get_server_admins_authz_id(DbContext),
+    oc_chef_authz:is_actor_transitive_member_of_group(
+      oc_chef_authz:superuser_id(),
+      RequestorAuthzId,
+      ServerAdminsAuthzId).
 
 %% Get the username from the request (and tell whether it is a superuser)
 -spec get_user(Req :: #wm_reqdata{}, #base_state{}) -> {binary(), boolean()}.


### PR DESCRIPTION
Finish up server-admins functionality by granting them permissions on orgs:
- Grant server-admins CRUD on the orgs container.
- Grant server-admins RUD on the org at org creation since the container defaults get disregarded there (should probably fix that...) via bootstrap and migration for existing installs.
- Grant server-admins CRUD on existing orgs via migration.
- Add server-admins into the admins group on org creation and for existing orgs via migration.
- Allow server-admins to bypass the org membership check for auth.
- Make all migrations idemopotent.

⚠️  ⚠️  ⚠️  ⚠️  ⚠️  
Would love to write pedant tests, but there is no global groups endpoint, so I can't programmatically add users into the server-admins group. Lots of manual testing was done. Additionally, our test coverage will at least show that normal users won't gain access to stuff they shouldn't which is the most important aspect of this work. 

⚠️ ⚠️  ⚠️  ⚠️  ⚠️ 

[Build](http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/212/downstreambuildview/)
