### PR TITLE
Add licensing information for the transitive dependencies of Chef Server

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -8,7 +8,8 @@ gem 'bundler', '>1.10'
 # Install omnibus software
 group :omnibus do
   gem 'omnibus', github: 'chef/omnibus'
-  gem 'omnibus-software', github: 'chef/omnibus-software'
+  gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'sersut/chef-server-dep-licensing'
+  gem 'license_scout', github: 'chef/license_scout', branch: 'sersut/chef-server-fixup'
 end
 
 group :test do

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -8,8 +8,8 @@ gem 'bundler', '>1.10'
 # Install omnibus software
 group :omnibus do
   gem 'omnibus', github: 'chef/omnibus'
-  gem 'omnibus-software', github: 'chef/omnibus-software', branch: 'sersut/chef-server-dep-licensing'
-  gem 'license_scout', github: 'chef/license_scout', branch: 'sersut/chef-server-fixup'
+  gem 'omnibus-software', github: 'chef/omnibus-software'
+  gem 'license_scout', github: 'chef/license_scout'
 end
 
 group :test do

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,16 +1,15 @@
 GIT
   remote: git://github.com/chef/license_scout.git
-  revision: da6e00563820e7ac8290ab7aab4745a272bb6d7f
-  branch: sersut/chef-server-fixup
+  revision: dfbf29902b32121a48cec6e8eecb06ec8fdb3ff4
   specs:
     license_scout (0.1.0)
+      berkshelf (~> 4.3)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
 
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: dfca8ba79e7937d4a942ac1f6eb5b52ee579abd5
-  branch: sersut/chef-server-dep-licensing
+  revision: 8893a503ab8d7d3a2229097131de502488060990
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -18,7 +17,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 9298ab41625670b12a254004a0e3c07967a473b1
+  revision: 9f8d05967531c93973c0406a0c68171fd52f238a
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -36,12 +35,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.5.5)
-      aws-sdk-resources (= 2.5.5)
-    aws-sdk-core (2.5.5)
+    aws-sdk (2.5.7)
+      aws-sdk-resources (= 2.5.7)
+    aws-sdk-core (2.5.7)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.5.5)
-      aws-sdk-core (= 2.5.5)
+    aws-sdk-resources (2.5.7)
+      aws-sdk-core (= 2.5.7)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -147,9 +146,9 @@ GEM
     mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.1)
+    mixlib-config (2.2.2)
     mixlib-log (1.7.1)
