### PR TITLE
Add a 'detail=granular' query option to GET ACL endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
       before_script: cd oc-chef-pedant
       script: bundle exec rake chef_zero_spec
       env:
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'mp/SPOOL-340' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'master' \""
       # Remove things only used by erlang
       install:
       after_failure:
@@ -93,7 +93,7 @@ matrix:
       before_script: cd oc-chef-pedant
       script: bundle exec rake chef_zero_spec
       env:
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'mp/SPOOL-340' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'master' \""
         - CHEF_FS=1
       # Remove things only used by erlang
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
       before_script: cd oc-chef-pedant
       script: bundle exec rake chef_zero_spec
       env:
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero'\""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'mp/SPOOL-340' \""
       # Remove things only used by erlang
       install:
       after_failure:
@@ -93,7 +93,7 @@ matrix:
       before_script: cd oc-chef-pedant
       script: bundle exec rake chef_zero_spec
       env:
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero'\""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'mp/SPOOL-340' \""
         - CHEF_FS=1
       # Remove things only used by erlang
       install:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,21 +10,30 @@ For prior releases, see [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
 ## 12.8.1
 
 ### Chef Server
-* The object ACL API now requires that any users being added to an
-  object's ACL exist in the same organization as the object itself.
-  Existing users that are not organization members and have already been added
-  to an ACL will not be affected, and can still be seen in the GET
+
+#### API Changes
+
+* The object ACL update API (`/organizations/ORG/OBJECT_TYPE/OBJECT_NAME/_acl/PERM`)
+  now requires that any users being added to an object's ACL exist in the same
+  organization as the object itself.  Existing users that are not organization members
+  and have already been added to an ACL will not be affected, and can still be seen in the GET
   response for this API.
 * When a client and a user of the same name exist in the organization,
   the HTTP response code `422` is returned and the error text will
   indicate which client/user was ambiguous.
 * The object ACL API now accepts `clients` and `users`
   fields which will allow you to disambiguate in this situation by separating
-  clients from users in the request. When using this option, the `actors` field must be set to `[]` in the request.
-  The GET API response for object ACL has not been changed.
+  clients from users in the request. When using this option, the `actors` field
+  must be set to `[]` in the request.
 * 400 responses in object ACL updates will now include the specific
   missing or incorrect entities where appropriate.
-
+* The GET
+  The GET API response for object ACL has not been changed by default,
+  but if the query argument `?detail=granular` is provided, the json
+  body will contain `actors` which will be an empty array; and
+  `clients:[...]`, `users:[...]`.  This body is compatible
+  with the PUT API changes, and can be used in that request without
+  modification.
 
 ## 12.8.0 (2016-07-06)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,8 +27,7 @@ For prior releases, see [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
   must be set to `[]` in the request.
 * 400 responses in object ACL updates will now include the specific
   missing or incorrect entities where appropriate.
-* The GET
-  The GET API response for object ACL has not been changed by default,
+* The GET API response for object ACL has not been changed by default,
   but if the query argument `?detail=granular` is provided, the json
   body will contain `actors` which will be an empty array; and
   `clients:[...]`, `users:[...]`.  This body is compatible

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -817,6 +817,8 @@ describe "ACL API", :acl do
         # the defaults of defaults, which are overridden below for the different
         # types:
         let(:actors) { ["pivotal", platform.admin_user.name].uniq }
+        let(:users) { ["pivotal", platform.admin_user.name].uniq }
+        let(:clients) { [] }
         let(:groups) { ["admins"] }
         let(:read_groups) { groups }
         let(:update_groups) { groups }
@@ -831,6 +833,14 @@ describe "ACL API", :acl do
             "grant" => {"actors" => actors, "groups" => grant_groups}
           }}
 
+        let(:granular_acl_body) {{
+          "create" => {"actors" => [], "users" => users, "clients" => clients, "groups" => groups},
+          "read" => {"actors" => [], "users" => users, "clients" => clients, "groups" => read_groups},
+          "update" => {"actors" => [], "users" => users, "clients" => clients, "groups" => update_groups},
+          "delete" => {"actors" => [], "users" => users, "clients" => clients, "groups" => delete_groups},
+          "grant" => {"actors" => [], "users" => users, "clients" => clients, "groups" => grant_groups},
+        }}
+
         # Mainly this is for the different creation bodies, but also for the
         # different default ACLs for each type, etc.  We love consistency!
         case type
@@ -841,6 +851,9 @@ describe "ACL API", :acl do
             # actors list
             ["pivotal", new_object, setup_user.name].uniq
           }
+          let(:clients) { [ new_object ] }
+          let(:users) { ["pivotal", setup_user.name].uniq }
+
           let(:read_groups) { ["users", "admins"] }
           let(:delete_groups) { ["users", "admins"] }
         when "groups"
