### PR TITLE
Enable mixlib-install to resolve backwards compatible packages

### DIFF
--- a/omnibus/config/software/mixlib-install.rb
+++ b/omnibus/config/software/mixlib-install.rb
@@ -15,7 +15,7 @@
 #
 
 name "mixlib-install"
-default_version "v2.0.0"
+default_version "v2.1.5"
 
 license "Apache-2.0"
 license_file "LICENSE"

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_wrapper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/add_ons_wrapper.rb
@@ -53,6 +53,7 @@ if OmnibusHelper.new(node).remote_install_addons?
       channel: :stable,
       product_name: pkg.split(/(chef-|opscode-)(.*)/).last,
       product_version: :latest,
+      platform_version_compatibility_mode: true
     ).detect_platform.artifact_info
 
     pkg_file = File.join(addon_path, File.basename(artifact_info.url))


### PR DESCRIPTION
This PR enables mixlib-install's `platform_version_compatibility_mode` option which allows platforms to return backwards compatible packages if they exist. Here are examples:

```ruby
# without option requesting Ubuntu Xenial (16.04)
installer = Mixlib::Install.new(product_name: "chef", channel: :stable, platform: "ubuntu", platform_version: "16.06", architecture: "x86_64")
=> #<Mixlib::Install:0x007fc734a5be70 @options=#<Mixlib::Install::Options:0x007fc734a5be48 @options={:product_name=>"chef", :channel=>:stable, :platform=>"ubuntu", :platform_version=>"16.06", :architecture=>"x86_64"}>>
irb(main):002:0> installer.artifact_info
=> []

# with option requesting Ubuntu Xenial (16.04)
installer = Mixlib::Install.new(product_name: "chef", channel: :stable, platform: "ubuntu", platform_version: "16.06", architecture: "x86_64", platform_version_compatibility_mode: true)
=> #<Mixlib::Install:0x007fc7350f9a70 @options=#<Mixlib::Install::Options:0x007fc7350f9a20 @options={:product_name=>"chef", :channel=>:stable, :platform=>"ubuntu", :platform_version=>"16.06", :architecture=>"x86_64", :platform_version_compatibility_mode=>true}>>
irb(main):004:0> installer.artifact_info
=> #<Mixlib::Install::ArtifactInfo:0x007fc734ab83f0 @architecture="x86_64", @license="Apache-2.0", @license_content=nil, @md5="abccf34672b1c53fee4e3cfedda6cd6e", @platform="ubuntu", @platform_version="16.04", @product_description="Chef Client", @product_name="chef", @sha1="a2de7d933734d3a0c4b859576d0be472c5cd55f7", @sha256="7073541beb4294c994d4035a49afcf06ab45b3b3933b98a65b8059b7591df6b8", @software_dependencies=nil, @url="https://packages.chef.io/files/stable/chef/12.15.19/ubuntu/16.04/chef_12.15.19-1_amd64.deb", @version="12.15.19">
```

Fixes issues like #969 

Also updates mixlib-install latest version for additional fixes

Signed-off-by: Patrick Wright <patrick@chef.io>