### PR TITLE
Accept passwords with special chars in `chef-server-ctl password`

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/password.rb
+++ b/omnibus/files/private-chef-ctl-commands/password.rb
@@ -5,6 +5,7 @@
 #
 
 require 'highline/import'
+require 'shellwords'
 
 knife_config = "/etc/opscode/pivotal.rb"
 knife_cmd    = "/opt/opscode/embedded/bin/knife opc user password"
@@ -46,11 +47,11 @@ add_command_under_category "password", "organization-and-user-management", "Set 
     end
 
     # enable system recovery and update the password
-    run_knife_opc_cmd("#{knife_cmd} #{username} #{password} -c #{knife_config}", message)
+    run_knife_opc_cmd("#{knife_cmd} #{Shellwords.escape(username)} #{Shellwords.escape(password)} -c #{knife_config}", message)
 
   else # if --enable-external-auth was passed, enable ldap for this user
     if ldap_authentication_enabled?
-      run_knife_opc_cmd("#{knife_cmd} #{username} --enable-external-auth -c #{knife_config}", "External authentication enable for user.")
+      run_knife_opc_cmd("#{knife_cmd} #{Shellwords.escape(username)} --enable-external-auth -c #{knife_config}", "External authentication enable for user.")
     else # doesn't make sense to pass --enable-external-auth if ldap isn't in use on the system
       STDERR.puts "External authentication (such as LDAP) must be enabled to clear a user's password."
       exit 1


### PR DESCRIPTION
chef-server-ctl password delegates to `knife-opc`. In doing so, it was
not escaping special characters in the user supplied data.  Now, it
does.

Fixes #366

Signed-off-by: Steven Danna <steve@chef.io>