### PR TITLE
Don't proxy to local bookshelf if it's disabled.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -77,8 +77,9 @@
     }
     <% end -%>
 
+    <% if node['private_chef']['bookshelf']['enable'] -%>
     # bookshelf
-    <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
+      <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
     location ~ "/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/{0,1}.*$" {
       set $destination @cached;
       if ($request_method !~ ^(GET)$) {
@@ -96,10 +97,11 @@
     location @uncached {
       proxy_pass http://bookshelf;
     }
-    <% else -%>
+      <% else -%>
     location ~ "/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/{0,1}.*$" {
       proxy_pass http://bookshelf;
     }
+      <% end -%>
     <% end -%>
 
     # erchef status endpoint

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -80,7 +80,7 @@
     <% if node['private_chef']['bookshelf']['enable'] -%>
     # bookshelf
       <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
-    location ~ "/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/{0,1}.*$" {
+    location ~ "^/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/organization-.+/" {
       set $destination @cached;
       if ($request_method !~ ^(GET)$) {
          set $destination @uncached;
@@ -98,7 +98,7 @@
       proxy_pass http://bookshelf;
     }
       <% else -%>
-    location ~ "/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/{0,1}.*$" {
+    location ~ "^/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/organization-.+/" {
       proxy_pass http://bookshelf;
     }
       <% end -%>


### PR DESCRIPTION
Issue described in https://github.com/chef/chef-server/issues/694.

It's not clear whether `nginx_bookshelf_caching` works for remote bookshelfs; if so, this would need an update to factor that in.