### PR TITLE
Pin lua to 5.1

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -29,6 +29,7 @@ build_iteration 1
 
 override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
+override :lua, version: "5.1.5"
 override :ruby, version: "2.2.5"
 override :rubygems, version: "2.6.6"
 override :'omnibus-ctl', version: "master"


### PR DESCRIPTION
The openresty lua plugin only supports 5.1.

Signed-off-by: Steven Danna <steve@chef.io>