### PR TITLE
[erchef] Improve reindex reliability when using ElasticSearch

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -277,6 +277,42 @@ default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
 default['private_chef']['opscode-erchef']['sql_password'] = "snakepliskin"
 default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
 default['private_chef']['opscode-erchef']['sql_ro_password'] = "shmunzeltazzen"
+#
+# Reindex configurables
+#
+# NOTE: The semantics of reindexing are very different between
+# ElasticSearch and Solr. Solr reindexing is only placing an item on a
+# queue, thus it is unlikely to fail at the erchef level.  Rather, you
+# will want to tune opscode-expander.
+#
+# These configuration items are consulted during reindex requests.
+# Such requests originate from users running chef-server-ctl reindex.
+#
+#   reindex_batch_size - Number of items to fetch from the database
+#                        and send to the search index at a time.
+#
+# reindex_sleep_min_ms - Minimum number of milliseconds to sleep
+#                        before retrying a failed attempt to index an
+#                        item. Retries are delayed a random number of
+#                        miliseconds between reindex_sleep_min_ms and
+#                        reindex_sleep_max_ms. Set both this and
+#                        reindex_sleep_max_ms to 0 to skip the sleep.
+#
+# reindex_sleep_max_ms - Maximum number of milliseconds to sleep
+#                        before retrying a failed attempt to index an
+#                        item. Retries are delayed a random number of
+#                        miliseconds between reindex_sleep_min_ms and
+#                        reindex_sleep_max_ms. Set both this and
+#                        reindex_sleep_min_ms to 0 to skip the sleep.
+#
+# reindex_item_retries - Number of times to retry indexing an object
+#                        if it fails.
+#
+default['private_chef']['opscode-erchef']['reindex_batch_size'] = 10
+default['private_chef']['opscode-erchef']['reindex_sleep_min_ms'] = 500
+default['private_chef']['opscode-erchef']['reindex_sleep_max_ms'] = 2000
+default['private_chef']['opscode-erchef']['reindex_item_retries'] = 3
+#
 # Pool configuration for postgresql connections
 #
 # db_pool_size - the number of pgsql connections in the pool

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_solr_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_solr_validator_spec.rb
@@ -1,0 +1,87 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative '../../libraries/preflight_solr_validator.rb'
+require_relative '../../libraries/private_chef.rb'
+require_relative '../../libraries/helper.rb'
+
+describe SolrPreflightValidator do
+  let(:solr_preflight) {
+    s = SolrPreflightValidator.new({'private_chef' => {
+      'opscode-erchef' => {
+        'reindex_sleep_min_ms' => 500,
+        'reindex_sleep_max_ms' => 2000,
+      },
+      'postgresql' => {}}})
+    allow(s).to receive(:fail_with).and_return(:i_failed)
+    s
+  }
+
+  context "when min and max sleep time has been given in the config" do
+    before(:each) do
+      allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
+      allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
+      allow(PrivateChef).to receive(:[]).with('opscode_erchef').and_return({
+        'reindex_sleep_min_ms' => min_sleep_time,
+        'reindex_sleep_max_ms' => max_sleep_time
+      })
+    end
+
+    context "when min is greater then max" do
+      let(:min_sleep_time) { 100 }
+      let(:max_sleep_time) { 2 }
+
+      it "raises an error" do
+        expect(solr_preflight.verify_sane_reindex_sleep_times).to eq(:i_failed)
+      end
+    end
+  end
+
+  context "when only min sleep time has been given in the config" do
+    before(:each) do
+      allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
+      allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
+      allow(PrivateChef).to receive(:[]).with('opscode_erchef').and_return({
+        'reindex_sleep_min_ms' => min_sleep_time,
+      })
+    end
+
+    context "when min is greater then max" do
+      let(:min_sleep_time) { 2001 }
+
+      it "raises an error" do
+        expect(solr_preflight.verify_sane_reindex_sleep_times).to eq(:i_failed)
+      end
+    end
+  end
+
+  context "when only max sleep time has been given in the config" do
+    before(:each) do
+      allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
+      allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
+      allow(PrivateChef).to receive(:[]).with('opscode_erchef').and_return({
+        'reindex_sleep_max_ms' => max_sleep_time,
+      })
+    end
+
+    context "when min is greater then max" do
+      let(:max_sleep_time) { 499 }
+
+      it "raises an error" do
+        expect(solr_preflight.verify_sane_reindex_sleep_times).to eq(:i_failed)
+      end
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -78,6 +78,11 @@
         {authz_timeout, <%= node['private_chef']['opscode-erchef']['authz_timeout'] %>},
         {authz_fanout, <%= node['private_chef']['opscode-erchef']['authz_fanout'] %>},
 
