### PR TITLE
Bump omnibus-software

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 778b2bb20cb3f64207ad822c1277e6068be5bbfc
+  revision: 97c85c6a608dbaf8f26bf075afa689df53e9e2fb
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)

--- a/omnibus/config/software/cleanup.rb
+++ b/omnibus/config/software/cleanup.rb
@@ -4,10 +4,6 @@ skip_transitive_dependency_licensing true
 license :project_license
 
 build do
-  # Remove relatively large, unused modules from the core erlang
-  # installation
-  delete "#{install_dir}/embedded/lib/erlang/lib/megaco-*"
-  delete "#{install_dir}/embedded/lib/erlang/lib/wx-*"
   # strip gecode shared object files related to gecode installs
   command "strip #{install_dir}/embedded/lib/libgecode*.so.32.0"
   command "strip #{install_dir}/embedded/lib/ruby/gems/2.2.0/gems/dep-selector-libgecode-*/lib/dep-selector-libgecode/vendored-gecode/lib/*.so"


### PR DESCRIPTION
The newest version of omnibus software builds an erlang without megaco
or wx, so their removal is no longer needed.  Further, depending on
the berkshelf recipe should only depend on 1 version of depselector
now.

Signed-off-by: Steven Danna <steve@chef.io>