### PR TITLE
[omnibus] update mixlib-install to 2.0 for PackageRouter support

### DIFF
--- a/omnibus/config/software/mixlib-install.rb
+++ b/omnibus/config/software/mixlib-install.rb
@@ -15,7 +15,7 @@
 #
 
 name "mixlib-install"
-default_version "v1.0.0"
+default_version "v2.0.0"
 
 license "Apache-2.0"
 license_file "LICENSE"


### PR DESCRIPTION
`chef-server-ctl install` needs to download from the correct source. PackageRouter will soon be the only available backend in mixlib-install.

I ran:
`$ chef-server-ctl install chef-manage`

Then I interrupted the download to force an error. The correct download URL is being used.

```
    remote_file("/var/opt/opscode/local-mode-cache/chef-manage_2.4.3-1_amd64.deb") do
      provider Chef::Provider::RemoteFile
      action [:create]

root@api:~#   retries 0
      retry_delay 2
      default_guard_interpreter :default
      source ["https://packages.chef.io/files/stable/chef-manage/2.4.3/ubuntu/14.04/chef-manage_2.4.3-1_amd64.deb"]
      use_etag true
      use_last_modified true
      declared_type :remote_file
      cookbook_name "private-chef"
      recipe_name "add_ons_wrapper"
      checksum "0af176eb721daf021559f7df9e72e99c2f5f55aa39a1b7358a643955fbe91349"
      path "/var/opt/opscode/local-mode-cache/chef-manage_2.4.3-1_amd64.deb"
    end
```

@chef/engineering-services 