### PR TITLE
Add cleanup build step

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -95,6 +95,7 @@ dependency "private-chef-upgrades"
 dependency "private-chef-cookbooks"
 dependency "chef-ha-plugin-config"
 dependency "chef" # for embedded chef-client -z runs (built from master - build last)
+dependency "cleanup" # MUST BE LAST DO NOT MOVE
 
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']

--- a/omnibus/config/software/cleanup.rb
+++ b/omnibus/config/software/cleanup.rb
@@ -1,0 +1,14 @@
+name 'cleanup'
+default_version '1.0.0'
+skip_transitive_dependency_licensing true
+license :project_license
+
+build do
+  # Remove relatively large, unused modules from the core erlang
+  # installation
+  delete "#{install_dir}/embedded/lib/erlang/lib/megaco-*"
+  delete "#{install_dir}/embedded/lib/erlang/lib/wx-*"
+  # strip gecode shared object files related to gecode installs
+  command "strip #{install_dir}/embedded/lib/libgecode*.so.32.0"
+  command "strip #{install_dir}/embedded/lib/ruby/gems/2.2.0/gems/dep-selector-libgecode-*/lib/dep-selector-libgecode/vendored-gecode/lib/*.so"
+end


### PR DESCRIPTION
This is similar to the cleanup done in delivery and the cleanup proposed
in #169. However, we are a bit less aggressive than the approaches
there since there were previously concerns about loosing too much
debugging information.

Currently we:

- Remove the megaco application from the erlang install
- Remove the wx application from the erlang install
- Strip all gecode related shared libraries

While we have avoided stripping executables in the past, the gecode
libraries are very large without stripping.

Signed-off-by: Steven Danna <steve@chef.io>