+        {reindex_batch_size, <%= @reindex_batch_size -%>},
+        {reindex_sleep_min_ms, <%= @reindex_sleep_min_ms -%>},
+        {reindex_sleep_max_ms, <%= @reindex_sleep_max_ms -%>},
+        {reindex_item_retries, <%= @reindex_item_retries -%>},
+
         {enable_actions, <%= node['private_chef']['dark_launch']['actions'] %>},
         <% if @ldap_enabled -%>
         {ldap, [

--- a/omnibus/files/private-chef-ctl-commands/reindex.rb
+++ b/omnibus/files/private-chef-ctl-commands/reindex.rb
@@ -51,9 +51,9 @@ end
 def enqueue_data_for_org(org)
   status = Dir.chdir(File.join(base_path, "embedded", "service", "opscode-erchef", "bin")) do
     if running_config["private_chef"]["fips_enabled"]
-      run_command("./reindex-opc-organization complete #{org} http://127.0.0.1 >/dev/null")
+      run_command("./reindex-opc-organization complete #{org} http://127.0.0.1")
     else
-      run_command("./reindex-opc-organization complete #{org} >/dev/null")
+      run_command("./reindex-opc-organization complete #{org}")
     end
   end
   if !status.success?

--- a/src/oc_erchef/apps/chef_index/src/chef_index.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index.erl
@@ -28,8 +28,7 @@
          transform_data/2,
          delete/4,
          add/5,
-         add_async/4,
-         add_async/5,
+         add_batch/1,
          search_provider/0
         ]).
 
@@ -89,12 +88,6 @@ transform_data(elasticsearch, Data) ->
 transform_data(solr, Data) ->
     chef_solr:transform_data(Data).
 
-%% The difference between add and add_async is that add_async
-%% will not block on the data being posted to our search store
-%% and will instantly return `ok` (regardless of queue mode);
-%% whereas, add will block the request until the queue has been
-%% flushed to our search store in batch queue mode or directly
-%% posted in inline queue mode.
 add(TypeName, Id, DbName, IndexEjson, ReqId) ->
     QueueMode = queue_mode(),
     case QueueMode of
@@ -111,15 +104,67 @@ add(TypeName, Id, DbName, IndexEjson, ReqId) ->
             send_to_solr(QueueMode, Doc, ReqId)
     end.
 
-add_async(TypeName, Id, DbName, IndexEjson, _ReqId) ->
-    %% No solr_time logging for add_async as this doesn't happen as
-    %% part of a request, But we provided a add_async/5 to make it
-    %% easier to call in oc_chef_object_db.
-    add_async(TypeName, Id, DbName, IndexEjson).
+-spec add_batch(list()) -> ok | {error, list()}.
+add_batch(Batch) ->
+    {ok, BatchWorker} = chef_wait_group:start_link(fun add_batch_item_with_retries/1, []),
+    [chef_wait_group:add(BatchWorker, {TypeName, Id, DbName}, Item) || {TypeName, Id, DbName, _} = Item <- Batch],
+    case chef_wait_group:wait(BatchWorker) of
+        {ok, Results}  ->
+            case all_ok(Results) of
+                true -> ok;
+                false -> {error, not_ok(Results)}
+            end;
+        {error, Results, FailedJobs} ->
+            {error, [not_ok(Results)|FailedJobs]}
+    end.
 
