### PR TITLE
Allow the ACLs endpoint to accept 'clients' and 'users'

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,8 +13,17 @@ For prior releases, see [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
 * The object ACL API now requires that any users being added to an
   object's ACL exist in the same organization as the object itself.
   Existing users that are not organization members and have already been added
-  to an ACL will not be affected.
-
+  to an ACL will not be affected, and can still be seen in the GET
+  response for this API.
+* When a client and a user of the same name exist in the organization,
+  the HTTP response code `422` is returned and the error text will
+  indicate which client/user was ambiguous.
+* The object ACL API now accepts `clients` and `users`
+  fields which will allow you to disambiguate in this situation by separating
+  clients from users in the request. When using this option, the `actors` field must be set to `[]` in the request.
+  The GET API response for object ACL has not been changed.
+* 400 responses in object ACL updates will now include the specific
+  missing or incorrect entities where appropriate.
 
 
 ## 12.8.0 (2016-07-06)

--- a/src/oc_erchef/apps/oc_chef_authz/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/oc_chef_authz/priv/pgsql_statements.config
@@ -187,11 +187,11 @@
       WHERE (g.org_id = $1 AND g.policy_group_name = $2)">>}.
 
  {find_client_name_in_authz_ids, <<"SELECT name, authz_id FROM clients WHERE authz_id = ANY($1)">>}.
- {find_client_authz_id_in_names, <<"SELECT authz_id FROM clients WHERE org_id = $1 AND name = ANY($2)">>}.
+ {find_client_authz_id_in_names, <<"SELECT name, authz_id FROM clients WHERE org_id = $1 AND name = ANY($2)">>}.
  {find_user_name_in_authz_ids, <<"SELECT username, authz_id FROM users WHERE authz_id = ANY($1)">>}.
- {find_user_authz_id_in_names, <<"SELECT authz_id FROM users WHERE username = ANY($1)">>}.
+ {find_user_authz_id_in_names, <<"SELECT username AS name, authz_id FROM users WHERE username = ANY($1)">>}.
  {find_group_name_in_authz_ids, <<"SELECT name, authz_id FROM groups WHERE authz_id = ANY($1)">>}.
- {find_group_authz_id_in_names, <<"SELECT authz_id FROM groups WHERE org_id = $1 AND name = ANY($2)">>}.
+ {find_group_authz_id_in_names, <<"SELECT name, authz_id FROM groups WHERE org_id = $1 AND name = ANY($2)">>}.
 
 
   %% cookbook artifact versions

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_tests.erl
@@ -23,7 +23,30 @@
 -compile([export_all]).
 
 -include_lib("eunit/include/eunit.hrl").
+safe_fetch_ids_test_() ->
+    Subject = fun oc_chef_authz_acl:safe_fetch_ids/3,
+    {foreach,
+     fun() ->
+             meck:new(oc_chef_authz_db),
+             meck:expect(oc_chef_authz_db, authz_records_by_name,
+                         fun valid_authz_records_by_name/3)
+     end,
+     fun(_) -> meck:unload(oc_chef_authz_db) end,
+     [
+      {"valid: the list of IDs are returned",
+       ?_assertEqual([<<"id1">>,<<"id2">>],
+                    Subject(client, <<"someorg">>, [<<"name1">>,<<"name2">>]))
+      },
+      {"invalid: an error is raised because a name is missing from the response",
+       ?_assertThrow({invalid, user, [<<"name3">>]},
+                    Subject(user, <<"someorg">>, [<<"name1">>,<<"name2">>, <<"name3">>]))
+      }
+     ]
+    }.
+
+
 fetch_actors_test_() ->
+    Subject = fun oc_chef_authz_acl:fetch_actors/2,
     {foreach,
      fun() ->
              meck:new(oc_chef_authz_db)
@@ -34,32 +57,61 @@ fetch_actors_test_() ->
        fun() ->
                meck:expect(oc_chef_authz_db, find_org_actors_by_name,
                            fun invalid_actor_data_response/2),
-               FetchActorResponse = oc_chef_authz_acl:fetch_actors(<<"any">>,
-                                                                   [<<"bob">>, <<"jane">>]),
-               ?assertEqual({error, {bad_actor, [<<"bob">>, <<"jane">>]}}, FetchActorResponse)
+               ?assertThrow({bad_actor, [<<"bob">>, <<"jane">>]},
+                            Subject(<<"orgid">>, [<<"bob">>, <<"jane">>]))
+
        end},
       {"ambiguous_actor: actors that have both user and client authz ids",
        fun() ->
                meck:expect(oc_chef_authz_db, find_org_actors_by_name,
                            fun ambiguous_actor_data_response/2),
-               FetchActorResponse = oc_chef_authz_acl:fetch_actors(<<"any">>, [<<"bob">>, <<"jane">>]),
-               ?assertEqual({error, {ambiguous_actor, [<<"bob">>, <<"jane">>]}}, FetchActorResponse)
+               ?assertThrow({ambiguous_actor, [<<"bob">>, <<"jane">>]},
+                            Subject(<<"orgid">>, [<<"bob">>, <<"jane">>]))
+
        end},
       {"ok: actors that have only a client authz id",
        fun() ->
                meck:expect(oc_chef_authz_db, find_org_actors_by_name,
                            fun valid_client_data_response/2),
-               FetchActorResponse = oc_chef_authz_acl:fetch_actors(<<"any">>, [<<"bob">>, <<"jane">>]),
-               ?assertEqual({ok, [<<"id-a">>, <<"id-a">>]}, FetchActorResponse)
+               FetchActorResponse = Subject(<<"any">>, [<<"bob">>, <<"jane">>]),
+               ?assertEqual([<<"id-a">>, <<"id-a">>], FetchActorResponse)
        end},
       {"ok: actors that have only a user authz id",
        fun() ->
                meck:expect(oc_chef_authz_db, find_org_actors_by_name,
                            fun valid_user_data_response/2),
-               FetchActorResponse = oc_chef_authz_acl:fetch_actors(<<"any">>, [<<"bob">>, <<"jane">>]),
-               ?assertEqual({ok, [<<"id-a">>, <<"id-a">>]}, FetchActorResponse)
+               FetchActorResponse = Subject(<<"any">>, [<<"bob">>, <<"jane">>]),
+               ?assertEqual([<<"id-a">>, <<"id-a">>], FetchActorResponse)
        end}
      ]}.
