### PR TITLE
Bump omnibus-software to pick up openssl version 1.0.2j.

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/license_scout.git
-  revision: ed2fe16bff7b1b337c3ae23fee8d63cce018303c
+  revision: c6c4a7bbcdbc73733217764db3bd5d278f63533e
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 11c88a2a983f6cd319e8a03c8f76dc3e02783688
+  revision: e72cafb03e6a7ee38f78dfda9feb9d683c60901a
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: fb7301850bb2ae7d4b576a161749e81c5db3119e
+  revision: 25078ff10e322c4c9ec7fd5b6ecc44136f13342d
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -34,12 +34,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.6.11)
-      aws-sdk-resources (= 2.6.11)
-    aws-sdk-core (2.6.11)
+    aws-sdk (2.6.13)
+      aws-sdk-resources (= 2.6.13)
+    aws-sdk-core (2.6.13)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.11)
-      aws-sdk-core (= 2.6.11)
+    aws-sdk-resources (2.6.13)
+      aws-sdk-core (= 2.6.13)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)


### PR DESCRIPTION
Tested via ad_hoc build:

http://wilson.ci.chef.co/job/chef-server-12-trigger-ad_hoc/285/downstreambuildview/

Signed-off-by: Serdar Sutay <serdarsutay@gmail.com>

/cc: @chef/chef-server-maintainers @danielsdeleo 