### PR TITLE
Segment-free cookbook data (RFC 67)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
       script: bundle exec rake chef_zero_spec
       env:
         - "PEDANT_OPTS=\"--skip-oc_id\""
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v14.0.5' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero' \""
       # Remove things only used by erlang
       install:
       after_failure:
@@ -102,7 +102,7 @@ matrix:
       script: bundle exec rake chef_zero_spec
       env:
         - "PEDANT_OPTS=\"--skip-oc_id\""
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v14.0.5' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero' \""
         - CHEF_FS=1
       # Remove things only used by erlang
       install:

--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -191,7 +191,7 @@ module Pedant
       $server_api_version  = Pedant::Config.server_api_version
     end
     def use_max_server_api_version
-      $server_api_version  = 1 # TODO Pedant::Config.max_server_api_version
+      $server_api_version  = 2 # TODO Pedant::Config.max_server_api_version
     end
 
   end

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/create_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/create_spec.rb
@@ -19,516 +19,518 @@ require 'pedant/rspec/validations'
 
 describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artifacts_create do
 
-  let(:cookbook_url_base) { "cookbook_artifacts" }
+  shared_examples "creates cookbook artifacts" do |api_version|
+    let(:api_version) { api_version }
 
-  let(:default_cookbook_id) { "1111111111111111111111111111111111111111" }
+    before do
+      platform.server_api_version = api_version
+    end
 
-  include Pedant::RSpec::CookbookUtil
+    after do
+      platform.reset_server_api_version
+    end
 
-  let(:default_version) { "1.0.0" }
-
-  context "PUT /cookbook_artifacts/<name>/<version> [create]" do
-
-    include Pedant::RSpec::Validations::Create
-
-    let(:request_method){:PUT}
-    let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
-    shared(:requestor){admin_user}
-
-    let(:cookbook_artifact_to_create){ new_cookbook_artifact(cookbook_name, cookbook_identifier)}
-
-    context 'with a basic cookbook', :smoke do
-      after(:each) { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
-
-      let(:cookbook_name) { "pedant_basic" }
-      let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
-
-      let(:expected_get_response_data) do
-        {
-          "name"=>"pedant_basic",
-          "identifier"=>"1111111111111111111111111111111111111111",
-          "version"=>"1.0.0",
-          "attributes" => [],
-          "chef_type"=>"cookbook_version",
-          "definitions" => [],
-          "files" => [],
-          "frozen?"=>false,
-          "providers" => [],
-          "recipes"=>[],
-          "resources" => [],
-          "root_files" => [],
-          "templates" => [],
-          "libraries" => [],
-          "metadata"=> {
-            "version"=>"1.0.0",
-            "name"=>"pedant_basic",
-            "maintainer"=>"Your Name",
-            "maintainer_email"=>"youremail@example.com",
-            "description"=>"A fabulous new cookbook",
-            "long_description"=>"",
-            "license"=>"Apache v2.0",
-            "dependencies"=>{},
-            "attributes"=>{},
-            "recipes"=>{}
-          }
-        }
-      end
-
-      it "creates a basic cookbook_artifact" do
-        # create it:
-        create_response = put(request_url, requestor, payload: cookbook_artifact_to_create)
-        expect(create_response.code.to_s).to eq("201")
-
-        # list:
-        list_response = get(api_url("/#{cookbook_url_base}/#{cookbook_name}"), requestor)
-
-        list_data = parse(list_response)
-        expect(list_data).to have_key("pedant_basic")
-        expect(list_data["pedant_basic"]["versions"].size).to eq(1)
-        expect(list_data["pedant_basic"]["versions"].first["identifier"]).to eq(cookbook_identifier)
-
-        # fetch it:
-        get_response = get(request_url, requestor)
-
-        expect(get_response.code.to_s).to eq("200")
-        expect(parse(get_response)).to eq(expected_get_response_data)
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
       end
     end
 
-    # Start using the new validation macros
-    context "when validating" do
+    let(:cookbook_url_base) { "cookbook_artifacts" }
 
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
+    let(:default_cookbook_id) { "1111111111111111111111111111111111111111" }
 
-      let(:resource_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
-      let(:persisted_resource_response){ get(resource_url, requestor) }
+    include Pedant::RSpec::CookbookUtil
 
-      after(:each){ delete_cookbook_artifact(requestor, cookbook_name, cookbook_identifier)}
+    let(:default_version) { "1.0.0" }
 
-      context "the cookbook version" do
+    context "PUT /cookbook_artifacts/<name>/<version> [create]" do
 
-        let(:cookbook_artifact_to_create) do
-          new_cookbook_artifact(cookbook_name, cookbook_identifier, version: cookbook_version)
+      include Pedant::RSpec::Validations::Create
+
+      let(:request_method){:PUT}
+      let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
+      shared(:requestor){admin_user}
+
+      let(:cookbook_artifact_to_create){ new_cookbook_artifact(cookbook_name, cookbook_identifier)}
+
+      context 'with a basic cookbook', :smoke do
+        after(:each) { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
+
+        let(:cookbook_name) { "pedant_basic" }
+        let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
+
+        let(:expected_get_response_data) do
+          new_cookbook_artifact(cookbook_name, cookbook_identifier, version: "1.0.0")
         end
 
-        let(:request_payload) { cookbook_artifact_to_create }
-        let(:default_resource_attributes) { cookbook_artifact_to_create }
+        it "creates a basic cookbook_artifact" do
+          # create it:
+          create_response = put(request_url, requestor, payload: cookbook_artifact_to_create)
+          expect(create_response.code.to_s).to eq("201")
 
-        context "with versions at exactly 4 bytes" do
-          int4_exact = "2147483647"
-          let(:cookbook_version) { "1.2.#{int4_exact}" }
-          it { should look_like http_201_response }
-        end
+          # list:
+          list_response = get(api_url("/#{cookbook_url_base}/#{cookbook_name}"), requestor)
 
-        context "with versions larger than 4 bytes" do
-          int4_overflow = "2147483669" # max = 2147483647 (add 42)
-          let(:cookbook_version) { "1.2.#{int4_overflow}" }
-          it { should look_like http_201_response }
-        end
+          list_data = parse(list_response)
+          expect(list_data).to have_key("pedant_basic")
+          expect(list_data["pedant_basic"]["versions"].size).to eq(1)
+          expect(list_data["pedant_basic"]["versions"].first["identifier"]).to eq(cookbook_identifier)
 
-        context "with versions with 'prerelease' fields" do
+          # fetch it:
+          get_response = get(request_url, requestor)
 
-          let(:cookbook_version) { "1.2.3.beta.5" }
-
-          it { should look_like http_201_response }
-        end
-      end
-
-    end
-
-    context "creating broken cookbook_artifacts to test validation and defaults", :validation do
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_version) { "1.2.3" }
-
-      let(:cookbook_identifier) { default_cookbook_id }
-      let(:base_payload) do
-        new_cookbook_artifact(cookbook_name, cookbook_identifier, version: cookbook_version).tap do |ca|
-          ca.delete("json_class")
+          expect(get_response.code.to_s).to eq("200")
+          expect(parse(get_response)).to eq(expected_get_response_data)
         end
       end
 
-      # delete b/c some tests actually do succeed w/ create or to clean up
-      # after failed negative test.
-      after(:each) { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
+      # Start using the new validation macros
+      context "when validating" do
 
-      def update_payload(key, value)
-        base_payload.dup.tap do |payload|
-          if (value == :delete)
-            payload.delete(key)
-          else
-            payload[key] = value
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
+
+        let(:resource_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
+        let(:persisted_resource_response){ get(resource_url, requestor) }
+
+        after(:each){ delete_cookbook_artifact(requestor, cookbook_name, cookbook_identifier)}
+
+        context "the cookbook version" do
+
+          let(:cookbook_artifact_to_create) do
+            new_cookbook_artifact(cookbook_name, cookbook_identifier, version: cookbook_version)
+          end
+
+          let(:request_payload) { cookbook_artifact_to_create }
+          let(:default_resource_attributes) { cookbook_artifact_to_create }
+
+          context "with versions at exactly 4 bytes" do
+            int4_exact = "2147483647"
+            let(:cookbook_version) { "1.2.#{int4_exact}" }
+            it { should look_like http_201_response }
+          end
+
+          context "with versions larger than 4 bytes" do
+            int4_overflow = "2147483669" # max = 2147483647 (add 42)
+            let(:cookbook_version) { "1.2.#{int4_overflow}" }
+            it { should look_like http_201_response }
+          end
+
+          context "with versions with 'prerelease' fields" do
+
+            let(:cookbook_version) { "1.2.3.beta.5" }
+
+            it { should look_like http_201_response }
           end
         end
+
       end
 
-      shared_examples_for "valid_cookbook_artifact" do
+      context "creating broken cookbook_artifacts to test validation and defaults", :validation do
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_version) { "1.2.3" }
 
-        it "create returns 201" do
-          #create it
-          put(request_url, requestor, :payload => payload) do |response|
-            expect(response.code).to eq(201)
-          end
-
-          # verify it looks correct
-          get(request_url, requestor) do |response|
-            response.
-              should look_like({
-              :status => 200,
-              :body => payload
-            })
+        let(:cookbook_identifier) { default_cookbook_id }
+        let(:base_payload) do
+          new_cookbook_artifact(cookbook_name, cookbook_identifier, version: cookbook_version).tap do |ca|
+            ca.delete("json_class")
           end
         end
-      end
 
-      shared_examples_for "invalid_cookbook_artifact" do
-        it "create returns 400" do
-          # create should respond with error
-          put(request_url, requestor, :payload => payload) do |response|
-            expect(response).to look_like({
-              :status => 400,
-              :body_exact => {"error" => [error_message]}
-            })
-          end
+        # delete b/c some tests actually do succeed w/ create or to clean up
+        # after failed negative test.
+        after(:each) { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
 
-          # double check it did't get created
-          get(request_url, requestor) do |response|
-            expect(response).to look_like({
-              :status => 404
-            })
-          end
-        end
-      end
-
-      context "basic tests" do
-        after(:each) do
-          delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
-        end
-
-        context "with empty metadata", skip: "FIXME - server needs to add validation" do
-          let(:payload) { update_payload("metadata", {}) }
-          let(:error_message) { "Field 'metadata.version' missing" }
-
-          include_examples("invalid_cookbook_artifact")
-        end
-      end # context basic tests
-
-      segment_names = %w{resources providers recipes definitions libraries attributes files templates root_files}
-      segment_names.each do |segment|
-
-        context "with segment '#{segment}' set to a String", skip: "FIXME - server returns 500" do
-
-          let(:payload) { update_payload(segment, "foo") }
-          let(:error_message) { "Field '#{segment}' invalid" }
-
-          include_examples("invalid_cookbook_artifact")
-        end
-
-        context "with segment '#{segment}' set to an Array with one empty JSON object", skip: "FIXME - server returns 500" do
-
-          let(:payload) { update_payload(segment, [ {} ]) }
-          let(:error_message) { "Invalid element in array value of '#{segment}'." }
-
-          include_examples("invalid_cookbook_artifact")
-
-        end
-      end # context checking segments
-
-      context "checking metadata sections" do
-
-        def update_payload_metadata(key, value)
+        def update_payload(key, value)
           base_payload.dup.tap do |payload|
-            payload["metadata"] = payload["metadata"].dup.tap do |md|
-              if (value == :delete)
-                md.delete(key)
-              else
-                md[key] = value
+            if (value == :delete)
+              payload.delete(key)
+            else
+              payload[key] = value
+            end
+          end
+        end
+
+        shared_examples_for "valid_cookbook_artifact" do
+
+          it "create returns 201" do
+            #create it
+            put(request_url, requestor, :payload => payload) do |response|
+              expect(response.code).to eq(201)
+            end
+
+            # verify it looks correct
+            get(request_url, requestor) do |response|
+              response.
+                should look_like({
+                :status => 200,
+                :body => payload
+              })
+            end
+          end
+        end
+
+        shared_examples_for "invalid_cookbook_artifact" do
+          it "create returns 400" do
+            # create should respond with error
+            put(request_url, requestor, :payload => payload) do |response|
+              expect(response).to look_like({
+                :status => 400,
+                :body_exact => {"error" => [error_message]}
+              })
+            end
+
+            # double check it did't get created
+            get(request_url, requestor) do |response|
+              expect(response).to look_like({
+                :status => 404
+              })
+            end
+          end
+        end
+
+        context "basic tests" do
+          after(:each) do
+            delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
+          end
+
+          context "with empty metadata", skip: "FIXME - server needs to add validation" do
+            let(:payload) { update_payload("metadata", {}) }
+            let(:error_message) { "Field 'metadata.version' missing" }
+
+            include_examples("invalid_cookbook_artifact")
+          end
+        end # context basic tests
+
+        segment_names = %w{resources providers recipes definitions libraries attributes files templates root_files}
+        segment_names.each do |segment|
+
+          context "with segment '#{segment}' set to a String", skip: "FIXME - server returns 500" do
+
+            let(:payload) { update_payload(segment, "foo") }
+            let(:error_message) { "Field '#{segment}' invalid" }
+
+            include_examples("invalid_cookbook_artifact")
+          end
+
+          context "with segment '#{segment}' set to an Array with one empty JSON object", skip: "FIXME - server returns 500" do
+
+            let(:payload) { update_payload(segment, [ {} ]) }
+            let(:error_message) { "Invalid element in array value of '#{segment}'." }
+
+            include_examples("invalid_cookbook_artifact")
+
+          end
+        end # context checking segments
+
+        context "checking metadata sections" do
+
+          def update_payload_metadata(key, value)
+            base_payload.dup.tap do |payload|
+              payload["metadata"] = payload["metadata"].dup.tap do |md|
+                if (value == :delete)
+                  md.delete(key)
+                else
+                  md[key] = value
+                end
               end
             end
           end
-        end
 
-        let(:malformed_constraint) { "s395dss@#" }
+          let(:malformed_constraint) { "s395dss@#" }
 
-        %w{platforms dependencies}.each do |section|
+          %w{platforms dependencies}.each do |section|
 
-          context "with metadata section '#{section}' set to a string", skip: "FIXME - missing server validation" do
+            context "with metadata section '#{section}' set to a string", skip: "FIXME - missing server validation" do
 
-            let(:payload) { update_payload_metadata(section, "foo") }
-            let(:error_message) { "Field 'metadata.#{section}' invalid" }
+              let(:payload) { update_payload_metadata(section, "foo") }
+              let(:error_message) { "Field 'metadata.#{section}' invalid" }
 
-            include_examples("invalid_cookbook_artifact")
+              include_examples("invalid_cookbook_artifact")
 
-          end
-
-          context "with a malformed constraint for metadata section #{section}", skip: "FIXME - missing server validation" do
-
-            let(:payload) { update_payload_metadata(section, {"foo" => malformed_constraint}) }
-            let(:error_message) { "Invalid value #{malformed_constraint} for metadata.#{section}" }
-
-            include_examples("invalid_cookbook_artifact")
-          end
-
-        end
-
-
-        ["> 1.0", "< 2.1.2", "3.3", "<= 4.6", "~> 5.6.2", ">= 6.0"].each do |dep|
-
-          context "with valid metadata dependency '#{dep}'" do
-            let(:payload) do
-              update_payload_metadata("dependencies", {"chef-client" => "> 2.0.0", "apt" => dep})
             end
 
-            include_examples("valid_cookbook_artifact")
+            context "with a malformed constraint for metadata section #{section}", skip: "FIXME - missing server validation" do
 
-          end
-        end
+              let(:payload) { update_payload_metadata(section, {"foo" => malformed_constraint}) }
+              let(:error_message) { "Invalid value #{malformed_constraint} for metadata.#{section}" }
 
-        ["> 1", "< 2", "3", "<= 4", "~> 5", ">= 6", "= 7", ">= 1.2.3.4", "<= 5.6.7.8.9.0"].each do |dep|
-
-          context "with invalid metadata dependency '#{dep}'", skip: "FIXME - missing server validation" do
-            let(:payload) do
-              update_payload_metadata("dependencies", {"chef-client" => "> 2.0.0", "apt" => dep})
+              include_examples("invalid_cookbook_artifact")
             end
 
-            let(:error_message) { "Invalid value '#{dep}' for metadata.dependencies" }
+          end
 
-            include_examples("invalid_cookbook_artifact")
+
+          ["> 1.0", "< 2.1.2", "3.3", "<= 4.6", "~> 5.6.2", ">= 6.0"].each do |dep|
+
+            context "with valid metadata dependency '#{dep}'" do
+              let(:payload) do
+                update_payload_metadata("dependencies", {"chef-client" => "> 2.0.0", "apt" => dep})
+              end
+
+              include_examples("valid_cookbook_artifact")
+
+            end
+          end
+
+          ["> 1", "< 2", "3", "<= 4", "~> 5", ">= 6", "= 7", ">= 1.2.3.4", "<= 5.6.7.8.9.0"].each do |dep|
+
+            context "with invalid metadata dependency '#{dep}'", skip: "FIXME - missing server validation" do
+              let(:payload) do
+                update_payload_metadata("dependencies", {"chef-client" => "> 2.0.0", "apt" => dep})
+              end
+
+              let(:error_message) { "Invalid value '#{dep}' for metadata.dependencies" }
+
+              include_examples("invalid_cookbook_artifact")
+            end
+          end
+
+          [
+            'cats::sleep',
+            'here(:kitty, :time_to_eat)',
+            'service[snuggle]',
+            '',
+            1,
+            true,
+            ['cats', 'sleep', 'here'],
+
+            { 'cats::sleep'                => '0.0.1',
+              'here(:kitty, :time_to_eat)' => '0.0.1',
+              'service[snuggle]'           => '0.0.1'  }
+          ].each do |valid_provides|
+
+            # http://docs.chef.io/config_rb_metadata.html#provides
+            context "with metadata.providing set to valid value #{valid_provides}" do
+
+              let(:payload) { update_payload_metadata("providing", valid_provides) }
+
+              include_examples("valid_cookbook_artifact")
+
+            end
+          end
+        end # context checking metadata sections
+
+        context 'with invalid cookbook artifact identifier in url' do
+
+          let(:cookbook_identifier) { "foo@bar" }
+          let(:payload){ new_cookbook_artifact(cookbook_name, cookbook_identifier)}
+
+          it "should respond with an error" do
+            put(request_url, requestor, :payload => payload) do |response|
+              expect(response.code).to eq(400)
+              expect(parse(response)).to eq({"error" => ["Field 'identifier' invalid"]})
+            end
+          end # it invalid version in URL is a 400
+        end # with invalid version in url
+
+        context "when the cookbook name is invalid" do
+
+          let(:cookbook_name) { "first@second" }
+          let(:payload){ new_cookbook_artifact(cookbook_name, default_cookbook_id)}
+
+          it "responds with a 400" do
+            put(request_url, requestor, :payload => payload) do |response|
+              expect(response).to look_like({
+                :status => 400,
+                :body => {
+                  "error" => ["Field 'name' invalid"]
+                }
+              })
+            end
           end
         end
 
-        [
-          'cats::sleep',
-          'here(:kitty, :time_to_eat)',
-          'service[snuggle]',
-          '',
-          1,
-          true,
-          ['cats', 'sleep', 'here'],
-
-          { 'cats::sleep'                => '0.0.1',
-            'here(:kitty, :time_to_eat)' => '0.0.1',
-            'service[snuggle]'           => '0.0.1'  }
-        ].each do |valid_provides|
-
-          # http://docs.chef.io/config_rb_metadata.html#provides
-          context "with metadata.providing set to valid value #{valid_provides}" do
-
-            let(:payload) { update_payload_metadata("providing", valid_provides) }
-
-            include_examples("valid_cookbook_artifact")
-
+        context "when the identifier in the URL doesn't match the payload" do
+          let(:payload) do
+            new_cookbook_artifact(cookbook_name, "ffffffffffffffffffffffffffffffffffffffff")
           end
-        end
-      end # context checking metadata sections
 
-      context 'with invalid cookbook artifact identifier in url' do
+          let(:request_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{default_cookbook_id}") }
 
-        let(:cookbook_identifier) { "foo@bar" }
-        let(:payload){ new_cookbook_artifact(cookbook_name, cookbook_identifier)}
-
-        it "should respond with an error" do
-          put(request_url, requestor, :payload => payload) do |response|
-            expect(response.code).to eq(400)
-            expect(parse(response)).to eq({"error" => ["Field 'identifier' invalid"]})
-          end
-        end # it invalid version in URL is a 400
-      end # with invalid version in url
-
-      context "when the cookbook name is invalid" do
-
-        let(:cookbook_name) { "first@second" }
-        let(:payload){ new_cookbook_artifact(cookbook_name, default_cookbook_id)}
-
-        it "responds with a 400" do
-          put(request_url, requestor, :payload => payload) do |response|
-            expect(response).to look_like({
-                                        :status => 400,
-                                        :body => {
-                                          "error" => ["Field 'name' invalid"]
-                                        }
-                                      })
-          end
-        end
-      end
-
-      context "when the identifier in the URL doesn't match the payload" do
-        let(:payload) do
-          new_cookbook_artifact(cookbook_name, "ffffffffffffffffffffffffffffffffffffffff")
+          it "responds with a 400" do
+            put(request_url, requestor, :payload => payload) do |response|
+              error = "Field 'identifier' invalid : 1111111111111111111111111111111111111111 does not match ffffffffffffffffffffffffffffffffffffffff"
+              response.should look_like({
+                :status => 400,
+                :body => {
+                  "error" => [error]
+                }
+              })
+            end
+          end # it mismatched metadata.cookbook_version is a 400
         end
 
-        let(:request_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{default_cookbook_id}") }
+        context "when the cookbook name in the URL doesn't match the payload" do
+          let(:payload) { new_cookbook_artifact("foobar", cookbook_version) }
+          let(:request_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}") }
 
-        it "responds with a 400" do
-          put(request_url, requestor, :payload => payload) do |response|
-            error = "Field 'identifier' invalid : 1111111111111111111111111111111111111111 does not match ffffffffffffffffffffffffffffffffffffffff"
-            response.should look_like({
-                                        :status => 400,
-                                        :body => {
-                                          "error" => [error]
-                                        }
-                                      })
-          end
-        end # it mismatched metadata.cookbook_version is a 400
-      end
-
-      context "when the cookbook name in the URL doesn't match the payload" do
-        let(:payload) { new_cookbook_artifact("foobar", cookbook_version) }
-        let(:request_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}") }
-
-        it "mismatched cookbook_name is a 400" do
-          put(request_url, requestor, :payload => payload) do |response|
-            error = "Field 'name' invalid : cookbook_name does not match foobar"
-            expect(response).to look_like({
-              :status => 400,
-              :body => {
-                "error" => [error]
-              }
-            })
+          it "mismatched cookbook_name is a 400" do
+            put(request_url, requestor, :payload => payload) do |response|
+              error = "Field 'name' invalid : cookbook_name does not match foobar"
+              expect(response).to look_like({
+                :status => 400,
+                :body => {
+                  "error" => [error]
+                }
+              })
+            end
           end
         end
-      end
 
-      context "when uploading a cookbook artifact with a missing checksum" do
-        after(:each) do
+        context "when uploading a cookbook artifact with a missing checksum" do
+          after(:each) do
+            delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
+          end
+
+          let(:payload) do
+            new_cookbook_artifact(cookbook_name, default_cookbook_id).tap do |p|
+              p["recipes"] = [
+                {
+                  "name" => "default.rb",
+                  "path" => "recipes/default.rb",
+                  "checksum" => "8288b67da0793b5abec709d6226e6b73",
+                  "specificity" => "default"
+                }
+              ]
+            end
+          end
+
+          it "specifying file not in sandbox is a 400" do
+            put(request_url, requestor, :payload => payload) do |response|
+              error = "Manifest has a checksum that hasn't been uploaded."
+              expect(response).to look_like({
+                :status => 400,
+                :body => {
+                  "error" => [error]
+                }
+              })
+            end
+          end # it specifying file not in sandbox is a 400
+        end # context sandbox checks
+      end # context creating broken cookbook_artifacts to test validation and defaults
+
+      context "creating good cookbook_artifacts to test defaults" do
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_version) { "1.2.3" }
+
+        let(:cookbook_identifier) { default_cookbook_id }
+
+        let(:description) { "my cookbook" }
+        let(:long_description) { "this is a great cookbook" }
+        let(:maintainer) { "This is my name" }
+        let(:maintainer_email) { "cookbook_author@example.com" }
+        let(:license) { "MPL" }
+
+        let (:opts) {
+          {
+            :version => cookbook_version,
+            :description => description,
+            :long_description => long_description,
+            :maintainer => maintainer,
+            :maintainer_email => maintainer_email,
+            :license => license
+          }
+        }
+
+        after :each do
           delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
         end
 
+        respects_maximum_payload_size
+
         let(:payload) do
-          new_cookbook_artifact(cookbook_name, default_cookbook_id).tap do |p|
-            p["recipes"] = [
-              {
-                "name" => "default.rb",
-                "path" => "recipes/default.rb",
-                "checksum" => "8288b67da0793b5abec709d6226e6b73",
-                "specificity" => "default"
-              }
-            ]
+          new_cookbook_artifact(cookbook_name, cookbook_identifier, opts)
+        end
+
+        let(:expected_get_response_data) do
+          payload.dup.tap do |artifact|
+            artifact.delete("json_class")
           end
         end
 
-        it "specifying file not in sandbox is a 400" do
+        it "allows override of defaults" do
           put(request_url, requestor, :payload => payload) do |response|
-            error = "Manifest has a checksum that hasn't been uploaded."
+            expect(response.code).to eq(201)
+          end
+          get(request_url, requestor) do |response|
             expect(response).to look_like({
-              :status => 400,
-              :body => {
-                "error" => [error]
-              }
+              :status => 200,
+              :body => expected_get_response_data
             })
           end
-        end # it specifying file not in sandbox is a 400
-      end # context sandbox checks
-    end # context creating broken cookbook_artifacts to test validation and defaults
+        end # it allows override of defaults
+      end # context creating good gookbooks to test defaults
+    end # context PUT /cookbook_artifacts/<name>/<version> [create]
 
-    context "creating good cookbook_artifacts to test defaults" do
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_version) { "1.2.3" }
+    context "PUT multiple cookbook_artifacts" do
+      let(:cookbook_name) { "multiple_versions" }
+      let(:cookbook_id_1) { "1111111111111111111111111111111111111111" }
+      let(:cookbook_id_2) { "2222222222222222222222222222222222222222" }
 
-      let(:cookbook_identifier) { default_cookbook_id }
+      let(:cookbook_1_payload) do
+        new_cookbook_artifact(cookbook_name, cookbook_id_1, {})
+      end
 
-      let(:description) { "my cookbook" }
-      let(:long_description) { "this is a great cookbook" }
-      let(:maintainer) { "This is my name" }
-      let(:maintainer_email) { "cookbook_author@example.com" }
-      let(:license) { "MPL" }
+      let(:cookbook_1_get_response) do
+        cookbook_1_payload.dup.tap { |c| c.delete("json_class") }
+      end
 
-      let (:opts) {
-        {
-          :version => cookbook_version,
-          :description => description,
-          :long_description => long_description,
-          :maintainer => maintainer,
-          :maintainer_email => maintainer_email,
-          :license => license
-        }
-      }
+      let(:cookbook_2_payload) do
+        new_cookbook_artifact(cookbook_name, cookbook_id_2, {})
+      end
+
+      let(:cookbook_2_get_response) do
+        cookbook_2_payload.dup.tap { |c| c.delete("json_class") }
+      end
 
       after :each do
-        delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
-      end
-
-      respects_maximum_payload_size
-
-      let(:payload) do
-        new_cookbook_artifact(cookbook_name, cookbook_identifier, opts)
-      end
-
-      let(:expected_get_response_data) do
-        payload.dup.tap do |artifact|
-          artifact.delete("json_class")
+        [cookbook_id_1, cookbook_id_2].each do |v|
+          delete(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{v}"), admin_user)
         end
       end
 
-      it "allows override of defaults" do
-        put(request_url, requestor, :payload => payload) do |response|
-          expect(response.code).to eq(201)
-        end
-        get(request_url, requestor) do |response|
-          expect(response).to look_like({
-            :status => 200,
-            :body => expected_get_response_data
-          })
-        end
-      end # it allows override of defaults
-    end # context creating good gookbooks to test defaults
-  end # context PUT /cookbook_artifacts/<name>/<version> [create]
+      it "allows us to create 2 revisions of the same cookbook" do
+        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_1}"),
+            admin_user,
+            :payload => cookbook_1_payload) do |response|
+              expect(response.code).to eq(201)
+            end
 
-  context "PUT multiple cookbook_artifacts" do
-    let(:cookbook_name) { "multiple_versions" }
-    let(:cookbook_id_1) { "1111111111111111111111111111111111111111" }
-    let(:cookbook_id_2) { "2222222222222222222222222222222222222222" }
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_2}"),
+                admin_user,
+                :payload => cookbook_2_payload) do |response|
+                  expect(response.code).to eq(201)
+                end
 
-    let(:cookbook_1_payload) do
-      new_cookbook_artifact(cookbook_name, cookbook_id_1, {})
-    end
+                get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_1}"),
+                    admin_user) do |response|
+                  response.should look_like({
+                    :status => 200,
+                    :body => cookbook_1_get_response
+                  })
+                end
 
