### PR TITLE
Bringing omnibus process in line with other Chef applications

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,17 +1,25 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'rake'
-gem 'chefspec'
-gem 'berkshelf'
-gem 'bundler', '>1.10'
+gem "omnibus", git: 'https://github.com/chef/omnibus'
+gem "omnibus-software", git: 'https://github.com/chef/omnibus-software'
+gem "license_scout", git: 'https://github.com/chef/license_scout'
 
-# Install omnibus software
-group :omnibus do
-  gem 'omnibus', git: 'https://github.com/chef/omnibus'
-  gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software'
-  gem 'license_scout', git: 'https://github.com/chef/license_scout'
+# Needed to find license for private-chef-cookbooks
+gem "berkshelf"
+
+# Needed to run Travis tests
+group :test do
+  gem "rspec"
+  gem "rake"
+  gem "chefspec"
 end
 
-group :test do
-  gem 'rspec'
+group :development do
+  gem "test-kitchen"
+  gem "kitchen-vagrant"
+  gem "winrm-fs"
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer"
+  gem "rb-readline"
 end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/license_scout
-  revision: 383ad28edeea0f587aee57b969c77a21b7909e77
+  revision: ae7f2412751dcb411d2bb60abe2086d8ae7ae86f
   specs:
     license_scout (0.1.2)
       ffi-yajl (~> 2.2)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus
-  revision: efd598e477148e5ed7a83579131c6604fafe5800
+  revision: af00366e4d8a5150d7b82b1b3faf91b19a20704e
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -35,15 +35,16 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    aws-sdk (2.7.2)
-      aws-sdk-resources (= 2.7.2)
-    aws-sdk-core (2.7.2)
+    artifactory (2.5.2)
+    aws-sdk (2.7.3)
+      aws-sdk-resources (= 2.7.3)
+    aws-sdk-core (2.7.3)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.7.2)
-      aws-sdk-core (= 2.7.2)
+    aws-sdk-resources (2.7.3)
+      aws-sdk-core (= 2.7.3)
     aws-sigv4 (1.0.0)
-    berkshelf (5.3.0)
+    berkshelf (5.5.0)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (>= 2.0.2, < 4.0)
       buff-config (~> 2.0)
