### PR TITLE
Validate user's 'name' before 'username'

### DIFF
--- a/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
@@ -249,6 +249,24 @@ parse_binary_json_tests(Version) ->
               ?_assertMatch({ok, _}, chef_user:parse_binary_json(Version, chef_json:encode(UserEJson2), create, undefined))
       end
      },
+     {?VD("Ignores invalid username if name exists"),
+      fun() ->
+              UserEJson = {make_min_valid_create_user_ejson()},
+              UserEJson1 = ej:set({<<"name">>}, UserEJson, <<"validname">>),
+              UserEJson2 = ej:set({<<"username">>}, UserEJson1, <<"invalid!">>),
+              Actual = chef_user:parse_binary_json(Version, chef_json:encode(UserEJson2), create, undefined),
+              ?_assertMatch({ok, _}, Actual)
+      end
+     },
+     {?VD("Errors on invalid name even if valid username exists"),
+      fun() ->
+              UserEJson = {make_min_valid_create_user_ejson()},
+              UserEJson1 = ej:set({<<"username">>}, UserEJson, <<"validname">>),
+              UserEJson2 = ej:set({<<"name">>}, UserEJson1, <<"invalid!">>),
+              ?assertThrow(#ej_invalid{key= <<"name">>},
+                           chef_user:parse_binary_json(Version, chef_json:encode(UserEJson2), create, undefined))
+      end
+     },
      {?VD("Error thrown with bad name"),
       fun() ->
               UserEJson = {make_min_valid_create_user_ejson()},


### PR DESCRIPTION
The function username_from_ejson/1 is used to extract the username from
the user-provided JSON for a user.  That function checks for the 'name'
key followed by the 'username' key.

The validate_user_name/1 function was previously validating the
'username' key first, followed by the 'name' key if it didn't exist.
This mismatch meant that it was possible to upload a user item with an
invalid name that you would then be unable to delete.

This commit changes validate_user_name to validate the 'name' field
first.

Fixes #90

Signed-off-by: Steven Danna <steve@chef.io>