### PR TITLE
SPOOL-322: Fix Elasticsearch Reindex

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -30,7 +30,14 @@ Requirements:
   you've acquired root by using `sudo -i`. Otherwise dvm won't be in your
   path.
 
-Go!
+First, add the following configuration to your `/etc/hosts` file:
+
+    192.168.33.100 api.chef-server.dev
+    192.168.33.150 database.chef-server.dev
+    192.168.33.151 backend.chef-server.dev
+    192.168.33.155 reportingdb.chef-server.dev
+
+Next, bring up the VMs!
 
     cd dev
     vagrant up

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -6,6 +6,7 @@ require "yaml"
 load "dvmtools.rb"
 CS_VM_ADDRESS="192.168.33.100"
 DB_VM_ADDRESS="192.168.33.150"
+BE_VM_ADDRESS="192.168.33.151"
 REPORTING_DB_VM_ADDRESS="192.168.33.155"
 DB_SUPERUSER="bofh"
 DB_SUPERPASS="i1uvd3v0ps"
@@ -45,6 +46,15 @@ Vagrant.configure("2") do |config|
     attributes['vm']['reporting_postgresql'] = nil
   end
 
+  if attributes['vm'].has_key? 'chef-backend'
+    if attributes['vm']['chef-backend']['start']
+      config.vm.define("backend") do |c|
+        define_backend_server(c, attributes)
+      end
+    end
+  else
+    attributes['vm']['chef-backend'] = nil
+  end
 
   config.vm.define("chef-server", primary: true) do |c|
     define_chef_server(c, attributes)
@@ -53,7 +63,7 @@ end
 
 
 def define_chef_server(config, attributes)
-  provisioning, installer, installer_path = prepare()
+  provisioning, installer, installer_path = prepare('INSTALLER', 'chef-server-core', 'Chef Server 12+')
   config.vm.hostname = "api.chef-server.dev"
   config.vm.network "private_network", ip: CS_VM_ADDRESS
 
@@ -114,12 +124,19 @@ def define_chef_server(config, attributes)
       chef.node_name = config.vm.hostname
       chef.cookbooks_path = "cookbooks"
       chef.add_recipe("provisioning::chef-server")
+      # If we're running chef-backend, let _it_ create the chef-server.rb
+      chef.add_recipe("provisioning::chef-server-rb") unless chef_backend_active?(attributes)
       chef.add_recipe("dev::system")
       chef.add_recipe("dev::user-env")
       chef.add_recipe("dev::dvm")
       chef.json = json || {}
       chef.nodes_path = "nodes"
     end
+
+    if chef_backend_active?(attributes)
+      config.vm.provision "shell", inline: "cp /installers/api.chef-server.dev.rb /etc/opscode/chef-server.rb"
+    end
+
     # Makes more sense here than in a one-off line in the dvm recipe, which
     # has no direct connection...
     config.vm.provision "shell", inline: "chef-server-ctl reconfigure"
@@ -144,6 +161,30 @@ def define_db_server(config, attributes)
   # Using shell here to ave the trouble of downloading
   # chef-client for the node.  May reconsider...
   config.vm.provision "shell", inline: configure_postgres
+end
+
+def define_backend_server(config, attribute)
+  provisioning, installer, installer_path = prepare('BE_INSTALLER', 'chef-backend', 'Chef Backend 1.1+')
+  config.vm.hostname = "backend.chef-server.dev"
+  config.vm.network "private_network", ip: BE_VM_ADDRESS
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id,
+                  "--name", "backend",
+                  # Elasticsearch requires much RAM
+                  "--memory", 2048,
+                  "--cpus", 2,
+                  "--usb", "off",
+                  "--usbehci", "off"
+    ]
+  end
+
+  if provisioning
+    config.vm.synced_folder installer_path, "/installers"
+
+    config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
+    config.vm.provision "shell", inline: install_hack(installer)
+    config.vm.provision "shell", inline: configure_backend
+  end
 end
 
 
@@ -176,11 +217,11 @@ end
 ##############
 
 