@@ -63,6 +64,8 @@ GEM
       faraday (~> 0.9)
       httpclient (~> 2.7)
       ridley (>= 4.5, < 6.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     buff-config (2.0.0)
       buff-extensions (~> 2.0)
       varia_model (~> 0.6)
@@ -72,83 +75,60 @@ GEM
     buff-shell_out (1.1.0)
       buff-ruby_engine (~> 1.0)
     builder (3.2.3)
+    byebug (9.0.6)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef (12.17.44)
-      addressable
-      bundler (>= 1.10)
-      chef-config (= 12.17.44)
-      chef-zero (>= 4.8)
-      diff-lcs (~> 1.2, >= 1.2.4)
-      erubis (~> 2.7)
-      ffi-yajl (~> 2.2)
-      highline (~> 1.6, >= 1.6.9)
-      iniparse (~> 1.4)
-      mixlib-archive (>= 0.2.0)
-      mixlib-authentication (~> 1.4)
-      mixlib-cli (~> 1.7)
-      mixlib-log (~> 1.3)
-      mixlib-shellout (~> 2.0)
-      net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (>= 2.9, < 4.0)
-      net-ssh-multi (~> 1.1)
-      ohai (>= 8.6.0.alpha.1, < 9)
-      plist (~> 3.2)
-      proxifier (~> 1.0)
-      rspec-core (~> 3.5)
-      rspec-expectations (~> 3.5)
-      rspec-mocks (~> 3.5)
-      rspec_junit_formatter (~> 0.2.0)
-      serverspec (~> 2.7)
-      specinfra (~> 2.10)
-      syslog-logger (~> 1.6)
-      uuidtools (~> 2.1.5)
-    chef-config (12.17.44)
+    chef-config (12.18.31)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     chef-sugar (3.4.0)
-    chef-zero (5.1.1)
-      ffi-yajl (~> 2.2)
-      hashie (>= 2.0, < 4.0)
-      mixlib-log (~> 1.3)
-      rack (~> 2.0)
-      uuidtools (~> 2.1)
-    chefspec (5.3.0)
-      chef (>= 12.0)
-      fauxhai (~> 3.6)
-      rspec (~> 3.0)
+    chefspec (0.0.1)
     cleanroom (1.0.0)
+    coderay (1.1.1)
+    debug_inspector (0.0.2)
     diff-lcs (1.3)
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    fauxhai (3.10.0)
-      net-ssh
     ffi (1.9.17)
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
+    gssapi (1.2.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
     hashie (3.4.6)
-    highline (1.7.8)
     hitimes (1.2.4)
     httpclient (2.8.3)
-    iniparse (1.4.2)
     ipaddress (0.8.3)
     jmespath (1.3.1)
     json (2.0.3)
+    kitchen-vagrant (1.0.0)
+      test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
+    little-plugger (1.1.4)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    method_source (0.8.2)
     minitar (0.5.4)
-    mixlib-archive (0.2.0)
+    mixlib-archive (0.3.0)
       mixlib-log
     mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
+    mixlib-install (2.1.10)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
+      thor
     mixlib-log (1.7.1)
     mixlib-shellout (2.2.7)
     mixlib-versioning (1.1.0)
@@ -157,16 +137,11 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-sftp (2.1.2)
+    net-ssh (4.0.1)
+    net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
-    net-ssh (3.2.0)
-    net-ssh-gateway (1.2.0)
-      net-ssh (>= 2.6.5)
-    net-ssh-multi (1.2.1)
-      net-ssh (>= 2.6.5)
-      net-ssh-gateway (>= 1.2.0)
-    net-telnet (0.1.1)
     nio4r (2.0.0)
+    nori (2.6.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (8.23.0)
@@ -182,10 +157,19 @@ GEM
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     plist (3.2.0)
-    proxifier (1.0.3)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     public_suffix (2.0.5)
-    rack (2.0.1)
     rake (12.0.0)
+    rb-readline (0.5.3)
     retryable (2.0.4)
     ridley (5.1.0)
       addressable
@@ -214,44 +198,51 @@ GEM
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
-    rspec-its (1.2.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rspec_junit_formatter (0.2.3)
-      builder (< 4)
-      rspec-core (>= 2, < 4, != 2.12.0)
     ruby-progressbar (1.8.1)
+    rubyntlm (0.6.1)
+    rubyzip (1.2.0)
+    safe_yaml (1.0.4)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     semverse (2.0.0)
-    serverspec (2.38.0)
-      multi_json
-      rspec (~> 3.0)
-      rspec-its
-      specinfra (~> 2.53)
-    sfl (2.3)
+    slop (3.6.0)
     solve (3.1.0)
       molinillo (>= 0.5)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.66.5)
-      net-scp
-      net-ssh (>= 2.7, < 5.0)
-      net-telnet
-      sfl
-    syslog-logger (1.6.8)
     systemu (2.6.5)
+    test-kitchen (1.15.0)
+      mixlib-install (>= 1.2, < 3.0)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-gateway (~> 1.2)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
     thor (0.19.1)
     timers (4.0.4)
       hitimes
-    uuidtools (2.1.5)
     varia_model (0.6.0)
       buff-extensions (~> 2.0)
       hashie (>= 2.0.2, < 4.0.0)
+    winrm (2.1.2)
+      builder (>= 2.1.2)
+      erubis (~> 2.7)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0, >= 0.6.1)
+    winrm-fs (1.0.1)
+      erubis (~> 2.7)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 1.1)
+      winrm (~> 2.0)
     wmi-lite (1.0.0)
 
 PLATFORMS
@@ -259,13 +250,19 @@ PLATFORMS
 
 DEPENDENCIES
   berkshelf
-  bundler (> 1.10)
   chefspec
+  kitchen-vagrant
   license_scout!
   omnibus!
   omnibus-software!
+  pry
+  pry-byebug
+  pry-stack_explorer
   rake
+  rb-readline
   rspec
+  test-kitchen
+  winrm-fs
 
 BUNDLED WITH
    1.13.7

--- a/omnibus/Makefile
+++ b/omnibus/Makefile
@@ -80,7 +80,7 @@ dev-build: clear_pkg_cache prune
 
 install:
 	gem install bundler -v 1.12.0
-	bundle _1.12.0_ install
+	bundle _1.12.0_ install --without development
 
 verify_encoding:
 	../scripts/filetype-check.sh .


### PR DESCRIPTION
These are some changes I found helpful while building https://github.com/chef/chef-server/pull/1065 locally. I wanted to move them into another PR to clean up that one.

This allowed me to `cd omnibus && bundle install && bundle exec kitchen converge centos-7` to get a good centos builder