### PR TITLE
Add validation endpoint to Chef Server.

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -101,6 +101,12 @@ module Pedant
     # RestClient::Response object).  Testing methods should use this to
     # carry out any validation tests of the response.
     def authenticated_request(method, url, requestor, opts={}, &validator)
+      headers, payload = construct_request(method, url, requestor, opts)
+      do_request(method, url, headers, payload, &validator)
+    end
+
+    # Construct an authenticated request against a Chef Server
+    def construct_request(method, url, requestor, opts={})
       user_headers = opts[:headers] || {}
       version = opts[:server_api_version]
       payload_raw = opts[:payload] || ""
@@ -131,11 +137,17 @@ module Pedant
       else
         host = "#{uri.host}:#{uri.port}"
       end
+
       final_headers = standard_headers.
         merge(auth_headers).
         merge(user_headers).
         merge(version_headers).
         merge({'Host' => host})
+
+      [final_headers, payload]
+    end
+
+    def do_request(method, url, final_headers, payload, &validator)
 
       response_handler = lambda{|response, request, result| response}
 

--- a/oc-chef-pedant/spec/api/validate_spec.rb
+++ b/oc-chef-pedant/spec/api/validate_spec.rb
@@ -1,0 +1,105 @@
+#
+# -*- indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+# ex: ts=4 sw=4 et
+#
+# Author:: Mark Anderson <mark@chef.io>
+# Copyright:: Copyright (c) 2016 Chef, Inc.
+#
+
+describe "Validation API Endpoint", :authentication do
+  let(:bad_client) { platform.bad_client }
+  let(:test_body) {
+    {foo: "bar"}
+  }
+  let(:user_body) {
+    {"requestor_name" => normal_user.name,
+     "requestor_type" => "user"}
+  }
+
+  let(:failed_to_authenticate_as_invalid_msg) {
+    ["Failed to authenticate as 'invalid'. Ensure that your node_name and client key are correct."] }
+
+  describe 'We make a request' do
+    describe 'with a valid user' do
+      describe 'and valid path' do
+        let(:real_url) { platform.internal_api_url("nodes") }
+        let(:redir_url) {
+          uri_path = URI(real_url).path
+          platform.internal_api_url("validate#{uri_path}")
+        }
+
+        [:GET, :POST, :PUT, :DELETE].each do |req|
+          it "is a #{req}" do
+            headers, payload = construct_request(req, real_url, normal_user, test_body)
+            do_request(req, redir_url, headers, payload) do |response|
+              response.should look_like({
+                                          :status => 200,
+                                          :body_exact => user_body
+                                        })
+            end
+          end
+        end
+      end
+    end
+    describe 'with a valid client' do
+      let(:client) { platform.non_admin_client }
+      let(:client_body) {
+        {"requestor_name" => client.name,
+         "requestor_type" => "client"}
+      }
+
+      describe 'and valid path' do
+        let(:real_url) { platform.internal_api_url("nodes") }
+        let(:redir_url) {
+          uri_path = URI(real_url).path
+          platform.internal_api_url("validate#{uri_path}")
+        }
+
+        [:GET, :POST, :PUT, :DELETE].each do |req|
+          it "is a #{req}" do
+            headers, payload = construct_request(req, real_url, client, test_body)
+            do_request(req, redir_url, headers, payload) do |response|
+              response.should look_like({
+                                          :status => 200,
+                                          :body_exact => client_body
+                                        })
+            end
+          end
+        end
+      end
+
+      describe 'with the wrong path' do
+        let(:real_url) { platform.internal_api_url("nodes") }
+        let(:redir_url) {
+          uri_path = URI(real_url).path
+          redir_url = platform.internal_api_url("validate/dog")
+        }
+
+        [:GET, :POST, :PUT, :DELETE].each do |req|
+          it "is a #{req}" do
+            headers, payload = construct_request(:POST, real_url, client, test_body)
+            do_request(:POST, redir_url, headers, payload) do |response|
+              response.should look_like({
+                                      :status => 401
+                                        })
+            end
+          end
+        end
+      end
+    end
+    describe 'with a valid client not in the org' do
+      it 'and valid path' do
+        real_url = platform.internal_api_url("nodes")
+        uri_path = URI(real_url).path
+        redir_url = platform.internal_api_url("validate#{uri_path}")
+
+        headers, payload = construct_request(:POST, real_url, bad_client, test_body)
+        do_request(:POST, redir_url, headers, payload) do |response|
+          response.should look_like({
+                                      :status => 401
+                                    })
+        end
+      end
+    end
+  end
+end

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -161,4 +161,7 @@
 %% universe endpoint
 {["organizations", organization_id, "universe"], chef_wm_universe, []}.
 