+
+validate_actors_clients_users_test_() ->
+    Subject = fun oc_chef_authz_acl:validate_actors_clients_users/2,
+    [
+      {"an ACL which contains only groups, actors is valid",
+       ?_assertEqual(ok,
+                     Subject(<<"read">>, valid_actors_only_ej()))
+      },
+      {"an ACL which contains only groups, empty actors plus users and clients is valid",
+       ?_assertEqual(ok,
+                     Subject(<<"read">>, valid_actors_users_clients_ej()))
+      },
+      {"an ACL which contains groups, non-empty actors plus users and clients is not valid",
+       ?_assertThrow(actors_must_be_empty,
+                     Subject(<<"read">>, invalid_actors_users_clients_ej()))},
+      {"an ACL which contains groups, actors,  plus clients is not valid",
+       ?_assertThrow({one_requires_all, <<"clients">>, [<<"users">>]},
+                     Subject(<<"read">>, invalid_clients_only_ej()))
+      },
+      {"an ACL which contains only groups, actors, plus users is not valid",
+       ?_assertThrow({one_requires_all, <<"users">>, [<<"clients">>]},
+                     Subject(<<"read">>, invalid_users_only_ej()))
+      }
+     ].
+
+%%
+%% Helpers for inputs and outputs.
+%%
 
 valid_user_data_response(_, Names) ->
     {ok, [{N, null, <<"id-a">>} || N <- Names]}.
@@ -73,3 +125,62 @@ invalid_actor_data_response(_, Names) ->
 ambiguous_actor_data_response(_, Names) ->
     {ok, [{N, <<"id1">>, <<"id2">>} || N <- Names]}.
 
+
+valid_authz_records_by_name(_Type, _OrgId, _Names) ->
+     [ {<<"name1">>, <<"id1">>},
+       {<<"name2">>, <<"id2">>} ].
+
+valid_actors_only_ej() ->
+    {
+     [{<<"read">>,
+       {[
+         {<<"groups">>,[<<"x">>]},
+         {<<"actors">>,[<<"a">>, <<"b">>, <<"c">>]}
+        ]}
+      }]
+    }.
+
+valid_actors_users_clients_ej() ->
+    {
+     [{<<"read">>,
+       {[
+         {<<"actors">>,[]},
+         {<<"groups">>,[<<"x">>]},
+         {<<"users">>,[<<"a">>,<<"b">>]},
+         {<<"clients">>,[<<"c">>]}
+        ]}
+      }]
+    }.
+invalid_actors_users_clients_ej() ->
+    {
+     [{<<"read">>,
+       {[
+         {<<"actors">>,[<<"a">>,<<"b">>, <<"c">>]},
+         {<<"groups">>,[<<"x">>]},
+         {<<"users">>,[<<"a">>,<<"b">>]},
+         {<<"clients">>,[<<"c">>]}
+        ]}
+      }]
+    }.
+
+invalid_clients_only_ej() ->
+    {
+     [{<<"read">>,
+       {[
+         {<<"actors">>,[]},
+         {<<"groups">>,[<<"x">>]},
+         {<<"clients">>,[<<"c">>]}
+        ]}
+      }]
+    }.
+
+invalid_users_only_ej() ->
+    {
+     [{<<"read">>,
+       {[
+         {<<"actors">>,[]},
+         {<<"groups">>,[<<"x">>]},
+         {<<"users">>,[<<"a">>,<<"b">>]}
+        ]}
+      }]
+    }.

