### PR TITLE
[SPOOL-490] Make java handle GC log rotation

### DIFF
--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -53,7 +53,8 @@ build do
       f.write FFI_Yajl::Encoder.encode(
         run_list: [
           'recipe[private-chef::post_11_upgrade_cleanup]',
-          'recipe[private-chef::post_12_upgrade_cleanup]'
+          'recipe[private-chef::post_12_upgrade_cleanup]',
+          'recipe[private-chef::solr4_gclog_cleanup]'
         ]
       )
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -224,6 +224,7 @@ default['private_chef']['opscode-solr4']['temp_directory'] = "/var/opt/opscode/o
 default['private_chef']['opscode-solr4']['log_directory'] = "/var/log/opscode/opscode-solr4"
 default['private_chef']['opscode-solr4']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['opscode-solr4']['log_rotation']['num_to_keep'] = 10
+default['private_chef']['opscode-solr4']['log_gc'] = true
 # defaults for heap size and new generation size are computed in the chef-solr
 # recipe based on node memory
 default['private_chef']['opscode-solr4']['heap_size'] = nil

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/solr4_gclog_cleanup.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/solr4_gclog_cleanup.rb
@@ -1,0 +1,27 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Delete old rotated log files for opscode-solr4
+#
+::Dir.glob(::File.join(node['private_chef']['opscode-solr4']['log_directory'], "gclog.log.*.gz")).each do |filename|
+  file filename do
+    action :delete
+  end
+end
+
+file ::File.join(node['private_chef']['opscode-solr4']['log_directory'], "gclog.log") do
+  action :delete
+end


### PR DESCRIPTION
With logrotate's copytruncate handling of
/var/log/opscode/opscode-solr4/gclog.log, the system could end up with
(truncated) sparse files that had a huge apparent size (`du
--apparent-size FILE`). Non-sparse-file-aware tools could then create a
mess when copying those logs.

See also http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7055309

Now, the rotation of those gclog files is handled by java (by passing
the right arguments). Also, it can be disabled in case you don't need
those files. For backwards compatibility, we've defaulted it to true.

Also, this adds another recipe for `chef-server-ctl cleanup` that
removes old rotated log files (when it was handled by logrotate).

Signed-off-by: Stephan Renatus <srenatus@chef.io>