-    let(:cookbook_1_get_response) do
-      cookbook_1_payload.dup.tap { |c| c.delete("json_class") }
-    end
+                get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_2}"),
+                    admin_user) do |response|
+                  response.should look_like({
+                    :status => 200,
+                    :body => cookbook_2_get_response
+                  })
+                end
+      end # it allows us to create 2 versions of the same cookbook
+    end # context PUT multiple cookbook_artifacts
+  end
 
-    let(:cookbook_2_payload) do
-      new_cookbook_artifact(cookbook_name, cookbook_id_2, {})
-    end
+  describe "API v0" do
+    it_behaves_like "creates cookbook artifacts", 0
+  end
 
-    let(:cookbook_2_get_response) do
-      cookbook_2_payload.dup.tap { |c| c.delete("json_class") }
-    end
+  describe "API v2" do
+    it_behaves_like "creates cookbook artifacts", 2
+  end
 
-    after :each do
-      [cookbook_id_1, cookbook_id_2].each do |v|
-        delete(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{v}"), admin_user)
-      end
-    end
-
-    it "allows us to create 2 revisions of the same cookbook" do
-      put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_1}"),
-        admin_user,
-        :payload => cookbook_1_payload) do |response|
-          expect(response.code).to eq(201)
-      end
-
-      put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_2}"),
-        admin_user,
-        :payload => cookbook_2_payload) do |response|
-          expect(response.code).to eq(201)
-      end
-
-      get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_1}"),
-        admin_user) do |response|
-        response.should look_like({
-                                   :status => 200,
-                                   :body => cookbook_1_get_response
-                                  })
-      end
-
-      get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_id_2}"),
-        admin_user) do |response|
-        response.should look_like({
-                                   :status => 200,
-                                   :body => cookbook_2_get_response
-                                  })
-      end
-    end # it allows us to create 2 versions of the same cookbook
-  end # context PUT multiple cookbook_artifacts
 end # describe cookbook_artifacts API endpoint

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/delete_spec.rb
@@ -17,33 +17,42 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artifacts_delete do
 
-  let(:cookbook_url_base) { "cookbook_artifacts" }
+  shared_examples "deletes cookbook artifacts" do |api_version|
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
+    before do
+      platform.server_api_version = api_version
+    end
 
-  context "DELETE /cookbook_artifacts/<name>/<version>" do
-    let(:request_method) { :DELETE }
-    let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
-    let(:requestor)      { admin_user }
+    after do
+      platform.reset_server_api_version
+    end
 
-    let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
-    let(:default_version) { "1.2.3" }
-
-    context "for non-existent cookbooks" do
-      let(:expected_response) { cookbook_version_not_found_exact_response }
-
-      let(:cookbook_name)    { "non_existent" }
-      let(:cookbook_version) { "1.2.3" }
-
-      it "returns 404" do
-        response = delete(request_url, requestor)
-        expect(response.code).to eq(404)
-        expect(parse(response)).to eq({"error"=>["not_found"]})
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
       end
+    end
 
-      context 'with bad identifier' do
+    let(:cookbook_url_base) { "cookbook_artifacts" }
 
-        let(:cookbook_identifier) { "foo@bar" }
+    include Pedant::RSpec::CookbookUtil
+
+    context "DELETE /cookbook_artifacts/<name>/<version>" do
+      let(:request_method) { :DELETE }
+      let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
+      let(:requestor)      { admin_user }
+
+      let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
+      let(:default_version) { "1.2.3" }
+
+      context "for non-existent cookbooks" do
+        let(:expected_response) { cookbook_version_not_found_exact_response }
+
+        let(:cookbook_name)    { "non_existent" }
+        let(:cookbook_version) { "1.2.3" }
 
         it "returns 404" do
           response = delete(request_url, requestor)
@@ -51,123 +60,144 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
           expect(parse(response)).to eq({"error"=>["not_found"]})
         end
 
-      end # with bad version
-    end # context for non-existent cookbooks
+        context 'with bad identifier' do
 
-    context "for existing cookbooks" do
+          let(:cookbook_identifier) { "foo@bar" }
 
-      let(:cookbook_name) { "cookbook-to-be-deleted" }
-
-      context "when deleting non-existent version of an existing cookbook" do
-        let(:non_existing_identifier) { "ffffffffffffffffffffffffffffffffffffffff" }
-        let(:non_existing_version_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{non_existing_identifier}") }
-
-        before(:each) { make_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
-        after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_identifier) }
-
-        it "should respond with 404 (\"Not Found\") and not delete existing versions" do
-          delete(non_existing_version_url, requestor) do |response|
+          it "returns 404" do
+            response = delete(request_url, requestor)
             expect(response.code).to eq(404)
             expect(parse(response)).to eq({"error"=>["not_found"]})
           end
 
-          expect(get(request_url, requestor).code).to eq(200)
-        end
-      end # it doesn't delete the wrong version of an existing cookbook
+        end # with bad version
+      end # context for non-existent cookbooks
 
-      context "when deleting existent version of an existing cookbook", :smoke do
+      context "for existing cookbooks" do
 
-        let(:recipe_name) { "test_recipe" }
-        let(:recipe_content) { "hello-#{unique_suffix}" }
-        let(:recipe_spec) do
+        let(:cookbook_name) { "cookbook-to-be-deleted" }
+
+        context "when deleting non-existent version of an existing cookbook" do
+          let(:non_existing_identifier) { "ffffffffffffffffffffffffffffffffffffffff" }
+          let(:non_existing_version_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{non_existing_identifier}") }
+
+          before(:each) { make_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
+          after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_identifier) }
+
+          it "should respond with 404 (\"Not Found\") and not delete existing versions" do
+            delete(non_existing_version_url, requestor) do |response|
+              expect(response.code).to eq(404)
+              expect(parse(response)).to eq({"error"=>["not_found"]})
+            end
+
+            expect(get(request_url, requestor).code).to eq(200)
+          end
+        end # it doesn't delete the wrong version of an existing cookbook
+
+        context "when deleting existent version of an existing cookbook", :smoke do
+
+          let(:recipe_name) { "test_recipe" }
+          let(:recipe_content) { "hello-#{unique_suffix}" }
+          let(:recipe_spec) do
             {
               :name => recipe_name,
               :content => recipe_content
             }
-        end
+          end
 
-        before(:each) do
-          make_cookbook_artifact_with_recipes(cookbook_name, cookbook_identifier, [recipe_spec])
-        end
+          before(:each) do
+            make_cookbook_artifact_with_recipes(cookbook_name, cookbook_identifier, [recipe_spec])
+          end
 
-        after(:each)  { delete_cookbook_artifact(requestor, cookbook_name, cookbook_identifier) }
+          after(:each)  { delete_cookbook_artifact(requestor, cookbook_name, cookbook_identifier) }
 
-        it "should cleanup unused checksum data in s3/bookshelf" do
-          artifact_json = get(request_url, requestor)
-          expect(artifact_json.code).to eq(200)
-          artifact_before_delete = parse(artifact_json)
-          existing_recipes = artifact_before_delete["recipes"]
+          it "should cleanup unused checksum data in s3/bookshelf" do
+            artifact_json = get(request_url, requestor)
+            expect(artifact_json.code).to eq(200)
+            artifact_before_delete = parse(artifact_json)
+            existing_recipes = extract_segment(artifact_before_delete, "recipes")
 
-          expect(existing_recipes.size).to eq(1)
-          remote_recipe_spec = existing_recipes.first
-          expect(remote_recipe_spec).to be_a_kind_of(Hash)
+            expect(existing_recipes.size).to eq(1)
+            remote_recipe_spec = existing_recipes.first
+            expect(remote_recipe_spec).to be_a_kind_of(Hash)
 
-          expect(remote_recipe_spec["name"]).to eq("test_recipe.rb")
-          expect(remote_recipe_spec["path"]).to eq("recipes/test_recipe.rb")
-          expect(remote_recipe_spec["checksum"]).to be_a_kind_of(String)
-          expect(remote_recipe_spec["specificity"]).to eq("default")
-          expect(remote_recipe_spec["url"]).to be_a_kind_of(String)
+            rn = platform.server_api_version >= 2 ? "recipes/#{recipe_name}.rb" : "#{recipe_name}.rb"
+            expect(remote_recipe_spec["name"]).to eq(rn)
+            expect(remote_recipe_spec["path"]).to eq("recipes/test_recipe.rb")
+            expect(remote_recipe_spec["checksum"]).to be_a_kind_of(String)
+            expect(remote_recipe_spec["specificity"]).to eq("default")
+            expect(remote_recipe_spec["url"]).to be_a_kind_of(String)
 
-          delete_response = delete(request_url, requestor)
-          expect(delete_response.code).to eq(200)
+            delete_response = delete(request_url, requestor)
+            expect(delete_response.code).to eq(200)
 
-          verify_checksum_url(remote_recipe_spec["url"], 404)
-        end
+            verify_checksum_url(remote_recipe_spec["url"], 404)
+          end
 
-      end # context when deleting existent version...
-    end # context for existing cookbooks
+        end # context when deleting existent version...
+      end # context for existing cookbooks
 
