### PR TITLE
[ldap] Allow user customization of field mapping

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -823,6 +823,32 @@ default['private_chef']['ldap'] = nil
 # default['private_chef']['ldap']['enable_tls'] = false
 
 ##
+# LDAP Attribute Mapping
+##
+# Attributes from a user's LDAP record are used during account-linking
+# to populate the erchef user record when it is created.  The
+# following attributes controls which LDAP record is used for the
+# specified information.
+#
+# For example, if the user's LDAP record stores their email address in
+# a field named 'address' instead of 'mail', then you could set:
+#
+#   default['private_chef']['ldap']['email_attribute'] = "address"
+#
+# in private-chef.rb this would look like:
+#
+#  ldap['email_attribute'] = "address"
+#
+##
+# default['private_chef']['ldap']['display_name_attribute'] = "displayname"
+# default['private_chef']['ldap']['first_name_attribute'] = "givenname"
+# default['private_chef']['ldap']['last_name_attribute'] = "sn"
+# default['private_chef']['ldap']['common_name_attribute'] = "cn"
+# default['private_chef']['ldap']['country_attribute'] = "c"
+# default['private_chef']['ldap']['city_attribute'] = "l"
+# default['private_chef']['ldap']['email_attribute'] = "mail"
+
+##
 # Upgrades/Partybus
 ##
 default['private_chef']['upgrades']['dir'] = "/var/opt/opscode/upgrades"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -92,6 +92,15 @@
             {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
             {group_dn, "<%= node['private_chef']['ldap']['group_dn'] || "" %>" },
             {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },
+            %% LDAP Attribute Mappings
+            {display_name_attribute, "<%= node['private_chef']['ldap']['display_name_attribute'] || 'displayname' %>" },
+            {first_name_attribute,   "<%= node['private_chef']['ldap']['first_name_attribute']   || 'givenname' %>" },
+            {last_name_attribute,    "<%= node['private_chef']['ldap']['last_name_attribute']    || 'sn' %>" },
+            {common_name_attribute,  "<%= node['private_chef']['ldap']['common_name_attribute']  || 'cn' %>" },
+            {country_attribute,      "<%= node['private_chef']['ldap']['country_attribute']      || 'c' %>" },
+            {city_attribute,         "<%= node['private_chef']['ldap']['city_attribute']         || 'l' %>" },
+            {email_attribute,        "<%= node['private_chef']['ldap']['email_attribute']        || 'mail' %>" },
+
             {case_sensitive_login_attribute, <%= node['private_chef']['ldap']['case_sensitive_login_attribute'] || false %>},
             {encryption, <%= @ldap_encryption_type %>}
         ]},


### PR DESCRIPTION
Attributes from a user's LDAP record are used during account-linking to
populate the erchef user record when it is created. Previously, the
mapping between LDAP attributes and chef user attributes were fixed.
Now, they are configurable.

For example, if the user's LDAP record stores their email address in a
field named 'address' instead of 'mail', then you could set the
following in private-chef.rb:

    ldap['email_attribute'] = "address"

Fixes #151
Fixes #800
Fixes #104
Partially addresses #675

Issue #800 was also addressed in #863 which allowed common_name to
service as a fallback for display name. The fallback is still in place
but now any field can be used for the display_name.

Issue #675 is an issue which our unicode handling. The unicode handling
is still broken; however, this would allow users to use a different
field that might not contain multi-byte characters.

Signed-off-by: Steven Danna <steve@chef.io>