### PR TITLE
Ignore `-w` option on `chef-server-ctl reindex` with Elasticsearch

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/Gemfile
+++ b/omnibus/files/private-chef-ctl-commands/Gemfile
@@ -1,8 +1,13 @@
 source "https://rubygems.org"
 
 # Used for rspec testing only
+gem "chef", git: "https://github.com/chef/chef.git"
+gem "chef_backup", git: "https://github.com/chef/chef_backup.git"
+gem "omnibus-ctl", git: "https://github.com/chef/omnibus-ctl.git"
+gem "pry"
+gem "rb-readline"
 gem "rspec"
-gem "chef", github: "chef/chef", branch: "master"
-gem "omnibus-ctl", github: "chef/omnibus-ctl", branch: "master"
-gem "chef_backup", github: "chef/chef_backup", branch: "master"
 gem "veil", path: File.join("..", "veil")
+
+# Dependencies of ctl commands
+gem "redis"

--- a/omnibus/files/private-chef-ctl-commands/Gemfile.lock
+++ b/omnibus/files/private-chef-ctl-commands/Gemfile.lock
@@ -1,19 +1,20 @@
 GIT
-  remote: git://github.com/chef/chef.git
-  revision: 741ac9dde480a934f2f4fc98ada2ffa7ad4f71c0
-  branch: master
+  remote: https://github.com/chef/chef.git
+  revision: e2c5935b818c8d1a74e24ba624de1ae489909fdb
   specs:
-    chef (12.12.12)
+    chef (12.17.47)
+      addressable
       bundler (>= 1.10)
-      chef-config (= 12.12.12)
-      chef-zero (~> 4.5)
+      chef-config (= 12.17.47)
+      chef-zero (>= 4.8)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
       ffi-yajl (~> 2.2)
       highline (~> 1.6, >= 1.6.9)
       iniparse (~> 1.4)
+      mixlib-archive (>= 0.2.0)
       mixlib-authentication (~> 1.4)
-      mixlib-cli (~> 1.4)
+      mixlib-cli (~> 1.7)
       mixlib-log (~> 1.3)
       mixlib-shellout (~> 2.0)
       net-sftp (~> 2.1, >= 2.1.2)
@@ -22,32 +23,31 @@ GIT
       ohai (>= 8.6.0.alpha.1, < 9)
       plist (~> 3.2)
       proxifier (~> 1.0)
-      rspec-core (~> 3.4)
-      rspec-expectations (~> 3.4)
-      rspec-mocks (~> 3.4)
+      rspec-core (~> 3.5)
+      rspec-expectations (~> 3.5)
+      rspec-mocks (~> 3.5)
       rspec_junit_formatter (~> 0.2.0)
       serverspec (~> 2.7)
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (12.12.12)
-      fuzzyurl (~> 0.8.0)
+    chef-config (12.17.47)
+      addressable
+      fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
 
 GIT
-  remote: git://github.com/chef/chef_backup.git
-  revision: a402a2ef6e209639e70aa5ec78193c493a9d6f4a
-  branch: master
+  remote: https://github.com/chef/chef_backup.git
+  revision: 67b1f51a084bd7b4afca6443421f84601d6ba49a
   specs:
     chef_backup (0.0.1)
       highline
       mixlib-shellout
 
 GIT
-  remote: git://github.com/chef/omnibus-ctl.git
+  remote: https://github.com/chef/omnibus-ctl.git
   revision: a0ccf08af008c5fd248a5dcc5af9ff1c48f2a1a9
-  branch: master
   specs:
     omnibus-ctl (0.5.0)
 
@@ -61,31 +61,37 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     bcrypt (3.1.11)
     builder (3.2.2)
-    chef-zero (4.7.0)
+    chef-zero (5.1.0)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 1.3)
-      rack (< 2)
+      rack (~> 2.0)
       uuidtools (~> 2.1)
