### PR TITLE
omnibus: Add arm build support for opscode-solr4

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: e72cafb03e6a7ee38f78dfda9feb9d683c60901a
+  revision: f1aa0f05e01438f3d6e3bc73f6fe60f105d466db
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -34,12 +34,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    aws-sdk (2.6.13)
-      aws-sdk-resources (= 2.6.13)
-    aws-sdk-core (2.6.13)
+    aws-sdk (2.6.14)
+      aws-sdk-resources (= 2.6.14)
+    aws-sdk-core (2.6.14)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.13)
-      aws-sdk-core (= 2.6.13)
+    aws-sdk-resources (2.6.14)
+      aws-sdk-core (= 2.6.14)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)

--- a/omnibus/config/software/opscode-solr4.rb
+++ b/omnibus/config/software/opscode-solr4.rb
@@ -28,6 +28,8 @@ if ppc64? || ppc64le? || ohai['kernel']['machine'] == "s390x"
   dependency "ibm-jre"
 elsif intel? && _64_bit?
   dependency "server-jre"
+elsif armhf?
+  dependency "jre-from-jdk"
 else
   raise "A JRE is required by opscode-solr4, but none are known for this platform"
 end


### PR DESCRIPTION
Following the merge of https://github.com/chef/omnibus-software/pull/751, this PR use the new `jre-from-jdk` software for opscode-solr4, allowing to build chef-server package for armhf, as demonstrated here: https://github.com/elthariel/chef-server/releases/tag/v12.5.0-arm-alpha

I've been running the chef server on a very small box (Scaleway.com C1 instance: 2GB RAM, Marvell Armada 370/XP CPU) for a few weeks, and it works well. For later reference, here's my `/etc/opscode/chef-server.rb` file:

```
# This line is *required*, without it, the keygen timeouts and starts new 'openssl genrsa' processes
# Completely slamming the box, preventin `reconfigure` from ever succeeding
opscode_erchef['keygen_timeout'] = 30000
# Tweak to your tastes
opscode_expander['nodes'] = 3
opscode_erchef['keygen_cache_workers'] = 1
# There's only 2GB of memory on my box, let's be conservative here
opscode_solr4['heap_size'] = 256
postgresql['shared_buffers'] = '256MB'
postgresql['shmall'] = 2097152
postgresql['shmmax'] = 4294967295
```

Signed-off-by: Julien 'Lta' BALLET contact@lta.io
