### PR TITLE
Add profiles forwarding to Automate endpoint

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -834,3 +834,15 @@ default['private_chef']['data_collector']['http_cull_interval'] = "{1, min}"
 default['private_chef']['data_collector']['http_max_connection_duration'] = "{70,sec}"
 # Options for the ibrowse connections (see ibrowse).
 default['private_chef']['data_collector']['ibrowse_options'] = "[{connect_timeout, 10000}]"
+
+##
+# Compliance Profiles
+##
+# Used to proxy Compliance Profile requests to the Automate Profiles storage
+#
+default['private_chef']['profiles'] = {}
+# Fully qualified URL to the compliance profiles server:
+# default['private_chef']['profiles']['root_url'] = 'https://profiles.example.com'
+# The authentication token to pass via the header to the data collector server
+# Define the token unless already set in this file
+# default['private_chef']['data_collector']['token'] = '123456789...'

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -116,7 +116,8 @@ lbconf = node['private_chef']['lb'].to_hash.merge(nginx_vars).merge(
  'route_checks.lua',
  'routes.lua',
  'dispatch_route.lua',
- 'check_token_using_endpoint.lua'].each do |script|
+ 'check_token_using_endpoint.lua',
+ 'check_token_using_endpoint_compliance.lua'].each do |script|
   template File.join(nginx_scripts_dir, script) do
     source "nginx/scripts/#{script}.erb"
     owner 'root'

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -79,6 +79,12 @@ http {
   }
   <% end -%>
 
+  <% if node['private_chef']['profiles']['root_url'] && node['private_chef']['data_collector']['token'] -%>
+  upstream compliance-profiles {
+    server <%= URI.parse(node['private_chef']['profiles']['root_url']).host %>:<%= URI.parse(node['private_chef']['profiles']['root_url']).port %>;
+  }
+  <% end -%>
+
   # Include upstream definitions for addons
   include <%= node['private_chef']['nginx']['dir'] %>/etc/addon.d/*_upstreams.conf;
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -64,6 +64,19 @@
     }
     <% end -%>
 
+    <% if node['private_chef']['profiles']['root_url'] && node['private_chef']['data_collector']['token'] -%>
+    # Compliance endpoint to forward profiles calls to the Automate API:
+    #   /organizations/ORG/owners/OWNER/compliance[/PROFILE]
+    # Supports the legacy(chef-gate) URLs as well:
+    #   /compliance/organizations/ORG/owners/OWNER/compliance[/PROFILE]
+    location ~ (?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*) {
+      set $request_org $1;
+      set $new_uri "/compliance/profiles/$2$3";
+      access_by_lua_file '/var/opt/opscode/nginx/etc/scripts/check_token_using_endpoint_compliance.lua';
+      proxy_pass $upstream;
+    }
+    <% end -%>
+
     # bookshelf
     <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
     location ~ "/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/{0,1}.*$" {

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/check_token_using_endpoint_compliance.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/check_token_using_endpoint_compliance.lua.erb
@@ -1,0 +1,27 @@
+-- ngx.req.read_body() is recommended when using ngx.location.capture()
+-- Also we need to pass the body of the request to the /validate call.
+ngx.req.read_body()
+
+-- Allow only GET requests at the moment
+if ngx.var.request_method ~= "GET" then
+  ngx.exit(ngx.HTTP_NOT_ALLOWED)
+end
+
+local res = ngx.location.capture("/organizations/" .. ngx.var.request_org .. "/validate" .. ngx.var.request_uri,
+    { method = ngx.HTTP_GET,
+      always_forward_body = true,
+      copy_all_vars = true,
+      vars = { upstream = "http://opscode_erchef" }
+    })
+
+if res.status == ngx.HTTP_OK then
+  ngx.var.upstream = 'https://compliance-profiles'
+  ngx.req.set_uri(ngx.var.new_uri)
+  ngx.req.set_header("x-data-collector-token", "<%= node['private_chef']['data_collector']['token'] %>")
+  ngx.req.set_header("x-data-collector-auth", "version=1.0")
+  return
+else
+  ngx.log(ngx.STDERR, "Validation of " .. ngx.var.request_uri .." returned status " .. res.status);
+end
+
+ngx.exit(res.status)


### PR DESCRIPTION
Similar to https://github.com/chef/chef-server/pull/984 but for Compliance Profiles retrieval from Chef Automate.

Once connected with Automate, it can be tested using:
```
[07:01:53 ~/chef-repo]$
$ knife raw /owners/admin/compliance/linux/tar
```

or via the `audit` 2.0 cookbook.