### PR TITLE
Lock chef-client and ohai to 12.17.44 and 9.22.1

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -31,7 +31,8 @@ override :rabbitmq, version: "3.3.4"
 override :erlang, version: "17.5"
 override :lua, version: "5.1.5"
 override :'omnibus-ctl', version: "master"
-
+override :chef, version: "v12.17.44"
+override :ohai, version: "8.22.1"
 override :ruby, version: "2.3.3"
 override :rubygems, version: "2.6.8"
 


### PR DESCRIPTION
Lock chef-client and ohai to a known working version.  Future updates will be pulled after each release.
