### PR TITLE
Install nodejs from binary packages

### DIFF
--- a/omnibus/config/software/oc_id.rb
+++ b/omnibus/config/software/oc_id.rb
@@ -22,7 +22,7 @@ license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "postgresql92" # for libpq
-dependency "nodejs"
+dependency "nodejs-binary"
 dependency "ruby"
 dependency "bundler"
 
@@ -30,6 +30,7 @@ relative_path "oc-id"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  env['PATH'] = "#{env['PATH']}:#{install_dir}/embedded/nodejs/bin"
 
   bundle "config build.nokogiri --use-system-libraries" \
          " --with-xml2-config=#{install_dir}/embedded/bin/xml2-config" \

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -142,7 +142,7 @@ execute "oc_id_schema" do
   # Also set the RAILS_ENV as is needed.
   environment("RAILS_ENV" => "production",
               "VERSION" => `ls -1 /opt/opscode/embedded/service/oc_id/db/migrate | tail -n 1 | sed -e "s/_.*//g"`.chomp,
-              "PATH" => "/opt/opscode/embedded/bin")
+              "PATH" => "/opt/opscode/embedded/bin:/opt/opscode/embedded/nodejs/bin")
 
   only_if { is_data_master? }
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
@@ -3,7 +3,7 @@ exec 2>&1
 
 DIR=/opt/opscode/embedded/service/oc_id
 export RAILS_ENV=production
-export PATH=/opt/opscode/embedded/bin:$PATH
+export PATH=/opt/opscode/embedded/bin:/opt/opscode/embedded/nodejs/bin:$PATH
 export LD_LIBRARY_PATH=/opt/opscode/embedded/lib
 export HOME=$DIR
 


### PR DESCRIPTION
Nodejs is a build-time dependency of oc_id. Previously, we were
installing this from source. Now, we install it from upstream-provided
binary packages, avoiding the python2.7 dependency. Further nodejs is
now contained in an easy-to-clean-up folder. We aren't yet cleaning it
up because oc_id's Gemfile setup will need some modification to allow us
to bundle exec without coffee-rails and other gems that require a
javascript runtime.

In terms of diskspace, overall this nodejs installation ends up being
larger than the nodejs built from source, but the increase is offset by
python no longer being needed. We can likely reduce the disk space used
by node further in follow-up efforts.

Signed-off-by: Steven Danna <steve@chef.io>