### PR TITLE
Make the ElasticSearch shard and replica count configurable

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -242,6 +242,8 @@ default['private_chef']['opscode-solr4']['poll_seconds'] = 20 # slave -> master 
 # To enable the rest of the admin API, set the enable_full_admin_api
 # to true.
 default['private_chef']['opscode-solr4']['enable_full_admin_api'] = false
+default['private_chef']['opscode-solr4']['elasticsearch_shard_count'] = 5
+default['private_chef']['opscode-solr4']['elasticsearch_replica_count'] = 1
 
 ####
 # Chef Expander

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
@@ -29,7 +29,9 @@ when 'elasticsearch'
                               "type" => "whitespace"
                             }
                           }
-                        }
+                        },
+                        "number_of_shards" => node['private_chef']['opscode-solr4']['elasticsearch_shard_count'],
+                        "number_of_replicas" => node['private_chef']['opscode-solr4']['elasticsearch_replica_count']
                       },
                       "mappings" => {
                         "object" => {


### PR DESCRIPTION
The default values for ElasticSearch's shard count (5) and replica count (1) may not be best for all customer topologies (3 nodes).    This PR makes them configurable, but reserves opinions on what our default values should be. 

Further reading:  https://www.elastic.co/guide/en/elasticsearch/guide/current/_scale_horizontally.html

Signed-off-by: Irving Popovetsky irving@getchef.com
