### PR TITLE
Fix bug where we can update a different user during an email change

### DIFF
--- a/src/oc-id/app/controllers/profiles_controller.rb
+++ b/src/oc-id/app/controllers/profiles_controller.rb
@@ -5,6 +5,7 @@ class ProfilesController < ApplicationController
   # Shows the user their profile page.
   #
   def show
+    redirect_to signin_path unless signed_in?
     @user = current_user
   end
 
@@ -15,6 +16,7 @@ class ProfilesController < ApplicationController
   #
   def update
     @user = current_user
+    updated_email = false
 
     # Note that if an email address is provided, don't update it right away.
     # Instead send a confirmation email and let that email link update the
@@ -22,12 +24,15 @@ class ProfilesController < ApplicationController
     if params[:user].key?(:email) && @user.email != params[:user][:email]
       EmailVerifyMailer.email_verify(@user, params[:user][:email]).deliver_now
       params[:user].delete(:email)
+      updated_email = true
     end
 
     if @user.update_attributes(params[:user])
-      redirect_to profile_path, :notice => I18n.t('profile.update_successful')
+      message = I18n.t('profile.update_successful')
+      message << "\n" + I18n.t('profile.email_change_sent') if updated_email
+      redirect_to profile_path, :notice => message
     else
-      render "show"
+      render 'show'
     end
   end
 
@@ -43,7 +48,7 @@ class ProfilesController < ApplicationController
     if @user.errors.empty?
       redirect_to profile_path, :notice => I18n.t('profile.password_changed')
     else
-      flash.now[:alert] = I18n.t("errors.passwords.problem")
+      flash.now[:alert] = I18n.t('errors.passwords.problem')
       render 'show', :status => :forbidden
     end
   end
@@ -59,22 +64,21 @@ class ProfilesController < ApplicationController
   # an email change. The handler for that sends an email with a link to this
   # end-point to confirm the change.
   #
+  # Important caveats: this method may be called when the user is signed into a
+  # different account or when the user is not signed in at all. If we are unable
+  # to redirect to a profile page because the user isn't signed in, we simply go
+  # to the signin page.
+  #
   def change_email
-    @user = current_user
-
-    unless valid_signature?
-      flash.now[:alert] = I18n.t("errors.emails.invalid_signature")
-      return render 'show', :status => :forbidden
-    end
+    @user = User.find(URI.escape(params[:username])) if params[:username].present?
+    return goto_forbidden('errors.emails.invalid_username', name: params[:username]) if @user.nil?
+    return goto_forbidden('errors.emails.invalid_signature') unless valid_signature?
 
     @user.update_attributes('email' => params[:email])
+    return goto_forbidden('errors.emails.problem') unless @user.errors.empty?
 
-    if @user.errors.empty?
-      redirect_to profile_path, :notice => I18n.t('profile.email_changed')
-    else
-      flash.now[:alert] = I18n.t("errors.emails.problem")
-      render 'show', :status => :forbidden
-    end
+    target_path = signed_in? ? profile_path : signin_path
+    redirect_to target_path, :notice => I18n.t('profile.email_changed', name: params[:username])
   end
 
   #
@@ -90,13 +94,28 @@ class ProfilesController < ApplicationController
 
   private
 
+  def goto_forbidden(message, *args)
+    if signed_in?
+      flash.now[:alert] = I18n.t(message, *args)
+      render 'show', status: :forbidden
+    else
+      redirect_to signin_path, notice: I18n.t(message, *args)
+    end
+  end
+
+
   def valid_signature?
-    [:signature, :username, :email, :expires].all? { |p| params[p].present? } &&
+    return false unless [:signature, :email, :expires].all? { |p| params[p].present? }
+
+    # Validate the signature against the user's current primary email address using
+    # the new email address as a "payload" to verify that the email change request
+    # link was not tampered with.
     Signature.new(
-      params[:username],
-      params[:email],
+      @user.username,
+      @user.email,
       params[:expires],
-      Settings.secret_key_base
+      Settings.secret_key_base,
+      params[:email],
     ).valid_for?(params[:signature])
   end
 end

--- a/src/oc-id/app/mailers/email_verify_mailer.rb
+++ b/src/oc-id/app/mailers/email_verify_mailer.rb
@@ -8,15 +8,21 @@ class EmailVerifyMailer < ActionMailer::Base
   # owns the new email address. We don't just want to forward the user a
   # "here's a way to just put in whatever email you want in this POST
   # request" token.
+  #
+  # The signature still contains the old email address at the time of the
+  # request so that once a user uses a link to change their email address,
+  # older links sent to any other email address are immediately expired.
+  #
   def email_verify(user, email)
     @user = user
     @email = email
     @expires = 1.day.from_now.to_i
     @signature = Signature.new(
       @user.username,
-      email,
+      @user.email,
       @expires,
-      Settings.secret_key_base
+      Settings.secret_key_base,
+      email
     )
     mail from: Settings.email_from_address,
          subject: "Verify Your Chef Email",

