### PR TITLE
travis: cache oc_erchef plt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
     - $HOME/.cpan
     - $HOME/perl5
     - $HOME/.cache/rebar3/
+    - src/oc_erchef/_dialyzer_cache
 before_cache:
   # Prevent build log from changing cache cand causing repackage
   - rm -f $HOME/.cpanm/work/*/build.log

--- a/src/oc_erchef/.gitignore
+++ b/src/oc_erchef/.gitignore
@@ -20,4 +20,5 @@ deps.plt
 apps/chef_index/src/chef_lucene.erl
 VERSION
 _build
+_dialyzer_cache
 *.coverdata

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -119,6 +119,7 @@
 ]}.
 
 {dialyzer,[
+    {plt_location, "_dialyzer_cache/"},
     {plt_extra_apps, [
         webmachine,
         common_test,


### PR DESCRIPTION
Rebar3 caches the PLT for the base version of erlang in
$HOME/.cache/rebar3. However, most of our time is spent adding 445
apps to this base PLT.  By setting the plt_location explicitly in the
rebar.config, we make it easier to cache this in travis and hopefully
save us a lot of time during the travis run.

I've opted to keep this cache inside the src/oc_erchef directory so
that the large number of apps we add to the PLT won't influence the
dialyzer runs for other erlang apps on your local workstation.

Signed-off-by: Steven Danna <steve@chef.io>