### PR TITLE
Downgrade Ruby to 2.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ install:
   - luarocks install --local lpeg
   - luarocks install --local lua-cjson
   - eval $(luarocks path)
-  - rvm install --binary 2.3.1
-  - rvm use 2.3.1
+  - rvm install --binary 2.2.5
+  - rvm use 2.2.5
   - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
   - cpanm --notest --quiet App::Sqitch
   - cd $COMPONENT && travis_retry make install
@@ -66,7 +66,7 @@ after_failure:
 matrix:
   include:
     - language: ruby
-      rvm: 2.3.1
+      rvm: 2.2.5
       gemfile: oc-chef-pedant/Gemfile
       # We remove Gemfile.lock because Travis does
       # "bundle install --path bundle/vendor" which breaks our ability
@@ -84,7 +84,7 @@ matrix:
       before_cache:
       cache:
     - language: ruby
-      rvm: 2.3.1
+      rvm: 2.2.5
       gemfile: oc-chef-pedant/Gemfile
       # We remove Gemfile.lock because Travis does
       # "bundle install --path bundle/vendor" which breaks our ability

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -7,8 +7,8 @@ gem 'bundler', '>1.10'
 
 # Install omnibus software
 group :omnibus do
-  gem 'omnibus', github: 'chef/omnibus', branch: 'ksubrama/gcc_investigate'
-  gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'ksubrama/ruby23'
+  gem 'omnibus', github: 'chef/omnibus'
+  gem 'omnibus-software', github: 'chef/omnibus-software'
 end
 
 group :test do

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: d042e24fa3053ab926bb6a7c066c80e76ad72c94
-  branch: ksubrama/ruby23
+  revision: 70edd2654e9e3cbd0b1ffb2f15a08347e70b28cb
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -9,8 +8,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 1a72ccaefe16c2265fd3d1a641fb4b0e35a1bea2
-  branch: ksubrama/gcc_investigate
+  revision: 9298ab41625670b12a254004a0e3c07967a473b1
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -29,7 +29,7 @@ build_iteration 1
 
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
-override :ruby, version: "2.3.1"
+override :ruby, version: "2.2.5"
 override :rubygems, version: "2.6.6"
 override :'omnibus-ctl', version: "master"
 override :bundler, version: "1.12.5"


### PR DESCRIPTION
We were hitting issues with omnibus and Ruby 2.3.1. Until those issues
can be fixed, we're downgrading to 2.2.5.