### PR TITLE
[bookshelf] Don't send Cache-Control headers for 404 responses

### DIFF
--- a/oc-chef-pedant/spec/api/cookbooks/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/delete_spec.rb
@@ -69,7 +69,7 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_delete do
 
       context "when deleting existent version of an existing cookbook", :smoke do
         let(:recipe_name) { "test_recipe" }
-        let(:recipe_content) { "hello-#{unique_suffix}" }
+        let(:recipe_content) { "hello-#{unique_suffix}-#{rand(1000)}-#{rand(1000)}" }
         let(:recipe_spec) do
             {
               :name => recipe_name,

--- a/src/bookshelf/src/bksw_cleanup_task.erl
+++ b/src/bookshelf/src/bksw_cleanup_task.erl
@@ -79,7 +79,7 @@ code_change(_OldVsn, State, _Extra) ->
 do_delete_cleanup(#state{deleted_cleanup_interval = Interval}) ->
     case sqerl:select(purge_expired, [Interval], first_as_scalar, [purge_expired]) of
         {ok, Count} ->
-            lager:debug("Cleanup task: cleaned up %p expired file_data elements", [Count]),
+            lager:debug("Cleanup task: cleaned up ~p expired file_data elements", [Count]),
             Count;
         _Error ->
             lager:debug("Cleanup task: error cleaning up expired file_data elements", []),
@@ -89,7 +89,7 @@ do_delete_cleanup(#state{deleted_cleanup_interval = Interval}) ->
 do_upload_cleanup(#state{upload_cleanup_interval = Interval}) ->
     case sqerl:select(cleanup_abandoned_uploads, [Interval], first_as_scalar, [cleanup_abandoned_uploads]) of
         {ok, Count} ->
-            lager:debug("Cleanup task: cleaned up %p expired file_data elements", [Count]),
+            lager:debug("Cleanup task: cleaned up ~p expired file_data elements", [Count]),
             Count;
         _Error ->
             lager:debug("Cleanup task: error cleaning up expired file_data elements", []),

--- a/src/bookshelf/src/bksw_wm_base.erl
+++ b/src/bookshelf/src/bksw_wm_base.erl
@@ -46,6 +46,10 @@ finish_request(Rq0, Ctx) ->
             500 ->
                 Rq1 = create_500_response(Rq0, Ctx),
                 {true, Rq1, Ctx};
+            %% Ensure we don't tell upstream servers to cache 404s
+            C when C >= 400 andalso C < 500 ->
+                Rq1 = wrq:remove_resp_header("Cache-Control", Rq0),
+                {true, Rq1, Ctx};
             _ ->
                 {true, Rq0, Ctx}
         end


### PR DESCRIPTION
The Chef Backend tests run Chef Server with nginx cookbook caching
enabled. This led to test failures because of cached responses from
previous test cases being returned by nginx.

In a few cases, we found that nginx was caching 404 responses because
bookshelf was always sending a Cache-Control header. Since we never
want to cache 404s, the Cache-Control header is now removed from the
response before it is sent.

For a case where the problem was caused by a cached 200 response
(which we normally want to be cached), I've changed the test so that
it is unlikely that the tests are referring to the file.

Signed-off-by: Steven Danna <steve@chef.io>