+    coderay (1.1.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    ffi (1.9.10)
-    ffi-yajl (2.2.3)
+    ffi (1.9.14)
+    ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
-    fuzzyurl (0.8.0)
-    hashie (3.4.4)
+    fuzzyurl (0.9.0)
+    hashie (3.4.6)
     highline (1.7.8)
     iniparse (1.4.2)
     ipaddress (0.8.3)
     libyajl2 (1.2.0)
+    method_source (0.8.2)
+    mixlib-archive (0.2.0)
+      mixlib-log
     mixlib-authentication (1.4.1)
       mixlib-log
-    mixlib-cli (1.6.0)
-    mixlib-config (2.2.1)
-    mixlib-log (1.6.0)
-    mixlib-shellout (2.2.6)
+    mixlib-cli (1.7.0)
+    mixlib-config (2.2.4)
+    mixlib-log (1.7.1)
+    mixlib-shellout (2.2.7)
     multi_json (1.12.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -98,14 +104,14 @@ GEM
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
-    ohai (8.17.1)
+    ohai (8.22.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
       mixlib-cli
       mixlib-config (~> 2.0)
-      mixlib-log
+      mixlib-log (>= 1.7.1, < 2.0)
       mixlib-shellout (~> 2.0)
       plist (~> 3.1)
       systemu (~> 2.6.4)
@@ -113,12 +119,19 @@ GEM
     pbkdf2 (0.1.0)
     plist (3.2.0)
     proxifier (1.0.3)
-    rack (1.6.4)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (2.0.4)
+    rack (2.0.1)
+    rb-readline (0.5.3)
+    redis (3.2.1)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.0)
+    rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -133,13 +146,14 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    serverspec (2.36.0)
+    serverspec (2.37.2)
       multi_json
       rspec (~> 3.0)
       rspec-its
       specinfra (~> 2.53)
-    sfl (2.2)
-    specinfra (2.59.4)
+    sfl (2.3)
+    slop (3.6.0)
+    specinfra (2.66.2)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
@@ -156,8 +170,11 @@ DEPENDENCIES
   chef!
   chef_backup!
   omnibus-ctl!
+  pry
+  rb-readline
+  redis
   rspec
   veil!
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/omnibus/files/private-chef-ctl-commands/reindex.rb
+++ b/omnibus/files/private-chef-ctl-commands/reindex.rb
@@ -102,7 +102,17 @@ add_command_under_category "reindex", "general", "Reindex all server data for a 
 
   OptionParser.new do |opts|
     opts.on("-w", "--wait", "Wait for reindex queue to clear before exiting") do |w|
-      options[:wait] = w
+      # Don't attempt to wait if the search_queue_mode is "batch"
+      search_queue_mode = running_config["private_chef"]["opscode-erchef"]["search_queue_mode"]
+      if search_queue_mode == "batch"
+        $stderr.puts <<-EOF
+The search queue mode is currently configured to be "#{search_queue_mode}."
+Ignoring "wait" option.
+EOF
+        options[:wait] = false
+      else
+        options[:wait] = w
+      end
     end
 
     opts.on("-d", "--disable-api", "Disable writes during reindexing") do |n|

--- a/omnibus/files/private-chef-ctl-commands/spec/reindex_spec.rb
+++ b/omnibus/files/private-chef-ctl-commands/spec/reindex_spec.rb
@@ -1,0 +1,78 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/config"
+require "chef/org"
+require "omnibus_ctl_helper"
+
+describe "chef-server-ctl reindex" do
+  subject(:reindex) do
+    OmnibusCtlHelper.new(["./reindex.rb"]).
+      run_test_omnibus_command("reindex", args)
+  end
+  let(:args) { [] }
+  let(:config) do
+    {
+      'private_chef' => {}
+    }
+  end
+
+  before :each do
+    allow(Chef::Config).to receive(:from_file).with("/etc/opscode/pivotal.rb")
+    allow(Chef::Org).to receive_message_chain(:list, :keys).and_return(
+      ["testorg"]
+    )
+    allow(Dir).to receive(:chdir).and_yield
+    allow_any_instance_of(Omnibus::Ctl).to receive(:running_config).and_return(
+      config
+    )
+    status = double("status")
+    allow(status).to receive(:success?).and_return true
+    allow_any_instance_of(Omnibus::Ctl).to receive(:run_command).and_return(
+      status
+    )
+    allow($stdout).to receive :puts
+    allow($stderr).to receive :puts
+  end
+
+  context "with the -w flag" do
+    context "when the search queue mode is 'batch'" do
+      let(:config) do
+        {
+          "private_chef" => {
+            "opscode-erchef" => {
+              "search_queue_mode" => "batch",
+            },
+          },
+        }
+      end
+
+      let(:args) { %w( -w --all-orgs ) }
+
+      it "does not wait" do
+        expect($stdout).to_not receive(:puts).with(
+          "- Waiting for reindexing to complete"
+        )
+        reindex
+      end
+
+      it "logs a message" do
+        expect($stderr).to receive(:puts).with(/batch/)
+        reindex
+      end
+    end
+  end
+end


### PR DESCRIPTION
Elasticsearch does not use RabbitMQ to reindex, and the `--wait` option
currently fails.

This makes it so the option does nothing and tells the user it will do
nothing.

Also changes to the omnibus/files/private-chef-ctl-commands Gemfile:

* Update to latest Chef (fixes problem with bundling the older version
  that was locked)
* Use HTTPS URLs for GitHub dependencies
* Sort things
* Include Pry (and rb-readline to make sure it works)
* Include Redis (needed by reindex ctl command)

![tumblr_mv33l3bh451re0c97o1_400](https://cloud.githubusercontent.com/assets/9912/20987572/d455472a-bc92-11e6-9012-2b6b2ffebb4e.gif)
