### PR TITLE
force chef_password:verify to fail if salt is null

### DIFF
--- a/src/oc_erchef/apps/chef_objects/src/chef_password.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_password.erl
@@ -99,9 +99,18 @@ verify(Password, {HashedPass, Salt, _}) ->
     end.
 
 sha1(Salt, Password, osc) ->
-    hexstring(crypto:hash(sha, ["--", Salt, "--", Password, "--"]));
+    hexstring(safe_crypto(["--", Salt, "--", Password, "--"]));
 sha1(Salt, Password, ec) ->
-    hexstring(crypto:hash(sha, [Salt, "--", Password, "--"])).
+    hexstring(safe_crypto([Salt, "--", Password, "--"])).
+
+%% Eat any exceptions so secure data doesn't escape
+-spec safe_crypto(list()) -> binary().
+safe_crypto(Data) ->
+    try crypto:hash(sha, Data) of
+        Digest -> Digest
+    catch
+        _:_ -> crypto:hash(sha, ["crypto", "hash", "failure"])
+    end.
 
 hexstring(<<X:160/big-unsigned-integer>>) ->
     lists:flatten(io_lib:format("~40.16.0b", [X])).
@@ -128,4 +137,3 @@ to_str(S) when is_list(S) ->
     S;
 to_str(S) when is_binary(S) ->
     binary_to_list(S).
-

--- a/src/oc_erchef/apps/chef_objects/test/chef_password_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_password_tests.erl
@@ -58,6 +58,12 @@ bcrypt_round_trip_test_() ->
                  || {P, Data} <- PassData ]
        end},
 
+      {"salt is null roundtrip",
+       fun() ->
+               P = "a long password",
+               ?assertEqual(false, chef_password:verify(P, {<<"Corned Beef">>, null, <<"some type">>}))
+       end},
+
       {"salt not specified roundtrip",
        fun() ->
                P = "a long password",
@@ -143,7 +149,6 @@ upgrade_test_() ->
        end}
      ]}.
 
-
 slow_compare_test_() ->
     Tests = [
              %% positive cases
@@ -208,4 +213,3 @@ do_ec_migration(SHA, Salt) ->
     {ok, BcryptSalt} = bcrypt:gen_salt(),
     {ok, HashedPass} = bcrypt:hashpw(SHA, BcryptSalt),
     {list_to_binary(HashedPass), Salt, ?MIGRATION_HASH_TYPE}.
-


### PR DESCRIPTION
Also, run `crypto:hash` in a case statement to prevent any secure data
from leaking into the logs.