### PR TITLE
[ER-459] Ruby templating missing newline

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.vm.args.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.vm.args.erb
@@ -37,6 +37,6 @@
 <%- if node['private_chef']['fips_enabled'] -%>
 ## Runtime switches to enable loading custom crypto module
 ## that supports OpenSSL-FIPS
--env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") =%>
--pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") =%>
+-env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") %>
+-pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") %>
 <%- end -%>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.vm.args.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.vm.args.erb
@@ -26,6 +26,6 @@
 <%- if node['private_chef']['fips_enabled'] -%>
 ## Runtime switches to enable loading custom crypto module
 ## that supports OpenSSL-FIPS
--env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") =%>
--pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") =%>
+-env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") %>
+-pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") %>
 <%- end -%>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.vm.args.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.vm.args.erb
@@ -33,6 +33,6 @@
 <%- if node['private_chef']['fips_enabled'] -%>
 ## Runtime switches to enable loading custom crypto module
 ## that supports OpenSSL-FIPS
--env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") =%>
--pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") =%>
+-env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") %>
+-pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") %>
 <%- end -%>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.vm.args.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.vm.args.erb
@@ -24,6 +24,6 @@
 <%- if node['private_chef']['fips_enabled'] -%>
 ## Runtime switches to enable loading custom crypto module
 ## that supports OpenSSL-FIPS
--env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") =%>
--pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") =%>
+-env ERLANG_CRYPTO2_PATH <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/priv") %>
+-pa <%= File.join(node['private_chef']['install_path'], "/embedded/lib/erlang-crypto2/ebin") %>
 <%- end -%>


### PR DESCRIPTION
\cc @chef/chef-server-maintainers 

This caused the vm.args to end up with

```
-env ERLANG_CRYPTO2_PATH /opt/opscode/embedded/lib/erlang-crypto2/priv-pa /opt/opscode/embedded/lib/erlang-crypto2/ebin
```

instead of

```
-env ERLANG_CRYPTO2_PATH /opt/opscode/embedded/lib/erlang-crypto2/priv
-pa /opt/opscode/embedded/lib/erlang-crypto2/ebin
```

I'm not really sure why that was happening. If anyone has a better suggestion, I'm open to that