--- a/src/oc-id/app/models/signature.rb
+++ b/src/oc-id/app/models/signature.rb
@@ -2,13 +2,14 @@ require 'digest/sha1'
 
 # Manages signatures used for password resets
 class Signature
-  attr_reader :email, :expiration, :secret_token, :username
+  attr_reader :email, :expiration, :payload, :secret_token, :username
 
-  def initialize(username, email, expiration, secret_token)
+  def initialize(username, email, expiration, secret_token, payload=nil)
     @username = username
     @email = email
     @expiration = expiration
     @secret_token = secret_token
+    @payload = payload
   end
 
   # String representation of signature
@@ -29,7 +30,7 @@ class Signature
   private
 
   def canonical_string
-    ["--#{username}", "--#{expiration}", "--#{email}", "--#{secret_token}"].join
+    ["--#{username}", "--#{expiration}", "--#{email}", "--#{payload}", "--#{secret_token}"].join
   end
 
   def expired?

--- a/src/oc-id/config/locales/en.yml
+++ b/src/oc-id/config/locales/en.yml
@@ -41,11 +41,12 @@ en:
     emails:
       problem: "There was a problem with your new email address."
       invalid_signature: "The given email reset link is expired or has an invalid signature."
+      invalid_username: "'%{name}' is not a valid username."
   password_resets:
     new:
       form_caption: Enter your Chef username and we'll send you a link to reset it.
   profile:
     update_successful: "Profile updated successfully."
     password_changed: "Password changed."
-    email_changed: "Email changed."
+    email_changed: "Email changed for account %{name}."
     email_change_sent: "If the new email address you entered exists, you should receive an email with a link shortly."

--- a/src/oc-id/spec/controllers/profiles_controller_spec.rb
+++ b/src/oc-id/spec/controllers/profiles_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ProfilesController do
   let(:username) { 'jimmy' }
   let(:email) { 'jim.kirk@federation-captains.org' }
-  let(:fake_user) {
+  let(:user1) do
     User.new({
       :username => username,
       :first_name => 'jimmy',
@@ -14,15 +14,32 @@ describe ProfilesController do
       :display_name => 'jimmy jammy',
       :password => 'awesomefuntimes'
     })
-  }
+  end
+  let(:user2) do
+    User.new({
+      :username => 'spock',
+      :first_name => 'Spock',
+      :last_name => 'Son Of Sarek',
+      :middle_name => '',
+      :email => 'spock@vulcan.net',
+      :public_key => 'fake public key',
+      :display_name => 'Spock',
+      :password => 'highlylogical'
+    })
+  end
 
+  let(:logged_in_user) { user1 }
   let(:fake_chef) {
     double(:chef_api, :put_rest => {'private_key' => 'fake private key'})
   }
 
   before do
-    allow(controller).to receive(:current_user).and_return(fake_user)
-    allow(fake_user).to receive(:chef).and_return(fake_chef)
+    allow(User).to receive(:find).with(user1.username).and_return(user1)
+    allow(User).to receive(:find).with(user2.username).and_return(user2)
+    allow(user1).to receive(:chef).and_return(fake_chef)
+    allow(user2).to receive(:chef).and_return(fake_chef)
+    allow(controller).to receive(:current_user).and_return(logged_in_user)
+
     allow(User).to receive(:authenticate).and_return(true)
   end
 
@@ -57,7 +74,7 @@ describe ProfilesController do
     end
 
     it 'renders the show template if the update failed' do
-      allow(fake_user).to receive(:chef).and_raise(StandardError)
+      allow(logged_in_user).to receive(:chef).and_raise(StandardError)
       put :update, user: put_user
 
       expect(response).to render_template('show')
@@ -66,62 +83,168 @@ describe ProfilesController do
 
   describe 'GET #change_email' do
     let(:new_email) { 'new-email@somewhere.org' }
-    let(:signature) { Signature.new(username, new_email, expires, Settings.secret_key_base) }
+    let(:signature) { Signature.new(username, email, expires, Settings.secret_key_base, new_email) }
     let(:expires) { 1.day.from_now.to_i }
 
-    describe 'invalid params' do
-      it 'requires a username' do
-        get :change_email, email: new_email, signature: signature, expires: expires
-        expect(response).to render_template('show')
-        expect(flash[:alert]).to match /invalid signature/
+    describe 'when logged in as user' do
+      describe 'invalid params' do
+        it 'requires a username' do
+          get :change_email, email: new_email, signature: signature, expires: expires
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /not a valid username/
+        end
+
+        it 'requires a new email' do
+          get :change_email, username: username, signature: signature, expires: expires
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /invalid signature/
+        end
+
+        it 'requires an expiration date' do
+          get :change_email, username: username, email: new_email, signature: signature
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /invalid signature/
+        end
+
+        it 'requires a signature' do
+          get :change_email, username: username, email: new_email, expires: expires
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /invalid signature/
+        end
+
+        it 'requires a valid signature - signing the new email address' do
+          get :change_email, username: username, email: new_email, expires: expires, signature: 'foo'
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /invalid signature/
+        end
       end
 
