### PR TITLE
replace node[fqdn] with server_name in nginx.conf

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -124,7 +124,7 @@ http {
   server {
     <%= @helper.listen_port(node['private_chef']['lb_internal']['chef_port']) %>
     # The name doesn't matter; this is the only listener on this port
-    server_name <%= node['fqdn'] %>;
+    server_name <%= @server_name %>;
 
     client_max_body_size <%= @client_max_body_size %>;
     proxy_set_header        Host            $host;
@@ -156,7 +156,7 @@ http {
   # internal service access for oc_bifrost
   server {
     <%= @helper.listen_port(node['private_chef']['lb_internal']['oc_bifrost_port']) %>
-    server_name <%= node['fqdn'] %>;
+    server_name <%= @server_name %>;
 
     client_max_body_size <%= @client_max_body_size %>;
     proxy_set_header        Host            $host;


### PR DESCRIPTION
This should mean we end up with the api_fqdn setting in those places,
irregardless of whether the node this is running on has an FQDN or not.

Tested by running an ad-hoc build, and replacing an OpsWorks instance's chef-server with this one; running reconfigure, and adding&&converging a node against it. ✅ 

Signed-off-by: Stephan Renatus <srenatus@chef.io>