### PR TITLE
Add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,116 @@
+Stephen Delano <stephen@opscode.com> sdelano <stephen@opscode.com>
+Stephen Delano <stephen@opscode.com> Stephen Delano <steviedu@gmail.com>
+
+Christopher Maier <cm@opscode.com> Christopher Maier <christopher.maier@gmail.com>
+
+Seth Falcon <seth@opscode.com> Seth Falcon <seth@userprimary.net>
+Seth Falcon <seth@opscode.com> seth <seth@opscode.com>
+
+Seth Chisamore <schisamo@chef.io> Seth Chisamore <schisamo@opscode.com>
+Seth Chisamore <schisamo@chef.io> Seth Chisamore <schisamo@getchef.com>
+
+Marc Paradise <marc@chef.io> Marc Paradise <marc@getchef.com>
+Marc Paradise <marc@chef.io> Marc A. Paradise <marcparadise@users.noreply.github.com>
+Marc Paradise <marc@chef.io> Marc Paradise <marc@opscode.com>
+Marc Paradise <marc@chef.io> Marc A. Paradise <marc.paradise@gmail.com>
+Marc Paradise <marc@chef.io> marc@opscode.com <marc@opscode.com>
+
+mmzyk <mmzyk@opscode.com> Mark Mzyk <mmzyk@programmersparadox.com>
+
+Steven Danna <steve@chef.io> Steven Danna <steve@opscode.com>
+
+Oliver Ferrigni <oliver@opscode.com> Oliver Ferrigni <oliver.ferrigni@gmail.com>
+
+Daniel DeLeo <dan@chef.io> danielsdeleo <dan@getchef.com>
+Daniel DeLeo <dan@chef.io> Daniel DeLeo <dan@opscode.com>
+Daniel DeLeo <dan@chef.io> danielsdeleo <dan@chef.io>
+Daniel DeLeo <dan@chef.io> danielsdeleo <dan@opscode.com>
+Daniel DeLeo <dan@chef.io> Dan DeLeo <danielsdeleo@mac.com>
+
+tylercloke <tyler@opscode.com> tylercloke <tylercloke@gmail.com>
+tylercloke <tyler@opscode.com> Tyler Cloke <tylercloke@gmail.com>
+tylercloke <tyler@opscode.com> Tyler Cloke <tylercloke@users.noreply.github.com>
+tylercloke <tyler@opscode.com> Tyler Ball <tyler-ball@users.noreply.github.com>
+
+Lamont Granquist <lamont@opscode.com> Lamont Granquist <lamont@scriptkiddie.org>
+Lamont Granquist <lamont@opscode.com> lamont-granquist <lamont@scriptkiddie.org>
+Lamont Granquist <lamont@opscode.com> lamont-opscode <lamont@opscode.com>
+
+Yvonne Lam <yvonne@chef.io> Yvonne Lam <yzl@users.noreply.github.com>
+Yvonne Lam <yvonne@chef.io> Yvonne Lam <yvonne@opscode.com>
+
+patrick-wright <patrick@chef.io> Patrick Wright <patrick@getchef.com>
+
+Ho-Sheng Hsiao <hosh@opscode.com> Ho-Sheng Hsiao <hosh@getchef.com>
+Ho-Sheng Hsiao <hosh@opscode.com> Ho-Sheng Hsiao <hosheng.hsiao@gmail.com>
+
+Douglas Triggs <doug@chef.io> Douglas Triggs <doug@opscode.com>
+Douglas Triggs <doug@chef.io> Douglas Triggs <doug@opscode.com>
+Douglas Triggs <doug@chef.io> doubt72 <doug@opscode.com>
+
+James Casey <james@chef.io> jamesc <james@opscode.com>
+James Casey <james@chef.io> James Casey <james@opscode.com>
+James Casey <james@chef.io> James Casey <james@opscode.com>
+
+Mark Anderson <mark@chef.io> Mark Anderson <mark@opscode.com>
+Mark Anderson <mark@chef.io> Mark Anderson <ot-git@muking.org>
+
+Kevin Smith <kevin@opscode.com> Kevin Smith <k@opscode.com>
+
+Nathan L Smith <smith@chef.io> Nathan L Smith <smith@getchef.com>
+Nathan L Smith <smith@chef.io> Nathan L Smith <nlloyds@gmail.com>
+
+John Keiser <jkeiser@opscode.com> jkeiser <jkeiser@opscode.com>
+John Keiser <jkeiser@opscode.com> John Keiser <john@johnkeiser.com>
+
+Eric Merritt <ericbmerritt@gmail.com> Eric B Merritt <ericbmerritt@gmail.com>
+
+Tim Dysinger <dysinger@opscode.com> Tim Dysinger <timd@opscode.com>
+Tim Dysinger <dysinger@opscode.com> Tim Dysinger <tim@dysinger.net>
+
+Christian Nunciato <cnunciato@opscode.com> Chris Nunciato <cnunciato@opscode.com>
+
+Prajakta Purohit <prajakta@opscode.com> PrajaktaPurohit <prajakta@opscode.com>
+
+Dave Parfitt <dparfitt@chef.io> Dave Parfitt <dparfitt@getchef.com>
+Dave Parfitt <dparfitt@chef.io> Dave Parfitt <diparfitt@gmail.com>
+
+Joe DeVivo <joe@devivo.com>
+Joe DeVivo <joe@devivo.com> Joe DeVivo <joedevivo@users.noreply.github.com>
+Joe DeVivo <joe@devivo.com> Joe DeVivo <joe@getchef.com>
+
+Paul Mooring <paul@chef.io> Paul Mooring <paul@opscode.com>
+Paul Mooring <paul@chef.io> Paul Mooring <paulmooringredirect+github@gmail.com>
+
+Jeremiah Snapp <jeremiah@chef.io> Jeremiah Snapp <jeremiah@getchef.com>
+Jeremiah Snapp <jeremiah@chef.io> Jeremiah Snapp <jeremiah.snapp@gmail.com>
+
+Tim Hinderliter <tim@opscode.com> timh <tim@opscode.com>
+
+Serdar Sutay <serdar@opscode.com> ssutay <serdar@opscode.com>
+
+Peter Burkholder <pburkholder@pobox.com> Peter Burkholder (@pburkholder) <pburkholder@pobox.com>
+Peter Burkholder <pburkholder@pobox.com> Peter Burkholder <peterb@getchef.com>
+
+kmacgugan <kmacgugan@chef.io> Kyleen <kmacgugan@chef.io>
+
+Isa Farnik <isa@getchef.com> curiositycasualty <isa@getchef.com>
+
+jmink <jmink@getchef.com> Jess <jmink@getchef.com>
+
+Jean-Philippe Langlois <jpl@opscode.com> langloisjp <jpl@opscode.com>
+
+Julian C. Dunn <jdunn@chef.io> Julian C. Dunn <jdunn@aquezada.com>
+Julian C. Dunn <jdunn@chef.io> Julian C. Dunn <jdunn@getchef.com>
+
+Rachel Adler <radler@chef.io> Rachel Adler <rmoshier@gmail.com>
+
+Thom May <thom@chef.io> Thom May <thom@may.lt>
+Thom May <thom@chef.io> Thom May <tmay@chef.io>
+Thom May <thom@chef.io> Thom May <thom@clearairturbulence.org>
+
+Chris Doherty <cdoherty@chef.io> Chris Doherty <randomcamel@users.noreply.github.com>
+
+Claire McQuin <claire@getchef.com> Claire McQuin <mcquin@users.noreply.github.com>
+
+Jordan Running <jr@getchef.com> Jordan Running <jrunning@gmail.com>


### PR DESCRIPTION
I don't know why I like these things but I do.  `git shortlog` will
read .mailmap and coalesce authors.  This mailmap cleans up most of
the dups I could find.

Signed-off-by: Steven Danna <steve@chef.io>