-      it 'requires a new email' do
-        get :change_email, username: username, signature: signature, expires: expires
-        expect(response).to render_template('show')
-        expect(flash[:alert]).to match /invalid signature/
+      describe 'expired link' do
+        let(:expires) { 1.day.ago.to_i }
+
+        it 'rejects the link' do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /invalid signature/
+        end
+
       end
 
-      it 'requires an expiration date' do
-        get :change_email, username: username, email: new_email, signature: signature
-        expect(response).to render_template('show')
-        expect(flash[:alert]).to match /invalid signature/
+      describe 'link with stale email' do
+        let(:old_email) { 'myfirstemail@email.org' }
+        let(:signature) { Signature.new(username, old_email, expires, Settings.secret_key_base, new_email) }
+
+        it 'rejects the link' do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /invalid signature/
+        end
       end
 
-      it 'requires a signature' do
-        get :change_email, username: username, email: new_email, expires: expires
-        expect(response).to render_template('show')
-        expect(flash[:alert]).to match /invalid signature/
-      end
+      describe 'valid params' do
+        before do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+        end
 
-      it 'requires a valid signature - signing the new email address' do
-        get :change_email, username: username, email: new_email, expires: expires, signature: 'foo'
-        expect(response).to render_template('show')
-        expect(flash[:alert]).to match /invalid signature/
+        it 'redirects to the profile page' do
+          expect(response).to redirect_to(profile_path)
+        end
+
+        it 'updates the email address' do
+          expect(logged_in_user.email).to eql(new_email)
+        end
       end
     end
 
-    describe 'expired link' do
-      let(:expires) { 1.day.ago.to_i }
+    describe 'when not logged in' do
+      let(:logged_in_user) { nil }
 
-      it 'rejects an expired link' do
-        get :change_email, username: username, email: new_email, expires: expires, signature: signature
-        expect(response).to render_template('show')
-        expect(flash[:alert]).to match /invalid signature/
+      describe 'invalid params' do
+        it 'requires a username' do
+          get :change_email, email: new_email, signature: signature, expires: expires
+          expect(response).to redirect_to(signin_path)
+        end
+
+        it 'requires a new email' do
+          get :change_email, username: username, signature: signature, expires: expires
+          expect(response).to redirect_to(signin_path)
+        end
+
+        it 'requires an expiration date' do
+          get :change_email, username: username, email: new_email, signature: signature
+          expect(response).to redirect_to(signin_path)
+        end
+
+        it 'requires a signature' do
+          get :change_email, username: username, email: new_email, expires: expires
+          expect(response).to redirect_to(signin_path)
+        end
+
+        it 'requires a valid signature - signing the new email address' do
+          get :change_email, username: username, email: new_email, expires: expires, signature: 'foo'
+          expect(response).to redirect_to(signin_path)
+        end
+      end
+
+      describe 'expired link' do
+        let(:expires) { 1.day.ago.to_i }
+
+        it 'rejects the link' do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+          expect(response).to redirect_to(signin_path)
+        end
+
+      end
+
+      describe 'link with stale email' do
+        let(:signature) { Signature.new(username, 'myfirstemail@email.org', expires, Settings.secret_key_base, new_email) }
+
+        it 'rejects the link' do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+          expect(response).to redirect_to(signin_path)
+        end
+      end
+
+      describe 'valid params' do
+        before do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+        end
+
+        it 'redirects to the signin page' do
+          expect(response).to redirect_to(signin_path)
+        end
+
+        it 'updates the email address' do
+          expect(user1.email).to eql(new_email)
+        end
       end
     end
 
-    describe 'valid params' do
-      before do
-        get :change_email, username: username, email: new_email, expires: expires, signature: signature
+    describe 'when logged in as someone else' do
+      let(:logged_in_user) { user2 }
+
+      describe 'link with stale email' do
+        let(:signature) { Signature.new(username, user2.email, expires, Settings.secret_key_base, new_email) }
+
+        it 'rejects the link' do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+          expect(response).to render_template('show')
+          expect(flash[:alert]).to match /invalid signature/
+        end
       end
 
-      it 'redirects to the profile page' do
-        expect(response).to redirect_to(profile_path)
-      end
+      describe 'valid params' do
+        before do
+          get :change_email, username: username, email: new_email, expires: expires, signature: signature
+        end
 
-      it 'updates the email address' do
-        expect(fake_user.email).to eql(new_email)
+        it 'redirects to the profile page' do
+          expect(response).to redirect_to(profile_path)
+        end
+
+        it 'updates the email address' do
+          expect(user1.email).to eql(new_email)
+        end
       end
     end
   end


### PR DESCRIPTION
If the logged in user was not the username mentioned in the email-update link, we were accidentally updating the email of the current user instead of the username mentioned in the link.

Further, in this PR, we no longer allow email change links to update the email of accounts whose email was already changed from the one that existed at the time the link was created.

There is also a small fix to redirect accesses to https://id.chef.io/id/profile to the signin page if nobody is signed in already.  Currently, accessing that page within first signing in yields a 500 error page.