-    mixlib-shellout (2.2.6)
+    mixlib-shellout (2.2.7)
     mixlib-versioning (1.1.0)
     molinillo (0.4.5)
     multi_json (1.12.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,16 @@
 GIT
+  remote: git://github.com/chef/license_scout.git
+  revision: da6e00563820e7ac8290ab7aab4745a272bb6d7f
+  branch: sersut/chef-server-fixup
+  specs:
+    license_scout (0.1.0)
+      ffi-yajl (~> 2.2)
+      mixlib-shellout (~> 2.2)
+
+GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 70edd2654e9e3cbd0b1ffb2f15a08347e70b28cb
+  revision: dfca8ba79e7937d4a942ac1f6eb5b52ee579abd5
+  branch: sersut/chef-server-dep-licensing
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -131,9 +141,6 @@ GEM
     jmespath (1.3.1)
     json (2.0.2)
     libyajl2 (1.2.0)
-    license_scout (0.1.0)
-      ffi-yajl (~> 2.2)
-      mixlib-shellout (~> 2.2)
     minitar (0.5.4)
     mixlib-archive (0.2.0)
       mixlib-log
@@ -252,6 +259,7 @@ DEPENDENCIES
   berkshelf
   bundler (> 1.10)
   chefspec
+  license_scout!
   omnibus!
   omnibus-software!
   rake

--- a/omnibus/config/software/chef-ha-plugin-config.rb
+++ b/omnibus/config/software/chef-ha-plugin-config.rb
@@ -19,6 +19,7 @@ description "generates chef-server-plugin.rb"
 default_version "0.0.1"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   block do

--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -26,6 +26,9 @@ dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
   gem "build chef_backup.gemspec", env: env
   gem "install chef_backup*.gem -n #{install_dir}/embedded/bin --no-rdoc --no-ri", env: env
 end

--- a/omnibus/config/software/ctl-man.rb
+++ b/omnibus/config/software/ctl-man.rb
@@ -19,6 +19,7 @@ name "ctl-man"
 default_version "7b25fa4de4d6663dafe2cbe853ada29eee67a6a6"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 dependency "private-chef-ctl"
 

--- a/omnibus/config/software/gpg-key.rb
+++ b/omnibus/config/software/gpg-key.rb
@@ -24,6 +24,7 @@ name "gpg-key"
 default_version "1.0.1"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 version "1.0.1" do
   source md5: "369efc3a19b9118cdf51c7e87a34f266"

--- a/omnibus/config/software/haproxy.rb
+++ b/omnibus/config/software/haproxy.rb
@@ -20,8 +20,9 @@ dependency "zlib"
 dependency "pcre"
 dependency "openssl"
 
-license "GPLv2"
+license "GPL-2.0"
 license_file "LICENSE"
+skip_transitive_dependency_licensing true
 
 # HTTPS is available but certificate validation fails on OS X
 source url: "http://www.haproxy.org/download/1.6/src/haproxy-#{version}.tar.gz",

--- a/omnibus/config/software/knife-ec-backup-gem.rb
+++ b/omnibus/config/software/knife-ec-backup-gem.rb
@@ -19,6 +19,9 @@ default_version "2.0.6"
 
 license "Apache-2.0"
 license_file "https://github.com/chef/knife-ec-backup/blob/master/LICENSE"
+# No need to collect license information for dependencies since
+# --ignore-dependencies flag is passed in during gem install.
+skip_transitive_dependency_licensing true
 
 dependency "pg-gem"
 dependency "sequel-gem"

--- a/omnibus/config/software/knife-opc-gem.rb
+++ b/omnibus/config/software/knife-opc-gem.rb
@@ -29,6 +29,8 @@ dependency "bundler"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  bundle "install --without development test", env: env
+
   gem "build knife-opc.gemspec", env: env
   gem "install knife-opc-*.gem", env: env
 end

--- a/omnibus/config/software/mixlib-install.rb
+++ b/omnibus/config/software/mixlib-install.rb
@@ -28,6 +28,8 @@ dependency "rubygems"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  bundle "install --without development", env: env
+
   gem "build mixlib-install.gemspec", env: env
   gem "install mixlib-install-*.gem", env: env
 end

--- a/omnibus/config/software/openresty-lpeg.rb
+++ b/omnibus/config/software/openresty-lpeg.rb
@@ -19,6 +19,7 @@ default_version "0.12"
 
 license "MIT"
 license_file "lpeg.html"
+skip_transitive_dependency_licensing true
 
 source url: "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-#{version}.tar.gz",
        md5: "4abb3c28cd8b6565c6a65e88f06c9162"

--- a/omnibus/config/software/opscode-solr4.rb
+++ b/omnibus/config/software/opscode-solr4.rb
@@ -19,6 +19,7 @@ default_version "4.10.4"
 
 license "Apache-2.0"
 license_file "LICENSE.txt"
+skip_transitive_dependency_licensing true
 
 source url: "http://archive.apache.org/dist/lucene/solr/#{version}/solr-#{version}.tgz",
        md5: "8ae107a760b3fc1ec7358a303886ca06"

--- a/omnibus/config/software/postgresql92.rb
+++ b/omnibus/config/software/postgresql92.rb
@@ -19,6 +19,7 @@ default_version "9.2.15"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
+skip_transitive_dependency_licensing true
 
 source url: "https://ftp.postgresql.org/pub/source/v9.2.15/postgresql-9.2.15.tar.bz2",
        md5: "235b4fc09eff4569a7972be65c449ecc"

--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -29,8 +29,7 @@ build do
       " -v 2.1.3" \
       " --no-rdoc --no-ri", env: env
 
-  command "berks vendor #{install_dir}/embedded/cookbooks",
-          env: env, cwd: "#{project_dir}/private-chef"
+  command "berks vendor #{install_dir}/embedded/cookbooks", env: env
 
   block do
     fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false

--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -29,7 +29,6 @@ build do
       " -v 2.1.3" \
       " --no-rdoc --no-ri", env: env
 
-
   command "berks vendor #{install_dir}/embedded/cookbooks",
           env: env, cwd: "#{project_dir}/private-chef"
 

--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -19,6 +19,7 @@ name "private-chef-ctl"
 source path: "#{project.files_path}/private-chef-ctl-commands"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 dependency "highline-gem"
 dependency "sequel-gem"

--- a/omnibus/config/software/private-chef-scripts.rb
+++ b/omnibus/config/software/private-chef-scripts.rb
@@ -19,6 +19,7 @@ name "private-chef-scripts"
 source path: "#{project.files_path}/private-chef-scripts"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   copy "#{project_dir}/*", "#{install_dir}/bin"

--- a/omnibus/config/software/private-chef-upgrades.rb
+++ b/omnibus/config/software/private-chef-upgrades.rb
@@ -19,6 +19,7 @@ name "private-chef-upgrades"
 source path: "#{project.files_path}/private-chef-upgrades"
 
 license :project_license
+skip_transitive_dependency_licensing true
 
 build do
   sync project_dir, "#{install_dir}/embedded/upgrades/"

--- a/omnibus/config/software/rest-client-gem.rb
+++ b/omnibus/config/software/rest-client-gem.rb
@@ -15,18 +15,21 @@
 #
 
 name "rest-client"
-default_version "1.8.0"
+default_version "v1.8.0"
 
 license "MIT"
 license_file "https://github.com/rest-client/rest-client/blob/master/LICENSE"
+
+source git: "https://github.com/rest-client/rest-client.git"
 
 dependency "ruby"
 dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  gem "install rest-client" \
-      " --version '#{version}'" \
-      " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc", env: env
+
+  bundle "install --without development test", env: env
+
+  gem "build rest-client.gemspec", env: env
+  gem "install rest-client-*.gem", env: env
 end

--- a/omnibus/config/software/veil-gem.rb
+++ b/omnibus/config/software/veil-gem.rb
@@ -24,8 +24,12 @@ dependency "ruby"
 dependency "rubygems"
 
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
   delete "veil-*.gem"
+
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development", env: env
+
   gem "build veil.gemspec", env: env
   gem "install veil*.gem --no-rdoc --no-ri --without development", env: env
 end

--- a/omnibus/files/private-chef-cookbooks/Berksfile
+++ b/omnibus/files/private-chef-cookbooks/Berksfile
@@ -1,9 +1,8 @@
 source "https://supermarket.chef.io"
 
-metadata
-
 cookbook 'enterprise', :git => 'https://github.com/chef-cookbooks/enterprise-chef-common', :tag => '0.10.1'
-cookbook 'chef-ha-drbd', :path => '../chef-ha-drbd'
+cookbook 'chef-ha-drbd', :path => './chef-ha-drbd'
+cookbook 'private-chef', :path => './private-chef'
 cookbook 'apt', '~> 2.0'
 cookbook 'yum', '~> 3.0'
 

--- a/omnibus/files/veil/veil.gemspec
+++ b/omnibus/files/veil/veil.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Veil is a Ruby Gem for generating secure secrets from a shared secret}
   spec.description   = spec.summary