-    context "with permissions for" do
-      let(:cookbook_name) {"delete-cookbook"}
-      let(:cookbook_identifier) { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
-      let(:not_found_msg) { ["Cannot find a cookbook named delete-cookbook with version 0.0.1"] }
+      context "with permissions for" do
+        let(:cookbook_name) {"delete-cookbook"}
+        let(:cookbook_identifier) { "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+        let(:not_found_msg) { ["Cannot find a cookbook named delete-cookbook with version 0.0.1"] }
 
-      let(:original_cookbook) { new_cookbook_artifact(cookbook_name, cookbook_identifier) }
-      let(:fetched_cookbook) { original_cookbook.dup.tap { |c| c.delete("json_class") } }
+        let(:original_cookbook) { new_cookbook_artifact(cookbook_name, cookbook_identifier) }
+        let(:fetched_cookbook) { original_cookbook.dup.tap { |c| c.delete("json_class") } }
 
-      before(:each) { make_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
-      after(:each) { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
+        before(:each) { make_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
+        after(:each) { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
 
-      context 'as admin user' do
+        context 'as admin user' do
 
-        it "should respond with 200 (\"OK\") and be deleted" do
-          delete_response = delete(request_url, admin_user)
-          expect(delete_response.code).to eq(200)
-          expect(parse(delete_response)).to eq(fetched_cookbook)
+          it "should respond with 200 (\"OK\") and be deleted" do
+            delete_response = delete(request_url, admin_user)
+            expect(delete_response.code).to eq(200)
+            expect(parse(delete_response)).to eq(fetched_cookbook)
 
-          expect(get(request_url, admin_user).code).to eq(404)
-        end # it admin user returns 200
-      end # as admin user
+            expect(get(request_url, admin_user).code).to eq(404)
+          end # it admin user returns 200
+        end # as admin user
 
-      context 'as normal user', :authorization do
-        let(:expected_response) { delete_cookbook_success_response }
+        context 'as normal user', :authorization do
+          let(:expected_response) { delete_cookbook_success_response }
 
-        let(:requestor) { normal_user }
-        it "should respond with 200 (\"OK\") and be deleted" do
-          expect(delete(request_url, requestor).code).to eq(200)
-        end # it admin user returns 200
-      end # with normal user
+          let(:requestor) { normal_user }
+          it "should respond with 200 (\"OK\") and be deleted" do
+            expect(delete(request_url, requestor).code).to eq(200)
+          end # it admin user returns 200
+        end # with normal user
 
-      context 'as a user outside of the organization', :authorization do
-        let(:expected_response) { unauthorized_access_credential_response }
-        let(:requestor) { outside_user }
+        context 'as a user outside of the organization', :authorization do
+          let(:expected_response) { unauthorized_access_credential_response }
+          let(:requestor) { outside_user }
 
-        it "should respond with 403 (\"Forbidden\") and does not delete cookbook" do
-          response.should look_like expected_response
-          should_not_be_deleted
-        end
-      end # it outside user returns 403
+          it "should respond with 403 (\"Forbidden\") and does not delete cookbook" do
+            response.should look_like expected_response
+            should_not_be_deleted
+          end
+        end # it outside user returns 403
 
-      context 'with invalid user', :authorization do
-        let(:expected_response) { invalid_credential_exact_response }
-        let(:requestor) { invalid_user }
+        context 'with invalid user', :authorization do
+          let(:expected_response) { invalid_credential_exact_response }
+          let(:requestor) { invalid_user }
 
-        it "should respond with 401 (\"Unauthorized\") and does not delete cookbook" do
-          response.should look_like expected_response
-          should_not_be_deleted
-        end # responds with 401
-      end # with invalid user
+          it "should respond with 401 (\"Unauthorized\") and does not delete cookbook" do
+            response.should look_like expected_response
+            should_not_be_deleted
+          end # responds with 401
+        end # with invalid user
 
-    end # context with permissions for
-  end # context DELETE /cookbook_artifacts/<name>/<version>
-end
+      end # context with permissions for
+    end # context DELETE /cookbook_artifacts/<name>/<version>
+  end
+
+  describe "API v0" do
+    it_behaves_like "deletes cookbook artifacts", 0
+  end
+
+  describe "API v2" do
+    it_behaves_like "deletes cookbook artifacts", 2
+  end
+
+end # describe cookbook_artifacts API endpoint

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
@@ -22,208 +22,240 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artifacts_read do
 
-  let(:cookbook_url_base) { "cookbook_artifacts" }
+  shared_examples "reads cookbook artifacts" do |api_version|
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
+    before do
+      platform.server_api_version = api_version
+    end
 
-  def cookbook_artifact_version_url(name, identifier)
-    api_url("/#{cookbook_url_base}/#{name}/#{identifier}")
-  end
+    after do
+      platform.reset_server_api_version
+    end
 
-  context "GET /cookbook_artifacts" do
-    let(:request_url){api_url("/#{cookbook_url_base}/")}
-    let(:requestor) { admin_user }
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
+      end
+    end
 
-    context "with no cookbook artifacts on the server", :smoke do
-      it "responds with 200" do
-        get(request_url, requestor) do |response|
-          expect(response.code).to eq(200)
-          expect(parse(response)).to eq({})
+    let(:cookbook_url_base) { "cookbook_artifacts" }
+
+    include Pedant::RSpec::CookbookUtil
+
+    def cookbook_artifact_version_url(name, identifier)
+      api_url("/#{cookbook_url_base}/#{name}/#{identifier}")
+    end
+
+    context "GET /cookbook_artifacts" do
+      let(:request_url){api_url("/#{cookbook_url_base}/")}
+      let(:requestor) { admin_user }
+
+      context "with no cookbook artifacts on the server", :smoke do
+        it "responds with 200" do
+          get(request_url, requestor) do |response|
+            expect(response.code).to eq(200)
+            expect(parse(response)).to eq({})
+          end
         end
       end
-    end
 
-    context "with existing cookbook_artifacts and multiple versions" do
+      context "with existing cookbook_artifacts and multiple versions" do
 
-      let(:request_url) { api_url("/#{cookbook_url_base}") }
+        let(:request_url) { api_url("/#{cookbook_url_base}") }
 
-      let(:fetched_cookbook_artifacts) { cookbook_collection }
+        let(:fetched_cookbook_artifacts) { cookbook_collection }
 
-      let(:default_version) { "1.0.0" }
+        let(:default_version) { "1.0.0" }
 
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_name2) { "cookbook_name2" }
-      let(:identifier_1) { "1111111111111111111111111111111111111111" }
-      let(:identifier_2) { "2222222222222222222222222222222222222222" }
-      let(:identifier_3) { "3333333333333333333333333333333333333333" }
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_name2) { "cookbook_name2" }
+        let(:identifier_1) { "1111111111111111111111111111111111111111" }
+        let(:identifier_2) { "2222222222222222222222222222222222222222" }
+        let(:identifier_3) { "3333333333333333333333333333333333333333" }
 
-      let(:cba_1_url) { request_url + "/#{cookbook_name}/#{identifier_1}" }
-      let(:cba_2_url) { request_url + "/#{cookbook_name}/#{identifier_2}" }
-      let(:cba_3_url) { request_url + "/#{cookbook_name2}/#{identifier_3}" }
+        let(:cba_1_url) { request_url + "/#{cookbook_name}/#{identifier_1}" }
+        let(:cba_2_url) { request_url + "/#{cookbook_name}/#{identifier_2}" }
+        let(:cba_3_url) { request_url + "/#{cookbook_name2}/#{identifier_3}" }
 
-      let(:cba_1) { new_cookbook_artifact(cookbook_name, identifier_1) }
-      let(:cba_2) { new_cookbook_artifact(cookbook_name, identifier_2) }
-      let(:cba_3) { new_cookbook_artifact(cookbook_name2, identifier_3) }
+        let(:cba_1) { new_cookbook_artifact(cookbook_name, identifier_1) }
+        let(:cba_2) { new_cookbook_artifact(cookbook_name, identifier_2) }
+        let(:cba_3) { new_cookbook_artifact(cookbook_name2, identifier_3) }
 
-      before(:each) do
-        r1 = put(cba_1_url, admin_user, payload: cba_1)
-        expect(r1.code).to eq(201)
+        before(:each) do
+          r1 = put(cba_1_url, admin_user, payload: cba_1)
+          expect(r1.code).to eq(201)
 
-        r2 = put(cba_2_url, admin_user, payload: cba_2)
-        expect(r2.code).to eq(201)
+          r2 = put(cba_2_url, admin_user, payload: cba_2)
+          expect(r2.code).to eq(201)
 
-        r3 = put(cba_3_url, admin_user, payload: cba_3)
-        expect(r3.code).to eq(201)
-      end
+          r3 = put(cba_3_url, admin_user, payload: cba_3)
+          expect(r3.code).to eq(201)
+        end
 
-      after(:each) do
-        r1 = delete(cba_1_url, admin_user)
-        expect(r1.code).to eq(200)
+        after(:each) do
+          r1 = delete(cba_1_url, admin_user)
+          expect(r1.code).to eq(200)
 
-        r2 = delete(cba_2_url, admin_user)
-        expect(r2.code).to eq(200)
+          r2 = delete(cba_2_url, admin_user)
+          expect(r2.code).to eq(200)
 
-        r3 = delete(cba_3_url, admin_user)
-        expect(r3.code).to eq(200)
-      end
+          r3 = delete(cba_3_url, admin_user)
+          expect(r3.code).to eq(200)
+        end
 
-      let(:expected_cookbook_artifact_collection) do
-        {
-          cookbook_name => {
-            "url" => cookbook_url(cookbook_name),
-            "versions" => [
-              { "identifier" => identifier_1,
-                "url" => cookbook_artifact_version_url(cookbook_name, identifier_1) },
+        let(:expected_cookbook_artifact_collection) do
+          {
+            cookbook_name => {
+              "url" => cookbook_url(cookbook_name),
+              "versions" => [
+                { "identifier" => identifier_1,
+                  "url" => cookbook_artifact_version_url(cookbook_name, identifier_1) },
               { "identifier" => identifier_2,
                 "url" => cookbook_artifact_version_url(cookbook_name, identifier_2) }
-            ]},
-          cookbook_name2 => {
-            "url" => cookbook_url(cookbook_name2),
-            "versions" => [
-              { "identifier" => identifier_3,
-                "url" => cookbook_artifact_version_url(cookbook_name2, identifier_3) }]}
-        }
+              ]},
+              cookbook_name2 => {
+                "url" => cookbook_url(cookbook_name2),
+                "versions" => [
+                  { "identifier" => identifier_3,
+                    "url" => cookbook_artifact_version_url(cookbook_name2, identifier_3) }]}
+          }
+        end
+
+        it 'should respond with a cookbook collection containing all versions of each cookbook' do
+          list_response = get(request_url, requestor)
+          expect(list_response.code).to eq(200)
+          expect(parse(list_response)).to strictly_match(expected_cookbook_artifact_collection)
+        end
+
       end
 
-      it 'should respond with a cookbook collection containing all versions of each cookbook' do
-        list_response = get(request_url, requestor)
-        expect(list_response.code).to eq(200)
-        expect(parse(list_response)).to strictly_match(expected_cookbook_artifact_collection)
-      end
+    end # context GET /cookbook_artifacts
 
-    end
-
-  end # context GET /cookbook_artifacts
-
-  context "GET /cookbook_artifacts/<name>/<version>" do
+    context "GET /cookbook_artifacts/<name>/<version>" do
 
 
-    let(:cookbook_name) { "the_cookbook_name" }
-    let(:default_version) { "1.2.3" }
-    let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
+      let(:cookbook_name) { "the_cookbook_name" }
+      let(:default_version) { "1.2.3" }
+      let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
 
-    let(:request_url)    { cookbook_artifact_version_url(cookbook_name, cookbook_identifier) }
+      let(:request_url)    { cookbook_artifact_version_url(cookbook_name, cookbook_identifier) }
 
-    let(:recipe_name) { "test_recipe" }
-    let(:recipe_content) { "hello-#{unique_suffix}" }
+      let(:recipe_name) { "test_recipe" }
+      let(:recipe_content) { "hello-#{unique_suffix}" }
 
-    let(:recipe_spec) do
+      let(:recipe_spec) do
         {
           :name => recipe_name,
           :content => recipe_content
         }
-    end
-
-    before(:each) do
-      make_cookbook_artifact_with_recipes(cookbook_name, cookbook_identifier, [recipe_spec])
-    end
-
-    after(:each)  { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
-
-    shared_examples_for "successful_cookbook_fetch" do
-
-      let(:expected_cookbook_artifact_data) do
-        new_cookbook_artifact(cookbook_name, cookbook_identifier).tap do |cba|
-          cba.delete("json_class")
-
-          # checksum and url are also present in the real data but they're not
-          # stable so we remove them before comparing
-          cba["recipes"] = [
-            {
-              "name" => "#{recipe_name}.rb",
-              "path" => "recipes/#{recipe_name}.rb",
-              "specificity" => "default"
-            }
-          ]
-          cba["metadata"]["providing"] = { "#{cookbook_name}::#{recipe_name}"=>">= 0.0.0" }
-          cba["metadata"]["recipes"] = { "#{cookbook_name}::#{recipe_name}"=>"" }
-        end
       end
 
-      it "returns a 200 response" do
-        get_response = get(request_url, requestor)
-        expect(get_response.code).to eq(200)
-        response_data = parse(get_response)
-        expect(response_data).to have_key("recipes")
-        expect(response_data["recipes"]).to be_a_kind_of(Array)
-        expect(response_data["recipes"].size).to eq(1)
-        expect(response_data["recipes"].first.keys).to match_array(%w[ name path checksum specificity url ])
-
-        # URL and checksum are not predictable.
-        response_data["recipes"].first.delete("url")
-        response_data["recipes"].first.delete("checksum")
-
-        expect(response_data).to eq(expected_cookbook_artifact_data)
+      before(:each) do
+        make_cookbook_artifact_with_recipes(cookbook_name, cookbook_identifier, [recipe_spec])
       end
 
-      # These tests verify that the pre-signed URL that comes back
-      # within cookbook_version responses is usable. Validating both
-      # the URL generation, but also the use of bookshelf via the
-      # load balancer.
-      it "returns valid file URLs" do
-        cookbook_artifact_data = parse(get(request_url, requestor))
-        recipe_url = cookbook_artifact_data["recipes"].first["url"]
+      after(:each)  { delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier) }
 
-        uri = URI.parse(recipe_url)
-        http = Net::HTTP.new(uri.hostname, uri.port)
-        if uri.scheme == "https"
-          http.use_ssl = true
-          http.ssl_version = Pedant::Config.ssl_version
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      shared_examples_for "successful_cookbook_fetch" do
+
+        let(:expected_cookbook_artifact_data) do
+          new_cookbook_artifact(cookbook_name, cookbook_identifier).tap do |cba|
+            cba.delete("json_class")
+
+            # checksum and url are also present in the real data but they're not
+            # stable so we remove them before comparing
+            target = platform.server_api_version >= 2 ? "all_files" : "recipes"
+            rn = platform.server_api_version >= 2 ? "recipes/#{recipe_name}.rb" : "#{recipe_name}.rb"
+            cba[target] = [
+              {
+                "name" => rn,
+                "path" => "recipes/#{recipe_name}.rb",
+                "specificity" => "default"
+              }
+            ]
+            cba["metadata"]["providing"] = { "#{cookbook_name}::#{recipe_name}"=>">= 0.0.0" }
+            cba["metadata"]["recipes"] = { "#{cookbook_name}::#{recipe_name}"=>"" }
+          end
         end
 
-        response = http.get(uri.request_uri, {})
-        response.body.should == recipe_content
+        it "returns a 200 response" do
+          get_response = get(request_url, requestor)
+          expect(get_response.code).to eq(200)
+          response_data = parse(get_response)
+          recipes = extract_segment(response_data, "recipes")
+          expect(recipes).to be_a_kind_of(Array)
+          expect(recipes.size).to eq(1)
+          expect(recipes.first.keys).to match_array(%w[ name path checksum specificity url ])
+
+          # URL and checksum are not predictable.
+          target = platform.server_api_version >= 2 ? "all_files" : "recipes"
+          response_data[target].first.delete("url")
+          response_data[target].first.delete("checksum")
+
+          expect(response_data).to eq(expected_cookbook_artifact_data)
+        end
+
+        # These tests verify that the pre-signed URL that comes back
+        # within cookbook_version responses is usable. Validating both
+        # the URL generation, but also the use of bookshelf via the
+        # load balancer.
+        it "returns valid file URLs" do
+          cookbook_artifact_data = parse(get(request_url, requestor))
+          recipe_url = extract_segment(cookbook_artifact_data, "recipes").first["url"]
+
+          uri = URI.parse(recipe_url)
+          http = Net::HTTP.new(uri.hostname, uri.port)
+          if uri.scheme == "https"
+            http.use_ssl = true
+            http.ssl_version = Pedant::Config.ssl_version
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          end
+
+          response = http.get(uri.request_uri, {})
+          response.body.should == recipe_content
+        end
+
+      end # as a normal user
+
+      context 'as a normal user' do
+        let(:requestor) { normal_user }
+
+        include_examples("successful_cookbook_fetch")
       end
 
-    end # as a normal user
+      context 'as an admin user' do
+        let(:requestor) { admin_user }
 
-    context 'as a normal user' do
-      let(:requestor) { normal_user }
+        include_examples("successful_cookbook_fetch")
+      end # as an admin user
 
-      include_examples("successful_cookbook_fetch")
-    end
+      context 'as an user outside of the organization', :authorization do
+        let(:request_method) { :GET }
+        let(:expected_response) { unauthorized_access_credential_response }
+        let(:requestor) { outside_user }
 
-    context 'as an admin user' do
-      let(:requestor) { admin_user }
+        should_respond_with 403
+      end # as an outside user
 
-      include_examples("successful_cookbook_fetch")
-    end # as an admin user
+      context 'with invalid user', :authentication do
+        let(:request_method) { :GET }
+        let(:expected_response) { invalid_credential_exact_response }
+        let(:requestor) { invalid_user }
 
-    context 'as an user outside of the organization', :authorization do
-      let(:request_method) { :GET }
-      let(:expected_response) { unauthorized_access_credential_response }
-      let(:requestor) { outside_user }
+        should_respond_with 401
+      end
+    end # context GET /cookbook_artifacts/<name>/<version>
+  end
 
-      should_respond_with 403
-    end # as an outside user
+  describe "API v0" do
+    it_behaves_like "reads cookbook artifacts", 0
+  end
 
-    context 'with invalid user', :authentication do
-      let(:request_method) { :GET }
-      let(:expected_response) { invalid_credential_exact_response }
-      let(:requestor) { invalid_user }
+  describe "API v2" do
+    it_behaves_like "reads cookbook artifacts", 2
+  end
 
-      should_respond_with 401
-    end
-  end # context GET /cookbook_artifacts/<name>/<version>
 end # describe cookbook_artifacts API endpoint

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/update_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/update_spec.rb
@@ -28,68 +28,69 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artifacts_update do
 
-  let(:cookbook_url_base) { "cookbook_artifacts" }
+  shared_examples "updates cookbook artifacts" do |api_version|
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
+    before do
+      platform.server_api_version = api_version
+    end
 
-  context "PUT /cookbook_artifacts/<name>/<version> [update]" do
+    after do
+      platform.reset_server_api_version
+    end
 
-    # for respects_maximum_payload_size
-    let(:request_method) { :PUT }
-    let(:requestor){admin_user}
-    let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
-    let(:cookbook_name) { "cookbook-to-be-modified" }
-    let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
-    let(:default_version) { "1.2.3" }
-
-    let(:updated_cookbook_artifact) do
-      new_cookbook_artifact(cookbook_name, cookbook_identifier).tap do |payload|
-        payload["metadata"]["description"] = "hi there"
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
       end
     end
 
-    before(:each) {
-      make_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
-    }
+    let(:cookbook_url_base) { "cookbook_artifacts" }
 
-    after(:each) {
-      delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
-    }
+    include Pedant::RSpec::CookbookUtil
 
-    respects_maximum_payload_size
+    context "PUT /cookbook_artifacts/<name>/<version> [update]" do
 
+      # for respects_maximum_payload_size
+      let(:request_method) { :PUT }
+      let(:requestor){admin_user}
+      let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_identifier}")}
+      let(:cookbook_name) { "cookbook-to-be-modified" }
+      let(:cookbook_identifier) { "1111111111111111111111111111111111111111" }
+      let(:default_version) { "1.2.3" }
 
-    context "as admin user" do
-
-      let(:fetched_cookbook_artifact) do
-        new_cookbook_artifact(cookbook_name, cookbook_identifier).tap do |c|
-          c.delete("json_class")
+      let(:updated_cookbook_artifact) do
+        new_cookbook_artifact(cookbook_name, cookbook_identifier).tap do |payload|
+          payload["metadata"]["description"] = "hi there"
         end
       end
 
-      it "should respond with 409 Conflict", :smoke do
-        put(request_url, admin_user, :payload => updated_cookbook_artifact) do |response|
-          expect(response).to look_like({
-            :status => 409,
-            :body_exact => {"error"=>"Cookbook artifact already exists"}
-          })
+      before(:each) {
+        make_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
+      }
+
+      after(:each) {
+        delete_cookbook_artifact(admin_user, cookbook_name, cookbook_identifier)
+      }
+
+      respects_maximum_payload_size
+
+      context "as admin user" do
+
+        let(:fetched_cookbook_artifact) do
+          new_cookbook_artifact(cookbook_name, cookbook_identifier).tap do |c|
+            c.delete("json_class")
+          end
         end
 
-        # verify change didn't happen
-        get(request_url, admin_user) do |response|
-          expect(response).to look_like({
-            :status => 200,
-            :body => fetched_cookbook_artifact
-          })
-        end
-      end # it admin user returns 200
-
-      context 'as a user outside of the organization', :authorization do
-        let(:expected_response) { unauthorized_access_credential_response }
-
-        it "should respond with 403 (\"Forbidden\") and does not update cookbook" do
-          put(request_url, outside_user, :payload => updated_cookbook_artifact) do |response|
-            response.should look_like expected_response
+        it "should respond with 409 Conflict", :smoke do
+          put(request_url, admin_user, :payload => updated_cookbook_artifact) do |response|
+            expect(response).to look_like({
+              :status => 409,
+              :body_exact => {"error"=>"Cookbook artifact already exists"}
+            })
           end
 
           # verify change didn't happen
@@ -99,27 +100,53 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
               :body => fetched_cookbook_artifact
             })
           end
-        end # it outside user returns 403 and does not update cookbook
-      end
+        end # it admin user returns 200
 
-      context 'with invalid user', :authentication do
-        let(:expected_response) { invalid_credential_exact_response }
+        context 'as a user outside of the organization', :authorization do
+          let(:expected_response) { unauthorized_access_credential_response }
 
-        it "returns 401 and does not update cookbook" do
-          put(request_url, invalid_user, :payload => updated_cookbook_artifact) do |response|
-            response.should look_like expected_response
-          end
+          it "should respond with 403 (\"Forbidden\") and does not update cookbook" do
+            put(request_url, outside_user, :payload => updated_cookbook_artifact) do |response|
+              response.should look_like expected_response
+            end
 
-          # verify change didn't happen
-          get(request_url, admin_user) do |response|
-            expect(response).to look_like({
-              :status => 200,
-              :body => fetched_cookbook_artifact
-            })
-          end
-        end # it invalid user returns 401 and does not update cookbook
-      end # with invalid user
-    end # context with permissions for
-  end # context PUT /cookbook_artifacts/<name>/<version> [update]
-end
+            # verify change didn't happen
+            get(request_url, admin_user) do |response|
+              expect(response).to look_like({
+                :status => 200,
+                :body => fetched_cookbook_artifact
+              })
+            end
+          end # it outside user returns 403 and does not update cookbook
+        end
 
+        context 'with invalid user', :authentication do
+          let(:expected_response) { invalid_credential_exact_response }
+
+          it "returns 401 and does not update cookbook" do
+            put(request_url, invalid_user, :payload => updated_cookbook_artifact) do |response|
+              response.should look_like expected_response
+            end
+
+            # verify change didn't happen
+            get(request_url, admin_user) do |response|
+              expect(response).to look_like({
+                :status => 200,
+                :body => fetched_cookbook_artifact
+              })
+            end
+          end # it invalid user returns 401 and does not update cookbook
+        end # with invalid user
+      end # context with permissions for
+    end # context PUT /cookbook_artifacts/<name>/<version> [update]
+  end
+
+  describe "API v0" do
+    it_behaves_like "updates cookbook artifacts", 0
+  end
+
+  describe "API v2" do
+    it_behaves_like "updates cookbook artifacts", 2
+  end
+
+end # describe cookbook_artifacts API endpoint

--- a/oc-chef-pedant/spec/api/cookbooks/create_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/create_spec.rb
@@ -19,348 +19,382 @@ require 'pedant/rspec/validations'
 
 describe "Cookbooks API endpoint", :cookbooks, :cookbooks_create do
 
-  let(:cookbook_url_base) { "cookbooks" }
+  shared_examples "creates cookbooks" do |api_version|
+    let(:cookbook_url_base) { "cookbooks" }
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
+    before do
+      platform.server_api_version = api_version
+    end
 
-  context "PUT /cookbooks/<name>/<version> [create]" do
-    include Pedant::RSpec::Validations::Create
-    let(:request_method){:PUT}
-    let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}")}
-    shared(:requestor){admin_user}
+    after do
+      platform.reset_server_api_version
+    end
 
-    let(:default_resource_attributes){ new_cookbook(cookbook_name, cookbook_version)}
-
-    context 'with a basic cookbook', :smoke do
-      after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_version) }
-
-      let(:request_payload) { default_resource_attributes }
-      let(:cookbook_name) { "pedant_basic" }
-      let(:cookbook_version) { "1.0.0" }
-      let(:created_resource) { default_resource_attributes }
-      it "creates a basic cookbook" do
-        should look_like created_exact_response
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
       end
     end
 
-    # Start using the new validation macros
-    context "when validating" do
+    include Pedant::RSpec::CookbookUtil
 
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_version) { "1.2.3" }
+    context "PUT /cookbooks/<name>/<version> [create]" do
+      include Pedant::RSpec::Validations::Create
+      let(:request_method){:PUT}
+      let(:request_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}")}
+      shared(:requestor){admin_user}
 
-      let(:resource_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}")}
-      let(:persisted_resource_response){ get(resource_url, requestor) }
+      let(:default_resource_attributes){ new_cookbook(cookbook_name, cookbook_version)}
 
-      after(:each){ delete_cookbook(requestor, cookbook_name, cookbook_version)}
+      context 'with a basic cookbook', :smoke do
+        after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_version) }
 
-      context "the 'json_class' field" do
-        let(:validate_attribute){"json_class"}
-        accepts_valid_value "Chef::CookbookVersion"
-        rejects_invalid_value "Chef::Node"
-      end
-
-      context "the cookbook version" do
         let(:request_payload) { default_resource_attributes }
-
-        context "with negative versions", :validation do
-          let(:cookbook_version) { "1.2.-42" }
-          it { should look_like http_400_response }
-        end
-
-        context "with versions at exactly 4 bytes" do
-          int4_exact = "2147483647"
-          let(:cookbook_version) { "1.2.#{int4_exact}" }
-          it { should look_like http_201_response }
-        end
-
-        context "with versions larger than 4 bytes" do
-          int4_overflow = "2147483669" # max = 2147483647 (add 42)
-          let(:cookbook_version) { "1.2.#{int4_overflow}" }
-          it { should look_like http_201_response }
-        end
-
-        context "with versions larger than 8 bytes", :validation do
-          int8_overflow = "9223372036854775849" # max = 9223372036854775807 (add 42)
-          let(:cookbook_version) { "1.2.#{int8_overflow}" }
-          it { should look_like http_400_response }
+        let(:cookbook_name) { "pedant_basic" }
+        let(:cookbook_version) { "1.0.0" }
+        let(:created_resource) { default_resource_attributes }
+        it "creates a basic cookbook" do
+          should look_like created_exact_response
         end
       end
 
-      rejects_invalid_keys
+      # Start using the new validation macros
+      context "when validating" do
 
-    end
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_version) { "1.2.3" }
 
-    context "creating broken cookbooks to test validation and defaults", :validation do
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_version) { "1.2.3" }
+        let(:resource_url){api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}")}
+        let(:persisted_resource_response){ get(resource_url, requestor) }
 
-      malformed_constraint = "s395dss@#"
+        after(:each){ delete_cookbook(requestor, cookbook_name, cookbook_version)}
 
-      context "basic tests" do
-        after(:each) do
-          delete_cookbook(admin_user, cookbook_name, cookbook_version)
+        context "the 'json_class' field" do
+          let(:validate_attribute){"json_class"}
+          accepts_valid_value "Chef::CookbookVersion"
+          rejects_invalid_value "Chef::Node"
         end
 
-        should_create('json_class', :delete, true, 'Chef::CookbookVersion')
-        should_fail_to_create('json_class', 'Chef::Role', 400, "Field 'json_class' invalid")
-        should_fail_to_create('metadata', {}, 400, "Field 'metadata.version' missing")
-      end # context basic tests
+        context "the cookbook version" do
+          let(:request_payload) { default_resource_attributes }
 
-      context "checking segments" do
-        %w{resources providers recipes definitions libraries attributes
-           files templates root_files}.each do |segment|
+          context "with negative versions", :validation do
+            let(:cookbook_version) { "1.2.-42" }
+            it { should look_like http_400_response }
+          end
 
-          should_fail_to_create(segment, "foo", 400,
-            "Field '#{segment}' invalid")
-          should_fail_to_create(segment, [ {} ], 400,
-            "Invalid element in array value of '#{segment}'.")
-        end
-      end # context checking segments
+          context "with versions at exactly 4 bytes" do
+            int4_exact = "2147483647"
+            let(:cookbook_version) { "1.2.#{int4_exact}" }
+            it { should look_like http_201_response }
+          end
 
-      context "checking metadata sections" do
-        %w{platforms dependencies}.each do |section|
-          should_fail_to_create_metadata(section, "foo", 400, "Field 'metadata.#{section}' invalid")
-          should_fail_to_create_metadata(section, {"foo" => malformed_constraint},
-                                         400, "Invalid value '#{malformed_constraint}' for metadata.#{section}")
-        end
+          context "with versions larger than 4 bytes" do
+            int4_overflow = "2147483669" # max = 2147483647 (add 42)
+            let(:cookbook_version) { "1.2.#{int4_overflow}" }
+            it { should look_like http_201_response }
+          end
 
-        def self.should_create_with_metadata(_attribute, _value)
-          context "when #{_attribute} is set to #{_value}" do
-            let(:cookbook_name) { Pedant::Utility.with_unique_suffix("pedant-cookbook") }
-
-            # These macros need to be refactored and updated for flexibility.
-            # The cookbook endpoint uses PUT for both create and update, so this
-            # throws a monkey wrench into the mix.
-            should_change_metadata _attribute, _value, _value, 201
+          context "with versions larger than 8 bytes", :validation do
+            int8_overflow = "9223372036854775849" # max = 9223372036854775807 (add 42)
+            let(:cookbook_version) { "1.2.#{int8_overflow}" }
+            it { should look_like http_400_response }
           end
         end
 
-        context "with metadata.dependencies" do
+        rejects_invalid_keys
+
+      end
+
+      context "creating broken cookbooks to test validation and defaults", :validation do
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_version) { "1.2.3" }
+
+        malformed_constraint = "s395dss@#"
+
+        context "basic tests" do
           after(:each) do
             delete_cookbook(admin_user, cookbook_name, cookbook_version)
           end
 
-          ["> 1.0", "< 2.1.2", "3.3", "<= 4.6", "~> 5.6.2", ">= 6.0"].each do |dep|
-            should_create_with_metadata 'dependencies', {"chef-client" => "> 2.0.0", "apt" => dep}
+          should_create('json_class', :delete, true, 'Chef::CookbookVersion')
+          should_fail_to_create('json_class', 'Chef::Role', 400, "Field 'json_class' invalid")
+          should_fail_to_create('metadata', {}, 400, "Field 'metadata.version' missing")
+        end # context basic tests
+
+        context "checking segments" do
+          segments = if api_version >= 2
+                       %w{all_files}
+                     else
+                       %w{resources providers recipes definitions libraries attributes files templates root_files}
+                     end
+
+          segments.each do |segment|
+
+            should_fail_to_create(segment, "foo", 400,
+                                  "Field '#{segment}' invalid")
+            should_fail_to_create(segment, [ {} ], 400,
+                                  "Invalid element in array value of '#{segment}'.")
+          end
+        end # context checking segments
+
+        context "checking metadata sections" do
+          %w{platforms dependencies}.each do |section|
+            should_fail_to_create_metadata(section, "foo", 400, "Field 'metadata.#{section}' invalid")
+            should_fail_to_create_metadata(section, {"foo" => malformed_constraint},
+                                           400, "Invalid value '#{malformed_constraint}' for metadata.#{section}")
           end
 
-          ["> 1", "< 2", "3", "<= 4", "~> 5", ">= 6", "= 7", ">= 1.2.3.4", "<= 5.6.7.8.9.0"].each do |dep|
-            should_fail_to_create_metadata(
-              'dependencies',
-              {"chef-client" => "> 2.0.0", "apt" => dep},
-              400, "Invalid value '#{dep}' for metadata.dependencies")
+          def self.should_create_with_metadata(_attribute, _value)
+            context "when #{_attribute} is set to #{_value}" do
+              let(:cookbook_name) { Pedant::Utility.with_unique_suffix("pedant-cookbook") }
+
+              # These macros need to be refactored and updated for flexibility.
+              # The cookbook endpoint uses PUT for both create and update, so this
+              # throws a monkey wrench into the mix.
+              should_change_metadata _attribute, _value, _value, 201
+            end
           end
-        end
 
-        context "with metadata.providing" do
-          after(:each) { delete_cookbook admin_user, cookbook_name, cookbook_version }
+          context "with metadata.dependencies" do
+            after(:each) do
+              delete_cookbook(admin_user, cookbook_name, cookbook_version)
+            end
 
-          # http://docs.chef.io/config_rb_metadata.html#provides
-          should_create_with_metadata 'providing', 'cats::sleep'
-          should_create_with_metadata 'providing', 'here(:kitty, :time_to_eat)'
-          should_create_with_metadata 'providing', 'service[snuggle]'
-          should_create_with_metadata 'providing', ''
-          should_create_with_metadata 'providing', 1
-          should_create_with_metadata 'providing', true
-          should_create_with_metadata 'providing', ['cats', 'sleep', 'here']
-          should_create_with_metadata 'providing',
-          { 'cats::sleep'                => '0.0.1',
-            'here(:kitty, :time_to_eat)' => '0.0.1',
-            'service[snuggle]'           => '0.0.1'  }
+            ["> 1.0", "< 2.1.2", "3.3", "<= 4.6", "~> 5.6.2", ">= 6.0"].each do |dep|
+              should_create_with_metadata 'dependencies', {"chef-client" => "> 2.0.0", "apt" => dep}
+            end
 
