### PR TITLE
[ldap] Don't mangle multi-byte characters

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authn_ldap.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authn_ldap.erl
@@ -231,9 +231,10 @@ value_of(Key, Data, Default) ->
     [R|_] = proplists:get_value(Key, Data, [Default]),
     characters_to_binary(R).
 
-characters_to_binary(Characters) when is_list(Characters);
-                                      is_binary(Characters) ->
-    unicode:characters_to_binary(Characters);
+characters_to_binary(Characters) when is_list(Characters) ->
+    list_to_binary(Characters);
+characters_to_binary(Characters) when is_binary(Characters) ->
+    Characters;
 % In case of unexpected value, don't crash the auth process:
 characters_to_binary(Atom) when is_atom(Atom) ->
     atom_to_binary(Atom, utf8).


### PR DESCRIPTION
Previously, if a user's ldap data contained multi-byte characters, we
would mangle it.

For example, if a user's displayname was "张伟" it would get returned as
"å¼ ä¼".  This was being caused by the call to characters_to_binary.

The UTF-8 representation of "张伟" is

    229,188,160,228,188,159

2 characters, each 3 bytes. unicode:characters_to_binary would transform
this into:

    <<195,165,194,188,194,160,195,164,194,188,194,159>>

It does this because characters_to_binary assumes that the input is a
list of unicode code points. In our example, it would expect

    [24352,20255]

and would then return

    <<229,188,160,228,188,159>>

Since we are sending it raw UTF-8 data rather than code points, our data
gets mangled.

Since we are already getting UTF-8 encoded data from eldap, it appears
that we can just forward it on without modification and it will display
correctly.

Fixes #675

Signed-off-by: Steven Danna <steve@chef.io>