### PR TITLE
Set environment before exec in chef-server-ctl psql

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/psql.rb
+++ b/omnibus/files/private-chef-ctl-commands/psql.rb
@@ -86,8 +86,9 @@ add_command_under_category "psql", "Database", "Launches an interactive psql ses
     STDOUT.puts "DBName: #{db_name}"
   end
 
-  cmd = "PGPASSWORD=#{db_password} PAGER=less LESS='-iMSx4 -FX' /opt/opscode/embedded/bin/psql --host #{db_host} --username #{db_username} --port #{db_port} --dbname #{db_name}#{psql_options}"
-
+  ENV['PGPASSWORD'] = db_password
+  ENV['PAGER'] = 'less'
+  ENV['LESS'] = '-iMSx4 -FX'
+  cmd = "/opt/opscode/embedded/bin/psql --host #{db_host} --username #{db_username} --port #{db_port} --dbname #{db_name}#{psql_options}"
   exec cmd
-
 end


### PR DESCRIPTION
Setting the environment as part of the command leads to the password
being revealed in ps output.  Since this command exec's we can set the
environment for the current process before exec.

Signed-off-by: Steven Danna <steve@chef.io>