-def prepare
+def prepare(installer_env, package_name, title)
   action = ARGV[0]
   if action =~ /^(provision|up|reload)$/
-    installer = prompt_installer
-    raise "Please set INSTALLER to the path of a .deb package for Chef Server 12+." if installer.nil?
+    installer = prompt_installer(installer_env, package_name)
+    raise "Please set #{installer_env} to the path of a .deb package for #{title}." if installer.nil?
     raise "#{installer} does not exist! Please fix this." unless File.file?(installer)
     installer_path = File.dirname(File.expand_path(installer))
     provisioning = true
@@ -188,16 +229,16 @@ def prepare
   [provisioning, installer, installer_path]
 end
 
-def prompt_installer
-  puts "Looking in #{Dir.home}/Downloads and #{base_path}/omnibus/pkg for installable chef-server-core package."
+def prompt_installer(installer_env, package_name)
+  puts "Looking in #{Dir.home}/Downloads and #{base_path}/omnibus/pkg for installable #{package_name} package."
   # TODO allow config override of location, multiple locations, search pattern, max count?
-  files = Dir.glob("#{Dir.home}/Downloads/chef-server-core*.deb") + Dir.glob("#{base_path}/omnibus/pkg/chef-server-core*.deb")
+  files = Dir.glob("#{Dir.home}/Downloads/#{package_name}*.deb") + Dir.glob("#{base_path}/omnibus/pkg/#{package_name}*.deb")
 
-  if ENV['INSTALLER']
-    if ENV['INSTALLER'] =~ /^.*chef-server-core.*deb$/ and File.file?(ENV['INSTALLER'])
-      user_installer = File.expand_path(ENV['INSTALLER'])
+  if ENV[installer_env]
+    if ENV[installer_env] =~ /^.*#{package_name}.*deb$/ and File.file?(ENV[installer_env])
+      user_installer = File.expand_path(ENV[installer_env])
     else
-      puts "INSTALLER #{ENV['INSTALLER']} is not a valid chef-server-core package. Ignoring."
+      puts "#{installer_env} #{ENV[installer_env]} is not a valid #{package_name} package. Ignoring."
     end
   end
 
@@ -207,7 +248,7 @@ def prompt_installer
 
   files = files.sort_by{ |f| File.mtime(f) }.last(10)
   files.reverse!
-  files << "[INSTALLER]: #{user_installer}" if user_installer
+  files << "[#{installer_env}]: #{user_installer}" if user_installer
 
   selection = 0
 
@@ -233,7 +274,7 @@ def prompt_installer
     end
 
   else
-    selection = get_selection(files)
+    selection = get_selection(installer_env, files)
   end
 
   if selection == files.length  and user_installer
@@ -244,13 +285,13 @@ def prompt_installer
 
 end
 
-def get_selection(files)
+def get_selection(env, files)
   selection = 0
   files.each_index do |x|
     puts " #{x+1}) #{files[x]}\n"
   end
   loop do
-    print "Select an image, or set the INSTALLER variable and run again: [1 - #{files.length}]: "
+    print "Select an image, or set the #{env} variable and run again: [1 - #{files.length}]: "
     selection = $stdin.gets.chomp.to_i
     break if selection > 0 and selection <= files.length
   end
@@ -326,6 +367,20 @@ service postgresql restart
 export PATH=/usr/lib/postgresql/9.2/bin:$PATH
 sudo -u postgres psql -c "CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v0ps';"
 BASH
+end
+
+def configure_backend
+<<BASH
+cat > /etc/chef-backend/chef-backend.rb <<EOF
+publish_address "#{BE_VM_ADDRESS}"
+EOF
+chef-backend-ctl create-cluster --accept-license
+chef-backend-ctl gen-server-config api.chef-server.dev > /installers/api.chef-server.dev.rb
+BASH
+end
+
+def chef_backend_active?(attributes)
+  attributes['vm']['chef-backend']['start'] and attributes['vm']['chef-backend']['use-external']
 end
 
 def base_path