-        end
-      end # context checking metadata sections
-
-      context 'with invalid version in url' do
-        let(:expected_response) { invalid_cookbook_version_response }
-        let(:url) { named_cookbook_url }
-        let(:payload) { {} }
-        let(:cookbook_version) { 'abc' }
-
-        it "should respond with an error" do
-          put(url, admin_user, :payload => payload) do |response|
-            response.should look_like expected_response
+            ["> 1", "< 2", "3", "<= 4", "~> 5", ">= 6", "= 7", ">= 1.2.3.4", "<= 5.6.7.8.9.0"].each do |dep|
+              should_fail_to_create_metadata(
+                'dependencies',
+                {"chef-client" => "> 2.0.0", "apt" => dep},
+                400, "Invalid value '#{dep}' for metadata.dependencies")
+            end
           end
-        end # it invalid version in URL is a 400
-      end # with invalid version in url
 
-      it "invalid cookbook name in URL is a 400" do
-        payload = {}
-        put(api_url("/#{cookbook_url_base}/first@second/1.2.3"), admin_user,
-            :payload => payload) do |response|
-          error = "Invalid cookbook name 'first@second' using regex: 'Malformed cookbook name. Must only contain A-Z, a-z, 0-9, _, . or -'."
-          response.should look_like({
-                                      :status => 400,
-                                      :body => {
-                                        "error" => [error]
-                                      }
-                                    })
-        end
-      end # it invalid cookbook name in URL is a 400
+          context "with metadata.providing" do
+            after(:each) { delete_cookbook admin_user, cookbook_name, cookbook_version }
 
-      it "mismatched metadata.cookbook_version is a 400" do
-        payload = new_cookbook(cookbook_name, "0.0.1")
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), admin_user,
-            :payload => payload) do |response|
-          error = "Field 'name' invalid"
-          response.should look_like({
-                                      :status => 400,
-                                      :body => {
-                                        "error" => [error]
-                                      }
-                                    })
-        end
-      end # it mismatched metadata.cookbook_version is a 400
+            # http://docs.chef.io/config_rb_metadata.html#provides
+            should_create_with_metadata 'providing', 'cats::sleep'
+            should_create_with_metadata 'providing', 'here(:kitty, :time_to_eat)'
+            should_create_with_metadata 'providing', 'service[snuggle]'
+            should_create_with_metadata 'providing', ''
+            should_create_with_metadata 'providing', 1
+            should_create_with_metadata 'providing', true
+            should_create_with_metadata 'providing', ['cats', 'sleep', 'here']
+            should_create_with_metadata 'providing',
+              { 'cats::sleep'                => '0.0.1',
+                'here(:kitty, :time_to_eat)' => '0.0.1',
+                'service[snuggle]'           => '0.0.1'  }
 
-      it "mismatched cookbook_name is a 400" do
-        payload = new_cookbook("foobar", cookbook_version)
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), admin_user,
-            :payload => payload) do |response|
-          error = "Field 'name' invalid"
-          response.should look_like({
-                                      :status => 400,
-                                      :body => {
-                                        "error" => [error]
-                                      }
-                                    })
-        end
-      end # it mismatched cookbook_name is a 400
+          end
+        end # context checking metadata sections
 
-      context "sandbox checks" do
-        after(:each) do
+        context 'with invalid version in url' do
+          let(:expected_response) { invalid_cookbook_version_response }
+          let(:url) { named_cookbook_url }
+          let(:payload) { {} }
+          let(:cookbook_version) { 'abc' }
+
+          it "should respond with an error" do
+            put(url, admin_user, :payload => payload) do |response|
+              response.should look_like expected_response
+            end
+          end # it invalid version in URL is a 400
+        end # with invalid version in url
+
+        it "invalid cookbook name in URL is a 400" do
+          payload = {}
+          put(api_url("/#{cookbook_url_base}/first@second/1.2.3"), admin_user,
+              :payload => payload) do |response|
+            error = "Invalid cookbook name 'first@second' using regex: 'Malformed cookbook name. Must only contain A-Z, a-z, 0-9, _, . or -'."
+            response.should look_like({
+              :status => 400,
+              :body => {
+                "error" => [error]
+              }
+            })
+          end
+        end # it invalid cookbook name in URL is a 400
+
+        it "mismatched metadata.cookbook_version is a 400" do
+          payload = new_cookbook(cookbook_name, "0.0.1")
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), admin_user,
+              :payload => payload) do |response|
+            error = "Field 'name' invalid"
+            response.should look_like({
+              :status => 400,
+              :body => {
+                "error" => [error]
+              }
+            })
+          end
+        end # it mismatched metadata.cookbook_version is a 400
+
+        it "mismatched cookbook_name is a 400" do
+          payload = new_cookbook("foobar", cookbook_version)
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), admin_user,
+              :payload => payload) do |response|
+            error = "Field 'name' invalid"
+            response.should look_like({
+              :status => 400,
+              :body => {
+                "error" => [error]
+              }
+            })
+          end
+        end # it mismatched cookbook_name is a 400
+
+        context "sandbox checks" do
+          after(:each) do
+            delete_cookbook(admin_user, cookbook_name, cookbook_version)
+          end
+          it "specifying file not in sandbox is a 400" do
+            payload = new_cookbook(cookbook_name, cookbook_version)
+            seg = platform.server_api_version >= 2 ? "all_files" : "recipes"
+            payload[seg] = [
+              {
+                "name" => "default.rb",
+                "path" => "recipes/default.rb",
+                "checksum" => "8288b67da0793b5abec709d6226e6b73",
+                "specificity" => "default"
+              }
+            ]
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user, :payload => payload) do |response|
+              error = "Manifest has a checksum that hasn't been uploaded."
+              response.should look_like({
+                :status => 400,
+                :body => {
+                  "error" => [error]
+                }
+              })
+            end
+          end # it specifying file not in sandbox is a 400
+        end # context sandbox checks
+      end # context creating broken cookbooks to test validation and defaults
+
+      context "creating good cookbooks to test defaults" do
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_version) { "1.2.3" }
+
+        let(:description) { "my cookbook" }
+        let(:long_description) { "this is a great cookbook" }
+        let(:maintainer) { "This is my name" }
+        let(:maintainer_email) { "cookbook_author@example.com" }
+        let(:license) { "MPL" }
+
+        let (:opts) {
+          {
+            :description => description,
+            :long_description => long_description,
+            :maintainer => maintainer,
+            :maintainer_email => maintainer_email,
+            :license => license
+          }
+        }
+
+        after :each do
           delete_cookbook(admin_user, cookbook_name, cookbook_version)
         end
-        it "specifying file not in sandbox is a 400" do
-          payload = new_cookbook(cookbook_name, cookbook_version)
-          payload["recipes"] = [
-                                {
-                                  "name" => "default.rb",
-                                  "path" => "recipes/default.rb",
-                                  "checksum" => "8288b67da0793b5abec709d6226e6b73",
-                                  "specificity" => "default"
-                                }
-                               ]
+
+        respects_maximum_payload_size
+
+        it "allows creation of a minimal cookbook with no data" do
+
+          # Since PUT returns the same thing it was given, we'll just
+          # define the input in terms of the response, since we use that
+          # elsewhere in the test suite.
+          payload = retrieved_cookbook(cookbook_name, cookbook_version)
+
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user,
+              :payload => payload) do |response|
+                response.
+                  should look_like({
+                  :status => 201,
+                  :body => payload
+                })
+              end
+        end # it allows creation of a minimal cookbook with no data
+
+        it "allows override of defaults" do
+          payload = new_cookbook(cookbook_name, cookbook_version, opts)
           put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
               admin_user, :payload => payload) do |response|
-            error = "Manifest has a checksum that hasn't been uploaded."
-            response.should look_like({
-                                        :status => 400,
-                                        :body => {
-                                          "error" => [error]
-                                        }
-                                      })
+            response.
+              should look_like({
+              :status => 201,
+              :body => retrieved_cookbook(cookbook_name, cookbook_version,
+                                          opts)
+            })
           end
-        end # it specifying file not in sandbox is a 400
-      end # context sandbox checks
-    end # context creating broken cookbooks to test validation and defaults
+        end # it allows override of defaults
+      end # context creating good gookbooks to test defaults
+    end # context PUT /cookbooks/<name>/<version> [create]
 
-    context "creating good cookbooks to test defaults" do
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_version) { "1.2.3" }
-
-      let(:description) { "my cookbook" }
-      let(:long_description) { "this is a great cookbook" }
-      let(:maintainer) { "This is my name" }
-      let(:maintainer_email) { "cookbook_author@example.com" }
-      let(:license) { "MPL" }
-
-      let (:opts) {
-        {
-          :description => description,
-          :long_description => long_description,
-          :maintainer => maintainer,
-          :maintainer_email => maintainer_email,
-          :license => license
-        }
-      }
+    context "PUT multiple cookbooks" do
+      let(:cookbook_name) { "multiple_versions" }
+      let(:cookbook_version1) { "1.2.3" }
+      let(:cookbook_version2) { "1.3.0" }
 
       after :each do
-        delete_cookbook(admin_user, cookbook_name, cookbook_version)
+        [cookbook_version1, cookbook_version2].each do |v|
+          delete(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{v}"), admin_user)
+        end
       end
 
-      respects_maximum_payload_size
-
-      it "allows creation of a minimal cookbook with no data" do
-
-        # Since PUT returns the same thing it was given, we'll just
-        # define the input in terms of the response, since we use that
-        # elsewhere in the test suite.
-        payload = retrieved_cookbook(cookbook_name, cookbook_version)
-
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+      it "allows us to create 2 versions of the same cookbook" do
+        payload = new_cookbook(cookbook_name, cookbook_version1, {})
+        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version1}"),
             admin_user,
             :payload => payload) do |response|
-          response.
-            should look_like({
-                               :status => 201,
-                               :body => payload
-                             })
-        end
-      end # it allows creation of a minimal cookbook with no data
+              response.should look_like({
+                :status => 201,
+                :body => payload
+              })
+            end
 
-      it "allows override of defaults" do
-        payload = new_cookbook(cookbook_name, cookbook_version, opts)
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user, :payload => payload) do |response|
-          response.
-            should look_like({
-                               :status => 201,
-                               :body => retrieved_cookbook(cookbook_name, cookbook_version,
-                                                      opts)
-                             })
-        end
-      end # it allows override of defaults
-    end # context creating good gookbooks to test defaults
-  end # context PUT /cookbooks/<name>/<version> [create]
+            payload2 = new_cookbook(cookbook_name, cookbook_version2, {})
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version2}"),
+                admin_user,
+                :payload => payload2) do |response|
+                  response.should look_like({
+                    :status => 201,
+                    :body => payload2
+                  })
+                end
 
-  context "PUT multiple cookbooks" do
-    let(:cookbook_name) { "multiple_versions" }
-    let(:cookbook_version1) { "1.2.3" }
-    let(:cookbook_version2) { "1.3.0" }
+                get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version1}"),
+                    admin_user) do |response|
+                  response.should look_like({
+                    :status => 200,
+                    :body => retrieved_cookbook(cookbook_name, cookbook_version1)
+                  })
+                end
 
-    after :each do
-      [cookbook_version1, cookbook_version2].each do |v|
-        delete(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{v}"), admin_user)
-      end
-    end
+                get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version2}"),
+                    admin_user) do |response|
+                  response.should look_like({
+                    :status => 200,
+                    :body => retrieved_cookbook(cookbook_name, cookbook_version2)
+                  })
+                end
+      end # it allows us to create 2 versions of the same cookbook
+    end # context PUT multiple cookbooks
+  end
 
-    it "allows us to create 2 versions of the same cookbook" do
-      payload = new_cookbook(cookbook_name, cookbook_version1, {})
-      put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version1}"),
-        admin_user,
-        :payload => payload) do |response|
-        response.should look_like({
-            :status => 201,
-            :body => payload
-          })
-      end
+  describe "API v0" do
+    it_behaves_like "creates cookbooks", 0
+  end
 
-      payload2 = new_cookbook(cookbook_name, cookbook_version2, {})
-      put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version2}"),
-        admin_user,
-        :payload => payload2) do |response|
-        response.should look_like({
-            :status => 201,
-            :body => payload2
-          })
-      end
+  describe "API v2" do
+    it_behaves_like "creates cookbooks", 2
+  end
 
-      get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version1}"),
-        admin_user) do |response|
-        response.should look_like({
-                                   :status => 200,
-                                   :body => retrieved_cookbook(cookbook_name, cookbook_version1)
-                                  })
-      end
-
-      get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version2}"),
-        admin_user) do |response|
-        response.should look_like({
-                                   :status => 200,
-                                   :body => retrieved_cookbook(cookbook_name, cookbook_version2)
-                                  })
-      end
-    end # it allows us to create 2 versions of the same cookbook
-  end # context PUT multiple cookbooks
 end # describe Cookbooks API endpoint

--- a/oc-chef-pedant/spec/api/cookbooks/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/delete_spec.rb
@@ -17,136 +17,163 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbooks API endpoint", :cookbooks, :cookbooks_delete do
 
-  let(:cookbook_url_base) { "cookbooks" }
+  shared_examples "deletes cookbooks" do |api_version|
+    let(:cookbook_url_base) { "cookbooks" }
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
+    before do
+      platform.server_api_version = api_version
+    end
 
-  context "DELETE /cookbooks/<name>/<version>" do
-    let(:request_method) { :DELETE }
-    let(:request_url)    { named_cookbook_url }
-    let(:requestor)      { admin_user }
+    after do
+      platform.reset_server_api_version
+    end
 
-    let(:fetched_cookbook) { original_cookbook }
-    let(:original_cookbook) { new_cookbook(cookbook_name, cookbook_version) }
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
+      end
+    end
 
-    context "for non-existent cookbooks" do
-      let(:expected_response) { cookbook_version_not_found_exact_response }
+    include Pedant::RSpec::CookbookUtil
 
-      let(:cookbook_name)    { "non_existent" }
-      let(:cookbook_version) { "1.2.3" }
+    context "DELETE /cookbooks/<name>/<version>" do
+      let(:request_method) { :DELETE }
+      let(:request_url)    { named_cookbook_url }
+      let(:requestor)      { admin_user }
 
-      should_respond_with 404
+      let(:fetched_cookbook) { original_cookbook }
+      let(:original_cookbook) { new_cookbook(cookbook_name, cookbook_version) }
 
-      context 'with bad version', :validation do
-        let(:expected_response) { invalid_cookbook_version_exact_response }
-        let(:cookbook_version) { "1.2.3.4" }
-        should_respond_with 400
-      end # with bad version
-    end # context for non-existent cookbooks
-
-    context "for existing cookbooks" do
-      let(:cookbook_name) { "cookbook-to-be-deleted" }
-      let(:cookbook_version) { "1.2.3" }
-
-      context "when deleting non-existent version of an existing cookbook" do
+      context "for non-existent cookbooks" do
         let(:expected_response) { cookbook_version_not_found_exact_response }
-        let(:cookbook_version_not_found_error_message) { ["Cannot find a cookbook named #{cookbook_name} with version #{non_existing_version}"] }
-        let(:non_existing_version) { "99.99.99" }
-        let(:non_existing_version_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{non_existing_version}") }
-        let(:fetched_cookbook) { original_cookbook }
 
-        before(:each) { make_cookbook(admin_user, cookbook_name, cookbook_version) }
-        after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_version) }
+        let(:cookbook_name)    { "non_existent" }
+        let(:cookbook_version) { "1.2.3" }
 
-        it "should respond with 404 (\"Not Found\") and not delete existing versions" do
-          delete(non_existing_version_url, admin_user) do |response|
-            response.should look_like expected_response
+        should_respond_with 404
+
+        context 'with bad version', :validation do
+          let(:expected_response) { invalid_cookbook_version_exact_response }
+          let(:cookbook_version) { "1.2.3.4" }
+          should_respond_with 400
+        end # with bad version
+      end # context for non-existent cookbooks
+
+      context "for existing cookbooks" do
+        let(:cookbook_name) { "cookbook-to-be-deleted" }
+        let(:cookbook_version) { "1.2.3" }
+
+        context "when deleting non-existent version of an existing cookbook" do
+          let(:expected_response) { cookbook_version_not_found_exact_response }
+          let(:cookbook_version_not_found_error_message) { ["Cannot find a cookbook named #{cookbook_name} with version #{non_existing_version}"] }
+          let(:non_existing_version) { "99.99.99" }
+          let(:non_existing_version_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{non_existing_version}") }
+          let(:fetched_cookbook) { original_cookbook }
+
+          before(:each) { make_cookbook(admin_user, cookbook_name, cookbook_version) }
+          after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_version) }
+
+          it "should respond with 404 (\"Not Found\") and not delete existing versions" do
+            delete(non_existing_version_url, admin_user) do |response|
+              response.should look_like expected_response
+            end
+
+            should_not_be_deleted
           end
+        end # it doesn't delete the wrong version of an existing cookbook
 
-          should_not_be_deleted
-        end
-      end # it doesn't delete the wrong version of an existing cookbook
-
-      context "when deleting existent version of an existing cookbook", :smoke do
-        let(:recipe_name) { "test_recipe" }
-        let(:recipe_content) { "hello-#{unique_suffix}-#{rand(1000)}-#{rand(1000)}" }
-        let(:recipe_spec) do
+        context "when deleting existent version of an existing cookbook", :smoke do
+          let(:recipe_name) { "test_recipe" }
+          let(:recipe_content) { "hello-#{unique_suffix}-#{rand(1000)}-#{rand(1000)}" }
+          let(:recipe_spec) do
             {
               :name => recipe_name,
               :content => recipe_content
             }
-        end
-
-        let(:cookbooks) do
-          {
-            cookbook_name => {
-              cookbook_version => [recipe_spec]
-            }
-          }
-        end
-
-        let(:fetched_cookbook) { original_cookbook }
-        let(:original_cookbook) { new_cookbook(cookbook_name, cookbook_version) }
-
-        before(:each) { setup_cookbooks(cookbooks) }
-        after(:each)  { remove_cookbooks(cookbooks) }
-
-        it "should cleanup unused checksum data in s3/bookshelf" do
-          verify_checksum_cleanup(:recipes) do
-            response.should look_like(:status => 200)
           end
-        end
 
-      end # context when deleting existent version...
-    end # context for existing cookbooks
+          let(:cookbooks) do
+            {
+              cookbook_name => {
+                cookbook_version => [recipe_spec]
+              }
+            }
+          end
 
-    context "with permissions for" do
-      let(:cookbook_name) {"delete-cookbook"}
-      let(:cookbook_version) { "0.0.1" }
-      let(:not_found_msg) { ["Cannot find a cookbook named delete-cookbook with version 0.0.1"] }
+          let(:fetched_cookbook) { original_cookbook }
+          let(:original_cookbook) { new_cookbook(cookbook_name, cookbook_version) }
 
-      before(:each) { make_cookbook(admin_user, cookbook_name, cookbook_version) }
-      after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_version) }
+          before(:each) { setup_cookbooks(cookbooks) }
+          after(:each)  { remove_cookbooks(cookbooks) }
 
-      context 'as admin user' do
-        let(:expected_response) { delete_cookbook_success_response }
+          it "should cleanup unused checksum data in s3/bookshelf" do
+            verify_checksum_cleanup(:recipes) do
+              response.should look_like(:status => 200)
+            end
+          end
 
-        it "should respond with 200 (\"OK\") and be deleted" do
-          should look_like expected_response
-          should_be_deleted
-        end # it admin user returns 200
-      end # as admin user
+        end # context when deleting existent version...
+      end # context for existing cookbooks
 
-      context 'as normal user', :authorization do
-        let(:expected_response) { delete_cookbook_success_response }
+      context "with permissions for" do
+        let(:cookbook_name) {"delete-cookbook"}
+        let(:cookbook_version) { "0.0.1" }
+        let(:not_found_msg) { ["Cannot find a cookbook named delete-cookbook with version 0.0.1"] }
 
-        let(:requestor) { normal_user }
-        it "should respond with 200 (\"OK\") and be deleted" do
-          should look_like expected_response
-          should_be_deleted
-        end # it admin user returns 200
-      end # with normal user
+        before(:each) { make_cookbook(admin_user, cookbook_name, cookbook_version) }
+        after(:each) { delete_cookbook(admin_user, cookbook_name, cookbook_version) }
 
-      context 'as a user outside of the organization', :authorization do
-        let(:expected_response) { unauthorized_access_credential_response }
-        let(:requestor) { outside_user }
+        context 'as admin user' do
+          let(:expected_response) { delete_cookbook_success_response }
 
-        it "should respond with 403 (\"Forbidden\") and does not delete cookbook" do
-          response.should look_like expected_response
-          should_not_be_deleted
-        end
-      end # it outside user returns 403
+          it "should respond with 200 (\"OK\") and be deleted" do
+            should look_like expected_response
+            should_be_deleted
+          end # it admin user returns 200
+        end # as admin user
 
-      context 'with invalid user', :authorization do
-        let(:expected_response) { invalid_credential_exact_response }
-        let(:requestor) { invalid_user }
+        context 'as normal user', :authorization do
+          let(:expected_response) { delete_cookbook_success_response }
 
-        it "should respond with 401 (\"Unauthorized\") and does not delete cookbook" do
-          response.should look_like expected_response
-          should_not_be_deleted
-        end # responds with 401
-      end # with invalid user
+          let(:requestor) { normal_user }
+          it "should respond with 200 (\"OK\") and be deleted" do
+            should look_like expected_response
+            should_be_deleted
+          end # it admin user returns 200
+        end # with normal user
 
-    end # context with permissions for
-  end # context DELETE /cookbooks/<name>/<version>
+        context 'as a user outside of the organization', :authorization do
+          let(:expected_response) { unauthorized_access_credential_response }
+          let(:requestor) { outside_user }
+
+          it "should respond with 403 (\"Forbidden\") and does not delete cookbook" do
+            response.should look_like expected_response
+            should_not_be_deleted
+          end
+        end # it outside user returns 403
+
+        context 'with invalid user', :authorization do
+          let(:expected_response) { invalid_credential_exact_response }
+          let(:requestor) { invalid_user }
+
+          it "should respond with 401 (\"Unauthorized\") and does not delete cookbook" do
+            response.should look_like expected_response
+            should_not_be_deleted
+          end # responds with 401
+        end # with invalid user
+
+      end # context with permissions for
+    end # context DELETE /cookbooks/<name>/<version>
+  end
+
+  describe "API v0" do
+    it_behaves_like "deletes cookbooks", 0
+  end
+
+  describe "API v2" do
+    it_behaves_like "deletes cookbooks", 2
+  end
 end

--- a/oc-chef-pedant/spec/api/cookbooks/named_filters_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/named_filters_spec.rb
@@ -17,188 +17,214 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbooks API endpoint, named filters", :cookbooks, :cookbooks_named_filters do
 
-  let(:cookbook_url_base) { "cookbooks" }
+  shared_examples "filters cookbooks" do |api_version|
+    let(:cookbook_url_base) { "cookbooks" }
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
-
-  let(:request_method) { :GET }
-  let(:request_url)    { api_url "/#{cookbook_url_base}/#{named_filter}" }
-  let(:requestor)      { admin_user }
-
-  # Generates a hash of cookbook name -> cookbook version url for the
-  # most recent version of each cookbook in a cookbook spec
-  def expected_for_latest(cookbooks)
-    latest = get_latest_cookbooks(cookbooks)
-    latest.inject({}) do |body, cookbook_spec|
-      name, version_specs  = cookbook_spec
-      latest_version = version_specs.first
-      version_string, _recipe_names = latest_version
-      body[name] = api_url("/#{cookbook_url_base}/#{name}/#{version_string}")
-      body
+    before do
+      platform.server_api_version = api_version
     end
-  end
 
