### PR TITLE
Support special characters in LDAP bind password

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -12,7 +12,7 @@ LDAP_VM_ADDRESS="192.168.33.152"
 REPORTING_DB_VM_ADDRESS="192.168.33.155"
 DB_SUPERUSER="bofh"
 DB_SUPERPASS="i1uvd3v0ps"
-LDAP_PASSWORD="TheWheelsOnTheBusGoBoom"
+LDAP_PASSWORD='H0\/\/!|\/|3tY0ur|\/|0th3r'
 
 nodes_dir = File.join(File.expand_path(File.dirname(__FILE__)), 'nodes')
 unless File.directory?(nodes_dir)

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -131,7 +131,7 @@ def define_chef_server(config, attributes)
       backend_compat_message('ldap') if chef_backend_active?(attributes)
       ldap = { "ldap['base_dn']" => '"ou=chefs,dc=chef-server,dc=dev"',
                "ldap['bind_dn']" => '"cn=admin,dc=chef-server,dc=dev"',
-               "ldap['bind_password']" => "\"#{LDAP_PASSWORD}\"",
+               "ldap['bind_password']" => "'#{LDAP_PASSWORD}'",
                "ldap['host']" => "'#{LDAP_VM_ADDRESS}'",
                "ldap['login_attribute']" => '"uid"'
              }
@@ -150,6 +150,7 @@ def define_chef_server(config, attributes)
 
     config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
     config.vm.provision "shell", inline: install_hack(installer, 'opscode')
+    config.vm.provision "shell", inline: 'echo "PATH=/opt/opscode/embedded/bin:$PATH" > /root/.bashrc'
     config.vm.provision "chef_zero" do |chef|
       chef.install = false
       chef.binary_path = "/opt/opscode/embedded/bin"
@@ -420,7 +421,6 @@ if [ -d "/opt/#{omnibus}/embedded" ]
 then
   echo "Bypassing server install, it appears done."
 else
-  echo "PATH=/opt/#{omnibus}/embedded/bin:$PATH" > /root/.bashrc
   sudo dpkg -i "/installers/#{server_installer_name}"
 fi
 SCRIPT

--- a/dev/cookbooks/provisioning/recipes/ldap-server.rb
+++ b/dev/cookbooks/provisioning/recipes/ldap-server.rb
@@ -92,7 +92,7 @@ cookbook_file '/etc/ldap/data/ou-chefs.ldif' do
 end
 
 execute 'configure-ou' do
-  command "ldapadd -x -H ldapi:/// -D cn=admin,#{node['ldap']['basedn']} -w #{node['ldap']['password']} -f /etc/ldap/data/ou-chefs.ldif"
+  command "ldapadd -x -H ldapi:/// -D cn=admin,#{node['ldap']['basedn']} -w '#{node['ldap']['password']}' -f /etc/ldap/data/ou-chefs.ldif"
   action :nothing
 end
 
@@ -110,7 +110,7 @@ end
   end
 
   execute "configure-#{user}" do
-    command "ldapadd -x -H ldapi:/// -D cn=admin,#{node['ldap']['basedn']} -w #{node['ldap']['password']} -f /etc/ldap/data/user-#{user}.ldif"
+    command "ldapadd -x -H ldapi:/// -D cn=admin,#{node['ldap']['basedn']} -w '#{node['ldap']['password']}' -f /etc/ldap/data/user-#{user}.ldif"
     user 'openldap'
     action :nothing
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -156,6 +156,15 @@ class OmnibusHelper
     self.class.erl_atom_or_string(term)
   end
 
+  def self.escape_characters_in_string(string)
+    pattern = /(\'|\"|\.|\*|\/|\-|\\)/
+    string.gsub(pattern){|match|"\\"  + match}
+  end
+
+  def escape_characters_in_string(string)
+    self.class.escape_characters_in_string(string)
+  end
+
   def s3_url_caching(setting)
     case setting.to_s
     when "off"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -85,7 +85,7 @@
             {port, <%= node['private_chef']['ldap']['port'] || (@ssl_enabled ? 636 : 389) %> },
             {timeout, <%= node['private_chef']['ldap']['timeout'] || 60000 %> },
             {bind_dn, "<%= node['private_chef']['ldap']['bind_dn'] || "" %>" },
-            {bind_password, "<%= node['private_chef']['ldap']['bind_password'] || "" %>" },
+            {bind_password, "<%= @helper.escape_characters_in_string(node['private_chef']['ldap']['bind_password']) || "" %>" },
             {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
             {group_dn, "<%= node['private_chef']['ldap']['group_dn'] || "" %>" },
             {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },


### PR DESCRIPTION
This addresses an issue where a valid LDAP password that contained special characters would not work as expected when configured in chef-server.rb.