### PR TITLE
bump redis version ~> 3.0.7

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -29,6 +29,7 @@ build_iteration 1
 
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
+override :redis, version: "3.0.7"
 override :ruby, version: "2.2.5"
 override :rubygems, version: "2.6.6"
 override :'omnibus-ctl', version: "master"


### PR DESCRIPTION
3.0.7 is the latest version of 3.0.x.

[These are the release notes](https://raw.githubusercontent.com/antirez/redis/3.0/00-RELEASENOTES), and they include some high urgency upgrades we've so far missed, using the [default_version 3.0.4](https://github.com/chef/omnibus-software/blob/master/config/software/redis.rb#L24).

Signed-off-by: Stephan Renatus <srenatus@chef.io>