@@ -854,6 +867,7 @@ describe "ACL API", :acl do
               "containerpath" => "/"
             }}
           let(:actors) { [platform.admin_user.name] }
+          let(:users) {  [platform.admin_user.name] }
           let(:groups) { [] }
           let(:grant_groups) { [] }
         when "data"
@@ -968,8 +982,15 @@ describe "ACL API", :acl do
             it "can get object ACL" do
               get(request_url, platform.admin_user).should look_like({
                   :status => 200,
-                  :body => acl_body
+                  :body_exact => acl_body
                 })
+            end
+            it "can get a granular object ACL" do
+              get("#{request_url}?detail=granular", platform.admin_user).should look_like({
+                  :status => 200,
+                  :body_exact => granular_acl_body
+                })
+
             end
           end
 

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -24,7 +24,7 @@ package_name    "chef-server-core"
 replace         "private-chef"
 conflict        "private-chef"
 install_dir     "/opt/opscode"
-build_version   "12.8.0"
+build_version   "12.8.1"
 build_iteration 1
 
 override :rabbitmq, version: "3.3.4"

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_group.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_group.erl
@@ -6,7 +6,6 @@
 -module(oc_chef_group).
 
 -include("oc_chef_types.hrl").
--include_lib("mixer/include/mixer.hrl").
 
 -behaviour(chef_object).
 
@@ -380,6 +379,8 @@ find_authz_id_in_names(QueryName, Args, CallbackFun) ->
             Other
     end.
 
+query_and_diff_authz_ids(_QueryName, [], _) ->
+    {[], []};
 query_and_diff_authz_ids(QueryName, AuthzIds, CallbackFun) ->
     case CallbackFun({QueryName, [AuthzIds]}) of
         not_found ->

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_tests.erl
@@ -1,4 +1,4 @@
-%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %%
 %% @author Marc A. Paradise <marc@chef.io>
@@ -109,8 +109,21 @@ validate_actors_clients_users_test_() ->
       }
      ].
 
+part_with_actors_test_() ->
+    Subject = fun oc_chef_authz_acl:part_with_actors/4,
+    [
+     {"when 'granular' is set, response includes clients, users, empty actors",
+      ?_assertEqual({[{<<"users">>, [<<"u1">>]},
+                      {<<"clients">>, [<<"c1">>]},
+                      {<<"actors">>, []}]},
+                    Subject({[]}, [<<"c1">>], [<<"u1">>], granular))},
+     {"when 'granular' is not set, response is only 'actors'",
+      ?_assertEqual({[{<<"actors">>, [<<"c1">>, <<"u1">>]}]},
+                    Subject({[]}, [<<"c1">>], [<<"u1">>], undefined))}
+    ].
+
 %%
-%% Helpers for inputs and outputs.
+%% Helpers for test inputs and outputs.
 %%
 
 valid_user_data_response(_, Names) ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -163,7 +163,9 @@ not_found_message(policy_group, Name) ->
 
 %% "Cannot load data bag item not_really_there for data bag sack"
 
--spec error_message_envelope(binary() | ejson_term()) -> ejson_term().
+-spec error_message_envelope(binary() | list() | ejson_term()) -> ejson_term().
+error_message_envelope(Message) when is_list(Message) ->
+    error_message_envelope(iolist_to_binary(Message));
 error_message_envelope(Message) when is_binary(Message) orelse
                                      is_tuple(Message) ->
     %% Tuple guard is really intended for grabbing EJson-encoded json objects, but we don't

--- a/src/oc_erchef/include/oc_chef_wm.hrl
+++ b/src/oc_erchef/include/oc_chef_wm.hrl
@@ -363,7 +363,9 @@
 -record(acl_state, {
           type,
           authz_id,
-          acl_data
+          acl_data,
+          granular :: 'granular' | undefined
+
          }).
 
 -record(association_state, {

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -63,7 +63,7 @@
             {d, 'CHEF_DB_DARKLAUNCH', xdarklaunch_req},
             {d, 'CHEF_WM_DARKLAUNCH', xdarklaunch_req},
             {parse_transform, lager_transform},
-            % warnings_as_errors,
+            warnings_as_errors,
             debug_info,
             {platform_define, "^[0-9]+", namespaced_types},
             {i, "include"},


### PR DESCRIPTION
When specified, this option will split out users and clients within
the body response, and will force 'actors' to be empty.  This body
response is compatible with re-PUTing the body back to the object ACE
endpoint as-is, which will simplify changes to tooling when updating it
to use recently-added new ACL endpoint functionality.

Pre-merge: 

* [x] merge https://github.com/chef/chef-zero/pull/240
* [x] repoint the branch referenced in `.travis.yml`  to master of chef-zero
* [x] publish gem knife-acl 1.0.3  