--- a/src/oc_erchef/include/chef_types.hrl
+++ b/src/oc_erchef/include/chef_types.hrl
@@ -64,6 +64,9 @@
                             %% these belong to EC and should
                             %% eventually be included in a pluggable
                             %% fashion.
+                            'policy' |
+                            'policy_group' |
+                            'organization' |
                             'oc_chef_container' |
                             'oc_chef_group'.
 

--- a/src/oc_erchef/include/oc_chef_types.hrl
+++ b/src/oc_erchef/include/oc_chef_types.hrl
@@ -1,7 +1,13 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2014-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright 2014-2016 Chef Software, Inc. All Rights Reserved.
+
+
+-type chef_authz_type() :: 'actor' |
+                           'container' |
+                           'group' |
+                           'object'.
 
 -record(oc_chef_container, {
           server_api_version,

--- a/src/oc_erchef/raml-docs/Makefile
+++ b/src/oc_erchef/raml-docs/Makefile
@@ -12,7 +12,7 @@ else
 		echo "You don't have raml2html, but we'll assume you want it" ; \
 		$(NPM) install -g raml2html; \
     fi;
-	$(RAML2HTML) index.raml > index.html
+	raml2html ./index.raml > index.html
 endif
 
 clean:

--- a/src/oc_erchef/raml-docs/resource-types.yaml
+++ b/src/oc_erchef/raml-docs/resource-types.yaml
@@ -46,7 +46,7 @@ acl_permission_endpoint:
       type: string
   put:
     description: Modify the given permission.
-    body: { schema: Acl }
+    body: { schema: AclUpdate }
     responses:
       200:
         body: { schema: ObjectUri }

--- a/src/oc_erchef/raml-docs/schemas.yaml
+++ b/src/oc_erchef/raml-docs/schemas.yaml
@@ -1,4 +1,7 @@
+#%RAML 0.8
+
 Acl:                       !include schemas/acl.json
+AclUpdate:                 !include schemas/acl_update.json
 AssociationRequest:        !include schemas/association-request.json
 AssociationRequestCount:   !include schemas/association-request-count.json
 AssociationRequestCreate:  !include schemas/association-request-create.json

--- a/src/oc_erchef/raml-docs/schemas/acl_update.json
+++ b/src/oc_erchef/raml-docs/schemas/acl_update.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "update $permission (create, read, update, delete, grant) of a Chef object",
+  "properties": {
+    "$permission": { "$ref": "common.json#AclUpdatePermission" }
+  }
+}

--- a/src/oc_erchef/raml-docs/schemas/common.json
+++ b/src/oc_erchef/raml-docs/schemas/common.json
@@ -36,9 +36,31 @@
     "description": "A version constraint. A series of comma separated constraints, each of which may include VERSION, \"> VERSION\", \"< VERSION\", \">= VERSION\", \"<= VERSION\", \"= VERSION\" and \"~> VERSION\".",
     "type": "string"
   },
+  "AclUpdatePermission": {
+    "description": "An access control list for updating a single permission (create, read, update, grant or delete) for an object.  Uses ",
+    "properties": {
+      "actors": {
+        "description": "The clients and users authorized for this permission on this Chef object.  Must have value [] if clients and users fields are used.",
+        "$ref": "common.json#ChefName"
+      },
+      "clients": {
+        "description": "The clients authorized for this permission on this Chef object.  Required if 'users' is included in the body.",
+        "$ref": "common.json#ChefName"
+      },
+      "users": {
+        "description": "The users authorized for this permission on this Chef object.  Required if 'clients' is included in the body. Can only be used if 'actors' = []",
+        "$ref": "common.json#ChefName"
+      },
+      "groups": {
+        "description": "The groups authorized for this permission on this Chef object.",
+        "type": "array",
+        "items": { "$ref": "common.json#ChefName" }
+      }
+    }
+  },
 
   "AclPermission": {
-    "description": "An access control list for a single permission (create, read, update, grant or delete) for an object.",
+    "description": "The access control list returned when GETing a single permission (create, read, update, grant or delete) for an object.",
     "properties": {
       "actors": {
         "description": "The clients and users authorized for this permission on this Chef object.",


### PR DESCRIPTION
With this change ACLs endpoint will accept 'clients' and 'users'
in the request body when 'actors' is present and is an empty list.

This change provides provides improvements to error handling - in any
case where an invalid actor or group is specified, the name(s) of any
invalid entities are included in the response.
