### PR TITLE
Don't include source in erlang releases

### DIFF
--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -98,7 +98,9 @@
 
 {profiles, [
     {dev, [
-        {relx, [{dev_mode, true}]}
+        {relx, [{dev_mode, true},
+                {include_src, true}
+               ]}
        ]},
     {fips, [
         {deps, [
@@ -130,10 +132,11 @@
      {pooler, load},
      {sqerl, load}
   ]},
+
+  {include_src, false},
   {extended_start_script,true},
   {overlay,[{template,"config/vm.args","vm.args"},
             {template,"config/app.config","sys.config"},
             {copy,"schema","."}
            ]}
 ]}.
-

--- a/src/chef-mover/rebar.config
+++ b/src/chef-mover/rebar.config
@@ -55,7 +55,9 @@
         ]}
        ]},
     {dev, [
-        {relx, [{dev_mode, true}]}
+        {relx, [{dev_mode, true},
+                {include_src, true}
+               ]}
     ]}
 ]}.
 
@@ -131,6 +133,8 @@
             {oc_chef_wm, load},
             eper
             ]},
+
+    {include_src, false},
     {lib_dirs,["_build/default/lib/oc_erchef/apps"]},
     {extended_start_script,true},
     {overlay_vars,"config/vars.config"},

--- a/src/oc_bifrost/rebar.config
+++ b/src/oc_bifrost/rebar.config
@@ -43,7 +43,9 @@
 
 {profiles, [
     {dev, [
-        {relx, [{dev_mode, true}]}
+        {relx, [{dev_mode, true},
+                {include_src, true}
+               ]}
     ]},
     {fips, [
         {deps, [
@@ -91,6 +93,8 @@
         lager,
         bifrost
        ]},
+
+  {include_src, false},
   {extended_start_script,true},
   {overlay,[{template,"config/vm.args","vm.args"},
             {template,"config/sys.config","sys.config"}]}

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -107,7 +107,9 @@
         ]}
        ]},
     {dev, [
-        {relx, [{dev_mode, true}]}
+        {relx, [{dev_mode, true},
+                {include_src, true}
+               ]}
     ]}
 ]}.
 
@@ -137,9 +139,10 @@
         syntax_tools,
         compiler,
         eper,
-	 efast_xs
+        efast_xs
     ]},
 
+    {include_src, false},
     {extended_start_script,true},
     {overlay_vars,"config/vars.config"},
     {overlay,[{mkdir,"log/sasl"},


### PR DESCRIPTION
Delivery also uses this config without an issue.  For us, it saves 50-60MB after unpacking (about 10MB in ubuntu deb size).

Signed-off-by: Steven Danna <steve@chef.io>