-  def expected_for_named_cookbook(cookbooks, named_cookbook)
-    cookbook = cookbooks.select{ |k,v| k == named_cookbook}
+    after do
+      platform.reset_server_api_version
+    end
+
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
+      end
+    end
+
+    include Pedant::RSpec::CookbookUtil
+
+    let(:request_method) { :GET }
+    let(:request_url)    { api_url "/#{cookbook_url_base}/#{named_filter}" }
+    let(:requestor)      { admin_user }
+
+    # Generates a hash of cookbook name -> cookbook version url for the
+    # most recent version of each cookbook in a cookbook spec
+    def expected_for_latest(cookbooks)
+      latest = get_latest_cookbooks(cookbooks)
+      latest.inject({}) do |body, cookbook_spec|
+        name, version_specs  = cookbook_spec
+        latest_version = version_specs.first
+        version_string, _recipe_names = latest_version
+        body[name] = api_url("/#{cookbook_url_base}/#{name}/#{version_string}")
+        body
+      end
+    end
+
+    def expected_for_named_cookbook(cookbooks, named_cookbook)
+      cookbook = cookbooks.select{ |k,v| k == named_cookbook}
 
 
-    cookbook.inject({}) do |body, cookbook_spec|
-      name, version_specs  = cookbook_spec
-      body[name] = {
-        "url" => api_url("/#{cookbook_url_base}/#{name}"),
-        "versions" => version_specs.map do |version, recipes|
-          { "version" => version,
-            "url" => api_url("/#{cookbook_url_base}/#{name}/#{version}")
-          }
+      cookbook.inject({}) do |body, cookbook_spec|
+        name, version_specs  = cookbook_spec
+        body[name] = {
+          "url" => api_url("/#{cookbook_url_base}/#{name}"),
+          "versions" => version_specs.map do |version, recipes|
+            { "version" => version,
+              "url" => api_url("/#{cookbook_url_base}/#{name}/#{version}")
+            }
+          end
+        }
+        body
+      end
+    end
+
+    # Generates a list of cookbook-qualified recipe names for the most
+    # recent cookbooks in a cookbook spec
+    def expected_for_recipes(cookbooks)
+      latest = get_latest_cookbooks(cookbooks)
+      nested = latest.map do |cookbook_spec|
+        cookbook_name, version_specs = cookbook_spec
+        latest_version = version_specs.first
+        _version_string, recipe_names =latest_version
+
+        # don't sort the recipes for the Ruby endpoint; CouchDB keeps them in insertion order
+        recipe_names.sort!
+
+        recipe_names.map do |recipe_name|
+          "#{cookbook_name}::#{recipe_name}"
         end
-      }
-      body
+      end
+      nested.flatten
     end
-  end
 
-  # Generates a list of cookbook-qualified recipe names for the most
-  # recent cookbooks in a cookbook spec
-  def expected_for_recipes(cookbooks)
-    latest = get_latest_cookbooks(cookbooks)
-    nested = latest.map do |cookbook_spec|
-      cookbook_name, version_specs = cookbook_spec
-      latest_version = version_specs.first
-      _version_string, recipe_names =latest_version
+    let(:cookbooks) { raise "Must define a cookbook spec!" }
+    let(:cookbook_name) {"my_cookbook"}
 
-      # don't sort the recipes for the Ruby endpoint; CouchDB keeps them in insertion order
-      recipe_names.sort!
+    # Changed from before(:all) to avoid some problems, but it slows down these tests
+    before(:each) { setup_cookbooks(cookbooks) }
+    after(:each)  { remove_cookbooks(cookbooks) }
 
-      recipe_names.map do |recipe_name|
-        "#{cookbook_name}::#{recipe_name}"
+    # All these tests are basically the same, and just have different
+    # cookbooks in the system, so I'm pulling it all out into a shared
+    # set of examples
+    def self.should_respond_with_latest_cookbooks
+      context 'when requesting /cookbooks/_latest' do
+        let(:named_filter) { :_latest }
+        let(:expected_response) { fetch_cookbook_success_exact_response }
+        let(:fetched_cookbook) { expected_for_latest(cookbooks) }
+
+        it "should respond with the 'latest' cookbooks" do
+          should look_like expected_response
+        end
       end
     end
-    nested.flatten
-  end
 
-  let(:cookbooks) { raise "Must define a cookbook spec!" }
-  let(:cookbook_name) {"my_cookbook"}
+    def self.should_respond_with_recipes_from_latest_cookbooks
+      context 'when requesting /cookbooks/_recipes' do
+        let(:named_filter) { :_recipes }
+        let(:expected_response) { fetch_cookbook_success_exact_response }
 
-  # Changed from before(:all) to avoid some problems, but it slows down these tests
-  before(:each) { setup_cookbooks(cookbooks) }
-  after(:each)  { remove_cookbooks(cookbooks) }
-
-  # All these tests are basically the same, and just have different
-  # cookbooks in the system, so I'm pulling it all out into a shared
-  # set of examples
-  def self.should_respond_with_latest_cookbooks
-    context 'when requesting /cookbooks/_latest' do
-      let(:named_filter) { :_latest }
-      let(:expected_response) { fetch_cookbook_success_exact_response }
-      let(:fetched_cookbook) { expected_for_latest(cookbooks) }
-
-      it "should respond with the 'latest' cookbooks" do
-        should look_like expected_response
+        it "shows the recipes from the latest cookbooks" do
+          should have_status_code 200
+          parse(response).should == expected_for_recipes(cookbooks)
+        end
       end
     end
-  end
 
-  def self.should_respond_with_recipes_from_latest_cookbooks
-    context 'when requesting /cookbooks/_recipes' do
-      let(:named_filter) { :_recipes }
-      let(:expected_response) { fetch_cookbook_success_exact_response }
+    def self.should_respond_with_single_cookbook
+      context 'when requesting /cookbooks/my_cookbook' do
+        let(:cookbook) { "my_cookbook" }
+        let(:named_filter) { "my_cookbook" }
+        let(:fetched_cookbook) { expected_for_named_cookbook(cookbooks, named_filter) }
+        let(:expected_response) { fetch_cookbook_success_exact_response }
 
-      it "shows the recipes from the latest cookbooks" do
-        should have_status_code 200
-        parse(response).should == expected_for_recipes(cookbooks)
+        it "should respond with the 'named' cookbook" do
+          should look_like expected_response
+        end
       end
     end
-  end
 
-  def self.should_respond_with_single_cookbook
-    context 'when requesting /cookbooks/my_cookbook' do
-      let(:cookbook) { "my_cookbook" }
-      let(:named_filter) { "my_cookbook" }
-      let(:fetched_cookbook) { expected_for_named_cookbook(cookbooks, named_filter) }
-      let(:expected_response) { fetch_cookbook_success_exact_response }
+    def self.should_respond_with_single_cookbook_not_found
+      context 'when requesting /cookbooks/my_cookbook' do
+        let(:named_filter) { "my_cookbook" }
+        let(:expected_response) { fetch_cookbook_not_found_exact_response }
 
-      it "should respond with the 'named' cookbook" do
-         should look_like expected_response
+        it "should respond with 404" do
+          should look_like expected_response
+        end
       end
     end
-  end
 
-  def self.should_respond_with_single_cookbook_not_found
-    context 'when requesting /cookbooks/my_cookbook' do
-      let(:named_filter) { "my_cookbook" }
-      let(:expected_response) { fetch_cookbook_not_found_exact_response }
 
-      it "should respond with 404" do
-         should look_like expected_response
+
+    ## Now for the actual tests
+
+    context "with no cookbooks" do
+      let(:cookbooks) { {} }
+
+      should_respond_with_latest_cookbooks
+      should_respond_with_recipes_from_latest_cookbooks
+      should_respond_with_single_cookbook_not_found
+    end
+
+    # TODO: This would be a good candidate for a smoke test
+    # if there were a way to turn off testing against exact body responses.
+    # We don't know what existing cookbooks are on the target server for
+    # smoke tests.
+    context "with one cookbook, one version" do
+      let(:cookbooks) do
+        {"my_cookbook" => {"1.0.0" => ["recipe1", "recipe2"]}}
       end
-    end
-  end
 
-
-
-  ## Now for the actual tests
-
-  context "with no cookbooks" do
-    let(:cookbooks) { {} }
-
-    should_respond_with_latest_cookbooks
-    should_respond_with_recipes_from_latest_cookbooks
-    should_respond_with_single_cookbook_not_found
-  end
-
-  # TODO: This would be a good candidate for a smoke test
-  # if there were a way to turn off testing against exact body responses.
-  # We don't know what existing cookbooks are on the target server for
-  # smoke tests.
-  context "with one cookbook, one version" do
-    let(:cookbooks) do
-      {"my_cookbook" => {"1.0.0" => ["recipe1", "recipe2"]}}
+      should_respond_with_latest_cookbooks
+      should_respond_with_recipes_from_latest_cookbooks
+      should_respond_with_single_cookbook
     end
 
-    should_respond_with_latest_cookbooks
-    should_respond_with_recipes_from_latest_cookbooks
-    should_respond_with_single_cookbook
-  end
+    context "with different cookbook, one version" do
+      let(:cookbooks) do
+        {"your_cookbook" => {"1.0.0" => ["recipe1", "recipe2"]}}
+      end
 
-  context "with different cookbook, one version" do
-    let(:cookbooks) do
-      {"your_cookbook" => {"1.0.0" => ["recipe1", "recipe2"]}}
+      should_respond_with_latest_cookbooks
+      should_respond_with_recipes_from_latest_cookbooks
+      should_respond_with_single_cookbook_not_found
     end
 
-    should_respond_with_latest_cookbooks
-    should_respond_with_recipes_from_latest_cookbooks
-    should_respond_with_single_cookbook_not_found
-  end
+    context "with multiple cookbooks, one version each" do
+      let(:cookbooks) do
+        {
+          "my_cookbook" => {"1.0.0" => ["recipe1", "recipe2"]},
+          "your_cookbook" => {"1.3.0" => ["foo", "bar"]},
+        }
+      end
 
-  context "with multiple cookbooks, one version each" do
-    let(:cookbooks) do
-      {
-        "my_cookbook" => {"1.0.0" => ["recipe1", "recipe2"]},
-        "your_cookbook" => {"1.3.0" => ["foo", "bar"]},
-      }
+      should_respond_with_latest_cookbooks
+      should_respond_with_recipes_from_latest_cookbooks
+      should_respond_with_single_cookbook
     end
 
-    should_respond_with_latest_cookbooks
-    should_respond_with_recipes_from_latest_cookbooks
-    should_respond_with_single_cookbook
-  end
+    context "with multiple cookbooks, multiple versions each" do
+      let(:cookbooks) do
+        {
+          "my_cookbook" => {
+            "1.0.0" => ["monitoring", "security"],
+            "1.5.0" => ["security", "users"]
+          },
+          "your_cookbook" => {
+            "1.3.0" => ["webserver", "database"],
+            "2.0.0" => ["webserver", "database", "load_balancer"]
+          },
+        }
+      end
 
-  context "with multiple cookbooks, multiple versions each" do
-    let(:cookbooks) do
-      {
-        "my_cookbook" => {
-        "1.0.0" => ["monitoring", "security"],
-        "1.5.0" => ["security", "users"]
-      },
-        "your_cookbook" => {
-        "1.3.0" => ["webserver", "database"],
-        "2.0.0" => ["webserver", "database", "load_balancer"]
-      },
-      }
+      should_respond_with_latest_cookbooks
+      should_respond_with_recipes_from_latest_cookbooks
+      should_respond_with_single_cookbook
     end
 
-    should_respond_with_latest_cookbooks
-    should_respond_with_recipes_from_latest_cookbooks
-    should_respond_with_single_cookbook
+  end
+  describe "API v0" do
+    it_behaves_like "filters cookbooks", 0
   end
 
+  describe "API v2" do
+    it_behaves_like "filters cookbooks", 2
+  end
 end

--- a/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
@@ -22,316 +22,342 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbooks API endpoint", :cookbooks, :cookbooks_read do
 
-  let(:cookbook_url_base) { "cookbooks" }
+  shared_examples "reads cookbooks" do |api_version|
+    let(:cookbook_url_base) { "cookbooks" }
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
-
-  context "GET /cookbooks" do
-    let(:url) { cookbook_collection_url }
-    let(:request_url) { cookbook_collection_url }
-    let(:request_method) { :GET }
-    let(:requestor) { admin_user }
-
-    let(:cookbook_collection_url) { api_url("/#{cookbook_url_base}") }
-    let(:fetch_cookbook_collection_success_exact_response) do
-      {
-        :status => 200,
-        :body_exact => fetched_cookbooks
-      }
+    before do
+      platform.server_api_version = api_version
     end
 
-    context "with an operational server", :smoke do
-      it { should look_like ok_response }
+    after do
+      platform.reset_server_api_version
     end
 
-    context "without existing cookbooks" do
-      let(:expected_response) { fetch_cookbook_collection_success_exact_response }
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
+      end
+    end
 
-      # Assert that there are no cookbooks
-      let(:fetched_cookbooks) { { } }
+    include Pedant::RSpec::CookbookUtil
 
-      # NOTE:  This test must the first one dealing with cookbooks
-      # so that there are no cookbooks existing on the server
+    context "GET /cookbooks" do
+      let(:url) { cookbook_collection_url }
+      let(:request_url) { cookbook_collection_url }
+      let(:request_method) { :GET }
+      let(:requestor) { admin_user }
 
-      should_respond_with 200, "and an empty collection"
+      let(:cookbook_collection_url) { api_url("/#{cookbook_url_base}") }
+      let(:fetch_cookbook_collection_success_exact_response) do
+        {
+          :status => 200,
+          :body_exact => fetched_cookbooks
+        }
+      end
 
-      # Add test to check for empty case with different num_versions
-      context 'with a num_versions' do
-        let(:expected_response) { bad_request_response }
-        let(:request_url) { api_url("/#{cookbook_url_base}?num_versions=#{num_versions}") }
-        let(:error_message) { invalid_versions_msg }
+      context "with an operational server", :smoke do
+        it { should look_like ok_response }
+      end
 
-        def self.expects_response_of_400_with(message, _value)
-          context "with #{message}", :validation do
-            let(:num_versions) { _value }
-            should_respond_with 400
+      context "without existing cookbooks" do
+        let(:expected_response) { fetch_cookbook_collection_success_exact_response }
+
+        # Assert that there are no cookbooks
+        let(:fetched_cookbooks) { { } }
+
+        # NOTE:  This test must the first one dealing with cookbooks
+        # so that there are no cookbooks existing on the server
+
+        should_respond_with 200, "and an empty collection"
+
+        # Add test to check for empty case with different num_versions
+        context 'with a num_versions' do
+          let(:expected_response) { bad_request_response }
+          let(:request_url) { api_url("/#{cookbook_url_base}?num_versions=#{num_versions}") }
+          let(:error_message) { invalid_versions_msg }
+
+          def self.expects_response_of_400_with(message, _value)
+            context "with #{message}", :validation do
+              let(:num_versions) { _value }
+              should_respond_with 400
+            end
           end
-        end
 
-        expects_response_of_400_with "a negative num_versions", '-1'
-        expects_response_of_400_with "a missing num_versions", ''
-        expects_response_of_400_with "an invalid num_versions", 'foo'
+          expects_response_of_400_with "a negative num_versions", '-1'
+          expects_response_of_400_with "a missing num_versions", ''
+          expects_response_of_400_with "an invalid num_versions", 'foo'
 
-      end # when requesting with num_versions
-    end # without existing cookbooks
+        end # when requesting with num_versions
+      end # without existing cookbooks
 
-    context "with existing cookbooks and multiple versions" do
-      let(:expected_response) { fetch_cookbook_collection_success_exact_response }
-      let(:request_url) { api_url("/#{cookbook_url_base}?num_versions=#{num_versions}") }
+      context "with existing cookbooks and multiple versions" do
+        let(:expected_response) { fetch_cookbook_collection_success_exact_response }
+        let(:request_url) { api_url("/#{cookbook_url_base}?num_versions=#{num_versions}") }
 
-      let(:fetched_cookbooks) { cookbook_collection }
+        let(:fetched_cookbooks) { cookbook_collection }
 
-      let(:cookbook_name) { "cookbook_name" }
-      let(:cookbook_name2) { "cookbook_name2" }
-      let(:version1) { "0.0.1" }
-      let(:version2) { "0.0.2" }
-      let(:cookbooks) do
-        {
-          cookbook_name => {
-            version1 => [],
-            version2 => []
-          },
-
-          cookbook_name2 => {
-            version1 => []
-          }
-        }
-      end
-
-      before(:each) do
-        setup_cookbooks(cookbooks)
-      end
-
-      after(:each) do
-        remove_cookbooks(cookbooks)
-      end
-
-      context 'with num_versions set to 0' do
-        let(:num_versions) { 0 }
-        let(:cookbook_collection) do
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_name2) { "cookbook_name2" }
+        let(:version1) { "0.0.1" }
+        let(:version2) { "0.0.2" }
+        let(:cookbooks) do
           {
-            cookbook_name  => { "url" => cookbook_url(cookbook_name), "versions" => [] },
-            cookbook_name2 => { "url" => cookbook_url(cookbook_name2), "versions" => [] }
+            cookbook_name => {
+              version1 => [],
+              version2 => []
+            },
+
+            cookbook_name2 => {
+              version1 => []
+            }
           }
         end
 
-        it "should respond with cookbook collection with no version" do
-          should look_like expected_response
+        before(:each) do
+          setup_cookbooks(cookbooks)
         end
-      end # with num_versions set to 0
-      let(:cookbook_collection_with_one_version) do
-        {
-          cookbook_name => {
-            "url" => cookbook_url(cookbook_name),
-            "versions" =>
-              [{ "version" => version2,
-                 "url" => cookbook_version_url(cookbook_name,version2) }]},
-          cookbook_name2 => {
-            "url" => cookbook_url(cookbook_name2),
-            "versions" =>
-               [{ "version" => version1,
-                  "url" => cookbook_version_url(cookbook_name2, version1) }]}
-        }
-      end
 
-      context 'when num_versions is not set' do
-        let(:request_url) { cookbook_collection_url }
-        let(:cookbook_collection) { cookbook_collection_with_one_version }
-
-        it 'should return cookbook collection with one version per cookbook' do
-          should look_like expected_response
+        after(:each) do
+          remove_cookbooks(cookbooks)
         end
-      end # without num_versions
 
-      context 'when num_versions is set to 1' do
-        let(:num_versions) { 1 }
-        let(:cookbook_collection) { cookbook_collection_with_one_version }
+        context 'with num_versions set to 0' do
+          let(:num_versions) { 0 }
+          let(:cookbook_collection) do
+            {
+              cookbook_name  => { "url" => cookbook_url(cookbook_name), "versions" => [] },
+              cookbook_name2 => { "url" => cookbook_url(cookbook_name2), "versions" => [] }
+            }
+          end
 
-        it 'should return cookbook collection with one version per cookbook' do
-          should look_like expected_response
-        end
-      end
-
-      context 'when num_versions is set to "all"' do
-        let(:num_versions) { 'all' }
-        let(:cookbook_collection) do
+          it "should respond with cookbook collection with no version" do
+            should look_like expected_response
+          end
+        end # with num_versions set to 0
+        let(:cookbook_collection_with_one_version) do
           {
             cookbook_name => {
               "url" => cookbook_url(cookbook_name),
-              "versions" => [
-                { "version" => version2,
-                  "url" => cookbook_version_url(cookbook_name, version2) },
+              "versions" =>
+              [{ "version" => version2,
+                 "url" => cookbook_version_url(cookbook_name,version2) }]},
+            cookbook_name2 => {
+                   "url" => cookbook_url(cookbook_name2),
+                   "versions" =>
+                 [{ "version" => version1,
+                    "url" => cookbook_version_url(cookbook_name2, version1) }]}
+          }
+        end
+
+        context 'when num_versions is not set' do
+          let(:request_url) { cookbook_collection_url }
+          let(:cookbook_collection) { cookbook_collection_with_one_version }
+
+          it 'should return cookbook collection with one version per cookbook' do
+            should look_like expected_response
+          end
+        end # without num_versions
+
+        context 'when num_versions is set to 1' do
+          let(:num_versions) { 1 }
+          let(:cookbook_collection) { cookbook_collection_with_one_version }
+
+          it 'should return cookbook collection with one version per cookbook' do
+            should look_like expected_response
+          end
+        end
+
+        context 'when num_versions is set to "all"' do
+          let(:num_versions) { 'all' }
+          let(:cookbook_collection) do
+            {
+              cookbook_name => {
+                "url" => cookbook_url(cookbook_name),
+                "versions" => [
+                  { "version" => version2,
+                    "url" => cookbook_version_url(cookbook_name, version2) },
                 { "version" => version1,
                   "url" => cookbook_version_url(cookbook_name, version1) } ]},
-            cookbook_name2 => {
-              "url" => cookbook_url(cookbook_name2),
-              "versions" => [
-                { "version" => version1,
-                  "url" => cookbook_version_url(cookbook_name2, version1) }]}
-          }
+              cookbook_name2 => {
+                    "url" => cookbook_url(cookbook_name2),
+                    "versions" => [
+                      { "version" => version1,
+                        "url" => cookbook_version_url(cookbook_name2, version1) }]}
+            }
+          end
+
+          it 'should respond with a cookbook collection containing all versions of each cookbook' do
+            should look_like expected_response
+          end
+
+        end
+      end # context returns different results depending on num_versions
+
+      context "with varying numbers of existing cookbooks" do
+        let(:expected_response) { fetch_cookbook_success_exact_response }
+        let(:request_url) { api_url("/#{cookbook_url_base}?num_versions=all") }
+
+        let(:fetched_cookbook) { cookbook_collection }
+        let(:cookbook_name) { "cookbook_name" }
+        let(:cookbook_version) { "1.2.3" }
+
+        context 'with a single, existing cookbook' do
+          let(:cookbook_collection) do
+            {
+              cookbook_name => {
+                "url" => cookbook_url(cookbook_name),
+                "versions" => [
+                  { "version" => cookbook_version,
+                    "url" => cookbook_version_url(cookbook_name, cookbook_version) }]}
+            }
+          end
+
+          it 'should respond with a single cookbook in the collection' do
+            make_cookbook(admin_user, cookbook_name, cookbook_version)
+            should look_like expected_response
+            delete_cookbook(admin_user, cookbook_name, cookbook_version)
+          end
         end
 
-        it 'should respond with a cookbook collection containing all versions of each cookbook' do
-          should look_like expected_response
-        end
+        context 'with multiple, existing cookbooks' do
+          let(:cookbook_collection) do
+            {
+              "cb1" => {
+                "url" => cookbook_url("cb1"),
+                "versions" => [
+                  { "version" => "0.0.1",
+                    "url" => cookbook_version_url("cb1", "0.0.1") }]},
+              "cb2" => {
+                      "url" => cookbook_url("cb2"),
+                      "versions" => [
+                        { "version" => "0.0.2",
+                          "url" => cookbook_version_url("cb2", "0.0.2") }]}
+            }
+          end
 
-      end
-    end # context returns different results depending on num_versions
+          it "multiple cookbooks can be listed" do
+            # Upload cookbook
+            make_cookbook(admin_user, "cb1", "0.0.1")
+            make_cookbook(admin_user, "cb2", "0.0.2")
 
-    context "with varying numbers of existing cookbooks" do
-      let(:expected_response) { fetch_cookbook_success_exact_response }
-      let(:request_url) { api_url("/#{cookbook_url_base}?num_versions=all") }
+            should look_like expected_response
 
-      let(:fetched_cookbook) { cookbook_collection }
-      let(:cookbook_name) { "cookbook_name" }
+            # cleanup
+            delete_cookbook(admin_user, "cb1", "0.0.1")
+            delete_cookbook(admin_user, "cb2", "0.0.2")
+          end # it multiple cookbooks can be listed
+        end # with multiple, existing cookbooks
+
+      end # with varying numbers of existing cookbooks
+    end # context GET /cookbooks
+
+    context "GET /cookbooks/<name>/<version>" do
+      let(:request_method) { :GET }
+      let(:request_url)    { named_cookbook_url }
+
+      let(:cookbook_name) { "the_cookbook_name" }
       let(:cookbook_version) { "1.2.3" }
