### PR TITLE
Fix chef-server build with clear caches

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -29,7 +29,7 @@ build_iteration 1
 
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
-override :ruby, version: "2.1.4"
+override :ruby, version: "2.2.5"
 override :rubygems, version: "2.4.5"
 override :'omnibus-ctl', version: "master"
 override :bundler, version: "1.10.6"

--- a/src/opscode-expander/Gemfile
+++ b/src/opscode-expander/Gemfile
@@ -2,7 +2,7 @@
 source "http://rubygems.org"
 
 gem "amqp", "~> 0.6.7"
-gem "eventmachine", '~> 0.12.10'
+gem "eventmachine", '~> 1.2.0'
 gem "em-http-request", "~> 0.2.11"
 gem 'yajl-ruby', "~> 0.7.7"
 gem 'mixlib-log', "~> 1.1.0"

--- a/src/opscode-expander/Gemfile.lock
+++ b/src/opscode-expander/Gemfile.lock
@@ -1,22 +1,22 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.1.1)
+    addressable (2.4.0)
     amqp (0.6.7)
       eventmachine (>= 0.12.4)
     bunny (0.6.0)
-    em-http-request (0.2.11)
+    em-http-request (0.2.15)
       addressable (>= 2.0.0)
       eventmachine (>= 0.12.9)
-    eventmachine (0.12.10)
+    eventmachine (1.2.0.1)
     fast_xs (0.7.3)
-    highline (1.6.1)
+    highline (1.6.21)
     mixlib-log (1.1.0)
     rake (0.8.7)
-    rspec (1.3.0)
-    uuidtools (2.1.1)
+    rspec (1.3.2)
+    uuidtools (2.1.5)
     word-salad (1.0.0)
-    yajl-ruby (0.7.7)
+    yajl-ruby (0.7.9)
 
 PLATFORMS
   ruby
@@ -25,7 +25,7 @@ DEPENDENCIES
   amqp (~> 0.6.7)
   bunny (~> 0.6.0)
   em-http-request (~> 0.2.11)
-  eventmachine (~> 0.12.10)
+  eventmachine (~> 1.2.0)
   fast_xs (~> 0.7.3)
   highline (~> 1.6.1)
   mixlib-log (~> 1.1.0)
@@ -34,3 +34,6 @@ DEPENDENCIES
   uuidtools (~> 2.1.1)
   word-salad (~> 1.0.0)
   yajl-ruby (~> 0.7.7)
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
Bumps the included Ruby version to 2.2.5 and eventmachine gem to 1.2.0.

The main reason for this is the version of berkshelf we are picking up requires buff-extensions which requires Ruby version >= 2.2.0. When we bump ruby, the older version of eventmachine can not build against ruby 2.2.X which needs a bump as well.

/cc: @chef/chef-server-maintainers 