-add_async(TypeName, Id, DbName, IndexEjson) ->
-    spawn(chef_index, add, [TypeName, Id, DbName, IndexEjson, none]),
-    ok.
+add_batch_item_with_retries(Item) ->
+    MaxRetries = envy:get(chef_index, reindex_item_retries, 3, non_neg_integer),
+    %% We don't need secure random numbers, we just want to make sure
+    %% that we get some variance across our workers. If we don't seed
+    %% here all items end up getting the same random numbers.
+    random:seed(os:timestamp()),
+    add_batch_item_with_retries(Item, 0, MaxRetries).
+
+add_batch_item_with_retries(Item, Failures, Max) ->
+    {TypeName, Id, DbName, IndexEjson} = Item,
+    case chef_index:add(TypeName, Id, DbName, IndexEjson, none) of
+        ok ->
+            ok;
+        Error when Failures >= Max ->
+            Error;
+        Error ->
+            Retries = Failures + 1,
+            lager:warning("chef_index:add failed for ~s[~s]: ~p retrying (~p/~p)", [TypeName, Id, Error, Retries, Max]),
+            wait_before_retry(),
+            add_batch_item_with_retries(Item, Retries, Max)
+    end.
+
+wait_before_retry() ->
+    Min = envy:get(chef_index, reindex_sleep_min_ms, 500, non_neg_integer),
+    Max = envy:get(chef_index, reindex_sleep_max_ms, 2000, non_neg_integer),
+    wait_before_retry(Min, Max).
+
+wait_before_retry(0, 0) ->
+    ok;
+wait_before_retry(Min, Min) ->
+    lager:info("chef_index: waiting ~B ms before retry", [Min]),
+    timer:sleep(Min);
+wait_before_retry(Min, Max) ->
+    Rand01 = random:uniform(),
+    %% Tranform (0, 1) -> (Min, Max)
+    %% Round to an integer since timer:sleep only takes an integer
+    RandMinMax = round(Min + (Rand01*(Max - Min))),
+    lager:info("chef_index: waiting ~B ms before retry", [RandMinMax]),
+    timer:sleep(RandMinMax).
+
+all_ok(Results) ->
+    Ok = fun({_, Res}) -> Res =:= ok end,
+    lists:all(Ok, Results).
+
+not_ok(Results) ->
+    NotOk = fun({_, Res}) -> Res =/= ok end,
+    lists:filter(NotOk, Results).
 
 delete(TypeName, Id, DbName, ReqId) ->
     case queue_mode() of

