### PR TITLE
Do not fail complete reindex when one object fails

### DIFF
--- a/src/oc_erchef/priv/reindex-opc-organization
+++ b/src/oc_erchef/priv/reindex-opc-organization
@@ -98,7 +98,15 @@ perform(drop, _Context, {OrgId, OrgName}) ->
     ok = rpc:call(?ERCHEF, chef_index, delete_search_db, [OrgId]);
 perform(reindex, Context, {_OrgId, OrgName}=OrgInfo) ->
     io:format("Sending all data for organization '~s' to be indexed again.  It may take some time before everything is available via search.~n", [OrgName]),
-    ok = rpc:call(?ERCHEF, chef_reindex, reindex, [Context, OrgInfo]);
+    {ok, Missing} = rpc:call(?ERCHEF, chef_reindex, reindex, [Context, OrgInfo]),
+    case Missing of
+        [] ->
+            ok;
+        _ ->
+            io:format(standard_error, "~nThe following objects in organization \"~s\" were unable to be reindexed:~n~n", [OrgName]),
+            [io:format(standard_error, "\t~s ~s~n", [Type, Name]) || {Type, Name} <- Missing],
+            io:format(standard_error, "~n", [])
+    end;
 perform(complete, Context, OrgInfo) ->
     %% Just do everything
     perform(drop, Context, OrgInfo),


### PR DESCRIPTION
There are cases when we do a reindex where the object name in the
serialized JSON does not match the name we get when selecting `(id, name)` from
the database.

Currently when this lookup fails, the entire reindex crashes. This
change makes it so that if we fail to find the name, instead of failing
entirely, we output a list of objects that failed to reindex to the
user.

![img](https://media.tenor.co/images/16971c89bc0549308e610de95f4695a4/raw)