### PR TITLE
[OPS-174] expose compliance profiles configurables in chef-server.rb

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -70,6 +70,7 @@ module PrivateChef
   license Mash.new
 
   folsom_graphite Mash.new
+  profiles Mash.new
 
   servers Mash.new
   backend_vips Mash.new
@@ -195,6 +196,7 @@ module PrivateChef
         "opscode_erchef",
         "oc_chef_authz",
         "folsom_graphite",
+        "profiles",
         "lb",
         "lb_internal",
         "postgresql",
@@ -252,6 +254,7 @@ module PrivateChef
       results["private_chef"]["dark_launch"] = PrivateChef["dark_launch"]
       results["private_chef"]["opscode-erchef"]["max_request_size"] = PrivateChef["opscode_erchef"]["max_request_size"]
       results["private_chef"]["folsom_graphite"] = PrivateChef["folsom_graphite"]
+      results["private_chef"]["profiles"] = PrivateChef["profiles"]
       results
     end
 


### PR DESCRIPTION
With this change, you can set

    data_collector['token'] = 'yeahrightsecure'
    profiles['root_url'] = 'https://automate.test'

to allow for signed requests to fetch compliance profiles from automate. (This should have been part of #999.)

Signed-off-by: Stephan Renatus <srenatus@chef.io>