-
-      context 'with a single, existing cookbook' do
-        let(:cookbook_collection) do
-          {
-            cookbook_name => {
-            "url" => cookbook_url(cookbook_name),
-            "versions" => [
-              { "version" => cookbook_version,
-                "url" => cookbook_version_url(cookbook_name, cookbook_version) }]}
-          }
-        end
-
-        it 'should respond with a single cookbook in the collection' do
-          make_cookbook(admin_user, cookbook_name, cookbook_version)
-          should look_like expected_response
-          delete_cookbook(admin_user, cookbook_name, cookbook_version)
-        end
-      end
-
-      context 'with multiple, existing cookbooks' do
-        let(:cookbook_collection) do
-          {
-            "cb1" => {
-              "url" => cookbook_url("cb1"),
-              "versions" => [
-                { "version" => "0.0.1",
-                  "url" => cookbook_version_url("cb1", "0.0.1") }]},
-            "cb2" => {
-              "url" => cookbook_url("cb2"),
-              "versions" => [
-                { "version" => "0.0.2",
-                  "url" => cookbook_version_url("cb2", "0.0.2") }]}
-          }
-        end
-
-        it "multiple cookbooks can be listed" do
-          # Upload cookbook
-          make_cookbook(admin_user, "cb1", "0.0.1")
-          make_cookbook(admin_user, "cb2", "0.0.2")
-
-          should look_like expected_response
-
-          # cleanup
-          delete_cookbook(admin_user, "cb1", "0.0.1")
-          delete_cookbook(admin_user, "cb2", "0.0.2")
-        end # it multiple cookbooks can be listed
-      end # with multiple, existing cookbooks
-
-    end # with varying numbers of existing cookbooks
-  end # context GET /cookbooks
-
-  context "GET /cookbooks/<name>/<version>" do
-    let(:request_method) { :GET }
-    let(:request_url)    { named_cookbook_url }
-
-    let(:cookbook_name) { "the_cookbook_name" }
-    let(:cookbook_version) { "1.2.3" }
-    let(:recipe_name) { "test_recipe" }
-    let(:recipe_content) { "hello-#{unique_suffix}" }
-    let(:recipe_spec) do
+      let(:recipe_name) { "test_recipe" }
+      let(:recipe_content) { "hello-#{unique_suffix}" }
+      let(:recipe_spec) do
         {
           :name => recipe_name,
           :content => recipe_content
         }
-    end
+      end
 
-    let(:cookbooks) do
-      {
-        cookbook_name => {
-          cookbook_version => [recipe_spec]
+      let(:cookbooks) do
+        {
+          cookbook_name => {
+            cookbook_version => [recipe_spec]
+          }
         }
-      }
-    end
+      end
 
-    before(:each) { setup_cookbooks(cookbooks) }
-    after(:each)  { remove_cookbooks(cookbooks) }
+      before(:each) { setup_cookbooks(cookbooks) }
+      after(:each)  { remove_cookbooks(cookbooks) }
 
-    let(:fetched_cookbook) do
-      # NOTE: the cookbook returned will actually have some recipe
-      # data. We don't yet have a nice way to do the required soft
-      # verification for the URL and checksum.
-      #
-      # To get around this, we'll just pass in a proc that asserts
-      # that the "recipes" key is an array of hashes with the correct
-      # keys.
-      retrieved_cookbook(cookbook_name,
-                         cookbook_version,
-                         :recipes => lambda{|recipes|
-                           recipes.is_a?(Array) &&
-                           recipes.all?{|recipe|
-                             recipe.is_a?(Hash) &&
-                             recipe.keys.sort == ["name", "path", "checksum", "specificity", "url"].sort
-                           }
-                         })
-    end
+      let(:fetched_cookbook) do
+        # NOTE: the cookbook returned will actually have some recipe
+        # data. We don't yet have a nice way to do the required soft
+        # verification for the URL and checksum.
+        #
+        # To get around this, we'll just pass in a proc that asserts
+        # that the "recipes" key is an array of hashes with the correct
+        # keys.
+        retrieved_cookbook(cookbook_name,
+                           cookbook_version,
+                           :recipes => lambda{|recipes|
+                             recipes.is_a?(Array) &&
+                               recipes.all?{|recipe|
+                               recipe.is_a?(Hash) &&
+                                 recipe.keys.sort == ["name", "path", "checksum", "specificity", "url"].sort
+                             }
+                           })
+      end
 
-    context 'as a normal user' do
-      let(:expected_response) { fetch_cookbook_success_exact_response }
-      let(:requestor) { normal_user }
+      context 'as a normal user' do
+        let(:expected_response) { fetch_cookbook_success_exact_response }
+        let(:requestor) { normal_user }
 
-      should_respond_with 200
+        should_respond_with 200
 
-      context "allows access to cookbook recipe files via" do
-        # These tests verify that the pre-signed URL that comes back
-        # within cookbook_version responses is usable. Validating both
-        # the URL generation, but also the use of bookshelf via the
-        # load balancer.
-        let(:cbv) { parse(response) }
-        let(:recipe_url) { cbv["recipes"].first["url"] }
+        context "allows access to cookbook recipe files via" do
+          # These tests verify that the pre-signed URL that comes back
+          # within cookbook_version responses is usable. Validating both
+          # the URL generation, but also the use of bookshelf via the
+          # load balancer.
+          let(:cbv) { parse(response) }
+          let(:recipe_url) { extract_segment(cbv, "recipes").first["url"] }
 
-        it "net/http" do
-          uri = URI.parse(recipe_url)
-          http = Net::HTTP.new(uri.hostname, uri.port)
-          if uri.scheme == "https"
-            http.use_ssl = true
-            http.ssl_version = Pedant::Config.ssl_version
-            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          it "net/http" do
+            uri = URI.parse(recipe_url)
+            http = Net::HTTP.new(uri.hostname, uri.port)
+            if uri.scheme == "https"
+              http.use_ssl = true
+              http.ssl_version = Pedant::Config.ssl_version
+              http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            end
+
+            response = http.get(uri.request_uri, {})
+            response.body.should == recipe_content
           end
 
-          response = http.get(uri.request_uri, {})
-          response.body.should == recipe_content
-        end
+        end # access to recipe file content
 
-      end # access to recipe file content
+      end # as a normal user
 
-    end # as a normal user
+      context 'as an admin user' do
+        let(:expected_response) { fetch_cookbook_success_exact_response }
+        let(:requestor) { admin_user }
 
-    context 'as an admin user' do
-      let(:expected_response) { fetch_cookbook_success_exact_response }
-      let(:requestor) { admin_user }
+        should_respond_with 200
+      end # as an admin user
 
-      should_respond_with 200
-    end # as an admin user
+      context 'as an user outside of the organization', :authorization do
+        let(:expected_response) { unauthorized_access_credential_response }
+        let(:requestor) { outside_user }
 
-    context 'as an user outside of the organization', :authorization do
-      let(:expected_response) { unauthorized_access_credential_response }
-      let(:requestor) { outside_user }
+        should_respond_with 403
+      end # as an outside user
 
-      should_respond_with 403
-    end # as an outside user
+      context 'with invalid user', :authentication do
+        let(:expected_response) { invalid_credential_exact_response }
+        let(:requestor) { invalid_user }
 
-    context 'with invalid user', :authentication do
-      let(:expected_response) { invalid_credential_exact_response }
-      let(:requestor) { invalid_user }
+        should_respond_with 401
+      end
+    end # context GET /cookbooks/<name>/<version>
+  end # describe Cookbooks API endpoint
 
-      should_respond_with 401
-    end
-  end # context GET /cookbooks/<name>/<version>
-end # describe Cookbooks API endpoint
+  describe "API v0" do
+    it_behaves_like "reads cookbooks", 0
+  end
 
+  describe "API v2" do
+    it_behaves_like "reads cookbooks", 2
+  end
+end

--- a/oc-chef-pedant/spec/api/cookbooks/update_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/update_spec.rb
@@ -28,875 +28,901 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbooks API endpoint", :cookbooks, :cookbooks_update do
 
-  let(:cookbook_url_base) { "cookbooks" }
+  shared_examples "updates cookbooks" do |api_version|
+    let(:cookbook_url_base) { "cookbooks" }
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
-
-  context "PUT /cookbooks/<name>/<version> [update]" do
-
-    let(:request_method){:PUT}
-    shared(:requestor){admin_user}
-    let(:request_url) { named_cookbook_url }
-    let(:cookbook_name) { "cookbook-to-be-modified" }
-    let(:cookbook_version) { self.class.cookbook_version }
-    let(:fetched_cookbook) { retrieved_cookbook(cookbook_name, cookbook_version) }
-    let(:original_cookbook) { new_cookbook(cookbook_name, cookbook_version) }
-
-    # This requires deep dup
-    let(:updated_cookbook) do
-      original_cookbook.dup.tap do |cookbook|
-        cookbook["metadata"] = cookbook["metadata"].dup.tap { |c| c["description"] = "hi there #{rand(10000)}" }
-      end
+    before do
+      platform.server_api_version = api_version
     end
 
-    # TODO: KLUDGE: Cop-out, because I am too tired to refactor the macros correctly
-    def self.cookbook_version
-      "11.2.3"
+    after do
+      platform.reset_server_api_version
     end
 
-    before(:each) {
-      make_cookbook(admin_user, cookbook_name, cookbook_version)
-    }
+    let(:segment_type) do
+      select_segment("files")
+    end
 
-    after(:each) {
-      delete_cookbook(admin_user, cookbook_name, cookbook_version)
-    }
+    include Pedant::RSpec::CookbookUtil
 
-    respects_maximum_payload_size
+    context "PUT /cookbooks/<name>/<version> [update]" do
 
-    context "as admin user" do
-      it "should respond with 200 Ok", :smoke do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        metadata = payload["metadata"]
-        metadata["description"] = "hi there"
-        payload["metadata"] = metadata
+      let(:request_method){:PUT}
+      shared(:requestor){admin_user}
+      let(:request_url) { named_cookbook_url }
+      let(:cookbook_name) { "cookbook-to-be-modified" }
+      let(:cookbook_version) { self.class.cookbook_version }
+      let(:fetched_cookbook) { retrieved_cookbook(cookbook_name, cookbook_version) }
+      let(:original_cookbook) { new_cookbook(cookbook_name, cookbook_version) }
 
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user, :payload => payload) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body_exact => payload
-                             })
+      # This requires deep dup
+      let(:updated_cookbook) do
+        original_cookbook.dup.tap do |cookbook|
+          cookbook["metadata"] = cookbook["metadata"].dup.tap { |c| c["description"] = "hi there #{rand(10000)}" }
         end
-
-        # verify change happened
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-        end
-      end # it admin user returns 200
-
-      context 'as a user outside of the organization', :authorization do
-        let(:expected_response) { unauthorized_access_credential_response }
-
-        it "should respond with 403 (\"Forbidden\") and does not update cookbook" do
-          put(request_url, outside_user, :payload => updated_cookbook) do |response|
-            response.should look_like expected_response
-          end
-
-          should_not_be_updated
-        end # it outside user returns 403 and does not update cookbook
       end
 
-      context 'with invalid user', :authentication do
-        let(:expected_response) { invalid_credential_exact_response }
+      # TODO: KLUDGE: Cop-out, because I am too tired to refactor the macros correctly
+      def self.cookbook_version
+        "11.2.3"
+      end
 
-        it "returns 401 and does not update cookbook" do
-          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), invalid_user, :payload => updated_cookbook) do |response|
-            response.should look_like expected_response
-          end
+      before(:each) {
+        make_cookbook(admin_user, cookbook_name, cookbook_version)
+      }
 
-          # Verified change did not happen
-          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), admin_user) do |response|
+      after(:each) {
+        delete_cookbook(admin_user, cookbook_name, cookbook_version)
+      }
+
+      respects_maximum_payload_size
+
+      context "as admin user" do
+        it "should respond with 200 Ok", :smoke do
+          payload = new_cookbook(cookbook_name, cookbook_version)
+          metadata = payload["metadata"]
+          metadata["description"] = "hi there"
+          payload["metadata"] = metadata
+
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user, :payload => payload) do |response|
             response.
               should look_like({
               :status => 200,
-              :body_exact => original_cookbook
+              :body_exact => payload
             })
           end
-        end # it invalid user returns 401 and does not update cookbook
-      end # with invalid user
-    end # context with permissions for
 
-    context "for checksums" do
-      include Pedant::RSpec::CookbookUtil
+          # verify change happened
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200,
+              :body => payload
+            })
+          end
+        end # it admin user returns 200
 
-      let(:sandbox) { create_sandbox(files) }
-      let(:upload) { ->(file) { upload_to_sandbox(file, sandbox) } }
-      let(:files) { (0..3).to_a.map { Pedant::Utility.new_random_file } }
+        context 'as a user outside of the organization', :authorization do
+          let(:expected_response) { unauthorized_access_credential_response }
 
-      let(:committed_files) do
-        files.each(&upload)
-        result = commit_sandbox(sandbox)
-        result
-      end
+          it "should respond with 403 (\"Forbidden\") and does not update cookbook" do
+            put(request_url, outside_user, :payload => updated_cookbook) do |response|
+              response.should look_like expected_response
+            end
 
-      let(:checksums) { parse(committed_files)["checksums"] }
+            should_not_be_updated
+          end # it outside user returns 403 and does not update cookbook
+        end
 
-      it "adding all new checksums should succeed" do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "files/default/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "files/default/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"},
-                            {"name" => "name3", "path" => "files/default/name3",
-                              "checksum" => checksums[2],
-                              "specificity" => "default"},
-                            {"name" => "name4", "path" => "files/default/name4",
-                              "checksum" => checksums[3],
-                              "specificity" => "default"}]
+        context 'with invalid user', :authentication do
+          let(:expected_response) { invalid_credential_exact_response }
 
-        verify_checksum_cleanup(:files) do
+          it "returns 401 and does not update cookbook" do
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), invalid_user, :payload => updated_cookbook) do |response|
+              response.should look_like expected_response
+            end
+
+            # Verified change did not happen
+            get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"), admin_user) do |response|
+              response.
+                should look_like({
+                :status => 200,
+                :body_exact => original_cookbook
+              })
+            end
+          end # it invalid user returns 401 and does not update cookbook
+        end # with invalid user
+      end # context with permissions for
+
+      context "for checksums" do
+        include Pedant::RSpec::CookbookUtil
+
+        let(:sandbox) { create_sandbox(files) }
+        let(:upload) { ->(file) { upload_to_sandbox(file, sandbox) } }
+        let(:files) { (0..3).to_a.map { Pedant::Utility.new_random_file } }
+
+        let(:committed_files) do
+          files.each(&upload)
+          result = commit_sandbox(sandbox)
+          result
+        end
+
+        let(:checksums) { parse(committed_files)["checksums"] }
+
+        it "adding all new checksums should succeed" do
+          payload = new_cookbook(cookbook_name, cookbook_version,
+                                 payload: {"files" => [{"name" => "name1", "path" => "files/default/name1",
+                                                        "checksum" => checksums[0],
+                                                        "specificity" => "default"},
+                                                        {"name" => "name2", "path" => "files/default/name2",
+                                                         "checksum" => checksums[1],
+                                                         "specificity" => "default"},
+                                                         {"name" => "name3", "path" => "files/default/name3",
+                                                          "checksum" => checksums[2],
+                                                          "specificity" => "default"},
+                                                          {"name" => "name4", "path" => "files/default/name4",
+                                                           "checksum" => checksums[3],
+                                                           "specificity" => "default"}]})
+
+          verify_checksum_cleanup(segment_type.to_sym) do
+
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user, :payload => payload) do |response|
+              response.
+                should look_like({
+                :status => 200,
+                :body_exact => payload
+              })
+            end
+
+            # verify change happened
+            # TODO make this match on body when URLs are parsable
+            get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user) do |response|
+              response.
+                should look_like({
+                :status => 200
+                #:body_exact => payload
+              })
+            end
+          end # verify_checksum_cleanup
+
+        end # it adding all new checksums should succeed
+
+        it "should return url when adding checksums" do
+          payload = new_cookbook(cookbook_name, cookbook_version,
+                                 payload: {"files" => [{"name" => "name1", "path" => "files/default/name1",
+                                                        "checksum" => checksums[0],
+                                                        "specificity" => "default"},
+                                                        {"name" => "name2", "path" => "files/default/name2",
+                                                         "checksum" => checksums[1],
+                                                         "specificity" => "default"}]})
 
           put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
               admin_user, :payload => payload) do |response|
             response.
               should look_like({
-                                 :status => 200,
-                                 :body_exact => payload
-                               })
+              :status => 200,
+              :body => payload
+            })
           end
-
+          # TODO original description indicated ruby returned URI, and also b ody_exact was commented out below.
+          # Look into it ...
           # verify change happened
           # TODO make this match on body when URLs are parsable
           get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
               admin_user) do |response|
             response.
               should look_like({
-                                 :status => 200
-                                 #:body_exact => payload
-                               })
+              :status => 200,
+              :body => payload
+            })
           end
-        end # verify_checksum_cleanup
-
-      end # it adding all new checksums should succeed
-
-      it "should return url when adding checksums" do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "files/default/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "files/default/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"}]
-
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user, :payload => payload) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-        end
-        # TODO original description indicated ruby returned URI, and also b ody_exact was commented out below.
-        # Look into it ...
-        # verify change happened
-        # TODO make this match on body when URLs are parsable
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-        end
-      end
-
-      it "adding invalid checksum should fail", :validation do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "files/path/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "files/path/name2",
-                              "checksum" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                              "specificity" => "default"}]
-
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user, :payload => payload) do |response|
-
-          error = ["Manifest has checksum aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa but it hasn't yet been uploaded"]
-          response.
-            should look_like({
-                               :status => 400,
-                               :body_exact => {
-                                 "error" => error
-                               }
-                             })
         end
 
-        # Verify change did not happen
-        payload.delete("files")
+        it "adding invalid checksum should fail", :validation do
+          payload = new_cookbook(cookbook_name, cookbook_version,
+                                 payload: {"files" => [{"name" => "name1", "path" => "files/path/name1",
+                                                        "checksum" => checksums[0],
+                                                        "specificity" => "default"},
+                                                        {"name" => "name2", "path" => "files/path/name2",
+                                                         "checksum" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                                         "specificity" => "default"}]})
 
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-        end
-      end # it adding invalid checksum should fail
-
-      it "deleting all checksums should succeed" do
-        delete_cookbook(admin_user, cookbook_name, cookbook_version)
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "files/default/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "files/default/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"},
-                            {"name" => "name3", "path" => "files/default/name3",
-                              "checksum" => checksums[2],
-                              "specificity" => "default"},
-                            {"name" => "name4", "path" => "files/default/name4",
-                              "checksum" => checksums[3],
-                              "specificity" => "default"}]
-        upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
-
-        # Verified initial cookbook
-        # TODO make this match on body when URLs are parsable
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200
-                               #:body_exact => payload
-                             })
-        end
-
-        verify_checksum_cleanup(:files) do
-
-          payload.delete("files")
           put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
               admin_user, :payload => payload) do |response|
+
+            error = ["Manifest has checksum aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa but it hasn't yet been uploaded"]
             response.
               should look_like({
-                                 :status => 200,
-                                 :body_exact => payload
-                               })
+              :status => 400,
+              :body_exact => {
+                "error" => error
+              }
+            })
           end
 
-          # verify change happened
+          # Verify change did not happen
+          payload.delete(segment_type)
+
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200,
+              :body => payload
+            })
+          end
+        end # it adding invalid checksum should fail
+
+        it "deleting all checksums should succeed" do
+          delete_cookbook(admin_user, cookbook_name, cookbook_version)
+          payload = new_cookbook(cookbook_name, cookbook_version,
+                                 payload: {"files" => [{"name" => "name1", "path" => "files/default/name1",
+                                                        "checksum" => checksums[0],
+                                                        "specificity" => "default"},
+                                                        {"name" => "name2", "path" => "files/default/name2",
+                                                         "checksum" => checksums[1],
+                                                         "specificity" => "default"},
+                                                         {"name" => "name3", "path" => "files/default/name3",
+                                                          "checksum" => checksums[2],
+                                                          "specificity" => "default"},
+                                                          {"name" => "name4", "path" => "files/default/name4",
+                                                           "checksum" => checksums[3],
+                                                           "specificity" => "default"}]})
+          upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
+
+          # Verified initial cookbook
           # TODO make this match on body when URLs are parsable
           get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
               admin_user) do |response|
             response.
               should look_like({
-                                 :status => 200
-                                 #:body_exact => payload
-                               })
+              :status => 200
+              #:body_exact => payload
+            })
           end
-        end # verify_checksum_cleanup
 
-      end # it deleting all checksums should succeed
+          verify_checksum_cleanup(segment_type.to_sym) do
 
-      it "deleting some checksums should succeed" do
-        delete_cookbook(admin_user, cookbook_name, cookbook_version)
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "path/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "path/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"},
-                            {"name" => "name3", "path" => "path/name3",
-                              "checksum" => checksums[2],
-                              "specificity" => "default"},
-                            {"name" => "name4", "path" => "path/name4",
-                              "checksum" => checksums[3],
-                              "specificity" => "default"}]
+            payload.delete(segment_type)
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user, :payload => payload) do |response|
+              response.
+                should look_like({
+                :status => 200,
+                :body_exact => payload
+              })
+            end
 
-        upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
+            # verify change happened
+            # TODO make this match on body when URLs are parsable
+            get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user) do |response|
+              response.
+                should look_like({
+                :status => 200
+                #:body_exact => payload
+              })
+            end
+          end # verify_checksum_cleanup
 
-        # Verified initial cookbook
-        # TODO make this match on body when URLs are parsable
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200
-                               #:body_exact => payload
-                             })
-        end
+        end # it deleting all checksums should succeed
 
-        verify_checksum_cleanup(:files) do
+        it "deleting some checksums should succeed" do
+          delete_cookbook(admin_user, cookbook_name, cookbook_version)
+          payload = new_cookbook(cookbook_name, cookbook_version,
+                                 payload: {"files" => [{"name" => "name1", "path" => "path/name1",
+                                                        "checksum" => checksums[0],
+                                                        "specificity" => "default"},
+                                                        {"name" => "name2", "path" => "path/name2",
+                                                         "checksum" => checksums[1],
+                                                         "specificity" => "default"},
+                                                         {"name" => "name3", "path" => "path/name3",
+                                                          "checksum" => checksums[2],
+                                                          "specificity" => "default"},
+                                                          {"name" => "name4", "path" => "path/name4",
+                                                           "checksum" => checksums[3],
+                                                           "specificity" => "default"}]})
 
-          payload["files"] = [{"name" => "name1", "path" => "path/name1",
-                                "checksum" => checksums[0],
-                                "specificity" => "default"},
-                              {"name" => "name2", "path" => "path/name2",
+          upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
+
+          # Verified initial cookbook
+          # TODO make this match on body when URLs are parsable
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200
+              #:body_exact => payload
+            })
+          end
+
+          verify_checksum_cleanup(segment_type.to_sym) do
+
+            payload[segment_type] = [{"name" => "name1", "path" => "path/name1",
+                                      "checksum" => checksums[0],
+                                      "specificity" => "default"},
+                                      {"name" => "name2", "path" => "path/name2",
+                                       "checksum" => checksums[1],
+                                       "specificity" => "default"}]
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user, :payload => payload) do |response|
+              response.
+                should look_like({
+                :status => 200,
+                :body_exact => payload
+              })
+            end
+
+            # verify change happened
+            # TODO make this match on body when URLs are parsable
+            get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user) do |response|
+              response.
+                should look_like({
+                :status => 200
+                #:body_exact => payload
+              })
+            end
+          end # verify_checksum_cleanup
+        end # it deleting some checksums should succeed
+
+        it "changing all different checksums should succeed" do
+          delete_cookbook(admin_user, cookbook_name, cookbook_version)
+          payload = new_cookbook(cookbook_name, cookbook_version,
+                                 payload: {"files" => [{"name" => "name1", "path" => "path/name1",
+                                                        "checksum" => checksums[0],
+                                                        "specificity" => "default"},
+                                                        {"name" => "name2", "path" => "path/name2",
+                                                         "checksum" => checksums[1],
+                                                         "specificity" => "default"}]})
+          upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
+
+          # Verified initial cookbook
+          # TODO make this match on body when URLs are parsable
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200
+              #:body_exact => payload
+            })
+          end
+
+          verify_checksum_cleanup(segment_type.to_sym) do
+
+            payload[segment_type] = [{"name" => "name3", "path" => "path/name3",
+                                      "checksum" => checksums[2],
+                                      "specificity" => "default"},
+                                      {"name" => "name4", "path" => "path/name4",
+                                       "checksum" => checksums[3],
+                                       "specificity" => "default"}]
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user, :payload => payload) do |response|
+              response.
+                should look_like({
+                :status => 200,
+                :body_exact => payload
+              })
+            end
+
+            # verify change happened
+            # TODO make this match on body when URLs are parsable
+            get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user) do |response|
+              response.
+                should look_like({
+                :status => 200
+                #:body_exact => payload
+              })
+            end
+          end # verify_checksum_cleanup
+        end # it changing all different checksums should succeed
+
+        it "changing some different checksums should succeed" do
+          delete_cookbook(admin_user, cookbook_name, cookbook_version)
+          payload = new_cookbook(cookbook_name, cookbook_version)
+          payload[segment_type] = [{"name" => "name1", "path" => "path/name1",
+                               "checksum" => checksums[0],
+                               "specificity" => "default"},
+                               {"name" => "name2", "path" => "path/name2",
                                 "checksum" => checksums[1],
-                                "specificity" => "default"}]
-          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-              admin_user, :payload => payload) do |response|
-            response.
-              should look_like({
-                                 :status => 200,
-                                 :body_exact => payload
-                               })
-          end
+                                "specificity" => "default"},
+                                {"name" => "name3", "path" => "path/name3",
+                                 "checksum" => checksums[2],
+                                 "specificity" => "default"}]
+          upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
 
