### PR TITLE
Add option to proxy insights data collector via the chef server

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -808,7 +808,11 @@ default['private_chef']['folsom_graphite']['retry_interval'] = 2000
 # data_collector configuration for erchef. These are used to configure an
 # opscoderl_httpc pool of HTTP connecton workers.
 # If a root_url and token are present the erchef will start the data_collector
-# application.
+# application. If proxy and root_url are present, nginx will send data_collector
+# events to the insights server
+
+# Proxy events to the insights data collector
+# default['private_chef']['data_collector']['proxy']
 
 # Fully qualified URL to the data collector server (e.g.: https://localhost/insights).
 # default['private_chef']['data_collector']['root_url']

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -45,6 +45,16 @@
       alias /opt/opscode/version-manifest.txt;
     }
 
+    <% if node['private_chef']['data_collector']['proxy'] -%>
+    location "/data-collector/" {
+      proxy_set_header        Host           $http_host;
+      proxy_set_header        X-Real-IP      $remote_addr;
+      proxy_set_header        X-Forwared-For $proxy_add_x_forwarded_for;
+      proxy_pass_request_headers on;
+      proxy_redirect off;
+      proxy_pass <%= node['private_chef']['data_collector']['root_url'] %>;
+    }
+    <% end -%>
     # bookshelf
     <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
     location ~ "/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/{0,1}.*$" {


### PR DESCRIPTION
Enterprise nodes won't necessarily have access to the chef automate server. This allows the nodes to report to the insights data collector via the chef server which they all already have access to instead of having to add more firewall rules.