### PR TITLE
[SPOOL-528] update chef-server to use Veil for pivotal/webui keys

### DIFF
--- a/oc-chef-pedant/Gemfile
+++ b/oc-chef-pedant/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rest-client', :git => 'git://github.com/opscode/rest-client.git'
+gem 'rest-client', github: 'chef/rest-client'
+# For debugging in dvm
+# gem 'veil',path: '/host/external-deps/chef_secrets'
+gem 'veil', github: 'chef/chef_secrets'
 gem 'pry'
 gem 'rake'
 

--- a/oc-chef-pedant/Gemfile.lock
+++ b/oc-chef-pedant/Gemfile.lock
@@ -1,5 +1,13 @@
 GIT
-  remote: git://github.com/opscode/rest-client.git
+  remote: git://github.com/chef/chef_secrets.git
+  revision: 1f99484d191729e8b26fd4215264847d31812842
+  specs:
+    veil (0.1.0)
+      bcrypt (~> 3.1)
+      pbkdf2
+
+GIT
+  remote: git://github.com/chef/rest-client.git
   revision: ba0d12258b77791d8f7d9776d008eb6fa3580ccc
   specs:
     rest-client (1.7.0.alpha)
@@ -21,27 +29,28 @@ PATH
       rspec (~> 3.2)
       rspec-rerun (~> 1.0)
       rspec_junit_formatter (~> 0.2)
+      veil (>= 0.0.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.0.1)
+    activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    builder (3.2.2)
+    bcrypt (3.1.11)
+    builder (3.2.3)
     coderay (1.1.1)
-    concurrent-ruby (1.0.2)
-    diff-lcs (1.2.5)
+    concurrent-ruby (1.0.5)
+    diff-lcs (1.3)
     erubis (2.7.0)
-    i18n (0.7.0)
-    json (1.8.3)
+    i18n (0.8.1)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    minitest (5.9.0)
+    minitest (5.10.1)
     mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-config (2.2.4)
@@ -49,18 +58,18 @@ GEM
     mixlib-shellout (2.2.7)
     net-http-spy (0.2.1)
     netrc (0.7.9)