--- a/dev/cookbooks/provisioning/recipes/chef-server-rb.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-server-rb.rb
@@ -1,0 +1,8 @@
+# Note that we do not run reconfigure at this time
+# We will allow the dvm recipe to handle when that should occur.
+template "/etc/opscode/chef-server.rb" do
+  source "chef-server.rb.erb"
+  owner "root"
+  group "root"
+  action :create
+end

--- a/dev/cookbooks/provisioning/recipes/chef-server.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-server.rb
@@ -28,15 +28,6 @@ directory "/etc/opscode" do
   action :create
 end
 
-# Note that we do not run reconfigure at this time
-# We will allow the dvm recipe to handle when that should occur.
-template "/etc/opscode/chef-server.rb" do
-  source "chef-server.rb.erb"
-  owner "root"
-  group "root"
-  action :create
-end
-
 directory "/etc/opscode-reporting" do
   owner "root"
   group "root"

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -23,6 +23,16 @@ vm:
     # chef reporting will be configured to use
     # this vm as an external postgresql server from the start.
     use-external: true
+  # Override this in config.yml if you want to bring up a separate chef-backend
+  # box, and if you want to automatically configure chef-server to use it in a
+  # 1 FE / 1 BE topology.
+  chef-backend:
+    # enable a separate backend vm but do not use it unless
+    # use-external is set.
+    start: false
+    # When this is set to true, and start is true,
+    # we will install chef-backend and configure the chef-server to use it.
+    use-external: true
 
   # All settings below apply only to the chef-server vm
   cpus: 4

--- a/oc-chef-pedant/lib/pedant/rspec/search_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/search_util.rb
@@ -809,7 +809,14 @@ module Pedant
       # client can just use validator to test; don't bother making a new one
       include_context "with testing data bag"
       include_context "with testing data bag items" do
-        let(:items){ [{'id' => "test_item", "key" => "value"}]}
+        let(:items) {
+          array = [{'id' => 'test_item', 'key' => 'value'}]
+          # add a bunch of junk so reindex will scroll
+          for i in 0..1010
+            array << {'id' => "test_item#{i}", 'key' => 'value'}
+          end
+          array
+        }
       end
 
       # Arguments supplied to the reindexing escript after the subcommand.

--- a/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
@@ -31,7 +31,7 @@ update(Body) ->
                     {error, {solr_400, string()}} |
                     {error, {solr_500, string()}}.
 search(#chef_solr_query{} = Query) ->
-    Url = "/chef/_search",
+    Url = "/chef/_search?scroll=1m",
     {ok, Code, _Head, Body} = chef_index_http:request(Url, get, query_body(Query)),
     case Code of
         "200" ->
@@ -45,11 +45,33 @@ search(#chef_solr_query{} = Query) ->
     end.
 
 handle_successful_search(ResponseBody) ->
-    Response = ej:get({<<"hits">>}, jiffy:decode(ResponseBody)),
+    EjsonBody = jiffy:decode(ResponseBody),
+    ScrollId = ej:get({<<"_scroll_id">>}, EjsonBody),
+    Response = ej:get({<<"hits">>}, EjsonBody),
     NumFound = ej:get({<<"total">>}, Response),
     DocList  = ej:get({<<"hits">>}, Response),
     Ids = [ ej:get({<<"_id">>}, Doc) || Doc <- DocList ],
-    {ok, undefined, NumFound, Ids}.
+    scroll(ScrollId, NumFound, length(Ids), Ids).
+
+scroll(ScrollId, NumFound, NumFound, Ids) ->
+    ok = chef_index_http:delete("/_search/scroll", ScrollId),
+    {ok, undefined, NumFound, Ids};
+scroll(ScrollId, NumFound, _, Ids) ->
+    Url = "/_search/scroll?scroll=1m",
+    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, ScrollId),
+    case Code of
+        "200" ->
+            DocList = ej:get({<<"hits">>, <<"hits">>}, jiffy:decode(Body)),
+            NewIds = [ ej:get({<<"_id">>}, Doc) || Doc <- DocList ],
+            AllIds = lists:append([ Ids, NewIds ]),
+            scroll(ScrollId, NumFound, length(AllIds), AllIds);
+        %% For now keep these error messages
+        %% consistent with chef_solr
+        "400" ->
+            {error, {solr_400, Url}};
+        "500" ->
+            {error, {solr_500, Url}}
+    end.
 
 transform_data(Data) ->
     Data.
@@ -59,11 +81,21 @@ commit() ->
 
 query_body(#chef_solr_query{
               query_string = Query,
+              filter_query = undefined,
+              start = Start,
+              rows = Rows}) ->
+    jiffy:encode({[{<<"fields">>, <<"_id">>},
+                   {<<"from">>, Start},
+                   {<<"size">>, Rows},
+                   query_string_query_ejson(Query)]});
+query_body(#chef_solr_query{
+              query_string = Query,
               filter_query = FilterQuery,
               start = Start,
               rows = Rows}) ->
     chef_index_query:assert_org_id_filter(FilterQuery),