+%% Validation endpoint
+{["organizations", organization_id, "validate", '*'], chef_wm_validate, []}.
+
 {["_status"], chef_wm_status, []}.

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_validate.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_validate.erl
@@ -1,0 +1,113 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Mark Anderson <mark@chef.io>
+%% Copyright 2016 Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_wm_validate).
+
+-include("oc_chef_wm.hrl").
+
+
+%% Webmachine resource callbacks
+-mixin([{oc_chef_wm_base, [content_types_provided/2,
+                           content_types_accepted/2,
+                           finish_request/2,
+                           malformed_request/2,
+                           ping/2,
+                           forbidden/2,
+                           {allow_all/2, auth_info},
+                           service_available/2]}]).
+
+-export([allowed_methods/2,
+         to_json/2,
+         from_json/2]).
+
+%% chef_wm behavior callbacks
+-behaviour(chef_wm).
+-export([init/1,
+         init_resource_state/1,
+         malformed_request_message/3,
+         is_authorized/2,
+         request_type/0,
+         validate_request/3,
+         delete_resource/2,
+         delete_completed/2,
+         process_post/2
+        ]).
+
+
+init(Config) ->
+    oc_chef_wm_base:init(?MODULE, Config).
+
+init_resource_state(_Config) ->
+    {ok, #base_state{}}.
+
+request_type() ->
+  "validate".
+
+allowed_methods(Req, State) ->
+    {['GET', 'PUT', 'POST', 'DELETE'], Req, State}.
+
+-spec validate_request(chef_wm:http_verb(), wm_req(), chef_wm:base_state()) ->
+                              {wm_req(), chef_wm:base_state()}.
+validate_request(_, Req, #base_state{organization_guid = OrgId, server_api_version = ApiVersion} = State) ->
+    {Req, State#base_state{resource_state = #oc_chef_organization{id = OrgId, server_api_version = ApiVersion}}}.
+
+is_authorized(Req, State) ->
+    oc_chef_wm_base:is_authorized(Req, State, fun validate_extractor/3).
+
+process_post(Req, State) ->
+    {Result, Req1, State1} = to_json(Req, State),
+    {true, wrq:set_resp_body(Result, Req1), State1}.
+
+delete_resource(Req, State) ->
+    make_and_set_body(Req, State).
+
+delete_completed(Req, State) ->
+    {true, Req, State}.
+
+make_body(Req, #base_state{requestor = #chef_requestor{name = Name, type = Type}} = State) ->
+    %% We may want to return other things here, possibily including a user/client GUID
+    EJson = {[
+              {requestor_name, Name},
+              {requestor_type, Type}
+             ]},
+    {chef_json:encode(EJson), Req, State}.
+
+make_and_set_body(Req, State) ->
+    {EJson, Req1, State1} = make_body(Req, State),
+    Req2 = wrq:set_resp_body(EJson, Req1),
+    {true, Req2, State1}.
+
+to_json(Req, State) ->
+    make_body(Req, State).
+
+from_json(Req, State) ->
+    make_and_set_body(Req, State).
+
+validate_extractor(path, Req, _State) ->
+    %% wrq:disp_path/1 returns the path portion matched by "*", ie.
+    %% foo/bar from /organizations/ORG/validate/foo/bar
+    ShortPath = iolist_to_binary(wrq:disp_path(Req)),
+    iolist_to_binary([<<"/">>, ShortPath]);
+validate_extractor(Other, Req, State) ->
+    oc_chef_wm_base:authorization_data_extractor(Other, Req, State).
+
+-spec malformed_request_message(any(), wm_req(), #base_state{}) -> no_return().
+malformed_request_message(Any, Req, State) ->
+    oc_chef_wm_base:default_malformed_request_message(Any, Req, State).

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
@@ -192,7 +192,8 @@ verify_request_signature_test_() ->
                meck:expect(chef_db, fetch_requestors, fun(_Context, _OrgId, _Name) ->
                                                               {error, no_connections}
                                                       end),
-               {Return, _Req1, State1} = oc_chef_wm_base:verify_request_signature(Req, State),
+               Extractor = fun oc_chef_wm_base:authorization_data_extractor/3,
+               {Return, _Req1, State1} = oc_chef_wm_base:verify_request_signature(Req, State, Extractor),
                ?assertEqual({halt, 503}, Return),
                ?assertEqual({error_finding_user_or_client, no_connections}, State1#base_state.log_msg)
        end},
@@ -203,7 +204,8 @@ verify_request_signature_test_() ->
                meck:expect(chef_db, fetch_requestors, fun(_Context, _OrgId, _Name) ->
                                                               {error, uh_oh}
                                                       end),
-               {Return, _Req1, State1} = oc_chef_wm_base:verify_request_signature(Req, State),
+               Extractor = fun oc_chef_wm_base:authorization_data_extractor/3,
+               {Return, _Req1, State1} = oc_chef_wm_base:verify_request_signature(Req, State, Extractor),
                ?assertEqual({halt, 500}, Return),
                ?assertEqual({error_finding_user_or_client, uh_oh}, State1#base_state.log_msg)
        end},
@@ -214,7 +216,8 @@ verify_request_signature_test_() ->
                meck:expect(chef_db, fetch_requestors, fun(_Context, _OrgId, _Name) ->
                                                               not_found
                                                       end),
-               {Return, _Req1, State1} = oc_chef_wm_base:verify_request_signature(Req, State),
+               Extractor = fun oc_chef_wm_base:authorization_data_extractor/3,
+               {Return, _Req1, State1} = oc_chef_wm_base:verify_request_signature(Req, State, Extractor),
                ?assertEqual(false, Return),
                ?assertEqual({not_found, user_or_client}, State1#base_state.log_msg)
        end}

--- a/src/oc_erchef/raml-docs/index.raml
+++ b/src/oc_erchef/raml-docs/index.raml
@@ -33,5 +33,6 @@ traits:
 /organizations/{organization}/sandboxes:            !include organizations/sandboxes.yaml
 /organizations/{organization}/search:               !include organizations/search.yaml
 /organizations/{organization}/users:                !include organizations/users.yaml
+/organizations/{organization}/validate:             !include organizations/validate.yaml
 /users: !include users.yaml
 /:                                                  !include server_endpoints.yaml

--- a/src/oc_erchef/raml-docs/organizations/validate.yaml
+++ b/src/oc_erchef/raml-docs/organizations/validate.yaml
@@ -1,0 +1,6 @@
+description: Validate a forwarded request
+type: validation_endpoint
+
+/~{validatedata}:
+  description: Validate a forwarded request
+  type: validation_endpoint

--- a/src/oc_erchef/raml-docs/resource-types.yaml
+++ b/src/oc_erchef/raml-docs/resource-types.yaml
@@ -53,3 +53,13 @@ acl_permission_endpoint:
 
 identifiers_endpoint:
   type: list_endpoint
+
+validation_endpoint:
+  get?:
+    is: [chef_endpoint]
+  put?:
+    is: [chef_endpoint]
+  post?:
+    is: [chef_endpoint]
+  delete?:
+    is: [chef_endpoint]

--- a/src/oc_erchef/raml-docs/schemas.yaml
+++ b/src/oc_erchef/raml-docs/schemas.yaml
@@ -55,3 +55,4 @@ SystemRecoveryAuthenticatedUser: !include schemas/system-recovery-authenticated-
 User:                      !include schemas/user.json
 UserCreate:                !include schemas/user-create.json
 UserCreated:               !include schemas/user-created.json
+Validate:                  !include schemas/validate.json

--- a/src/oc_erchef/raml-docs/schemas/validate.json
+++ b/src/oc_erchef/raml-docs/schemas/validate.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+      "requestor_name": {
+	  "description": "The name of the validated requestor",
+	  "$ref": "common.json#ChefName"
+      },
+      "requestor_type": {
+          "description": "The type of the principal (user or client)",
+          "type": "string",
+          "enum": [ "user", "client" ]
+      }
+  },
+  "example": {
+      "requestor_name": "yargh",
+      "requestor_type": "client"
+  }
+}


### PR DESCRIPTION
Add validation endpoint to Chef Server.

We sometimes have the need to be able to determine if a request signed
with a client key is valid.  This adds an endpoint
/organizations/ORGNAME/validate/PATH that accepts a forwarded post,
and checks the signing as if it were sent to the PATH resource (PATH
can be any resource string). If the request validates, it returns 200,
and some potentially useful data. If it doesn't it returns 401 like
any other request with a bad signature.
- [x] Verify it works with the nginx code
- [x] Add RAML docs
- [x] Wait for chef server release to finish.
- [x] Rebase/Squash