+    pbkdf2 (0.1.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (12.0.0)
-    rdoc (4.2.2)
-      json (~> 1.4)
+    rdoc (5.1.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.3)
+    rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -75,7 +84,7 @@ GEM
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
     slop (3.6.0)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -87,6 +96,7 @@ DEPENDENCIES
   pry
   rake
   rest-client!
+  veil!
 
 BUNDLED WITH
-   1.13.7
+   1.14.5

--- a/oc-chef-pedant/Gemfile.lock
+++ b/oc-chef-pedant/Gemfile.lock
@@ -1,6 +1,18 @@
 GIT
+  remote: git://github.com/chef/chef-zero.git
+  revision: c5298daaec5e7729409036d1d1bb46a9532bf41a
+  branch: master
+  specs:
+    chef-zero (5.3.0)
+      ffi-yajl (~> 2.2)
+      hashie (>= 2.0, < 4.0)
+      mixlib-log (~> 1.3)
+      rack (~> 2.0)
+      uuidtools (~> 2.1)
+
+GIT
   remote: git://github.com/chef/chef_secrets.git
-  revision: 1f99484d191729e8b26fd4215264847d31812842
+  revision: 39dd7ff4b0a1a669346aa5c4915adafd53ab2fee
   specs:
     veil (0.1.0)
       bcrypt (~> 3.1)
@@ -45,7 +57,11 @@ GEM
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubis (2.7.0)
+    ffi-yajl (2.3.0)
+      libyajl2 (~> 1.2)
+    hashie (3.5.5)
     i18n (0.8.1)
+    libyajl2 (1.2.0)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -63,6 +79,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rack (2.0.1)
     rake (12.0.0)
     rdoc (5.1.0)
     rspec (3.5.0)
@@ -87,11 +104,13 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uuidtools (2.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  chef-zero!
   oc-chef-pedant!
   pry
   rake

--- a/oc-chef-pedant/Gemfile.lock
+++ b/oc-chef-pedant/Gemfile.lock
@@ -1,18 +1,6 @@
 GIT
-  remote: git://github.com/chef/chef-zero.git
-  revision: c5298daaec5e7729409036d1d1bb46a9532bf41a
-  branch: master
-  specs:
-    chef-zero (5.3.0)
-      ffi-yajl (~> 2.2)
-      hashie (>= 2.0, < 4.0)
-      mixlib-log (~> 1.3)
-      rack (~> 2.0)
-      uuidtools (~> 2.1)
-
-GIT
   remote: git://github.com/chef/chef_secrets.git
-  revision: 39dd7ff4b0a1a669346aa5c4915adafd53ab2fee
+  revision: d9695b10fc05d10b6b32d79e82c568f13510888a
   specs:
     veil (0.1.0)
       bcrypt (~> 3.1)
@@ -57,11 +45,7 @@ GEM
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubis (2.7.0)
-    ffi-yajl (2.3.0)
-      libyajl2 (~> 1.2)
-    hashie (3.5.5)
     i18n (0.8.1)
-    libyajl2 (1.2.0)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -79,7 +63,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (2.0.1)
     rake (12.0.0)
     rdoc (5.1.0)
     rspec (3.5.0)
@@ -104,13 +87,11 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uuidtools (2.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  chef-zero!
   oc-chef-pedant!
   pry
   rake

--- a/oc-chef-pedant/Rakefile
+++ b/oc-chef-pedant/Rakefile
@@ -1,18 +1,24 @@
 require 'rubygems'
 require 'tempfile'
 require 'bundler'
+require 'json'
+require 'openssl'
+require 'veil'
 
 CURRENT_GEM_NAME = 'oc-chef-pedant'
 CURRENT_GEM_PATH = File.expand_path('../..', __FILE__)
 
 task :chef_zero_spec do
+  tmp_file = Tempfile.new("secrets").path
+  create_secrets_file(tmp_file)
+  @secrets_path = tmp_file
   bundle_exec_with_chef("chef-zero", "rake pedant")
 end
 
 def bundle_exec_with_chef(test_gem, commands)
   gem_path = Bundler.environment.specs[test_gem].first.full_gem_path
-  gemfile_path = File.join(gem_path, "Gemfile.#{CURRENT_GEM_NAME}-external-test")
-  gemfile = File.open(gemfile_path, "w")
+  @gemfile_path = File.join(gem_path, "Gemfile.#{CURRENT_GEM_NAME}-external-test")
+  gemfile = File.open(@gemfile_path, "w")
   begin
     IO.read(File.join(gem_path, "Gemfile")).each_line do |line|
       if line =~ /^\s*gemspec/
@@ -27,21 +33,35 @@ def bundle_exec_with_chef(test_gem, commands)
       gemfile.puts(line)
     end
     gemfile.puts("gem #{CURRENT_GEM_NAME.inspect}, path: #{CURRENT_GEM_PATH.inspect}")
+    # veil is not on rubygems
+    gemfile.puts("gem 'veil', github: 'chef/chef_secrets'")
     gemfile.puts("gemspec path: #{gem_path.inspect}")
     gemfile.close
     Dir.chdir(gem_path) do
       Bundler.with_clean_env do
-        unless system({ "BUNDLE_GEMFILE" => gemfile_path, "RUBYOPT" => nil, "GEMFILE_MOD" => nil }, "bundle update")
-          raise "Error running bundle update of #{gemfile_path} in #{gem_path}: #{$?.exitstatus}\nGemfile:\n#{IO.read(gemfile_path)}"
+        unless system(bundler_env, "bundle update")
+          raise "Error running bundle update of #{@gemfile_path} in #{gem_path}: #{$?.exitstatus}\nGemfile:\n#{IO.read(@gemfile_path)}"
         end
         Array(commands).each do |command|
-          unless system({ "BUNDLE_GEMFILE" => gemfile_path, "RUBYOPT" => nil, "GEMFILE_MOD" => nil }, "bundle exec #{command}")
-            raise "Error running bundle exec #{command} in #{gem_path} with BUNDLE_GEMFILE=#{gemfile_path}: #{$?.exitstatus}\nGemfile:\n#{IO.read(gemfile_path)}"
+          unless system(bundler_env, "bundle exec #{command}")
+            raise "Error running bundle exec #{command} in #{gem_path} with BUNDLE_GEMFILE=#{@gemfile_path}: #{$?.exitstatus}\nGemfile:\n#{IO.read(@gemfile_path)}"
           end
         end
       end
     end
   ensure
-    File.delete(gemfile_path) if File.exist?(gemfile_path)
+    File.delete(@gemfile_path) if File.exist?(@gemfile_path)
   end
+end
+
+def bundler_env
+  { "BUNDLE_GEMFILE" => @gemfile_path, "RUBYOPT" => nil, "GEMFILE_MOD" => nil,
+    "SECRETS_FILE" => @secrets_path }
+end
+
+def create_secrets_file(file_path)
+  credentials = Veil::CredentialCollection::ChefSecretsFile.new(path: file_path)
+  key = OpenSSL::PKey::RSA.new(2048).to_pem
+  credentials.add("chef-server", "superuser_key", value: key)
+  credentials.save
 end

--- a/oc-chef-pedant/Rakefile
+++ b/oc-chef-pedant/Rakefile
@@ -62,6 +62,8 @@ end
 def create_secrets_file(file_path)
   credentials = Veil::CredentialCollection::ChefSecretsFile.new(path: file_path)
   key = OpenSSL::PKey::RSA.new(2048).to_pem
+  webui_key = OpenSSL::PKey::RSA.new(2048).to_pem
   credentials.add("chef-server", "superuser_key", value: key)
+  credentials.add("chef-server", "webui_key", value: webui_key)
   credentials.save
 end

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -81,8 +81,8 @@ module Pedant
     # Let's not expose the secrets store by default
 
     # TODO 2017-02-28 mp:  configurable location:
-    credentials = Veil::CredentialCollection::ChefSecretsFile.
-      from_file("/etc/opscode/private-chef-secrets.json")
+    path = ENV['SECRETS_FILE'] || "/etc/opscode/private-chef-secrets.json"
+    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(path)
 
     config.pedant_platform = Pedant::Platform.new(config.chef_server,
                                                   credentials.get('chef-server', 'superuser_key'),

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -85,8 +85,8 @@ module Pedant
       from_file("/etc/opscode/private-chef-secrets.json")
 
     config.pedant_platform = Pedant::Platform.new(config.chef_server,
-                                                credentials.get('chef-server', 'superuser_key'),
-                                                config.superuser_name)
+                                                  credentials.get('chef-server', 'superuser_key'),
+                                                  config.superuser_name)
   end
 
   def self.configure_rspec

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -85,7 +85,7 @@ module Pedant
     credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(path)
 
     config.pedant_platform = Pedant::Platform.new(config.chef_server,
-                                                  credentials.get('chef-server', 'superuser_key'),
+                                                  credentials,
                                                   config.superuser_name)
   end
 

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -37,6 +37,8 @@ require 'pedant/ui'
 require 'pedant/rspec/matchers'
 require 'pedant/rspec/common'
 
+require 'veil'
+
 module Pedant
   def self.config
     # This is a bit of a hack: for some reason, we have UTF-8/US-ASCII encoding
@@ -76,9 +78,15 @@ module Pedant
   end
 
   def self.create_platform
+    # Let's not expose the secrets store by default
+
+    # TODO 2017-02-28 mp:  configurable location:
+    credentials = Veil::CredentialCollection::ChefSecretsFile.
+      from_file("/etc/opscode/private-chef-secrets.json")
+
     config.pedant_platform = Pedant::Platform.new(config.chef_server,
-                                                  config.superuser_key,
-                                                  config.superuser_name)
+                                                credentials.get('chef-server', 'superuser_key'),
+                                                config.superuser_name)
   end
 
   def self.configure_rspec

--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -101,7 +101,7 @@ module Pedant
       format_args = if junit_file
                       %W[-r rspec_junit_formatter -f progress -f RspecJunitFormatter -o #{junit_file} -f documentation]
                     else
-                      %w[ --color -f progress --tty]
+                      %w[ --color --tty]
                     end
       format_args + %w(--require rspec-rerun/formatter --format RSpec::Rerun::Formatter)
     end

--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -99,9 +99,9 @@ module Pedant
     # Returns just the arguments for formatting
     def self.rspec_formatting_args
       format_args = if junit_file
-                      %W[-r rspec_junit_formatter -f progress -f RspecJunitFormatter -o #{junit_file} -f documentation]
+                      %W[-r rspec_junit_formatter -f RspecJunitFormatter -o #{junit_file} -f documentation]
                     else
-                      %w[ --color --tty]
+                      %w[ --color -f documentation --tty]
                     end
       format_args + %w(--require rspec-rerun/formatter --format RSpec::Rerun::Formatter)
     end

--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -99,9 +99,9 @@ module Pedant
     # Returns just the arguments for formatting
     def self.rspec_formatting_args
       format_args = if junit_file
-                      %W[-r rspec_junit_formatter -f RspecJunitFormatter -o #{junit_file} -f documentation]
+                      %W[-r rspec_junit_formatter -f progress -f RspecJunitFormatter -o #{junit_file} -f documentation]
                     else
-                      %w[ --color -f documentation --tty]
+                      %w[ --color -f progress --tty]
                     end
       format_args + %w(--require rspec-rerun/formatter --format RSpec::Rerun::Formatter)
     end

--- a/oc-chef-pedant/lib/pedant/platform.rb
+++ b/oc-chef-pedant/lib/pedant/platform.rb
@@ -28,17 +28,17 @@ module Pedant
 
     attr_reader :test_org, :test_org_owner, :validate_org, :internal_account_url,
                 :internal_server, :ldap, :ldap_testing,
-                :server, :superuser, :superuser_key_file
+                :server, :superuser, :superuser_key_data
 
     # Create a Platform object for a given server (specified by
     # protocol, hostname, and port ONLY).  You must supply the
-    # superuser's key file, which can either be the path to the file,
-    # or the contents of the file.
-    def initialize(server, superuser_key_file, superuser_name='pivotal')
+    # superuser's key data in PEM form.
+    #
+    def initialize(server, superuser_key_data, superuser_name='pivotal')
       @server = (Pedant.config.explicit_port_url ? explicit_port_url(server) : server )
       puts "Configured URL: #{@server}"
-      @superuser_key_file = superuser_key_file
-      @superuser = Pedant::Requestor.new(superuser_name, superuser_key_file, platform: self)
+      @superuser_key_data = superuser_key_data
+      @superuser = Pedant::Requestor.new(superuser_name, superuser_key_data, platform: self)
       @test_org = org_from_config
       @internal_account_url = Pedant::Config[:internal_account_url]
       @internal_server = Pedant::Config.internal_server || (fail "Missing internal_server in Pedant config.")

--- a/oc-chef-pedant/lib/pedant/platform.rb
+++ b/oc-chef-pedant/lib/pedant/platform.rb
@@ -28,17 +28,18 @@ module Pedant
 
     attr_reader :test_org, :test_org_owner, :validate_org, :internal_account_url,
                 :internal_server, :ldap, :ldap_testing,
-                :server, :superuser, :superuser_key_data
+                :server, :superuser, :superuser_key_data, :webui_key
 
     # Create a Platform object for a given server (specified by
     # protocol, hostname, and port ONLY).  You must supply the
     # superuser's key data in PEM form.
     #
-    def initialize(server, superuser_key_data, superuser_name='pivotal')
+    def initialize(server, creds_or_key_data , superuser_name='pivotal')
+      load_credentials(creds_or_key_data)
+
       @server = (Pedant.config.explicit_port_url ? explicit_port_url(server) : server )
       puts "Configured URL: #{@server}"
-      @superuser_key_data = superuser_key_data
-      @superuser = Pedant::Requestor.new(superuser_name, superuser_key_data, platform: self)
+      @superuser = Pedant::Requestor.new(superuser_name, @superuser_key_data, platform: self)
       @test_org = org_from_config
       @internal_account_url = Pedant::Config[:internal_account_url]
       @internal_server = Pedant::Config.internal_server || (fail "Missing internal_server in Pedant config.")
@@ -46,6 +47,19 @@ module Pedant
       @ldap_testing = Pedant::Config[:ldap_testing]
       self.pedant_run_timestamp # Cache the global timestamp at initialization
       self
+    end
+
+    def load_credentials(creds_or_key_data)
+      case creds_or_key_data
+      when String
+        @superuser_key_data = creds_or_key_data
+      else
+        creds = creds_or_key_data
+        @superuser_key_data = creds.get('chef-server', 'superuser_key')
+        if creds.exist?('chef-server', 'webui_key')
+          @webui_key = creds.get('chef-server', 'webui_key')
+        end
+      end
     end
 
     DEFAULT_ORG_REWRITE = /^\/?(search|nodes|cookbooks|data|roles|sandboxes|environments|clients|principals|runs|groups|containers|keys)/

--- a/oc-chef-pedant/lib/pedant/rspec/auth_headers_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/auth_headers_util.rb
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'pedant/rspec/common'
+require 'pedant/platform'
+
 module Pedant
   module RSpec
     module AuthHeadersUtil
@@ -335,7 +338,7 @@ module Pedant
 
         # X-Ops-Request-Source
         context 'when X-Ops-Request-Source is web' do
-          if Pedant::Config.webui_key
+          if Pedant::Config.pedant_platform.webui_key
             # If no webui_key defined (i.e., in pushy pedant) skip
             # these tests
 
@@ -363,7 +366,7 @@ module Pedant
 
             context 'impersonating successful user' do
               it 'succeeds',
-                :skip => 'no webui_key defined in pedant config' do
+                :skip => 'no webui_key available in key store' do
                 ;
               end
             end

--- a/oc-chef-pedant/lib/pedant/rspec/auth_headers_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/auth_headers_util.rb
@@ -338,6 +338,7 @@ module Pedant
 
         # X-Ops-Request-Source
         context 'when X-Ops-Request-Source is web' do
+          # TODO mp 2017/03/02 revisit for pushy integration - with webui key present, will it behave?
           if Pedant::Config.pedant_platform.webui_key
             # If no webui_key defined (i.e., in pushy pedant) skip
             # these tests

--- a/oc-chef-pedant/lib/pedant/rspec/common.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/common.rb
@@ -488,6 +488,7 @@ module Pedant
 
         shared(:superuser) { platform.superuser }
         shared(:superuser_key) { platform.superuser_key }
+        shared(:webui_key) { platform.webui_key }
 
         # Given a requestor, create a new one with the same name, but
         # with the web UI's private key for 'impersonation' tests

--- a/oc-chef-pedant/lib/pedant/rspec/common.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/common.rb
@@ -487,13 +487,12 @@ module Pedant
         # Platform object
 
         shared(:superuser) { platform.superuser }
-        shared(:superuser_key_file) { platform.superuser_key_file }
-        shared(:webui_key_file) { Pedant::Config.webui_key || (fail "Missing webui_key in Pedant config!") }
+        shared(:superuser_key) { platform.superuser_key }
 
         # Given a requestor, create a new one with the same name, but
         # with the web UI's private key for 'impersonation' tests
         def impersonate(requestor_to_impersonate)
-          Pedant::Requestor.new(requestor_to_impersonate.name, webui_key_file)
+          Pedant::Requestor.new(requestor_to_impersonate.name, platform.webui_key)
         end
 
         # Need a well-formed yet invalid key for a requestor to test authentiction

--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('net-http-spy', '~> 0.2')
   s.add_dependency('erubis', '~> 2.7')
   s.add_dependency('rspec-rerun', '~> 1.0')
+  s.add_dependency('veil', '>= 0.0.1')
 end

--- a/oc-chef-pedant/spec/api/knife/opc/org/create_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/opc/org/create_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'pedant/rspec/user_util'
 
-describe 'knife', :validation do
+describe 'knife', :validation, :knife do
   context 'opc' do
     context 'org' do
       context 'create' do

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -90,11 +90,16 @@ class ChefServerDataBootstrap
   # insert the erchef superuser's key into the erchef keys table,
   # and the user record into the users table.
   def create_superuser_in_erchef(conn)
+    require 'openssl'
+
+    raw_key = PrivateChef.credentials.get('chef-server', 'superuser_key')
+    public_key = OpenSSL::PKey::RSA.new(raw_key).public_key.to_s
+
     user_id = SecureRandom.uuid.gsub("-", "")
     simple_insert(conn, 'keys',
                     id: user_id,
                     key_name: 'default',
-                    public_key: node['bootstrap']['superuser_public_key'],
+                    public_key: public_key,
                     key_version: 0,
                     created_at: bootstrap_time,
                     expires_at: "infinity")

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
@@ -56,7 +56,7 @@ class BootstrapPreflightValidator < PreflightValidator
     #  - fetch pivotal public key(s) from opscode_chef keys view + users
     #  - extract public key from local pivotal.pem
     #   * If we fail with an auth error at this time, it means that either the
-    #     username/password for erchefare not set up (in which case db/schema bootstrap has
+    #     username/password for erchef are not set up (in which case db/schema bootstrap has
     #     not been run and we are working from an outdated secrets file), or we
     #     don't have the correct credentials due to an old secrets file.
     #     This should raise its own error.
@@ -176,7 +176,7 @@ EOM
 BOOT006: The superuser key is present in the key store,
          but the file /etc/opscode/private-chef-secrets.json is missing.
 
-         Ensure that pivotal.pem is copied over into /etc/opscode from the
+         Ensure that the secrets file has been copied into /etc/opscode from the
          first Chef Server node that you brought online, then run
          'chef-server-ctl reconfigure' again.
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
@@ -85,7 +85,10 @@ class BootstrapPreflightValidator < PreflightValidator
   end
 
   def pivotal_key_exists?
-    PrivateChef.credentials.exist?('chef-server', 'superuser_key')
+    # on upgrades, we haven't had a chance to ingest the pivotal key, so we
+    # still need to check if the file is on disk
+    ::File.exist?("/etc/opscode/pivotal.pem") ||
+      PrivateChef.credentials.exist?('chef-server', 'superuser_key')
   end
 
   def validate_sane_state

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -45,8 +45,15 @@ class PreflightValidator
     previous_run.nil?
   end
 
+  # TODO mp 2017/03/01 - ugh -  at the very least let's change this to use a single shared
+  # source of known keys, instead of having yet another place we retype key names.
+  # However, the need for this in the first place is more about things being more complicated
+  # because of the bootstrap process than anything else...
   def secrets_exists?
-    PrivateChef.credentials.length > 0
+    len = PrivateChef.credentials.length
+    len -= 1 if PrivateChef.credentials.exist?('chef-server', 'webui_key')
+    len -= 1 if PrivateChef.credentials.exist?('chef-server', 'superuser_key')
+    len > 0
   end
 
   def backend?

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -46,9 +46,7 @@ class PreflightValidator
   end
 
   def secrets_exists?
-    secrets_json = "/etc/opscode/private-chef-secrets.json"
-    File.exist?(secrets_json) &&
-      Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_json).size > 0
+    PrivateChef.credentials.length > 0
   end
 
   def backend?

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -452,7 +452,7 @@ module PrivateChef
         if File.exist?(secrets_json)
           Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_json)
         #elsif PrivateChef["topology"] == "ha" && !PrivateChef["servers"][node_name]["bootstrap"]
-          # TODO - take a look at bootstrap preflight and see if this is covered - if not,
+          # TODO mp 2017/02/28 - take a look at bootstrap preflight and see if this is covered - if not,
           # handle it separately there.  Disabling it here for now since w e should
           # be able to rely on referencing credentials without raising once
           # we're past preflight.

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -463,7 +463,7 @@ module PrivateChef
 
     def gen_secrets_default(node_name)
       # Sanity check:  don't generate secrets if we're in an HA cluster and are not the bootstap node.
-      unless File.exist? secrets_json#
+      unless File.exist? secrets_json
         if  PrivateChef["topology"] == "ha" && !PrivateChef["servers"][node_name]["bootstrap"]
           Chef::Log.fatal("In an H/A topology the secrets must be created on the bootstrap node. "\
                           "Please copy the contents of /etc/opscode/ from your bootstrap Server " \

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -458,8 +458,6 @@ module PrivateChef
         end
     end
 
-
-
     def gen_secrets_default(node_name)
       # Sanity check:  don't generate secrets if we're in an HA cluster and are not the bootstap node.
       unless File.exist? secrets_json#

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/actions.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/actions.rb
@@ -20,12 +20,13 @@ if is_data_master?
 
   # Write out the config files for actions to load in order to interface with this EC
   # instance
-  #
+  # TODO 2017-02-28 mp: well this won't do...
   file "/etc/opscode-analytics/webui_priv.pem" do
     owner OmnibusHelper.new(node).ownership['owner']
     group "root"
     mode "0600"
-    content lazy {::File.open('/etc/opscode/webui_priv.pem').read}
+    sensitive true
+    content lazy { PrivateChef.credentials.get('chef-server', 'webui_key') }
   end
 
   rabbitmq = OmnibusHelper.new(node).rabbitmq_configuration

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -45,6 +45,7 @@ end
 opscode_webui_deprecation_notice = OpscodeWebuiDeprecationNotice.new(
   PrivateChef['opscode_webui']
 )
+
 log 'opscode_webui deprecation notice' do
   message opscode_webui_deprecation_notice.message
   level :warn

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
@@ -45,7 +45,7 @@ describe BootstrapPreflightValidator do
       context "when the secrets file doesn't exist" do
         before do
           credentials = double(Object)
-          allow(PrivateChef).to_receive(:credentials?).and_return(credentials)
+          allow(PrivateChef).to receive(:credentials?).and_return(credentials)
           allow(credentials).to receive(:exist?).with('chef-server', 'superuser_key').and_return(true)
           allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
         end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
@@ -44,7 +44,9 @@ describe BootstrapPreflightValidator do
 
       context "when the secrets file doesn't exist" do
         before do
-          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(true)
+          credentials = double(Object)
+          allow(PrivateChef).to_receive(:credentials?).and_return(credentials)
+          allow(credentials).to receive(:exist?).with('chef-server', 'superuser_key').and_return(true)
           allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
         end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
@@ -22,6 +22,19 @@ describe BootstrapPreflightValidator do
   let(:subject) { BootstrapPreflightValidator.new(node_object) }
 
   describe "#bypass_bootstrap?" do
+    let(:superuser_key_exists) { true }
+    let(:num_secrets) { 1 }
+    let(:credentials) { double(Object) }
+    # TODO mp 2017/03/01
+    let(:secret_count ) { num_secrets + ( superuser_key_exists ? 2 : 0 ) }
+    before do
+      credentials = double(Object)
+      allow(PrivateChef).to receive(:credentials).and_return(credentials)
+      allow(credentials).to receive(:length).and_return( secret_count )
+      allow(credentials).to receive(:exist?).with('chef-server', anything()).and_return(superuser_key_exists)
+      allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
+    end
+
     context "when a previous run exists" do
       let(:node_object) do { "private_chef" => {},
                              "previous_run" => {"some" => "has"}}
@@ -42,40 +55,21 @@ describe BootstrapPreflightValidator do
         { "private_chef" => {} }
       end
 
-      context "when the secrets file doesn't exist" do
-        before do
-          credentials = double(Object)
-          allow(PrivateChef).to receive(:credentials?).and_return(credentials)
-          allow(credentials).to receive(:exist?).with('chef-server', 'superuser_key').and_return(true)
-          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
-        end
-
+      context "when the superuser key does exist and creds do" do
+      let(:num_secrets) { 0 }
         it "returns false" do
           expect(subject.bypass_bootstrap?).to eq(false)
         end
       end
 
-      context "when the pivotal.pem file doesn't exist" do
-        before do
-          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
-          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
-        end
-
+      context "when the superuser key doesn't exist and creds do" do
+        let(:superuser_key_exists) { false }
         it "returns false" do
           expect(subject.bypass_bootstrap?).to eq(false)
         end
       end
 
-      context "when both private-chef-secrets.json and pivotal.pem exist" do
-        before do
-          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(true)
-          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
-          allow(Veil::CredentialCollection::ChefSecretsFile).to receive(:from_file)
-                                                                 .with("/etc/opscode/private-chef-secrets.json")
-                                                                 .and_return(double("SecretsFile", size: 10))
-        end
-
-
+      context "when credentials and superuser key both exist" do
         context "when postgresql is running externally" do
           before do
             allow(PrivateChef).to receive(:[]).with('postgresql').and_return({"external" => true})

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
@@ -33,6 +33,7 @@ describe BootstrapPreflightValidator do
       allow(credentials).to receive(:length).and_return( secret_count )
       allow(credentials).to receive(:exist?).with('chef-server', anything()).and_return(superuser_key_exists)
       allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
+      allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
     end
 
     context "when a previous run exists" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_checks_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_checks_spec.rb
@@ -1,0 +1,97 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative '../../libraries/private_chef.rb'
+require_relative '../../libraries/helper.rb'
+
+
+describe PreflightChecks do
+  let(:credentials) { double("Credentials") }
+  let(:node_object)  {
+    {
+      "private_chef" => {},
+      "previous_run" => {"some" => "has"}
+    }
+  }
+
+  let(:subject) { PreflightValidator.new(node_object) }
+
+  describe "#first_run?" do
+    context "when no previous run exists" do
+      let(:node_object) {{ "private_chef" => {} }}
+      it "replies true" do
+        expect(subject.first_run?).to be true
+      end
+    end
+
+    context "when a previous run does exist" do
+      let(:node_object) {{ "private_chef" => {}, "previous_run" => { "a" => "b" } }}
+      # default node_object has
+      it "replies false" do
+        expect(subject.first_run?).to be false
+      end
+    end
+  end
+
+  describe "#secrets_exists?" do
+    # If true, Veil will tell us that the superuser/webui keys exist in the store.
+    let(:keys_exist) { true }
+    # Adjust this for number of secrets you want Veil to say it has
+    let(:num_secrets ) { 1 }
+    let(:secret_count ) {
+      num_secrets + ( keys_exist ? 2 : 0 )
+    }
+    let(:credentials) { double("Credentials") }
+
+    before do
+      allow(credentials).to receive(:exist?).with('chef-server', anything()).and_return keys_exist
+      allow(credentials).to receive(:length).and_return secret_count
+      allow(PrivateChef).to receive(:credentials).and_return credentials
+    end
+
+    context "when no application keys have been stored" do
+      let(:keys_exist) { false }
+      context "and there are no other secrets loaded" do
+        let(:num_secrets) { 0 }
+        it "returns false" do
+          expect(subject.secrets_exists?).to be false
+        end
+      end
+      context "and there are other secrets loaded" do
+        let(:num_secrets) { 1 }
+        it "returns true" do
+          expect(subject.secrets_exists?).to be true
+        end
+      end
+    end
+
+    context "when application keys have been stored" do
+      let(:keys_exist) { true }
+      context "and there are no other secrets loaded" do
+        let(:num_secrets) { 0 }
+        it "returns false" do
+          expect(subject.secrets_exists?).to be false
+        end
+      end
+      context "and there are other secrets loaded" do
+        let(:num_secrets) { 1 }
+        it "returns true" do
+          expect(subject.secrets_exists?).to be true
+        end
+      end
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -14,6 +14,17 @@ def config_for(hostname)
 end
 
 describe PrivateChef do
+  let(:node) {
+    {
+      "private_chef" => {
+        "postgresql" => {
+          "version" => "9.2"
+        },
+        "user" => { "username" => "opscode" },
+      },
+    }
+  }
+
   before(:each) {
     PrivateChef.reset
     # May Cthulhu have mercy on our souls. PrivateChef.reset seems to do
@@ -21,7 +32,7 @@ describe PrivateChef do
     # the default Mashes
     Object.send(:remove_const, :PrivateChef)
     load ::File.expand_path("#{::File.dirname(__FILE__)}/../../libraries/private_chef.rb")
-    PrivateChef[:node] = node
+    allow(PrivateChef).to receive(:node).and_return(node)
     allow(PrivateChef).to receive(:exit!).and_raise(SystemExit)
     allow_any_instance_of(Veil::CredentialCollection::ChefSecretsFile).to receive(:save).and_return(true)
     allow_any_instance_of(Kernel).to receive(:system).with("chmod 0600 /etc/opscode/private-chef-secrets.json").and_return(true)
@@ -78,15 +89,6 @@ EOF
     filename
   }
 
-  let(:node) {
-    {
-      "private_chef" => {
-        "postgresql" => {
-          "version" => "9.2"
-        }
-      }
-    }
-  }
 
   context "When FIPS is enabled at the kernel" do
     let(:config) { <<-EOF

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -4,6 +4,7 @@ require 'chef/log'
 def expect_existing_secrets
   allow(File).to receive(:exist?).and_call_original
   allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+  allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
   allow(IO).to receive(:read).and_call_original
   allow(IO).to receive(:read).with("/etc/opscode/private-chef-secrets.json").and_return(secrets)
 end
@@ -417,14 +418,14 @@ EOF
 
       it "should add a key that exists and return true" do
         expect(File).to receive(:readable?).with("/my_key").and_return true
-        expect(secrets_mock).to receive(:add_key_from_file).with("group", "name", "/my_key")
+        expect(secrets_mock).to receive(:add_from_file).with("/my_key", "group", "name")
         result = PrivateChef.add_key_from_file_if_present("group", "name", "/my_key")
         expect(result).to be true
       end
 
       it "should not add a key that does not and return false" do
         expect(File).to receive(:readable?).with("/my_key").and_return false
-        result = PrivateChef.add_key_from_file_if_present("group", "name", "/my_key")
+        result = PrivateChef.add_key_from_file_if_present( "group", "name", "/my_key")
         expect(result).to be false
 
       end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -136,6 +136,11 @@ server "backend-passive.chef.io",
 EOF
     }
 
+    before  do
+      allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return false
+    end
+
+
     it "generates secrets on the backend bootstrap node" do
       rendered_config = config_for("backend-active.chef.io")
       expect(rendered_config["private_chef"]["rabbitmq"]).to have_key("password")

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -108,8 +108,6 @@ ssl_version :<%= @ssl_version %>
 # running on/ to a private key for that user.
 
 superuser_name 'pivotal'
-superuser_key  '/etc/opscode/pivotal.pem'
-webui_key '/etc/opscode/webui_priv.pem'
 
 requestors({
              :clients => {

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
@@ -1,6 +1,17 @@
+require "tempfile"
+require "veil"
+
+secrets_file = ENV['SECRETS_FILE'] || "/etc/opscode/private-chef-secrets.json"
+credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file)
+
+key = Tempfile.new("latovip")
+key.puts credentials.get("chef-server", "superuser_key")
+key.flush
+key.close
+
 node_name "pivotal"
 chef_server_url "<%= @prefix %>://<%= @vip %>"
 chef_server_root "<%= @prefix %>://<%= @vip %>"
 no_proxy "<%= node['private_chef']['lb']['vip'] %>"
-client_key "/etc/opscode/pivotal.pem"
+client_key key.path
 ssl_verify_mode :verify_none

--- a/omnibus/files/private-chef-ctl-commands/Gemfile.lock
+++ b/omnibus/files/private-chef-ctl-commands/Gemfile.lock
@@ -47,10 +47,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/chef_secrets.git
-  revision: 2c89a21b8d85d510e202eab10562b7af190c5b4a
+  revision: d9695b10fc05d10b6b32d79e82c568f13510888a
   specs:
     veil (0.1.0)
-      bcrypt
+      bcrypt (~> 3.1)
       pbkdf2
 
 GIT

--- a/omnibus/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
+++ b/omnibus/files/private-chef-ctl-commands/open_source_chef12_upgrade.rb
@@ -498,6 +498,7 @@ EOF
     # or else give the user a way to specify them
     # The server root is likely the same as was set for the knife config
     # used by knife download
+    # TODO 2017-02-28 mp: closer look her when we're looking at cleaning migrations
     config = <<-EOH
     chef_server_root '#{@options.chef12_server_url}'
     node_name 'pivotal'

--- a/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
+++ b/omnibus/files/private-chef-ctl-commands/rotate_credentials.rb
@@ -32,7 +32,7 @@ add_command_under_category "rotate-credentials", "credential-rotation", "Rotate 
     backup_file = backup_secrets_file
 
     log("Rotating #{service}'s credentials...", :notice)
-    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path)
+    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path, owner)
     credentials.rotate(service)
     credentials.save
   rescue => e
@@ -73,7 +73,7 @@ add_command_under_category "rotate-all-credentials", "credential-rotation", "Rot
     backup_file = backup_secrets_file
 
     log("Rotating all Chef Server service credentials...", :notice)
-    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path)
+    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path, owner)
     credentials.rotate_credentials
     credentials.save
   rescue => e
@@ -113,7 +113,7 @@ add_command_under_category "rotate-shared-secrets", "credential-rotation", "Rota
   # Rotate and save the credentials
   begin
     log("Rotating shared credential secrets and service credentials...", :notice)
-    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path)
+    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path, owner)
     credentials.rotate_hasher
     credentials.save
   rescue => e
@@ -145,7 +145,7 @@ end
 add_command_under_category "show-service-credentials", "credential-rotation", "Show the service credentials", 2 do
   ensure_configured!
 
-  credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path)
+  credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file_path, owner)
   pp(credentials.legacy_credentials_hash)
   exit(0)
 end
