### PR TITLE
Cleanup cached gem files in ruby install

### DIFF
--- a/omnibus/config/software/cleanup.rb
+++ b/omnibus/config/software/cleanup.rb
@@ -4,6 +4,9 @@ skip_transitive_dependency_licensing true
 license :project_license
 
 build do
+  # Delete cached .gem files and git checkouts
+  delete "#{install_dir}/embedded/lib/ruby/gems/2.2.0/cache/*.gem"
+  delete "#{install_dir}/embedded/service/gem/ruby/2.2.0/cache/*.gem"
   # strip gecode shared object files related to gecode installs
   command "strip #{install_dir}/embedded/lib/libgecode*.so.32.0"
   command "strip #{install_dir}/embedded/lib/ruby/gems/2.2.0/gems/dep-selector-libgecode-*/lib/dep-selector-libgecode/vendored-gecode/lib/*.so"


### PR DESCRIPTION
This is similar to the cleanup that chefdk does in its cleanup software
definition.

Their definition also cleans up the checked out git sources. My initial
attempts to clean up the git checkouts caused pedant to fail to start,
so I've excluded that for now.

Signed-off-by: Steven Danna <steve@chef.io>