### PR TITLE
[omnibus] Allow user to override ssl cert generation

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -138,6 +138,7 @@ class PreflightChecks
       end
       AuthPreflightValidator.new(node).run!
       SolrPreflightValidator.new(node).run!
+      SslPreflightValidator.new(node).run!
       BookshelfPreflightValidator.new(node).run!
     rescue PreflightValidationFailed => e
       # use of exit! prevents exit handlers from running, ensuring the last thing

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_ssl_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_ssl_validator.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative './preflight_checks.rb'
+
+class SslPreflightValidator < PreflightValidator
+  def initialize(node)
+    super
+    @user_config = PrivateChef['nginx']
+  end
+
+  def run!
+    verify_cert_pair
+  end
+
+  def verify_cert_pair
+    cert = @user_config['ssl_certificate']
+    key  = @user_config['ssl_certificate_key']
+    if !cert.nil? && key.nil?
+        fail_with <<EOF
+Your configuration has specified
+
+nginx['ssl_certificate'] = "#{cert}"
+
+but has not specified nginx['ssl_certificate_key'].  You must specify
+both configuration options or neither.
+EOF
+    elsif cert.nil? && !key.nil?
+        fail_with <<EOF
+Your configuration has specified
+
+nginx['ssl_certificate_key'] = "#{key}"
+
+but has not specified nginx['ssl_certificate'].  You must specify
+both configuration options or neither.
+EOF
+    end
+  end
+end


### PR DESCRIPTION
Previously we would generate certs and dhparams even if the user had
specified files for us to use.

Signed-off-by: Steven Danna <steve@chef.io>