### PR TITLE
Return correct number of rows when searching with Elasticsearch

### DIFF
--- a/oc-chef-pedant/spec/api/search/search_spec.rb
+++ b/oc-chef-pedant/spec/api/search/search_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) 2012-2016 Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,6 +65,7 @@ describe 'Search API endpoint', :search do
       let(:request_method){:GET}
       can_perform_basic_searches_for :environment
       can_perform_a_search_that_is_acl_filtered_for :environment
+      can_perform_a_search_with_limited_rows_for :environment
     end # GET
 
     context 'POST'  do
@@ -96,6 +97,7 @@ describe 'Search API endpoint', :search do
       can_perform_basic_searches_for :node
 
       can_perform_a_search_that_is_acl_filtered_for :node
+      can_perform_a_search_with_limited_rows_for :node
 
       unless Pedant.config['old_runlists_and_search']
         recipe_variants("pedant_testing_cookbook", "1.0.0").each do |run_list_recipe|
@@ -333,6 +335,7 @@ describe 'Search API endpoint', :search do
       let(:request_method){:GET}
       can_perform_basic_searches_for :role
       can_perform_a_search_that_is_acl_filtered_for :role
+      can_perform_a_search_with_limited_rows_for :role
     end # GET
 
     # Partial Search

--- a/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
@@ -31,7 +31,7 @@ update(Body) ->
                     {error, {solr_400, string()}} |
                     {error, {solr_500, string()}}.
 search(#chef_solr_query{} = Query) ->
-    Url = "/chef/_search?scroll=1m",
+    Url = "/chef/_search",
     {ok, Code, _Head, Body} = chef_index_http:request(Url, get, query_body(Query)),
     case Code of
         "200" ->
@@ -45,33 +45,11 @@ search(#chef_solr_query{} = Query) ->
     end.
 
 handle_successful_search(ResponseBody) ->
-    EjsonBody = jiffy:decode(ResponseBody),
-    ScrollId = ej:get({<<"_scroll_id">>}, EjsonBody),
-    Response = ej:get({<<"hits">>}, EjsonBody),
+    Response = ej:get({<<"hits">>}, jiffy:decode(ResponseBody)),
     NumFound = ej:get({<<"total">>}, Response),
     DocList  = ej:get({<<"hits">>}, Response),
     Ids = [ ej:get({<<"_id">>}, Doc) || Doc <- DocList ],
-    scroll(ScrollId, NumFound, length(Ids), Ids).
-
-scroll(ScrollId, NumFound, NumFound, Ids) ->
-    ok = chef_index_http:delete("/_search/scroll", ScrollId),
-    {ok, undefined, NumFound, Ids};
-scroll(ScrollId, NumFound, _, Ids) ->
-    Url = "/_search/scroll?scroll=1m",
-    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, ScrollId),
-    case Code of
-        "200" ->
-            DocList = ej:get({<<"hits">>, <<"hits">>}, jiffy:decode(Body)),
-            NewIds = [ ej:get({<<"_id">>}, Doc) || Doc <- DocList ],
-            AllIds = lists:append([ Ids, NewIds ]),
-            scroll(ScrollId, NumFound, length(AllIds), AllIds);
-        %% For now keep these error messages
-        %% consistent with chef_solr
-        "400" ->
-            {error, {solr_400, Url}};
-        "500" ->
-            {error, {solr_500, Url}}
-    end.
+    {ok, undefined, NumFound, Ids}.
 
 transform_data(Data) ->
     Data.
@@ -138,7 +116,7 @@ delete_search_db_by_type(OrgId, Type)
                              query_string = chef_index_query:search_db_from_orgid(OrgId) ++
                                 "AND" ++ chef_index_query:search_type_constraint(Type)
                             },
-    {ok, _, _, Ids} = search(Query),
+    {ok, _, _, Ids} = search_with_scroll(Query),
     delete_ids(Ids).
 
 -spec delete_search_db(OrgId :: binary()) -> ok.
@@ -149,8 +127,54 @@ delete_search_db(OrgId) ->
                              search_provider = elasticsearch,
                              query_string = chef_index_query:search_db_from_orgid(OrgId)
                             },
-    {ok, _, _, Ids} = search(Query),
+    {ok, _, _, Ids} = search_with_scroll(Query),
     delete_ids(Ids).
+
+%% Do a search query using the Elasticsearch Scroll API. We only use this when
+%% doing the search used for reindexing.
+-spec search_with_scroll(#chef_solr_query{}) ->
+                    {ok, non_neg_integer(), non_neg_integer(), [binary()]} |
+                    {error, {solr_400, string()}} |
+                    {error, {solr_500, string()}}.
+search_with_scroll(#chef_solr_query{} = Query) ->
+    Url = "/chef/_search?scroll=1m",
+    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, query_body(Query)),
+    case Code of
+        "200" ->
+            EjsonBody = jiffy:decode(Body),
+            ScrollId = ej:get({<<"_scroll_id">>}, EjsonBody),
+            Response = ej:get({<<"hits">>}, EjsonBody),
+            NumFound = ej:get({<<"total">>}, Response),
+            DocList  = ej:get({<<"hits">>}, Response),
+            Ids = [ ej:get({<<"_id">>}, Doc) || Doc <- DocList ],
+            scroll(ScrollId, NumFound, length(Ids), Ids);
+        %% For now keep these error messages
+        %% consistent with chef_solr
+        "400" ->
+            {error, {solr_400, Url}};
+        "500" ->
+            {error, {solr_500, Url}}
+    end.
+
+scroll(ScrollId, NumFound, NumFound, Ids) ->
+    ok = chef_index_http:delete("/_search/scroll", ScrollId),
+    {ok, undefined, NumFound, Ids};
+scroll(ScrollId, NumFound, _, Ids) ->
+    Url = "/_search/scroll?scroll=1m",
+    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, ScrollId),
+    case Code of
+        "200" ->
+            DocList = ej:get({<<"hits">>, <<"hits">>}, jiffy:decode(Body)),
+            NewIds = [ ej:get({<<"_id">>}, Doc) || Doc <- DocList ],
+            AllIds = lists:append([ Ids, NewIds ]),
+            scroll(ScrollId, NumFound, length(AllIds), AllIds);
+        %% For now keep these error messages
+        %% consistent with chef_solr
+        "400" ->
+            {error, {solr_400, Url}};
+        "500" ->
+            {error, {solr_500, Url}}
+    end.
 
 delete_ids([]) ->
     ok = commit(),


### PR DESCRIPTION
Recent changes to the way we use the Elasticsearch paging APIs to do
Chef searches had caused searches to always return all rows when given a
`rows` query parameter.

This change fixes the Elasticsearch behavior.

It also adds Pedant tests to test that the `rows` parameter returns the
correct number of rows.

(Note that our internal CI testing infrastructure only runs the Pedant
test suite against a default installation with Solr as the search
provider. These new tests should pass on either provider given the
changes included in this commit, or fail against an Elasticsearch-backed
earlier version.)

![tumblr_o6gi6gpjx21uluepno1_400](https://cloud.githubusercontent.com/assets/9912/20874033/d26d872c-ba73-11e6-8bdc-863073ab3991.gif)