-          # verify change happened
+          # Verified initial cookbook
           # TODO make this match on body when URLs are parsable
           get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
               admin_user) do |response|
             response.
               should look_like({
-                                 :status => 200
-                                 #:body_exact => payload
-                               })
-          end
-        end # verify_checksum_cleanup
-      end # it deleting some checksums should succeed
-
-      it "changing all different checksums should succeed" do
-        delete_cookbook(admin_user, cookbook_name, cookbook_version)
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "path/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "path/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"}]
-        upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
-
-        # Verified initial cookbook
-        # TODO make this match on body when URLs are parsable
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200
-                               #:body_exact => payload
-                             })
-        end
-
-        verify_checksum_cleanup(:files) do
-
-          payload["files"] = [{"name" => "name3", "path" => "path/name3",
-                                "checksum" => checksums[2],
-                                "specificity" => "default"},
-                              {"name" => "name4", "path" => "path/name4",
-                                "checksum" => checksums[3],
-                                "specificity" => "default"}]
-          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-              admin_user, :payload => payload) do |response|
-            response.
-              should look_like({
-                                 :status => 200,
-                                 :body_exact => payload
-                               })
+              :status => 200
+              #:body_exact => payload
+            })
           end
 
-          # verify change happened
-          # TODO make this match on body when URLs are parsable
-          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-              admin_user) do |response|
-            response.
-              should look_like({
-                                 :status => 200
-                                 #:body_exact => payload
-                               })
-          end
-        end # verify_checksum_cleanup
-      end # it changing all different checksums should succeed
+          verify_checksum_cleanup(:files) do
 
-      it "changing some different checksums should succeed" do
-        delete_cookbook(admin_user, cookbook_name, cookbook_version)
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "path/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "path/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"},
-                            {"name" => "name3", "path" => "path/name3",
-                              "checksum" => checksums[2],
-                              "specificity" => "default"}]
-        upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
+            payload[segment_type] = [{"name" => "name2", "path" => "path/name2",
+                                 "checksum" => checksums[1],
+                                 "specificity" => "default"},
+                                 {"name" => "name3", "path" => "path/name3",
+                                  "checksum" => checksums[2],
+                                  "specificity" => "default"},
+                                  {"name" => "name4", "path" => "path/name4",
+                                   "checksum" => checksums[3],
+                                   "specificity" => "default"}]
+            put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user, :payload => payload) do |response|
+              response.
+                should look_like({
+                :status => 200,
+                :body_exact => payload
+              })
+            end
 
-        # Verified initial cookbook
-        # TODO make this match on body when URLs are parsable
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200
-                               #:body_exact => payload
-                             })
-        end
+            # verify change happened
+            # TODO make this match on body when URLs are parsable
+            get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+                admin_user) do |response|
+              response.
+                should look_like({
+                :status => 200
+                #:body_exact => payload
+              })
+            end
+          end # verify_checksum_cleanup
+        end # it changing some different checksums should succeed
 
-        verify_checksum_cleanup(:files) do
+        it "changing to invalid checksums should fail", :validation do
+          delete_cookbook(admin_user, cookbook_name, cookbook_version)
 
-          payload["files"] = [{"name" => "name2", "path" => "path/name2",
-                                "checksum" => checksums[1],
-                                "specificity" => "default"},
-                              {"name" => "name3", "path" => "path/name3",
-                                "checksum" => checksums[2],
-                                "specificity" => "default"},
-                              {"name" => "name4", "path" => "path/name4",
-                                "checksum" => checksums[3],
-                                "specificity" => "default"}]
-          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-              admin_user, :payload => payload) do |response|
-            response.
-              should look_like({
-                                 :status => 200,
-                                 :body_exact => payload
-                               })
-          end
-
-          # verify change happened
-          # TODO make this match on body when URLs are parsable
-          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-              admin_user) do |response|
-            response.
-              should look_like({
-                                 :status => 200
-                                 #:body_exact => payload
-                               })
-          end
-        end # verify_checksum_cleanup
-      end # it changing some different checksums should succeed
-
-      it "changing to invalid checksums should fail", :validation do
-        delete_cookbook(admin_user, cookbook_name, cookbook_version)
-
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["files"] = [{"name" => "name1", "path" => "path/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "path/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"},
-                            {"name" => "name3", "path" => "path/name3",
-                              "checksum" => checksums[2],
-                              "specificity" => "default"}]
-        upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
-
-        # Verified initial cookbook
-        # TODO make this match on body when URLs are parsable
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200
-                               #:body_exact => payload
-                             })
-        end
-
-        payload["files"] = [{"name" => "name2", "path" => "path/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"},
-                            {"name" => "name3", "path" => "path/name3",
-                              "checksum" => checksums[2],
-                              "specificity" => "default"},
-                            {"name" => "name4", "path" => "path/name4",
-                              "checksum" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                              "specificity" => "default"}]
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user, :payload => payload) do |response|
-
-          error = ["Manifest has checksum aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa but it hasn't yet been uploaded"]
-          response.
-            should look_like({
-                               :status => 400,
-                               :body_exact => {
-                                 "error" => error
-                               }
-                             })
-        end
-
-        # verify change did not happen
-        payload["files"] = [{"name" => "name1", "path" => "path/name1",
-                              "checksum" => checksums[0],
-                              "specificity" => "default"},
-                            {"name" => "name2", "path" => "path/name2",
-                              "checksum" => checksums[1],
-                              "specificity" => "default"},
-                            {"name" => "name3", "path" => "path/name3",
-                              "checksum" => checksums[2],
-                              "specificity" => "default"}]
-
-        # TODO make this match on body when URLs are parsable
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200
-                               #:body_exact => payload
-                             })
-        end
-      end # it changing to invalid checksums should fail
-
-      # Coverge for CHEF-3716
-      #
-      # The ultimate problem was that we were inadvertently deleting some files
-      # from S3 / Bookshelf on cookbook updates. When a file was no longer
-      # referenced by that cookbook version, we would delete it without first
-      # checking that it wasn't being referenced by any other cookbooks. The
-      # database was internally consistent (modulo some "garbage" checksums
-      # remaining), but it was inconsistent with S3 / Bookshelf, which resulted
-      # in the 404 errors when trying to download.
-      context "CHEF-3716 coverage" do
-        let(:cookbook_version2) { "11.2.4" }
-
-        after(:each) {
-          delete_cookbook(admin_user, cookbook_name, cookbook_version2)
-        }
-
-        it "it does not delete checksums in use by another version" do
-
-          # Might be a little paranoid, but lets ensure the version strings
-          # versions are indeed different since the whole test hinges on this.
-          cookbook_version.should_not eq cookbook_version2
-
-          # Create two cookbook versions that share a single file
-          payload1 = new_cookbook(cookbook_name, cookbook_version)
-          payload1["files"] = [{"name" => "name1", "path" => "path/name1",
-                                "checksum" => checksums[0],
-                                "specificity" => "default"},
-                              {"name" => "name2", "path" => "path/name2",
-                                "checksum" => checksums[1],
-                                "specificity" => "default"}]
-          payload2 = new_cookbook(cookbook_name, cookbook_version2)
-          payload2["files"] = [{"name" => "name1", "path" => "path/name1",
-                                "checksum" => checksums[0],
-                                "specificity" => "default"},
-                              {"name" => "name2", "path" => "path/name2",
-                                "checksum" => checksums[2],
-                                "specificity" => "default"}]
-          upload_cookbook(admin_user, cookbook_name, cookbook_version, payload1)
-          upload_cookbook(admin_user, cookbook_name, cookbook_version2, payload2)
-
-          # compute an intersection and difference
-          cbv_1_checksums = checksums_for_segment_type(:files, cookbook_version)
-          cbv_2_checksums = checksums_for_segment_type(:files, cookbook_version2)
-          intersection_checksums = cbv_1_checksums.keys & cbv_2_checksums.keys
-          cbv_2_difference_checksums = cbv_2_checksums.keys - cbv_1_checksums.keys
+          payload = new_cookbook(cookbook_name, cookbook_version)
 
           # Make changes to the files in cookbook version 2. This effectively
           # deletes all the old files.
-          payload2["files"] = [{"name" => "name5", "path" => "path/name5",
-                                "checksum" => checksums[3],
-                                "specificity" => "default"}]
-          upload_cookbook(admin_user, cookbook_name, cookbook_version2, payload2)
 
-          # Checksums unique to first iteration of cookbook version 2 should
-          # have been deleted
-          cbv_2_difference_checksums.each do |checksum|
-            verify_checksum_url(cbv_2_checksums[checksum], 404)
+          payload[segment_type] = [{"name" => "name1", "path" => "path/name1",
+                               "checksum" => checksums[0],
+                               "specificity" => "default"},
+                               {"name" => "name2", "path" => "path/name2",
+                                "checksum" => checksums[1],
+                                "specificity" => "default"},
+                                {"name" => "name3", "path" => "path/name3",
+                                 "checksum" => checksums[2],
+                                 "specificity" => "default"}]
+          upload_cookbook(admin_user, cookbook_name, cookbook_version, payload)
+
+          # Verified initial cookbook
+          # TODO make this match on body when URLs are parsable
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200
+              #:body_exact => payload
+            })
           end
 
-          # Checksums shared between the original iterations of the cookbook
-          # versions should still exist
-          intersection_checksums.each do |checksum|
-            verify_checksum_url(cbv_2_checksums[checksum], 200)
+          payload[segment_type] = [{"name" => "name2", "path" => "path/name2",
+                               "checksum" => checksums[1],
+                               "specificity" => "default"},
+                               {"name" => "name3", "path" => "path/name3",
+                                "checksum" => checksums[2],
+                                "specificity" => "default"},
+                                {"name" => "name4", "path" => "path/name4",
+                                 "checksum" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                 "specificity" => "default"}]
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user, :payload => payload) do |response|
+
+            error = ["Manifest has checksum aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa but it hasn't yet been uploaded"]
+            response.
+              should look_like({
+              :status => 400,
+              :body_exact => {
+                "error" => error
+              }
+            })
+          end
+
+          # verify change did not happen
+          payload[segment_type] = [{"name" => "name1", "path" => "path/name1",
+                               "checksum" => checksums[0],
+                               "specificity" => "default"},
+                               {"name" => "name2", "path" => "path/name2",
+                                "checksum" => checksums[1],
+                                "specificity" => "default"},
+                                {"name" => "name3", "path" => "path/name3",
+                                 "checksum" => checksums[2],
+                                 "specificity" => "default"}]
+
+          # TODO make this match on body when URLs are parsable
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200,
+              #:body_exact => payload
+            })
+          end
+        end # it changing to invalid checksums should fail
+
+        # Coverge for CHEF-3716
+        #
+        # The ultimate problem was that we were inadvertently deleting some files
+        # from S3 / Bookshelf on cookbook updates. When a file was no longer
+        # referenced by that cookbook version, we would delete it without first
+        # checking that it wasn't being referenced by any other cookbooks. The
+        # database was internally consistent (modulo some "garbage" checksums
+        # remaining), but it was inconsistent with S3 / Bookshelf, which resulted
+        # in the 404 errors when trying to download.
+        context "CHEF-3716 coverage" do
+          let(:cookbook_version2) { "11.2.4" }
+
+          after(:each) {
+            delete_cookbook(admin_user, cookbook_name, cookbook_version2)
+          }
+
+          it "it does not delete checksums in use by another version" do
+
+            # Might be a little paranoid, but lets ensure the version strings
+            # versions are indeed different since the whole test hinges on this.
+            cookbook_version.should_not eq cookbook_version2
+
+            # Create two cookbook versions that share a single file
+            payload1 = new_cookbook(cookbook_name, cookbook_version,
+                                    payload: {"files" => [{"name" => "name1", "path" => "path/name1",
+                                                           "checksum" => checksums[0],
+                                                           "specificity" => "default"},
+                                                           {"name" => "name2", "path" => "path/name2",
+                                                            "checksum" => checksums[1],
+                                                            "specificity" => "default"}]})
+
+            payload2 = new_cookbook(cookbook_name, cookbook_version2,
+                                    payload: { "files" => [{"name" => "name1", "path" => "path/name1",
+                                                            "checksum" => checksums[0],
+                                                            "specificity" => "default"},
+                                                            {"name" => "name2", "path" => "path/name2",
+                                                             "checksum" => checksums[2],
+                                                             "specificity" => "default"}]})
+
+            upload_cookbook(admin_user, cookbook_name, cookbook_version, payload1)
+            upload_cookbook(admin_user, cookbook_name, cookbook_version2, payload2)
+
+            # compute an intersection and difference
+            cbv_1_checksums = checksums_for_segment_type(:files, cookbook_version)
+            cbv_2_checksums = checksums_for_segment_type(:files, cookbook_version2)
+            intersection_checksums = cbv_1_checksums.keys & cbv_2_checksums.keys
+            cbv_2_difference_checksums = cbv_2_checksums.keys - cbv_1_checksums.keys
+
+            # Make changes to the files in cookbook version 2. This effectively
+            # deletes all the old files.
+            payload2[segment_type] = [{"name" => "name5", "path" => "path/name5",
+                               "checksum" => checksums[3],
+                               "specificity" => "default"}]
+            upload_cookbook(admin_user, cookbook_name, cookbook_version2, payload2)
+
+            # Checksums unique to first iteration of cookbook version 2 should
+            # have been deleted
+            cbv_2_difference_checksums.each do |checksum|
+              verify_checksum_url(cbv_2_checksums[checksum], 404)
+            end
+
+            # Checksums shared between the original iterations of the cookbook
+            # versions should still exist
+            intersection_checksums.each do |checksum|
+              verify_checksum_url(cbv_2_checksums[checksum], 200)
+            end
           end
         end
-      end
 
-    end # context for checksums
+      end # context for checksums
 
-    context "for frozen?" do
-      before(:each) do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["frozen?"] = true
-
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user, :payload => payload) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body_exact => payload
-                             })
-        end
-      end # before :each
-
-      it "can set frozen? to true" do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["frozen?"] = true
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-        end
-      end # it can set frozen? to true
-
-      it "can not edit cookbook when frozen? is set to true" do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["frozen?"] = false
-        metadata = payload["metadata"]
-        metadata["description"] = "this is different"
-        payload["metadata"] = metadata
-
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user, :payload => payload) do |response|
-          response.
-            should look_like({
-                               :status => 409,
-                               :body_exact => {
-                                 "error" => ["The cookbook #{cookbook_name} at version #{cookbook_version} is frozen. Use the 'force' option to override."]
-                               }
-                             })
-        end
-
-        # Verify that change did not occur
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["frozen?"] = true
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-          end
-      end # it can not edit cookbook when frozen? is set to true
-
-      it "can override frozen? with force set to true" do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["frozen?"] = false
-        metadata = payload["metadata"]
-        metadata["description"] = "this is different"
-        payload["metadata"] = metadata
-
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}?force=true"),
-            admin_user, :payload => payload) do |response|
-          # You can modify things, but you can't unfreeze the cookbook
-          payload["frozen?"] = true
-          response.
-            should look_like({
-                               :status => 200,
-                               :body_exact => payload
-                             })
-        end
-
-        # Verify that change did occur
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-        end
-      end # it can override frozen? with force set to true
-
-      it "can not override frozen? with force set to false" do
-        payload = new_cookbook(cookbook_name, cookbook_version)
-        payload["frozen?"] = false
-        metadata = payload["metadata"]
-        metadata["description"] = "this is different"
-        payload["metadata"] = metadata
-
-        put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}?force=false"),
-            admin_user, :payload => payload) do |response|
-          # You can modify things, but you can't unfreeze the cookbook
-          payload["frozen?"] = true
-          response.
-            should look_like({
-                               :status => 409,
-                               :body_exact => {
-                                 "error" => ["The cookbook #{cookbook_name} at version #{cookbook_version} is frozen. Use the 'force' option to override."]
-                               }
-                             })
-        end
-
-        # Verify that change did occur
-        get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
-            admin_user) do |response|
+      context "for frozen?" do
+        before(:each) do
           payload = new_cookbook(cookbook_name, cookbook_version)
           payload["frozen?"] = true
-          response.
-            should look_like({
-                               :status => 200,
-                               :body => payload
-                             })
-        end
-      end # it can not override frozen? with force set to false
-    end # context for frozen?
 
-    context "when modifying data" do
-      context "for cookbook_name" do
-        [1, true, [], {}].each do |value|
-          should_fail_to_change('cookbook_name', value, 400, "Field 'cookbook_name' invalid")
-        end
-        ['new_cookbook_name', 'with a space', '外国語'].each do |value|
-          should_fail_to_change('cookbook_name', value, 400, "Field 'cookbook_name' invalid")
-        end
-        should_fail_to_change('cookbook_name', :delete, 400, "Field 'cookbook_name' missing")
-      end # context for cookbook_name
-
-      context "for json_class" do
-        should_not_change('json_class', :delete, 'Chef::CookbookVersion')
-        should_fail_to_change('json_class', 1, 400, "Field 'json_class' invalid")
-        should_fail_to_change('json_class', 'Chef::NonCookbook', 400, "Field 'json_class' invalid")
-        should_fail_to_change('json_class', 'all wrong', 400, "Field 'json_class' invalid")
-      end # context for json_class
-
-      context "for chef_type" do
-        should_not_change('chef_type', :delete, 'cookbook_version')
-        should_fail_to_change('chef_type', 'not_cookbook', 400, "Field 'chef_type' invalid")
-        should_fail_to_change('chef_type', false, 400, "Field 'chef_type' invalid")
-        should_fail_to_change('chef_type', ['just any', 'old junk'], 400, "Field 'chef_type' invalid")
-      end # context for chef_type
-
-      context "for version" do
-        should_change('version', :delete)
-        error = "Field 'version' invalid"
-        should_fail_to_change('version', 1, 400, error)
-        should_fail_to_change('version', ['all', 'ignored'], 400, error)
-        should_fail_to_change('version', {}, 400, error)
-
-        error = "Field 'version' invalid"
-        should_fail_to_change('version', '0.0', 400, error)
-        should_fail_to_change('version', 'something invalid', 400, error)
-      end # context for version
-
-      context "for collections" do
-        ['attributes', 'definitions', 'files', 'libraries', 'providers', 'recipes',
-         'resources', 'root_files', 'templates'].each do |segment|
-          context "for #{segment}" do
-            should_fail_to_change(segment, 'foo', 400, "Field '#{segment}' invalid")
-            error = "Invalid element in array value of '#{segment}'."
-            should_fail_to_change(segment, ['foo'], 400, error)
-            should_change(segment, [])
-            should_fail_to_change(segment, [{}, {}], 400, error)
-            should_fail_to_change(segment, [{'foo' => 'bar'}], 400, error)
-          end # context for #{segment}
-        end # [loop over attributes, definitions, files, libraries, providers,
-          #              recipes, resources, root_files, templates
-      end # context for collections
-
-      context "for other stuff" do
-        should_change('frozen?', true)
-      end # context for other stuff
-    end # context when modifying data
-
-    context "when modifying metadata" do
-      should_fail_to_change('metadata', {'new_name' => 'foo'}, 400, "Field 'metadata.version' missing")
-
-      context "for name" do
-        should_change_metadata('name', 'new_name', nil, 200, :validation)
-        should_change_metadata('name', :delete)
-        [[1, 'number'], [true, 'boolean'], [{}, 'object'],
-        [[], 'array']].each do |error|
-          json_error = "Field 'metadata.name' invalid"
-          should_fail_to_change_metadata('name', error[0], 400, json_error)
-        end
-        ['invalid name', 'ダメよ'].each do |name|
-          should_fail_to_change_metadata('name', name, 400, "Field 'metadata.name' invalid")
-        end
-      end # context for name
-
-      context "for description" do
-        should_change_metadata('description', 'new description')
-        should_change_metadata('description', :delete)
-        should_fail_to_change_metadata('description', 1, 400, "Field 'metadata.description' invalid")
-      end # context for description
-
-      context "for long description" do
-        should_change_metadata('long_description', 'longer description')
-
-        # Deleting the long description results in it being "reset" to
-        # the empty string
-        should_change_metadata('long_description', :delete, "")
-        should_fail_to_change_metadata('long_description', false, 400, "Field 'metadata.long_description' invalid")
-      end # context for long description
-
-      context "for version" do
-        should_fail_to_change_metadata('version', '0.0', 400, "Field 'metadata.version' invalid")
-        should_fail_to_change_metadata('version', 'not a version', 400, "Field 'metadata.version' invalid")
-        should_fail_to_change_metadata('version', :delete, 400, "Field 'metadata.version' missing")
-        should_fail_to_change_metadata('version', 1, 400, "Field 'metadata.version' invalid")
-      end # context for version
-
-      context "for maintainer" do
-        should_change_metadata('maintainer', 'Captain Stupendous')
-        should_change_metadata('maintainer', :delete)
-        should_fail_to_change_metadata('maintainer', true, 400, "Field 'metadata.maintainer' invalid")
-        should_change_metadata('maintainer_email', 'cap@awesome.com')
-        should_change_metadata('maintainer_email', 'not really an email')
-        should_change_metadata('maintainer_email', :delete)
-        should_fail_to_change_metadata('maintainer_email', false, 400, "Field 'metadata.maintainer_email' invalid")
-      end # context for maintainer
-
-      context "for license" do
-        should_change_metadata('license', 'to_kill')
-        should_change_metadata('license', :delete)
-        should_fail_to_change_metadata('license', 1, 400, "Field 'metadata.license' invalid")
-      end # context for license
-
-      context "for collections" do
-        context "for platforms" do
-          json_error = "Field 'metadata.platforms' invalid"
-          should_fail_to_change_metadata('platforms', [], 400, json_error)
-          should_change_metadata('platforms', {})
-          should_change_metadata('platforms', :delete)
-          should_fail_to_change_metadata('platforms', "foo", 400, json_error)
-          should_fail_to_change_metadata('platforms', ["foo"], 400, json_error)
-          should_fail_to_change_metadata('platforms', {"foo" => {}}, 400, "Invalid value '{[]}' for metadata.platforms")
-        end
-
-        def self.should_change_with_metadata(_attribute, _value)
-          context "when #{_attribute} is set to #{_value}" do
-            let(:cookbook_name) { Pedant::Utility.with_unique_suffix("pedant-cookbook") }
-            # These macros need to be refactored and updated for flexibility.
-            # The cookbook endpoint uses PUT for both create and update, so this
-            # throws a monkey wrench into the mix.
-            should_change_metadata _attribute, _value, _value, 200
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user, :payload => payload) do |response|
+            response.
+              should look_like({
+              :status => 200,
+              :body_exact => payload
+            })
           end
-        end
+        end # before :each
 
-        context "with metadata.providing" do
-          # In erchef, we are not validating the "providing" metadata
-          # See: http://tickets.chef.io/browse/CHEF-3976
+        it "can set frozen? to true" do
+          payload = new_cookbook(cookbook_name, cookbook_version)
+          payload["frozen?"] = true
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200,
+              :body => payload
+            })
+          end
+        end # it can set frozen? to true
 
-          after(:each) { delete_cookbook admin_user, cookbook_name, cookbook_version }
+        it "can not edit cookbook when frozen? is set to true" do
+          payload = new_cookbook(cookbook_name, cookbook_version)
+          payload["frozen?"] = false
+          metadata = payload["metadata"]
+          metadata["description"] = "this is different"
+          payload["metadata"] = metadata
 
