### PR TITLE
Use xz compression (level 1) for RPM and DEBs

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -102,6 +102,13 @@ dependency "cleanup" # MUST BE LAST DO NOT MOVE
 
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']
+  compression_level 1
+  compression_type :xz
+end
+
+package :deb do
+  compression_level 1
+  compression_type :xz
 end
 
 exclude "**/.git"


### PR DESCRIPTION
This reduces the package size considerably, with a similar run time.

[Ad-hoc build is here](http://wilson.ci.chef.co/view/Chef%20Server%2012/job/chef-server-12-trigger-ad_hoc/325/downstreambuildview/).

Glancing at the numbers, we find for el-7/x86_64 (size in MB, packaging time in seconds)

old: 327M, 458s
new: 275M, 369s

and for ubuntu-12.04/amd64:

old: 324M, 299s
new: 270M, 248s