### PR TITLE
Updates Omnibus-Software to latest

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/license_scout.git
-  revision: 81f1e5c0afc76bd86132464c8ad2b94d884a4845
+  revision: 4fd26d99d0617d6336ae372f026c190617800e6b
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 8893a503ab8d7d3a2229097131de502488060990
+  revision: 2186b5816b13c5712d17ffe66e7cab8cf28ca735
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: 9f8d05967531c93973c0406a0c68171fd52f238a
+  revision: ed8a050dc3df3fca242f068879cfc867762428d3
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -34,12 +34,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.5.7)
-      aws-sdk-resources (= 2.5.7)
-    aws-sdk-core (2.5.7)
+    aws-sdk (2.6.3)
+      aws-sdk-resources (= 2.6.3)
+    aws-sdk-core (2.6.3)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.5.7)
-      aws-sdk-core (= 2.5.7)
+    aws-sdk-resources (2.6.3)
+      aws-sdk-core (= 2.6.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -166,7 +166,7 @@ GEM
     nio4r (1.2.1)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.19.2)
+    ohai (8.20.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)


### PR DESCRIPTION
This change is to update omnibus software to the
latest version so that we pickup the latest version
of openssl.