-          # http://docs.chef.io/config_rb_metadata.html#provides
-          should_change_with_metadata 'providing', 'cats::sleep'
-          should_change_with_metadata 'providing', 'here(:kitty, :time_to_eat)'
-          should_change_with_metadata 'providing', 'service[snuggle]'
-          should_change_with_metadata 'providing', ''
-          should_change_with_metadata 'providing', 1
-          should_change_with_metadata 'providing', true
-          should_change_with_metadata 'providing', ['cats', 'sleep', 'here']
-          should_change_with_metadata 'providing',
-            { 'cats::sleep'                => '0.0.1',
-              'here(:kitty, :time_to_eat)' => '0.0.1',
-              'service[snuggle]'           => '0.0.1'  }
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user, :payload => payload) do |response|
+            response.
+              should look_like({
+              :status => 409,
+              :body_exact => {
+                "error" => ["The cookbook #{cookbook_name} at version #{cookbook_version} is frozen. Use the 'force' option to override."]
+              }
+            })
+          end
 
-        end
+          # Verify that change did not occur
+          payload = new_cookbook(cookbook_name, cookbook_version)
+          payload["frozen?"] = true
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200,
+              :body => payload
+            })
+          end
+        end # it can not edit cookbook when frozen? is set to true
+
+        it "can override frozen? with force set to true" do
+          payload = new_cookbook(cookbook_name, cookbook_version)
+          payload["frozen?"] = false
+          metadata = payload["metadata"]
+          metadata["description"] = "this is different"
+          payload["metadata"] = metadata
+
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}?force=true"),
+              admin_user, :payload => payload) do |response|
+            # You can modify things, but you can't unfreeze the cookbook
+            payload["frozen?"] = true
+            response.
+              should look_like({
+              :status => 200,
+              :body_exact => payload
+            })
+          end
+
+          # Verify that change did occur
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            response.
+              should look_like({
+              :status => 200,
+              :body => payload
+            })
+          end
+        end # it can override frozen? with force set to true
+
+        it "can not override frozen? with force set to false" do
+          payload = new_cookbook(cookbook_name, cookbook_version)
+          payload["frozen?"] = false
+          metadata = payload["metadata"]
+          metadata["description"] = "this is different"
+          payload["metadata"] = metadata
+
+          put(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}?force=false"),
+              admin_user, :payload => payload) do |response|
+            # You can modify things, but you can't unfreeze the cookbook
+            payload["frozen?"] = true
+            response.
+              should look_like({
+              :status => 409,
+              :body_exact => {
+                "error" => ["The cookbook #{cookbook_name} at version #{cookbook_version} is frozen. Use the 'force' option to override."]
+              }
+            })
+          end
+
+          # Verify that change did occur
+          get(api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}"),
+              admin_user) do |response|
+            payload = new_cookbook(cookbook_name, cookbook_version)
+            payload["frozen?"] = true
+            response.
+              should look_like({
+              :status => 200,
+              :body => payload
+            })
+          end
+        end # it can not override frozen? with force set to false
+      end # context for frozen?
+
+      context "when modifying data" do
+        context "for cookbook_name" do
+          [1, true, [], {}].each do |value|
+            should_fail_to_change('cookbook_name', value, 400, "Field 'cookbook_name' invalid")
+          end
+          ['new_cookbook_name', 'with a space', '外国語'].each do |value|
+            should_fail_to_change('cookbook_name', value, 400, "Field 'cookbook_name' invalid")
+          end
+          should_fail_to_change('cookbook_name', :delete, 400, "Field 'cookbook_name' missing")
+        end # context for cookbook_name
+
+        context "for json_class" do
+          should_not_change('json_class', :delete, 'Chef::CookbookVersion')
+          should_fail_to_change('json_class', 1, 400, "Field 'json_class' invalid")
+          should_fail_to_change('json_class', 'Chef::NonCookbook', 400, "Field 'json_class' invalid")
+          should_fail_to_change('json_class', 'all wrong', 400, "Field 'json_class' invalid")
+        end # context for json_class
+
+        context "for chef_type" do
+          should_not_change('chef_type', :delete, 'cookbook_version')
+          should_fail_to_change('chef_type', 'not_cookbook', 400, "Field 'chef_type' invalid")
+          should_fail_to_change('chef_type', false, 400, "Field 'chef_type' invalid")
+          should_fail_to_change('chef_type', ['just any', 'old junk'], 400, "Field 'chef_type' invalid")
+        end # context for chef_type
+
+        context "for version" do
+          should_change('version', :delete)
+          error = "Field 'version' invalid"
+          should_fail_to_change('version', 1, 400, error)
+          should_fail_to_change('version', ['all', 'ignored'], 400, error)
+          should_fail_to_change('version', {}, 400, error)
+
+          error = "Field 'version' invalid"
+          should_fail_to_change('version', '0.0', 400, error)
+          should_fail_to_change('version', 'something invalid', 400, error)
+        end # context for version
+
+        context "for collections", if: api_version.to_i < 2 do
+          ['attributes', 'definitions', 'files', 'libraries', 'providers', 'recipes',
+           'resources', 'root_files', 'templates'].each do |segment|
+            context "for #{segment}" do
+              should_fail_to_change(segment, 'foo', 400, "Field '#{segment}' invalid")
+              error = "Invalid element in array value of '#{segment}'."
+              should_fail_to_change(segment, ['foo'], 400, error)
+              should_change(segment, [])
+              should_fail_to_change(segment, [{}, {}], 400, error)
+              should_fail_to_change(segment, [{'foo' => 'bar'}], 400, error)
+            end # context for #{segment}
+          end # [loop over attributes, definitions, files, libraries, providers,
+          #              recipes, resources, root_files, templates
+        end # context for collections
+
+        context "for other stuff" do
+          should_change('frozen?', true)
+        end # context for other stuff
+      end # context when modifying data
+
+      context "when modifying metadata" do
+        should_fail_to_change('metadata', {'new_name' => 'foo'}, 400, "Field 'metadata.version' missing")
+
+        context "for name" do
+          should_change_metadata('name', 'new_name', nil, 200, :validation)
+          should_change_metadata('name', :delete)
+          [[1, 'number'], [true, 'boolean'], [{}, 'object'],
+           [[], 'array']].each do |error|
+            json_error = "Field 'metadata.name' invalid"
+            should_fail_to_change_metadata('name', error[0], 400, json_error)
+          end
+          ['invalid name', 'ダメよ'].each do |name|
+            should_fail_to_change_metadata('name', name, 400, "Field 'metadata.name' invalid")
+          end
+        end # context for name
+
+        context "for description" do
+          should_change_metadata('description', 'new description')
+          should_change_metadata('description', :delete)
+          should_fail_to_change_metadata('description', 1, 400, "Field 'metadata.description' invalid")
+        end # context for description
+
+        context "for long description" do
+          should_change_metadata('long_description', 'longer description')
+
+          # Deleting the long description results in it being "reset" to
+          # the empty string
+          should_change_metadata('long_description', :delete, "")
+          should_fail_to_change_metadata('long_description', false, 400, "Field 'metadata.long_description' invalid")
+        end # context for long description
+
+        context "for version" do
+          should_fail_to_change_metadata('version', '0.0', 400, "Field 'metadata.version' invalid")
+          should_fail_to_change_metadata('version', 'not a version', 400, "Field 'metadata.version' invalid")
+          should_fail_to_change_metadata('version', :delete, 400, "Field 'metadata.version' missing")
+          should_fail_to_change_metadata('version', 1, 400, "Field 'metadata.version' invalid")
+        end # context for version
+
+        context "for maintainer" do
+          should_change_metadata('maintainer', 'Captain Stupendous')
+          should_change_metadata('maintainer', :delete)
+          should_fail_to_change_metadata('maintainer', true, 400, "Field 'metadata.maintainer' invalid")
+          should_change_metadata('maintainer_email', 'cap@awesome.com')
+          should_change_metadata('maintainer_email', 'not really an email')
+          should_change_metadata('maintainer_email', :delete)
+          should_fail_to_change_metadata('maintainer_email', false, 400, "Field 'metadata.maintainer_email' invalid")
+        end # context for maintainer
+
+        context "for license" do
+          should_change_metadata('license', 'to_kill')
+          should_change_metadata('license', :delete)
+          should_fail_to_change_metadata('license', 1, 400, "Field 'metadata.license' invalid")
+        end # context for license
+
+        context "for collections" do
+          context "for platforms" do
+            json_error = "Field 'metadata.platforms' invalid"
+            should_fail_to_change_metadata('platforms', [], 400, json_error)
+            should_change_metadata('platforms', {})
+            should_change_metadata('platforms', :delete)
+            should_fail_to_change_metadata('platforms', "foo", 400, json_error)
+            should_fail_to_change_metadata('platforms', ["foo"], 400, json_error)
+            should_fail_to_change_metadata('platforms', {"foo" => {}}, 400, "Invalid value '{[]}' for metadata.platforms")
+          end
+
+          def self.should_change_with_metadata(_attribute, _value)
+            context "when #{_attribute} is set to #{_value}" do
+              let(:cookbook_name) { Pedant::Utility.with_unique_suffix("pedant-cookbook") }
+              # These macros need to be refactored and updated for flexibility.
+              # The cookbook endpoint uses PUT for both create and update, so this
+              # throws a monkey wrench into the mix.
+              should_change_metadata _attribute, _value, _value, 200
+            end
+          end
+
+          context "with metadata.providing" do
+            # In erchef, we are not validating the "providing" metadata
+            # See: http://tickets.chef.io/browse/CHEF-3976
+
+            after(:each) { delete_cookbook admin_user, cookbook_name, cookbook_version }
+
+            # http://docs.chef.io/config_rb_metadata.html#provides
+            should_change_with_metadata 'providing', 'cats::sleep'
+            should_change_with_metadata 'providing', 'here(:kitty, :time_to_eat)'
+            should_change_with_metadata 'providing', 'service[snuggle]'
+            should_change_with_metadata 'providing', ''
+            should_change_with_metadata 'providing', 1
+            should_change_with_metadata 'providing', true
+            should_change_with_metadata 'providing', ['cats', 'sleep', 'here']
+            should_change_with_metadata 'providing',
+              { 'cats::sleep'                => '0.0.1',
+                'here(:kitty, :time_to_eat)' => '0.0.1',
+                'service[snuggle]'           => '0.0.1'  }
+
+          end
 
           context "for dependencies" do
             json_error = "Field 'metadata.dependencies' invalid"
             should_fail_to_change_metadata("dependencies", [], 400, json_error)
             should_change_metadata("dependencies", {})
 
-            # Attempting to delete dependencies will result in it
-            # getting set to an empty hash, since we need to have
-            # something present for that key
             should_change_metadata("dependencies", :delete, {})
 
             should_fail_to_change_metadata("dependencies", "foo", 400, json_error)
             should_fail_to_change_metadata("dependencies", ["foo"], 400, json_error)
             should_fail_to_change_metadata("dependencies", {"foo" => {}}, 400, "Invalid value '{[]}' for metadata.dependencies")
-        end # [loop over dependencies, recommendations, suggestions,
-            #            conflicting, replacing]
-      end # context for collections
-    end # context when modifying metadata
-  end # context PUT /cookbooks/<name>/<version> [update]
+          end # context for #{type}
+        end # context for collections
+      end # context when modifying metadata
+    end # context PUT /cookbooks/<name>/<version> [update]
+  end
+
+  describe "API v0" do
+    it_behaves_like "updates cookbooks", 0
+  end
+
+  describe "API v2" do
+    it_behaves_like "updates cookbooks", 2
+  end
+
 end

--- a/oc-chef-pedant/spec/api/cookbooks/version_conversion_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/version_conversion_spec.rb
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# Copyright: Copyright (c) 2018 Chef Software, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "pedant/rspec/cookbook_util"
+
+describe "Cookbooks API endpoint", :cookbooks, :cookbooks_conversion do
+  let(:cookbook_url_base) { "cookbooks" }
+
+  before do
+    platform.reset_server_api_version
+  end
+
+  after do
+    platform.reset_server_api_version
+  end
+
+  include Pedant::RSpec::CookbookUtil
+
+  context "requests with different API versions" do
+    include Pedant::RSpec::Validations::Create
+
+    let(:sandbox) { create_sandbox(files) }
+    let(:upload) { ->(file) { upload_to_sandbox(file, sandbox) } }
+    let(:files) { (0..3).to_a.map { Pedant::Utility.new_random_file } }
+
+    let(:committed_files) do
+      files.each(&upload)
+      result = commit_sandbox(sandbox)
+      result
+    end
+
+    let(:checksums) { parse(committed_files)["checksums"] }
+
+    let(:request_method) { :PUT }
+    shared(:requestor) { admin_user }
+    let(:request_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/#{cookbook_version}") }
+    let(:cookbook_name) { "vconv" }
+    let(:cookbook_version) { self.class.cookbook_version }
+    let(:cookbook_payload) do
+      {
+        "recipes" => [{
+          "name" => "default.rb",
+          "path" => "recipes/default.rb",
+          "checksum" => checksums[0],
+          "specificity" => "default"
+        }],
+        "root_files" => [{
+          "name" => "CHANGELOG",
+          "path" => "CHANGELOG",
+          "checksum" => checksums[1],
+          "specificity" => "default",
+        }]
+      }
+    end
+    let(:cb_v0) { new_cookbook_v0(cookbook_name, cookbook_version, payload: cookbook_payload) }
+    let(:cb_v2) { new_cookbook_v2(cookbook_name, cookbook_version, payload: cookbook_payload) }
+
+    after do
+      delete_cookbook(admin_user, cookbook_name, cookbook_version)
+    end
+
+    # TODO: KLUDGE: Cop-out, because I am too tired to refactor the macros correctly
+    def self.cookbook_version
+      "1.2.3"
+    end
+
+    it "uploads as v0, downloads as v2" do
+      platform.server_api_version = 0
+      put(request_url, admin_user, payload: cb_v0) do |response|
+        response.should look_like({
+          status: 201,
+          body: cb_v0,
+        })
+      end
+
+      platform.server_api_version = 2
+      get(request_url, admin_user) do |response|
+        response.should look_like({
+          status: 200,
+          body: cb_v2,
+        })
+      end
+    end
+
+    it "uploads as v2, downloads as v0" do
+      platform.server_api_version = 2
+      put(request_url, admin_user, payload: cb_v2) do |response|
+        response.should look_like({
+          status: 201,
+          body: cb_v2,
+        })
+      end
+
+      platform.server_api_version = 0
+      get(request_url, admin_user) do |response|
+        response.should look_like({
+          status: 200,
+          body: cb_v0,
+        })
+      end
+    end
+  end
+end

--- a/oc-chef-pedant/spec/api/cookbooks/version_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/version_spec.rb
@@ -17,100 +17,126 @@ require 'pedant/rspec/cookbook_util'
 
 describe "Cookbook Versions API endpoint, GET", :cookbooks, :cookbooks_version do
 
-  let(:cookbook_url_base) { "cookbooks" }
+  shared_examples "versions cookbooks" do |api_version|
+    let(:cookbook_url_base) { "cookbooks" }
+    let(:api_version) { api_version }
 
-  include Pedant::RSpec::CookbookUtil
-
-  let(:request_method) { :GET }
-  let(:request_url)    { named_cookbook_url }
-  let(:requestor)      { admin_user }
-
-  let(:non_existent_cookbook){ "fakecookbook" }
-  let(:fake_version){ "1.0.0" }
-  let(:latest_cookbook_version_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/_latest") }
-
-  let(:fetch_cookbook_version_success_response) do
-    {
-      :status => 200,
-      :body => retrieved_cookbook(cookbook_name, cookbook_version)
-    }
-  end
-  let(:cookbook_version_not_found_exact_response) do
-    {
-      :status => 404,
-      :body_exact => { "error" => ["Cannot find a cookbook named #{cookbook_name} with version #{cookbook_version}"] }
-    }
-  end
-
-  context "with no cookbooks on the server" do
-    let(:expected_response) { cookbook_version_not_found_exact_response }
-    let(:cookbook_name) { non_existent_cookbook }
-    let(:cookbook_version) { fake_version }
-
-    should_respond_with 404
-  end # with no cookbooks on the server
-
-  context "with cookbooks on the server" do
-
-    let(:cookbook_name) { existing_cookbook_name }
-    let(:cookbook_version) { existing_cookbook_version }
-    let(:existing_cookbook_name){ "the_art_of_french_cooking" }
-    let(:existing_cookbook_version){ "1.0.0" }
-    let(:latest){ "1.0.1" }
-
-    before :each do
-      make_cookbook(admin_user, existing_cookbook_name, existing_cookbook_version)
-      # Erchef doesn't handle multipe versions yet
-      make_cookbook(admin_user, existing_cookbook_name, latest)
+    before do
+      platform.server_api_version = api_version
     end
 
-    after :each do
-      delete_cookbook(admin_user, existing_cookbook_name, existing_cookbook_version)
-      delete_cookbook(admin_user, existing_cookbook_name, latest)
+    after do
+      platform.reset_server_api_version
     end
 
-    context 'when fetching existing version of cookbook' do
-      let(:expected_response) { fetch_cookbook_version_success_response }
-
-      should_respond_with 200, 'and the cookbook version'
+    let(:segment_type) do
+      if api_version.to_i < 2
+        "files"
+      else
+        "all_files"
+      end
     end
 
-    context 'when fetching non-existant version of cookbook' do
-      let(:expected_response) { cookbook_version_not_found_exact_response }
-      let(:cookbook_version) { '6.6.6' }
+    include Pedant::RSpec::CookbookUtil
 
-      should_respond_with 404
+    let(:request_method) { :GET }
+    let(:request_url)    { named_cookbook_url }
+    let(:requestor)      { admin_user }
+
+    let(:non_existent_cookbook){ "fakecookbook" }
+    let(:fake_version){ "1.0.0" }
+    let(:latest_cookbook_version_url) { api_url("/#{cookbook_url_base}/#{cookbook_name}/_latest") }
+
+    let(:fetch_cookbook_version_success_response) do
+      {
+        :status => 200,
+        :body => retrieved_cookbook(cookbook_name, cookbook_version)
+      }
+    end
+    let(:cookbook_version_not_found_exact_response) do
+      {
+        :status => 404,
+        :body_exact => { "error" => ["Cannot find a cookbook named #{cookbook_name} with version #{cookbook_version}"] }
+      }
     end
 
-    context 'as a non-admin user' do
-      let(:expected_response) { fetch_cookbook_version_success_response }
-      let(:requestor) { normal_user }
-
-      should_respond_with 200, 'and the cookbook version'
-    end
-
-    context 'as a user outside the organization', :authorization do
-      let(:expected_response) { unauthorized_access_credential_response }
-      let(:requestor) { outside_user }
-
-      should_respond_with 403
-    end
-
-    context "when requesting the 'latest' Cookbook version", :smoke do
-      let(:expected_response) { fetch_cookbook_version_success_response }
-      let(:request_url) { latest_cookbook_version_url }
-      let(:cookbook_version) { latest }
-
-      should_respond_with 200, 'and the latest cookbook version'
-    end # when requesting the 'latest' cookbook version
-
-    context "when requesting the 'latest' version of a non-existent cookbook" do
+    context "with no cookbooks on the server" do
       let(:expected_response) { cookbook_version_not_found_exact_response }
       let(:cookbook_name) { non_existent_cookbook }
-      let(:cookbook_version) { '_latest' }
+      let(:cookbook_version) { fake_version }
 
       should_respond_with 404
-    end # when requesting the 'latest' version of a non-existent cookbook
-  end # with existing cookbook
-end
+    end # with no cookbooks on the server
 
+    context "with cookbooks on the server" do
+
+      let(:cookbook_name) { existing_cookbook_name }
+      let(:cookbook_version) { existing_cookbook_version }
+      let(:existing_cookbook_name){ "the_art_of_french_cooking" }
+      let(:existing_cookbook_version){ "1.0.0" }
+      let(:latest){ "1.0.1" }
+
+      before :each do
+        make_cookbook(admin_user, existing_cookbook_name, existing_cookbook_version)
+        # Erchef doesn't handle multipe versions yet
+        make_cookbook(admin_user, existing_cookbook_name, latest)
+      end
+
+      after :each do
+        delete_cookbook(admin_user, existing_cookbook_name, existing_cookbook_version)
+        delete_cookbook(admin_user, existing_cookbook_name, latest)
+      end
+
+      context 'when fetching existing version of cookbook' do
+        let(:expected_response) { fetch_cookbook_version_success_response }
+
+        should_respond_with 200, 'and the cookbook version'
+      end
+
+      context 'when fetching non-existant version of cookbook' do
+        let(:expected_response) { cookbook_version_not_found_exact_response }
+        let(:cookbook_version) { '6.6.6' }
+
+        should_respond_with 404
+      end
+
+      context 'as a non-admin user' do
+        let(:expected_response) { fetch_cookbook_version_success_response }
+        let(:requestor) { normal_user }
+
+        should_respond_with 200, 'and the cookbook version'
+      end
+
+      context 'as a user outside the organization', :authorization do
+        let(:expected_response) { unauthorized_access_credential_response }
+        let(:requestor) { outside_user }
+
+        should_respond_with 403
+      end
+
+      context "when requesting the 'latest' Cookbook version", :smoke do
+        let(:expected_response) { fetch_cookbook_version_success_response }
+        let(:request_url) { latest_cookbook_version_url }
+        let(:cookbook_version) { latest }
+
+        should_respond_with 200, 'and the latest cookbook version'
+      end # when requesting the 'latest' cookbook version
+
+      context "when requesting the 'latest' version of a non-existent cookbook" do
+        let(:expected_response) { cookbook_version_not_found_exact_response }
+        let(:cookbook_name) { non_existent_cookbook }
+        let(:cookbook_version) { '_latest' }
+
+        should_respond_with 404
+      end # when requesting the 'latest' version of a non-existent cookbook
+    end # with existing cookbook
+  end
+
+  describe "API v0" do
+    it_behaves_like "versions cookbooks", 0
+  end
+
+  describe "API v2" do
+    it_behaves_like "versions cookbooks", 2
+  end
+end

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_cookbook_artifact_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_cookbook_artifact_SUITE.erl
@@ -169,7 +169,7 @@ http_round_trip(Config) ->
 
     %% and the only difference with the original JSON that we sent should
     %% be the download URLs on each file
-    ExpectedGetBody = chef_cookbook_version:annotate_with_s3_urls(CreateEjson, OrgId, ""),
+    ExpectedGetBody = chef_cookbook_version:annotate_with_urls(CreateEjson, OrgId, ""),
     ?assertEqual(ok, ej:valid(ExpectedGetBody, GetBody)).
 
 http_get_nonexistant(_Config) ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -277,7 +277,7 @@ wm_halt(Code, Req, State, ErrorData, LogMsg) ->
 %% Note the cookbook object we return back is a stripped-down version,
 %% removing large fields such as long_description and attributes in
 %% the metadata that are not required by chef-client
-assemble_response(Req, State, CookbookVersions) ->
+assemble_response(Req, #base_state{server_api_version = ApiVersion} = State, CookbookVersions) ->
     case oc_chef_wm_base:check_cookbook_authz(CookbookVersions, Req, State) of
         ok ->
             %% We iterate over the list again since we only want to construct the s3urls
@@ -285,7 +285,7 @@ assemble_response(Req, State, CookbookVersions) ->
             %% cookbook which has just enough information for chef-client to run
             JsonList = {
                     [ { CBV#chef_cookbook_version.name,
-                       chef_cookbook_version:minimal_cookbook_ejson(CBV, chef_wm_util:base_uri(Req)) }
+                       chef_cookbook_version:minimal_cookbook_ejson(CBV, chef_wm_util:base_uri(Req), ApiVersion) }
                       || CBV <- CookbookVersions ]
                     },
             CBMapJson = chef_json:encode(JsonList),

--- a/src/oc_erchef/include/server_api_version.hrl
+++ b/src/oc_erchef/include/server_api_version.hrl
@@ -10,12 +10,15 @@
 % and not product version.
 -define(API_v1, 1).
 
+% Deprecates cookbook segments
+-define(API_v2, 2).
+
 %% Highest level of deprecated API version that will be removed in the nxt major product release.
 %% This is used in eunit tests for version range testing across objects.
 -define(API_DEPRECATED_VER, ?API_v0).
 
 
 -define(API_MIN_VER, ?API_v0).
--define(API_MAX_VER, ?API_v1).
+-define(API_MAX_VER, ?API_v2).
 
 -type api_version() :: non_neg_integer() | -1.


### PR DESCRIPTION
https://chef.github.io/chef-rfc/rfc067-cookbook-segment-deprecation.html
This bumps API version for cookbook requests to 2.0, and transforms
cookbook metadata to provide all_files.