### PR TITLE
Rewrite the POST to the correct Automate endpoint

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/check_token_using_endpoint.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/check_token_using_endpoint.lua.erb
@@ -16,6 +16,7 @@ local res = ngx.location.capture("/organizations/" .. ngx.var.request_org .. "/v
 <% if node['private_chef']['data_collector']['root_url'] && node['private_chef']['data_collector']['token'] -%>
 if res.status == ngx.HTTP_OK then
   ngx.var.upstream = '<%= URI.parse(node['private_chef']['data_collector']['root_url']).scheme %>://data-collector<%= URI.parse(node['private_chef']['data_collector']['root_url']).path %>'
+  ngx.req.set_uri('/data-collector/v0/')
   ngx.req.set_header("x-data-collector-token", "<%= node['private_chef']['data_collector']['token'] %>")
   ngx.req.set_header("x-data-collector-auth", "version=1.0")
   return


### PR DESCRIPTION
Without this, the URI received by chef-server(ex: `/organizations/:org/data-collector`) is forwarded to Automate where a 404 is returned.