### PR TITLE
Adds retry behavior for expander

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -253,7 +253,8 @@ default['private_chef']['opscode-expander']['log_rotation']['file_maxbytes'] = 1
 default['private_chef']['opscode-expander']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['opscode-expander']['consumer_id'] = "default"
 default['private_chef']['opscode-expander']['nodes'] = 2
-
+default['private_chef']['opscode-expander']['max_retries'] = 1
+default['private_chef']['opscode-expander']['retry_wait'] = 1
 ####
 # Erlang Chef Server API
 ####

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/expander.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/expander.rb.erb
@@ -7,3 +7,6 @@ amqp_user '<%= node['private_chef']['rabbitmq']['user'] %>'
 amqp_pass '<%= node['private_chef']['rabbitmq']['password'] %>'
 amqp_vhost '<%= node['private_chef']['rabbitmq']['vhost'] %>'
 ps_tag ''
+
+max_retries <%= @options['max_retries'] %>
+retry_wait <%= @options['retry_wait'] %>

--- a/src/opscode-expander/conf/opscode-expander.rb.example
+++ b/src/opscode-expander/conf/opscode-expander.rb.example
@@ -1,6 +1,9 @@
 # The URL is the only Solr config Opscode Expander needs #
 solr_url        "http://localhost:8983"
 
+max_retries 1
+retry_wait 1
+
 # Parameters for connecting to RabbitMQ
 amqp_host   'localhost'
 amqp_port   5672

--- a/src/opscode-expander/lib/opscode/expander/configuration.rb
+++ b/src/opscode-expander/lib/opscode/expander/configuration.rb
@@ -109,6 +109,14 @@ module Opscode
           invalid("The cluster size (node-count) cannot be smaller than the index") unless node_count >= index.to_i
         end
 
+        configurable :max_retries do
+          invalid("You must specify the retry count as an integer") unless max_retries.kind_of?(Integer)
+        end
+
+        configurable :retry_wait do
+          invalid("You must specify the retry count as an integer") unless retry_wait.kind_of?(Integer)
+        end
+
         configurable :ps_tag, ""
 
         configurable :solr_url, "http://localhost:8983"

--- a/src/opscode-expander/lib/opscode/expander/solrizer.rb
+++ b/src/opscode-expander/lib/opscode/expander/solrizer.rb
@@ -218,7 +218,7 @@ module Opscode
           log.error { "Failed to post to solr (connection error): #{indexed_object}" }
 
           if retries < max_retries
-            log.info { "Retrying solr connection: #{indexed_object} attempt #{retries}" }
+            log.info { "Retrying solr connection in #{retry_wait} seconds: #{indexed_object} attempt #{retries}" }
             EM.add_timer(retry_wait) do
               post_to_solr(document, retries + 1, &logger_block)
             end

--- a/src/opscode-expander/lib/opscode/expander/solrizer.rb
+++ b/src/opscode-expander/lib/opscode/expander/solrizer.rb
@@ -218,9 +218,12 @@ module Opscode
           completed
           log.error { "Failed to post to solr (connection error): #{indexed_object}" }
 
-          EM.add_timer(retry_wait) do
-            post_to_solr(document, retries += 1, &logger_block)
-          end unless retries >= max_retries
+          if retries < max_retries
+            log.info { "Retrying solr connection: #{indexed_object} attempt #{retries}" }
+            EM.add_timer(retry_wait) do
+              post_to_solr(document, retries += 1, &logger_block)
+            end
+          end
         end
       end
 

--- a/src/opscode-expander/spec/unit/vnode_supervisor_spec.rb
+++ b/src/opscode-expander/spec/unit/vnode_supervisor_spec.rb
@@ -37,6 +37,7 @@ describe Expander::VNodeSupervisor do
   end
 
   it "subscribes to the control queue" do
+    pending "disabled until broadcast_message is used"
     control_queue_msg = nil
     AMQP.start(OPSCODE_EXPANDER_MQ_CONFIG) do
       @vnode_supervisor.start([])


### PR DESCRIPTION
Currently expander will drop jobs when solr is unavailable.  This PR adds configurable options to expander for `max_retries` and `retry_wait` to allow expander to retry writing to solr for a configurable number of times.  This allows Solr restarts without dropping tasks.