### PR TITLE
Revert ruby to 2.2.6

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -33,7 +33,7 @@ override :lua, version: "5.1.5"
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v12.17.44"
 override :ohai, version: "8.22.1"
-override :ruby, version: "2.3.3"
+override :ruby, version: "2.2.6"
 override :rubygems, version: "2.6.8"
 
 # creates required build directories


### PR DESCRIPTION
The goal is to move to 2.3.3 soon; however, since moving to 2.3.3
we've seen an increased rate of Timeout errors during particular
tests. We currently believe that this may be because of poor
interactions between our forked version of rest-client, our net/http
IPv6 patches, and the newer Ruby version.  Rolling this back for now
gives us more time to sort that out while keeping the build working.

Signed-off-by: Steven Danna <steve@chef.io>