### PR TITLE
Use OpenSSL::Digest instead of Digest for FIPS

### DIFF
--- a/omnibus/files/veil/lib/veil/hasher/base.rb
+++ b/omnibus/files/veil/lib/veil/hasher/base.rb
@@ -1,4 +1,4 @@
-require "digest"
+require "openssl"
 require "veil/exceptions"
 
 module Veil
@@ -37,7 +37,7 @@ module Veil
       #
       # @return [String]
       def hex_digest(data)
-        Digest::SHA512.hexdigest(data)
+        OpenSSL::Digest::SHA512.hexdigest(data)
       end
     end
   end

--- a/omnibus/files/veil/spec/hasher/base_spec.rb
+++ b/omnibus/files/veil/spec/hasher/base_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "digest"
 
 describe Veil::Hasher::Base do
   let(:data) { "let him enter" }
@@ -7,7 +8,12 @@ describe Veil::Hasher::Base do
 
   describe "#hex_digest" do
     it "returns a SHA512 hex digest of the data" do
-      expect(subject.send(:hex_digest, data)).to eq(Digest::SHA512.hexdigest(data))
+      expect(subject.send(:hex_digest, data)).to eq(OpenSSL::Digest::SHA512.hexdigest(data))
+    end
+
+    it "does not use Digest, which uses low level APIs prohibited by FIPS" do
+      expect(Digest::SHA512).not_to receive(:hexdigest)
+      subject.send(:hex_digest, data)
     end
   end
 end


### PR DESCRIPTION
Low level API calls to encryption algorithms are not allowed when using the
OpenSSL FIPS 140-2 module. When FIPS mode is enabled, all calls must go through
the FIPS module.

Fixes #1024

Signed-off-by: Bryan McLellan <btm@loftninjas.org>