### PR TITLE
Retry connection errors when bootstrapping bifrost

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -186,20 +186,18 @@ class ChefServerDataBootstrap
       else
         RestClient.send(method, "http://#{bifrost['vip']}:#{bifrost['port']}/#{rel_path}",  body, headers)
       end
-    rescue RestClient::Exception => e
+    rescue RestClient::Exception, Errno::ECONNREFUSED => e
+      error = e.respond_to?(:response) ? e.response.chomp : e.message
       if retries > 0
         sleep_time = 2**((5 - retries))
         retries -= 1
-        Chef::Log.warn "Error from bifrost: #{e.response.chomp}, retrying after #{sleep_time}s. Retries remaining: #{retries}"
+        Chef::Log.warn "Error from bifrost: #{error}, retrying after #{sleep_time}s. Retries remaining: #{retries}"
         sleep sleep_time
         retry
       else
-        Chef::Log.error "Error from bifrost #{e.response.chomp}, retries have been exhausted"
+        Chef::Log.error "Error from bifrost: #{error}, retries have been exhausted"
         raise
       end
     end
-
   end
-
 end
-


### PR DESCRIPTION
When bootstrapping new Chef Servers we've found a race condition where
the bifrost bootstrap is attempted before the service is avilable. This
change retries the ECONNREFUSED error that is raised when this occurs.

```
Recipe: private-chef::bootstrap
  * execute[/opt/opscode/bin/chef-server-ctl start postgresql] action run
    - execute /opt/opscode/bin/chef-server-ctl start postgresql
  * execute[/opt/opscode/bin/chef-server-ctl start oc_bifrost] action run
    - execute /opt/opscode/bin/chef-server-ctl start oc_bifrost
  * ruby_block[bootstrap-chef-server-data] action run[2016-11-29T18:34:09+00:00] WARN: Error from bifrost: Connection refused - connect(2) for "127.0.0.1" port 946
3, retrying after 1s. Retries remaining: 4

    - execute the ruby block bootstrap-chef-server-data
  * file[/var/opt/opscode/bootstrapped] action create
    - create new file /var/opt/opscode/bootstrapped
    - update content in file /var/opt/opscode/bootstrapped from none to 66e3eb
    --- /var/opt/opscode/bootstrapped   2016-11-29 18:34:10.497090364 +0000
    +++ /var/opt/opscode/.chef-bootstrapped20161129-4253-tqdg75 2016-11-29 18:34:10.497090364 +0000
    @@ -1 +1,2 @@
    +bootstrapped on 2016-11-29T18:33:41+00:00 (you punk)
    - change mode from '' to '0600'
    - change owner from '' to 'root'
    - change group from '' to 'root'
```