### PR TITLE
Use instance variables in expander.rb template

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/expander.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/expander.rb.erb
@@ -8,5 +8,5 @@ amqp_pass '<%= node['private_chef']['rabbitmq']['password'] %>'
 amqp_vhost '<%= node['private_chef']['rabbitmq']['vhost'] %>'
 ps_tag ''
 
-max_retries <%= @options['max_retries'] %>
-retry_wait <%= @options['retry_wait'] %>
+max_retries <%= @max_retries %>
+retry_wait <%= @retry_wait %>


### PR DESCRIPTION
There is no `@options` hash available in the template. Rather, max_retries
and retry_wait are available as instance variables.

Signed-off-by: Steven Danna <steve@chef.io>