### PR TITLE
[erchef] Improve error message on user conflict

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_users.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_users.erl
@@ -138,11 +138,8 @@ verbose_user(#chef_user{username = UserName, email = EMail, serialized_object = 
                   {<<"first_name">>, ej:get({<<"first_name">>}, EJ, "")},
                   {<<"last_name">>, ej:get({<<"last_name">>}, EJ, "")} ]} }.
 
-
-
-conflict_message(Name) ->
-    Msg = iolist_to_binary([<<"User '">>, Name, <<"' already exists">>]),
-    {[{<<"error">>, [Msg]}]}.
+conflict_message(_Name) ->
+    {[{<<"error">>, [<<"Username or email address already in use.">>]}]}.
 
 malformed_request_message(Any, _Req, _state) ->
     error({unexpected_malformed_request_message, Any}).


### PR DESCRIPTION
We can get a conflict from the DB in two cases, username conflict or
email conflict. This fixes the error message to alert the user of both
possibilities.

The old error message confused a lot of people:

Fixes #59

Signed-off-by: Steven Danna <steve@chef.io>