### PR TITLE
[ER-455] Run pedant tests with FIPS enabled

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -11,5 +11,5 @@ then
   echo "Sleeping 120 seconds to allow the Chef Server to reconfigure in FIPS mode"
   echo ""
   sleep 120
-  sudo chef-server-ctl test -J $WORKSPACE/pedant-fips.xml
+  sudo chef-server-ctl test -J $WORKSPACE/pedant-fips.xml --smoke
 fi

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
 set -evx
 
-chef-server-ctl test -J $WORKSPACE/pedant.xml --all
+sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --all
+
+if [ $OMNIBUS_FIPS_MODE == "true" ]
+then
+  echo "fips true" >> /etc/opscode/chef-server.rb
+  sudo chef-server-ctl reconfigure
+  echo ""
+  echo "Sleeping 120 seconds to allow the Chef Server to reconfigure in FIPS mode"
+  echo ""
+  sleep 120
+  sudo chef-server-ctl test -J $WORKSPACE/pedant-fips.xml
+fi


### PR DESCRIPTION
This only happens on FIPS supported environments.

Signed-off-by: tyler-ball <tyleraball@gmail.com>

\cc @chef/chef-server-maintainers 