### PR TITLE
Pass email address along when resetting password

### DIFF
--- a/src/oc-id/app/views/password_resets/show.html.erb
+++ b/src/oc-id/app/views/password_resets/show.html.erb
@@ -16,5 +16,6 @@
     <%= hidden_field_tag :expires, params[:expires] %>
     <%= hidden_field_tag :signature, params[:signature] %>
     <%= hidden_field_tag :username, params[:username] %>
+    <%= hidden_field_tag :email, params[:email] %>
   <% end -%>
 </div>


### PR DESCRIPTION
The signature verification code uses the username, email address and
expiry parameters to validate the signature (see
src/oc-id/app/models/signature.rb), but we don't pass it along as a
hidden form parameter. This means that all password reset attempts fail
with a signature doesn't match message. Passing along the email address
as well fixes this.