### PR TITLE
Added db init and max pool size options

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -286,6 +286,8 @@ default['private_chef']['opscode-erchef']['sql_ro_password'] = "shmunzeltazzen"
 # in the queue before timing out.  Request queueing is only effective
 # if db_pooler_timeout > 0
 default['private_chef']['opscode-erchef']['db_pool_size'] = 20
+default['private_chef']['opscode-erchef']['db_pool_max'] = nil
+default['private_chef']['opscode-erchef']['db_pool_init'] = nil
 default['private_chef']['opscode-erchef']['db_pool_queue_max'] = 20
 default['private_chef']['opscode-erchef']['db_pooler_timeout'] = 2000
 default['private_chef']['opscode-erchef']['sql_db_timeout'] = 5000
@@ -583,6 +585,8 @@ default['private_chef']['oc_bifrost']['listen'] = '127.0.0.1'
 default['private_chef']['oc_bifrost']['port'] = 9463
 default['private_chef']['oc_bifrost']['superuser_id'] = '5ca1ab1ef005ba111abe11eddecafbad'
 default['private_chef']['oc_bifrost']['db_pool_size'] = '20'
+default['private_chef']['oc_bifrost']['db_pool_max'] = nil
+default['private_chef']['oc_bifrost']['db_pool_init'] = nil
 # The db_pool is only effective for a db_pooler_timeout > 0
 default['private_chef']['oc_bifrost']['db_pooler_timeout'] = 2000
 default['private_chef']['oc_bifrost']['db_pool_queue_max'] = 20

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -111,8 +111,8 @@
                ]},
  {pooler, [
            {pools, [[{name, sqerl},
-                     {max_count, <%= @db_pool_size %> },
-                     {init_count, <%= @db_pool_size %> },
+                     {max_count, <%= @db_pool_max || @db_pool_size %> },
+                     {init_count, <%= @db_pool_init || @db_pool_size %> },
                      {queue_max, <%= @db_pool_queue_max %>},
                      {start_mfa, {sqerl_client, start_link, []}}]]}
            %%,{metrics_module, folsom_metrics}

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -314,8 +314,8 @@
         {pools, [
             [
                 {name, sqerl},
-                {max_count, <%= @db_pool_size %>},
-                {init_count, <%= @db_pool_size %>},
+                {max_count, <%= @db_pool_max || @db_pool_size %>},
+                {init_count, <%= @db_pool_init || @db_pool_size %>},
                 {start_mfa, {sqerl_client, start_link, []}},
                 {queue_max, <%= @db_pool_queue_max %>}
             ],


### PR DESCRIPTION
Added options to configure db_pool_max and db_pool_init to chef-server.rb for bifrost and erchef.  db_pool_size is still the only default set and max and init are only used if set by the user.