### PR TITLE
[ER-444] Enable FIPS configuration at runtime via chef-server.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ version-manifest.json
 MODIFIED_COMPONENTS_CHANGELOG.md
 /dev/nodes
 dev/*.deb
+src/oc_erchef/log

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,19 @@ This document contains release notes for the current major release and all patch
 For prior releases, see
 [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
 
+## Unreleased
+
+### FIPS runtime flag exposed
+
+We are updating the Chef Server package to expose a `fips` configuration flag
+in the `chef-server.rb`. Setting `fips true` and reconfiguring will start the
+server in FIPS mode. The default value of this flag is `false` except
+on systems where FIPS is enabled at the Kernel where it defaults to `true`.
+
+The only supported systems at this time for FIPS mode are RHEL. Package for
+other systems will be missing the required OpenSSL FIPS module and will fail
+to start if reconfigured with `fips true`.
+
 ## 12.12.0 (2017-01-26)
 
 This release addresses a number of bugs, the most notable are describe

--- a/dev/README.md
+++ b/dev/README.md
@@ -19,9 +19,7 @@ Requirements:
 * VirtualBox 4.3+
 * Vagrant 1.7+
 * At least one recent Chef Server 12.0.9+ debian package download,
-  which you can grab from https://bintray.com/chef/current/chef-server. Note
-  that you should download the chef-server-core package, and not run the
-  installer. dvm will then look for the package in either the Downloads dir
+  which you can get using this command (if you have the most recent chefdk) `mixlib-install download chef-server -p ubuntu -a x86_64 -l 14`. dvm will then look for the package in either the Downloads dir
   on your machine or the omnibus/pkg directory under the chef-server repo
   where dvm is running. You can also set the INSTALLER environment variable
   to tell dvm where to find the package if it is not in one of those locations.
@@ -57,7 +55,7 @@ knife config on your workstation.
     vagrant ssh
     sudo -i
     # create a user to access chef with
-    chef-server-ctl user-create -f /tmp/admin.pem admin Admin User admin@example.com password 
+    chef-server-ctl user-create -f /tmp/admin.pem admin Admin User admin@example.com password
     # create an organization
     chef-server-ctl org-create -f /tmp/test-validator.pem test Test
     # associate the user with the organization

--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -34,7 +34,6 @@ build do
   block do
     File.open("#{install_dir}/embedded/cookbooks/dna.json", "w") do |f|
       run_list = Array.new.tap do |r|
-        r << 'recipe[private-chef::fips]' if fips_mode?
         r << 'recipe[private-chef::default]'
       end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -39,11 +39,7 @@ default['private_chef']['license']['upgrade_url'] = "http://www.chef.io/contact/
 
 default['private_chef']['default_orgname'] = nil
 
-# Enable fips mode (openssl)
-# This requires the chef-server-fips package. If you do not have this,
-# your chef-server will probably not work. If you have to manually
-# change this, you're doing it wrong.
-default['private_chef']['fips_enabled'] = false
+default['private_chef']['fips_enabled'] = ChefConfig.fips?
 
 ###
 # Options for installing addons

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -82,6 +82,7 @@ module PrivateChef
   from_email nil
   role nil
   user Mash.new
+  fips nil
 
   ldap Mash.new
   disabled_plugins []
@@ -244,6 +245,7 @@ module PrivateChef
       results["private_chef"]["oc-chef-pedant"] = PrivateChef["oc_chef_pedant"]
       results["private_chef"]["notification_email"] = PrivateChef["notification_email"]
       results["private_chef"]["from_email"] = PrivateChef["from_email"]
+      results["private_chef"]["fips_enabled"] = PrivateChef["fips"]
       results["private_chef"]["role"] = PrivateChef["role"]
       results["private_chef"]["topology"] = PrivateChef["topology"]
       results["private_chef"]["servers"] = PrivateChef["servers"]

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -37,6 +37,10 @@ include_recipe "private-chef::plugin_discovery"
 include_recipe "private-chef::plugin_config_extensions"
 include_recipe "private-chef::config"
 
+if node['private_chef']['fips_enabled']
+  include_recipe "private-chef::fips"
+end
+
 # Warn about deprecated opscode_webui settings
 opscode_webui_deprecation_notice = OpscodeWebuiDeprecationNotice.new(
   PrivateChef['opscode_webui']

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/fips.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/fips.rb
@@ -1,3 +1,2 @@
-node.default['private_chef']['fips_enabled'] = true
 node.default['private_chef']['nginx']['enable_non_ssl'] = true
 node.default['private_chef']['nginx']['ssl_ciphers'] = "FIPS@STRENGTH:!aNULL:!eNULL"

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -87,6 +87,17 @@ EOF
     }
   }
 
+  context "When FIPS is enabled at the kernel" do
+    let(:config) { <<-EOF
+fips true
+EOF
+    }
+    it "sets fips_enabled to true" do
+      rendered_config = config_for("api.chef.io")
+      expect(rendered_config["private_chef"]["fips_enabled"]).to eq(true)
+    end
+  end
+
   context "in a standalone topology" do
     let(:config) { <<-EOF
 topology "standalone"


### PR DESCRIPTION
Instead of at build time. Setting 'fips true' in your chef-server.rb and
reconfiguring will run the existing fips recipe. If FIPS is enabled at
the Kernel level this value is defaulted to true and can be overridden
with 'fips false'.

Signed-off-by: tyler-ball <tyleraball@gmail.com>
Signed-off-by: rmoshier <rmoshier@gmail.com>

For the `chef-server-12` pipeline this should not cause any differences. The `fips_mode?` method was returning false and will keep returning false. It does default the `fips_enabled` attribute to true if FIPS is enabled in your Kernel. This could potentially break customers until we start including the OpenSSL-FIPS module (the next card in our backlog).

- [x] Update README or docs to show the new `fips true` flag available in `chef-server.rb`
- [x] Update tests