+  spec.license       = "Apache-2.0"
   spec.homepage      = "https://github.com/chef/chef-server/"
 
   spec.files         = Find.find("./").select { |f| !File.directory?(f) }

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -18,3 +18,7 @@ fetcher_read_timeout 120
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
+
+# TODO::Licensing Enable this when we complete Berkshelf based dependency
+# license gatherer.
+# fatal_transitive_dependency_licensing_warnings true

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -19,6 +19,4 @@ fetcher_read_timeout 120
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
 
-# TODO::Licensing Enable this when we complete Berkshelf based dependency
-# license gatherer.
-# fatal_transitive_dependency_licensing_warnings true
+fatal_transitive_dependency_licensing_warnings true


### PR DESCRIPTION
This PR contains the minor fixes to the software definitions which will enable Chef Server to collect licensing information of transitive dependencies. Fixes are generally in one of the two nature:

1-) Include a `bundle install` so that we create the `Gemfile.lock` which is used by license_scout to collect the license information of dependencies.
2-) Include `skip_transitive_dependency_licensing` for the software which does not need license collection for transitive dependencies.

You can read https://github.com/chef/omnibus/pull/705 about the details of the licensing feature. Also notice that https://github.com/chef/license_scout/pull/15 and https://github.com/chef/omnibus-software/pull/716 are the accompanying PRs and once approved I will fix the `Gemfile` before merging this. 

With these we will have 3 things remaining in Chef Server which I will fix with subsequent PRs. Wanted to get this big set in before it gets even bigger 😄 The remaining things are:

- [x] Implement license collection via Berkshelf in license_scout and fix this error.
- [x] Fix a bug in license_scout which can interpret `BUNDLE_PATH` while collecting licenses and fix this issue:
- [x] Add license overrides for perl dependencies and fix errors in https://gist.github.com/sersut/2f826a14db412f2321f29f4bbc0e7984

/cc: @danielsdeleo @ryancragun @chef/chef-server-maintainers 