### PR TITLE
Fix Makefiles to not distclean by default

### DIFF
--- a/src/bookshelf/Makefile
+++ b/src/bookshelf/Makefile
@@ -1,6 +1,4 @@
-distclean:
-	rm -rf _build
-
+.DEFAULT_GOAL=all
 
 ## For Rebar
 REBAR3_URL=https://s3.amazonaws.com/rebar3/rebar3
@@ -37,6 +35,9 @@ ct: $(REBAR3)
 
 version_clean:
 	@rm -f VERSION
+
+distclean:
+	rm -rf _build
 
 ## echo -n only works in bash shell
 SHELL=bash

--- a/src/chef-mover/Makefile
+++ b/src/chef-mover/Makefile
@@ -1,3 +1,4 @@
+.DEFAULT_GOAL=all
 REBAR3_URL=https://s3.amazonaws.com/rebar3/rebar3
 
 # If there is a rebar in the current directory, use it

--- a/src/oc_bifrost/Makefile
+++ b/src/oc_bifrost/Makefile
@@ -1,6 +1,4 @@
-distclean:
-	rm -rf _build
-
+.DEFAULT_GOAL=all
 REBAR3_URL=https://s3.amazonaws.com/rebar3/rebar3
 
 # If there is a rebar in the current directory, use it
@@ -64,6 +62,9 @@ travis: update all pedant
 
 version_clean:
 	@rm -f VERSION
+
+distclean:
+	rm -rf _build
 
 ## echo -n only works in bash shell
 SHELL=bash

--- a/src/oc_erchef/Makefile
+++ b/src/oc_erchef/Makefile
@@ -1,3 +1,4 @@
+.DEFAULT_GOAL=all
 REBAR3_URL=https://s3.amazonaws.com/rebar3/rebar3
 
 # If there is a rebar in the current directory, use it


### PR DESCRIPTION
At some point `distclean` became the default goal for a few of
Makefiles. This is frustrating. This fixes the Makefile's for our
top-level erlang projects to ensure all is the default goal.

Signed-off-by: Steven Danna <steve@chef.io>