### PR TITLE
Don't pass nil to escape_characters_in_string

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -157,6 +157,7 @@ class OmnibusHelper
   end
 
   def self.escape_characters_in_string(string)
+    return "" unless string.is_a? String
     pattern = /(\'|\"|\.|\*|\/|\-|\\)/
     string.gsub(pattern){|match|"\\"  + match}
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
@@ -22,6 +22,23 @@ describe OmnibusHelper do
     end
   end
 
+  describe "escape_characters_in_string" do
+    subject(:helper) { described_class.escape_characters_in_string(input_string) }
+    let(:input_string) { "foo'" }
+
+    it "escapes special characters" do
+      expect(helper).to eq("foo\\'")
+    end
+
+    context "with nil" do
+      let(:input_string) { nil }
+
+      it "returns an empty string" do
+        expect(helper).to eq("")
+      end
+    end
+  end
+
   describe '#nginx_ssl_url' do
     let(:node) do
       {

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -85,7 +85,7 @@
             {port, <%= node['private_chef']['ldap']['port'] || (@ssl_enabled ? 636 : 389) %> },
             {timeout, <%= node['private_chef']['ldap']['timeout'] || 60000 %> },
             {bind_dn, "<%= node['private_chef']['ldap']['bind_dn'] || "" %>" },
-            {bind_password, "<%= @helper.escape_characters_in_string(node['private_chef']['ldap']['bind_password']) || "" %>" },
+            {bind_password, "<%= @helper.escape_characters_in_string(node['private_chef']['ldap']['bind_password'] || "") %>" },
             {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
             {group_dn, "<%= node['private_chef']['ldap']['group_dn'] || "" %>" },
             {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -85,7 +85,7 @@
             {port, <%= node['private_chef']['ldap']['port'] || (@ssl_enabled ? 636 : 389) %> },
             {timeout, <%= node['private_chef']['ldap']['timeout'] || 60000 %> },
             {bind_dn, "<%= node['private_chef']['ldap']['bind_dn'] || "" %>" },
-            {bind_password, "<%= @helper.escape_characters_in_string(node['private_chef']['ldap']['bind_password'] || "") %>" },
+            {bind_password, "<%= @helper.escape_characters_in_string(node['private_chef']['ldap']['bind_password']) %>" },
             {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
             {group_dn, "<%= node['private_chef']['ldap']['group_dn'] || "" %>" },
             {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },


### PR DESCRIPTION
The escape_characters_in_string function expects a string. Since we
might get a nil bind password in the case of anonymous bind, pass it the
empty string instead.

Signed-off-by: Steven Danna <steve@chef.io>