--- a/src/oc_erchef/apps/chef_index/src/chef_wait_group.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_wait_group.erl
@@ -1,0 +1,205 @@
+%% Copyright 2017 Chef Software, Inc
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+-module(chef_wait_group).
+
+-behaviour(gen_server).
+
+%% API Exports
+-export([start_link/2,
+         add/3,
+         state/1,
+         wait/1
+        ]).
+
+%% gen_server Exports
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(chef_wait_group_state, {
+          waiting_pid :: {pid(), term()},
+          waiting_workers = []:: list(),
+          done_jobs = [] :: list(),
+          failed_jobs = [] :: list(),
+          job_fun :: fun()
+         }).
+
+%%===================================================================
+%% API
+%%===================================================================
+%%
+%% Example Usage
+%%
+%% Fun = fun(SomeArgs) -> do_stuff(SomeArgs) end,
+%% {ok, Pid} = chef_wait_group:start(Fun, Config)
+%% chef_wait_group:add(Pid, JobId0, JobArgs0)
+%% chef_wait_group:add(Pid, JobId1, JobArgs1)
+%% chef_wait_group:add(Pid, JobId2, JobArgs2)
+%% Result = chef_wait_group:wait()
+%%
+
+-spec start_link(fun(), proplists:proplist()) -> {ok, pid()} | ignored | {error, term()}.
+start_link(Fun, Config) ->
+    %% Use start_link/3 here as the caller
+    gen_server:start_link(?MODULE, [Fun, Config], []).
+
+-spec add(pid(), term(), list()|term()) -> ok | {error, wait_called}.
+add(Pid, JobName, JobArgs) when is_list(JobArgs)->
+    gen_server:call(Pid, {add_job, JobName, JobArgs});
+add(Pid, JobName, JobArgs) ->
+    add(Pid, JobName, [JobArgs]).
+
+-spec wait(pid()) -> {ok, list()}|{error, already_waiting}|{error, list(), list()}.
+wait(Pid) ->
+    gen_server:call(Pid, gather, infinity).
+
+-spec state(pid()) -> #chef_wait_group_state{}.
+state(Pid) ->
+    gen_server:call(Pid, get_state).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+init([Fun, _Config]) ->
+    process_flag(trap_exit, true),
+    {ok, #chef_wait_group_state{job_fun = Fun}}.
+
+handle_call({add_job, JobName, JobArgs}, _From, State = #chef_wait_group_state{waiting_pid = undefined}) ->
+    {ok, State1} = spawn_worker(JobName, JobArgs, State),
+    {reply, ok, State1};
+%% We don't allow jobs to be added once someone is waiting
+handle_call({add_job, _Data}, _From, State = #chef_wait_group_state{waiting_pid = _Pid}) ->
+    {reply, {error, wait_called}, State};
+%% If someone calls wait and we are already done, return immediately
+handle_call(gather, _From, #chef_wait_group_state{waiting_pid = undefined,
+                                                  waiting_workers = [],
+                                                  done_jobs = Done,
+                                                  failed_jobs = Failed}) ->
+    {stop, normal, make_gather_reply(Done, Failed), #chef_wait_group_state{}};
+%% If someone calls wait and we aren't done, store their pid so we can reply later
+handle_call(gather, From, State = #chef_wait_group_state{waiting_pid = undefined,
+                                                         waiting_workers = _StillWaiting}) ->
+    {noreply, State#chef_wait_group_state{waiting_pid = From}};
+%% If someone is already waiting, error
+handle_call(gather, _From, State = #chef_wait_group_state{waiting_pid = _Pid}) ->
+    {reply, {error, already_waiting}, State};
+%% If a job is done, remove it from the waiting list.  If this is the
+%% last job, rely to the waiting pid if we have one.
+handle_call({job_done, Result}, {Pid, _Tag}, State) ->
+    State1 = mark_job_done(Pid, Result, State),
+    case maybe_reply_to_waiter(State1) of
+        true ->
+            {stop, normal, ok, #chef_wait_group_state{}};
+        false ->
+            {reply, ok, State1}
+    end;
+handle_call({job_failed, Result}, {Pid, _Tag}, State) ->
+    State1 = mark_job_failed(Pid, Result, State),
+    case maybe_reply_to_waiter(State1) of
+        true ->
+            {stop, normal, ok, #chef_wait_group_state{}};
+        false ->
+            {reply, ok, State1}
+    end;
+handle_call(get_state, _From, State) ->
+    {reply, State, State}.
+
+handle_info({'EXIT', _From, normal}, State) ->
+    {noreply, State};
+handle_info({'EXIT', From, Reason}, State) ->
+    lager:error("Worker ~p failed unexpectedly: ~p", [From, Reason]),
+    State1 = mark_job_failed(From, {worker_failed, Reason}, State),
+    case maybe_reply_to_waiter(State1) of
+        true ->
+            {stop, normal, State1};
+        false ->
+            {noreply, State1}
+    end.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+spawn_worker(JobName, JobArgs, State = #chef_wait_group_state{job_fun = Fun,
+                                                              waiting_workers = Workers}) ->
+    Parent = self(),
+    Pid = spawn_link(fun() -> run_user_callback(Fun, JobArgs, Parent) end),
+    {ok, State#chef_wait_group_state{waiting_workers = [{Pid, JobName}|Workers]}}.
+
+run_user_callback(Fun, JobArgs, Parent) ->
+    try apply(Fun, JobArgs) of
+        Res -> gen_server:call(Parent, {job_done, Res})
+    catch
+        Exception:Reason -> gen_server:call(Parent, {job_failed, {Exception, Reason}})
+    end.
+
+-spec maybe_reply_to_waiter(#chef_wait_group_state{}) -> boolean().
+maybe_reply_to_waiter(#chef_wait_group_state{waiting_pid = undefined}) ->
+    false;
+maybe_reply_to_waiter(#chef_wait_group_state{waiting_pid = Pid,
+                                             waiting_workers = [],
+                                             done_jobs = Done,
+                                             failed_jobs = Failed}) ->
+    gen_server:reply(Pid, make_gather_reply(Done, Failed)),
+    true;
+maybe_reply_to_waiter(#chef_wait_group_state{waiting_pid = _Pid,
+                                             waiting_workers = _NotEmpty}) ->
+    false.
+
+-spec mark_job_done(pid(), term(), #chef_wait_group_state{}) -> #chef_wait_group_state{}.
+mark_job_done(Pid, Result, State = #chef_wait_group_state{
+                                      waiting_workers = Workers,
+                                      done_jobs = DoneList}) ->
+    {ok, {_Pid, JobName}, WaitingWorkers} = worker_from_list(Pid, Workers),
+    State#chef_wait_group_state{done_jobs = [{JobName, Result}|DoneList],
+                                waiting_workers = WaitingWorkers}.
+
+-spec mark_job_failed(pid(), term(), #chef_wait_group_state{}) -> #chef_wait_group_state{}.
+mark_job_failed(Pid, Result, State = #chef_wait_group_state{
+                                        waiting_workers = Workers,
+                                        failed_jobs = FailedList}) ->
+    {ok, {_Pid, JobName}, WaitingWorkers} = worker_from_list(Pid, Workers),
+    State#chef_wait_group_state{failed_jobs = [{JobName, Result}|FailedList],
+                                waiting_workers = WaitingWorkers}.
+
+-spec worker_from_list(pid(), [{pid(), term()}]) -> {ok, {pid(), term()}, [{pid(), term()}]} | {error, no_worker}.
+worker_from_list(Pid, Workers) ->
+    worker_from_list(Pid, Workers, []).
+
+worker_from_list(_Pid, [], _Acc) ->
+    {error, no_worker};
+worker_from_list(Pid, [Found = {Pid, _JobName}|Rest], Acc) ->
+    {ok, Found, lists:append(Acc, Rest)};
+worker_from_list(Pid, [NotFound|Rest], Acc)->
+    worker_from_list(Pid, Rest, [NotFound|Acc]).
+
+-spec make_gather_reply(list(), list()) -> {ok, list()} | {error, list(), list()}.
+make_gather_reply(Done, []) ->
+    {ok, Done};
+make_gather_reply(Done, Failed) ->
+    {error, Done, Failed}.

--- a/src/oc_erchef/apps/chef_index/src/chef_wait_group.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_wait_group.erl
@@ -35,7 +35,7 @@
 
 -record(chef_wait_group_state, {
           waiting_pid :: {pid(), term()},
-          waiting_workers = []:: list(),
+          waiting_workers = [] :: list(),
           done_jobs = [] :: list(),
           failed_jobs = [] :: list(),
           job_fun :: fun()
@@ -66,7 +66,7 @@ add(Pid, JobName, JobArgs) when is_list(JobArgs)->
 add(Pid, JobName, JobArgs) ->
     add(Pid, JobName, [JobArgs]).
 
--spec wait(pid()) -> {ok, list()}|{error, already_waiting}|{error, list(), list()}.
+-spec wait(pid()) -> {ok, list()} | {error, already_waiting} | {error, list(), list()}.
 wait(Pid) ->
     gen_server:call(Pid, gather, infinity).
 

--- a/src/oc_erchef/apps/chef_index/test/chef_index_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_tests.erl
@@ -72,6 +72,16 @@ chef_index_test_() ->
                ?assert(meck:validate(chef_index_expand))
        end
       },
+      {"add_batch adds each item passed to it",
+       fun() ->
+               application:set_env(chef_index, search_queue_mode, inline),
+               meck:expect(chef_index_expand, send_item, fun(?EXPECTED_DOC) -> ok end),
+               chef_index:add_batch([{role, <<"a1">>, <<"db1">>, Item},
+                                     {role, <<"a1">>, <<"db1">>, Item},
+                                     {role, <<"a1">>, <<"db1">>, Item}]),
+               ?assertEqual(3, meck:num_calls(chef_index_expand, send_item, '_'))
+       end
+      },
       {"delete calls chef_index_queue:delete when search_queue_mode is rabbitmq",
        fun() ->
                application:set_env(chef_index, search_queue_mode, rabbitmq),

--- a/src/oc_erchef/apps/chef_index/test/chef_wait_group_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_wait_group_tests.erl
@@ -21,14 +21,14 @@ wait_returns_error_if_the_worker_fails_test() ->
     chef_wait_group:add(Pid, test_id1, []),
     ?assertEqual({error, [], [{test_id1, {throw, badfun}}]}, chef_wait_group:wait(Pid)).
 
-wait_returns_error_with_finished_jobs_and_faild_jobs_test() ->
+wait_returns_error_with_finished_jobs_and_failed_jobs_test() ->
     {ok, Pid} = chef_wait_group:start_link(fun(Arg) ->
                                                      Arg = item1,
                                                      ok
                                              end, []),
     chef_wait_group:add(Pid, test_id1, [item1]),
     chef_wait_group:add(Pid, test_id2, [item2]),
-    ?assertEqual({error, [{test_id1, ok}], [{test_id2, {error,{badmatch,item1}}}]},
+    ?assertEqual({error, [{test_id1, ok}], [{test_id2, {error, {badmatch, item1}}}]},
                  chef_wait_group:wait(Pid)).
 
 wait_blocks_until_jobs_are_done_test() ->

--- a/src/oc_erchef/apps/chef_index/test/chef_wait_group_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_wait_group_tests.erl
@@ -1,0 +1,45 @@
+-module(chef_wait_group_tests).
+-include_lib("eunit/include/eunit.hrl").
+-compile([export_all]).
+
+start_link_returns_a_pid_test() ->
+    {ok, Pid} = chef_wait_group:start_link(fun() -> ok end, []),
+    ?assertEqual(true, erlang:is_process_alive(Pid)).
+
+add_takes_a_jobid_and_arguments_test() ->
+    {ok, Pid} = chef_wait_group:start_link(fun(MyArg) -> MyArg end, []),
+    ?assertEqual(ok, chef_wait_group:add(Pid, test_id1, testarg)),
+    ?assertEqual(ok, chef_wait_group:add(Pid, test_id2, [testarg])).
+
+wait_returns_ok_and_the_responses_on_success_test() ->
+    {ok, Pid} = chef_wait_group:start_link(fun(MyArg) -> MyArg end, []),
+    chef_wait_group:add(Pid, test_id1, testarg),
+    ?assertEqual({ok, [{test_id1, testarg}]}, chef_wait_group:wait(Pid)).
+
+wait_returns_error_if_the_worker_fails_test() ->
+    {ok, Pid} = chef_wait_group:start_link(fun() -> throw(badfun) end, []),
+    chef_wait_group:add(Pid, test_id1, []),
+    ?assertEqual({error, [], [{test_id1, {throw, badfun}}]}, chef_wait_group:wait(Pid)).
+
+wait_returns_error_with_finished_jobs_and_faild_jobs_test() ->
+    {ok, Pid} = chef_wait_group:start_link(fun(Arg) ->
+                                                     Arg = item1,
+                                                     ok
+                                             end, []),
+    chef_wait_group:add(Pid, test_id1, [item1]),
+    chef_wait_group:add(Pid, test_id2, [item2]),
+    ?assertEqual({error, [{test_id1, ok}], [{test_id2, {error,{badmatch,item1}}}]},
+                 chef_wait_group:wait(Pid)).
+
+wait_blocks_until_jobs_are_done_test() ->
+    {ok, Pid} = chef_wait_group:start_link(fun(MyArg) ->
+                                                     timer:sleep(50),
+                                                     MyArg
+                                             end, []),
+    chef_wait_group:add(Pid, test_id1, testarg),
+    ?assertEqual({ok, [{test_id1, testarg}]}, chef_wait_group:wait(Pid)).
+
+gen_server_exits_after_wait_test() ->
+    {ok, Pid} = chef_wait_group:start_link(fun() -> ok end, []),
+    chef_wait_group:wait(Pid),
+    ?assertEqual(false, erlang:is_process_alive(Pid)).

--- a/src/oc_erchef/priv/reindex-opc-organization
+++ b/src/oc_erchef/priv/reindex-opc-organization
@@ -100,10 +100,7 @@ perform(reindex, Context, {_OrgId, OrgName}=OrgInfo) ->
     io:format("Sending all data for organization '~s' to be indexed again.  It may take some time before everything is available via search.~n", [OrgName]),
     case rpc:call(?ERCHEF, chef_reindex, reindex, [Context, OrgInfo]) of
         {ok, Missing} ->
-            case Missing of
-                [] -> ok;
-                _ -> print_missing(Missing, OrgName)
-            end;
+            print_missing(Missing, OrgName);
         {error, Failed, Missing} ->
             print_missing(Missing, OrgName),
             print_errors(Failed, OrgName),

--- a/src/oc_erchef/priv/reindex-opc-organization
+++ b/src/oc_erchef/priv/reindex-opc-organization
@@ -98,19 +98,33 @@ perform(drop, _Context, {OrgId, OrgName}) ->
     ok = rpc:call(?ERCHEF, chef_index, delete_search_db, [OrgId]);
 perform(reindex, Context, {_OrgId, OrgName}=OrgInfo) ->
     io:format("Sending all data for organization '~s' to be indexed again.  It may take some time before everything is available via search.~n", [OrgName]),
-    {ok, Missing} = rpc:call(?ERCHEF, chef_reindex, reindex, [Context, OrgInfo]),
-    case Missing of
-        [] ->
-            ok;
-        _ ->
-            io:format(standard_error, "~nThe following objects in organization \"~s\" were unable to be reindexed:~n~n", [OrgName]),
-            [io:format(standard_error, "\t~s ~s~n", [Type, Name]) || {Type, Name} <- Missing],
-            io:format(standard_error, "~n", [])
+    case rpc:call(?ERCHEF, chef_reindex, reindex, [Context, OrgInfo]) of
+        {ok, Missing} ->
+            case Missing of
+                [] -> ok;
+                _ -> print_missing(Missing, OrgName)
+            end;
+        {error, Failed, Missing} ->
+            print_missing(Missing, OrgName),
+            print_errors(Failed, OrgName),
+            halt(1)
     end;
 perform(complete, Context, OrgInfo) ->
     %% Just do everything
     perform(drop, Context, OrgInfo),
     perform(reindex, Context, OrgInfo).
+
+print_errors(Failed, OrgName) ->
+    io:format(standard_error, "Reindexing the organization \"~s\" has failed.~n", [OrgName]),
+    io:format(standard_error, "The following objects failed to be reindexed in the last batch:~n~n", []),
+    [io:format(standard_error, "\t~s[~s]: ~s~n", [Type, Id, Reason]) || {{Type, Id, _Db}, Reason} <- Failed].
+
+print_missing([], _OrgName) ->
+    ok;
+print_missing(Missing, OrgName) ->
+    io:format(standard_error, "~nThe following objects in organization \"~s\" were not sent for indexing:~n~n", [OrgName]),
+    [io:format(standard_error, "\t~s ~s~n", [Type, Name]) || {Type, Name} <- Missing],
+    io:format(standard_error, "~n", []).
 
 make_context(OrgName, IntLB) ->
     {ok, ServerAPIMinVersion} = rpc:call(?ERCHEF, oc_erchef_app, server_api_version, [min]),


### PR DESCRIPTION
The fire-and-forget reindex process make sense for
RabbitMQ+opscode-expander but does not make sense for the direct-to-ES
indexing methods.  In Hosted and other large environments, a reindex
may quickly overwhelm the HTTP connection pool, leading to reindex
failures that go unreported to the user.

This change collects all errors so that they can be reported at the
end of the reindex run. It also introduces retries with randomized
sleep to help reduce the chance of overall failures.

For large organizations, this new strategy may reduce the throughput
of reindexing. Such users may need to tune the reindex_batch_size and
the search_batch_max_wait parameters. Further, to finish reindexing in
a reasonable time, users may still need to adjust the HTTP connection
pool size and the batch size.