### PR TITLE
Remove nodejs from the final package

### DIFF
--- a/omnibus/config/software/cleanup.rb
+++ b/omnibus/config/software/cleanup.rb
@@ -7,6 +7,8 @@ build do
   # Delete cached .gem files and git checkouts
   delete "#{install_dir}/embedded/lib/ruby/gems/2.2.0/cache/*.gem"
   delete "#{install_dir}/embedded/service/gem/ruby/2.2.0/cache/*.gem"
+  # Remove nodejs
+  delete "#{install_dir}/embedded/nodejs"
   # strip gecode shared object files related to gecode installs
   command "strip #{install_dir}/embedded/lib/libgecode*.so.32.0"
   command "strip #{install_dir}/embedded/lib/ruby/gems/2.2.0/gems/dep-selector-libgecode-*/lib/dep-selector-libgecode/vendored-gecode/lib/*.so"

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -142,7 +142,7 @@ execute "oc_id_schema" do
   # Also set the RAILS_ENV as is needed.
   environment("RAILS_ENV" => "production",
               "VERSION" => `ls -1 /opt/opscode/embedded/service/oc_id/db/migrate | tail -n 1 | sed -e "s/_.*//g"`.chomp,
-              "PATH" => "/opt/opscode/embedded/bin:/opt/opscode/embedded/nodejs/bin")
+              "PATH" => "/opt/opscode/embedded/bin")
 
   only_if { is_data_master? }
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
@@ -3,7 +3,7 @@ exec 2>&1
 
 DIR=/opt/opscode/embedded/service/oc_id
 export RAILS_ENV=production
-export PATH=/opt/opscode/embedded/bin:/opt/opscode/embedded/nodejs/bin:$PATH
+export PATH=/opt/opscode/embedded/bin:$PATH
 export LD_LIBRARY_PATH=/opt/opscode/embedded/lib
 export HOME=$DIR
 

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '= 4.2.5.2'
 gem 'chef', '~> 11.14'
-gem 'coffee-rails', '~> 4.0.0'
 gem 'jbuilder', '~> 1.2'
 gem 'jquery-rails'
 gem 'jwt' # For Zendesk SSO
@@ -10,7 +9,6 @@ gem 'rails_config', '~> 0.4.2'
 gem 'rb-readline', '~> 0.5.2', require: false
 gem 'sass-rails', '>= 4.0.3'
 gem 'turbolinks', '~> 2.2.1'
-gem 'uglifier', '~> 2.4.0'
 gem 'unicorn-rails', '~> 1.1.0'
 gem 'omniauth', '~> 1.2.1'
 gem 'omniauth-chef'
@@ -23,6 +21,16 @@ gem 'responders', '~> 2.0'
 gem 'newrelic_rpm'
 
 gem 'doorkeeper', '~> 1.4.0'
+
+#
+# These gems require a javascript runtime.  We don't want to ship a
+# javascript runtime so we put them in a separate group such that they
+# don't get automatically required by rake.
+#
+group :node do
+  gem 'coffee-rails', '~> 4.0.0'
+  gem 'uglifier', '~> 2.4.0'
+end
 
 group :development, :test do
   # Loading it this way makes it work with Ruby 2.1.2. See


### PR DESCRIPTION
Encouraged by rails-coffee and uglifier, nodejs used up 51MB of disk
space!  In retaliation rm and rf teamed up at tribal council and voted
her off the island.

We've moved the two gems that require a javascript runtime into a new
group in the Gemfile.  They will still be installed by default, but
`rake` and `rails server` won't require them by default when starting
up.

Signed-off-by: Steven Danna <steve@chef.io>