### PR TITLE
[chef_index] Fix racy chef_wait_group test

### DIFF
--- a/src/oc_erchef/Makefile
+++ b/src/oc_erchef/Makefile
@@ -62,5 +62,13 @@ bundle:
 	@echo bundling up depselector, This might take a while...
 	@cd apps/chef_objects/priv/depselector_rb; bundle install --deployment --path .bundle
 
+travis_env:
+	@echo export CHEFDK_GECODE_PATH=/opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/
+	@echo export TRAVIS=1
+	@echo export USE_SYSTEM_GECODE=1
+	@echo export LIBRARY_PATH=$$CHEFDK_GECODE_PATH/lib
+	@echo export LD_LIBRARY_PATH=$$CHEFDK_GECODE_PATH/lib
+	@echo export CPLUS_INCLUDE_PATH=$$CHEFDK_GECODE_PATH/include
+
 distclean:
 	@rm -rf _build

--- a/src/oc_erchef/apps/chef_index/test/chef_wait_group_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_wait_group_tests.erl
@@ -41,5 +41,9 @@ wait_blocks_until_jobs_are_done_test() ->
 
 gen_server_exits_after_wait_test() ->
     {ok, Pid} = chef_wait_group:start_link(fun() -> ok end, []),
+    MonRef = erlang:monitor(process, Pid),
     chef_wait_group:wait(Pid),
-    ?assertEqual(false, erlang:is_process_alive(Pid)).
+    %% Test will timeout if the gen_server doesn't exit
+    receive
+        {'DOWN', MonRef, process, Pid, normal} -> ok
+    end.


### PR DESCRIPTION
The old test was racy because it expected the gen_server to stop
faster than it would take to get to the erlang:is_process_alive call.
This wasn't always true in CI. Now, we install a monitor and wait for
it. If the gen_server doesn't stop, the test will timeout.

Signed-off-by: Steven Danna <steve@chef.io>