### PR TITLE
Remove old comment in omnibus.rb

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -19,9 +19,4 @@ fetcher_read_timeout 120
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
 
-# This is temporarily disabled due to a high number of failures
-# while trying to resolve sqitch licensing due to the cpan
-# service timing out. .  We'll re-enable it
-# once we have a process available that lets us declare
-# component licensing outside of the build itself.
 fatal_transitive_dependency_licensing_warnings true


### PR DESCRIPTION
This comment should have been removed when we flipped it back to true.

Signed-off-by: Steven Danna <steve@chef.io>