@@ -244,6 +244,10 @@ def ensure_configured!
     log("You must reconfigure the Chef Server before a backup can be performed", :error)
     exit(1)
   end
+end
+
+def owner
+  { user: running_config["private_chef"]["user"]["username"] }
 end
 
 def log(message, level = :info)

--- a/omnibus/files/private-chef-ctl-commands/spec/rotate_credentials_spec.rb
+++ b/omnibus/files/private-chef-ctl-commands/spec/rotate_credentials_spec.rb
@@ -29,12 +29,15 @@ describe "chef-server-ctl rotate credentials" do
            save: true)
   end
 
+  let(:running_config) { { 'private_chef' => { 'user' => { 'username' => 'opscode' } } } }
+
   before do
     allow(subject.ctl).to receive(:ensure_configured!).and_return(true)
     allow(subject.ctl).to receive(:backup_secrets_file).and_return("/tmp/backup.json")
     allow(subject.ctl).to receive(:restore_secrets_file).and_return(true)
     allow(subject.ctl).to receive(:remove_backup_file).and_return(true)
     allow(subject.ctl).to receive(:run_chef).and_return(double("ProcessStatus", success?: true))
+    allow(subject.ctl).to receive(:running_config).and_return(running_config)
     allow(Veil::CredentialCollection::ChefSecretsFile).to receive(:from_file).and_return(veil_creds)
   end
 


### PR DESCRIPTION
Do not merge.

IMPORTANT:  This PR will break upgrades.  See first task below

This set of changes does the following:

* replace usage of the files pivotal.pem and webui pem with the Vail key store in chef-server-ctl reconfigure/cookbooks
* update pedant the same

There are some tasks left:
* [x] IMPORTANT: a partybus migration must be created to put the existing keys into Veil. The changes in this PR assume that if the key is not there, it must be created.
* [x] omnibus test cleanup is needed  to get them passing again, this was expected
* [ ] embedded knife - ship a plugin that teaches knife how to pull the creds from Veil.

