### PR TITLE
Re-enable fatal licensing warnings

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/license_scout.git
-  revision: b29c341d5abcfaa69a71f051b0c156ff24ccb634
+  revision: 81f1e5c0afc76bd86132464c8ad2b94d884a4845
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -24,4 +24,4 @@ fetcher_read_timeout 120
 # service timing out. .  We'll re-enable it
 # once we have a process available that lets us declare
 # component licensing outside of the build itself.
-fatal_transitive_dependency_licensing_warnings false
+fatal_transitive_dependency_licensing_warnings true


### PR DESCRIPTION
Last week we have disabled fatal licensing warnings because we had a dependency on cpan build service which is slow & unreliable and cause lots of failures during the builds.

Now license_scout does not have a network dependency on the cpan build service anymore. This change picks up the latest license_scout with this functionality and re-enables fatal licensing checks to catch any missing license as our software evolves.

It is tested in wilson (3 new errors popped and they were fixed). 

http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/261/downstreambuildview/

/cc: @chef/chef-server-maintainers @marcparadise 