### PR TITLE
Update omnibus software for latest redis and lua

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/license_scout.git
-  revision: ca9e8fe08581bc6352d6d23389dcfdcddc44a76b
+  revision: ed2fe16bff7b1b337c3ae23fee8d63cce018303c
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 59e7d9f924d565a910555bd3b86e626822e6c635
+  revision: 11c88a2a983f6cd319e8a03c8f76dc3e02783688
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: f43b144a3e0379383e964c4badf5d198ba72a4ee
+  revision: fb7301850bb2ae7d4b576a161749e81c5db3119e
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -34,12 +34,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.6.6)
-      aws-sdk-resources (= 2.6.6)
-    aws-sdk-core (2.6.6)
+    aws-sdk (2.6.11)
+      aws-sdk-resources (= 2.6.11)
+    aws-sdk-core (2.6.11)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.6)
-      aws-sdk-core (= 2.6.6)
+    aws-sdk-resources (2.6.11)
+      aws-sdk-core (= 2.6.11)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -166,7 +166,7 @@ GEM
     nio4r (1.2.1)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.20.0)
+    ohai (8.21.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)


### PR DESCRIPTION
Upgrades to redis and lua address security issues as described in this
pull request: https://github.com/chef/omnibus-software/pull/752

Signed-off-by: Daniel DeLeo <dan@chef.io>

Ad hoc build with the omnibus-software branch was done here: http://wilson.ci.chef.co/view/Chef%20Server%2012/job/chef-server-12-build/507/