### PR TITLE
Try caching the plt in _build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
 cache:
   apt: true
   directories:
+    - src/oc_erchef/_build/default/rebar3_17.5_plt
     - src/oc-id/vendor/bundle
     - $HOME/.luarocks/rocks
     - $HOME/.cpanm


### PR DESCRIPTION
Adding all of our apps to the base plt in ~/.cache/rebar3 still takes
FOREVER.

We could play with the base_plt_apps rebar.config option, but at 500+
files currently being added to the plt, that might get interesting.

Signed-off-by: Steven Danna <steve@chef.io>