### PR TITLE
[oc-id] Bump omniauth to 1.3.2

### DIFF
--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -10,7 +10,7 @@ gem 'rb-readline', '~> 0.5.2', require: false
 gem 'sass-rails', '>= 4.0.3'
 gem 'turbolinks', '~> 2.2.1'
 gem 'unicorn-rails', '~> 1.1.0'
-gem 'omniauth', '~> 1.2.1'
+gem 'omniauth', '~> 1.3.2'
 gem 'omniauth-chef'
 gem 'nokogiri', '~> 1.6.2'
 gem 'pg'

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -227,9 +227,9 @@ GEM
       mixlib-shellout (~> 1.2)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    omniauth (1.2.2)
+    omniauth (1.3.2)
       hashie (>= 1.2, < 4)
-      rack (~> 1.0)
+      rack (>= 1.0, < 3)
     omniauth-chef (0.2.0)
       chef (~> 11)
       omniauth (~> 1.2)
@@ -261,7 +261,7 @@ GEM
       pry (>= 0.9.11)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -409,7 +409,7 @@ DEPENDENCIES
   mixlib-authentication (~> 1.3.0)
   newrelic_rpm
   nokogiri (~> 1.6.2)
-  omniauth (~> 1.2.1)
+  omniauth (~> 1.3.2)
   omniauth-chef
   pg
   pry-byebug
@@ -432,4 +432,4 @@ DEPENDENCIES
   unicorn-rails (~> 1.1.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.7


### PR DESCRIPTION
Recently, omniauth shipped a fix to a security vulnerability:

  https://github.com/omniauth/omniauth/pull/867

I haven't investigated whether this is a serious issue for us, but it
seemed prudent to just try an update.

Signed-off-by: Steven Danna <steve@chef.io>