-    jiffy:encode({[{<<"from">>, Start},
+    jiffy:encode({[{<<"fields">>, <<"_id">>},
+                   {<<"from">>, Start},
                    {<<"size">>, Rows},
                    {<<"sort">>, [{[{<<"X_CHEF_id_CHEF_X">>, {[{<<"order">>, <<"asc">>}]}}]}]},
                    {<<"query">>, {[
@@ -80,20 +112,49 @@ query_string_query_ejson(QueryString) ->
          }
     }.
 
+%%
+%% A note on deleting
+%%
+%% The delete-by-query API was removed from Elasticsearch in 2.0, and is only
+%% available as a plugin. As a result, we can't rely on it being there in external
+%% Elasticsearch instances we don't control. Rather, we replicate the delete-by-query
+%% by performing a search, iterating over the results, and then deleting the
+%% documents individually.
+%%
+%% Because the number of documents is unknown, we use the Scroll API, which
+%% allows us to return all the results without having to set size to some ungodly
+%% high number. While this does increase network traffic to/from Elasticsearch, it
+%% reduces the memory load. If network performance becomes a problem, we could
+%% increase the number of rows we return with each query.
 -spec delete_search_db_by_type(OrgId :: binary(), Type :: atom()) -> ok.
 delete_search_db_by_type(OrgId, Type)
   when Type == client orelse Type == data_bag_item orelse
        Type == environment orelse Type == node orelse
        Type == role ->
-    DeleteQuery = jiffy:encode({[query_string_query_ejson(
-                                   chef_index_query:search_db_from_orgid(OrgId) ++
-                                       "AND" ++
-                                       chef_index_query:search_type_constraint(Type))]}),
-    ok = chef_index_http:delete("/chef/_query", DeleteQuery).
+    Query = #chef_solr_query{
+                             rows = 1000,
+                             start = 0,
+                             search_provider = elasticsearch,
+                             query_string = chef_index_query:search_db_from_orgid(OrgId) ++
+                                "AND" ++ chef_index_query:search_type_constraint(Type)
+                            },
+    {ok, _, _, Ids} = search(Query),
+    delete_ids(Ids).
 
+-spec delete_search_db(OrgId :: binary()) -> ok.
 delete_search_db(OrgId) ->
-    DeleteQuery = jiffy:encode({[query_string_query_ejson(
-                                   chef_index_query:search_db_from_orgid(OrgId))]}),
-    ok = chef_index_http:delete("/chef/_query", DeleteQuery),
+    Query = #chef_solr_query{
+                             rows = 1000,
+                             start = 0,
+                             search_provider = elasticsearch,
+                             query_string = chef_index_query:search_db_from_orgid(OrgId)
+                            },
+    {ok, _, _, Ids} = search(Query),
+    delete_ids(Ids).
+
+delete_ids([]) ->
     ok = commit(),
-    ok.
+    ok;
+delete_ids([Id | Ids]) ->
+    ok = chef_index_http:delete("/chef/object/" ++ Id, []),
+    delete_ids(Ids).


### PR DESCRIPTION
1. Adds chef-backend to DVM
2. Replaces use of deprecated delete-by-query API with recommended reindexing strategy: scroll query and then delete.