### PR TITLE
Don't render redis password to redis.config

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -24,7 +24,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 79ba746f2e921b4ea7f8a9050e4025635eade335
+  revision: c0715498df6704fdbc2362994012e4a517040c88
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -292,4 +292,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.13.7
+   1.14.3

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/redis_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/redis_lb.conf.erb
@@ -6,8 +6,6 @@ port <%= @port %>
 bind <%= @bind %> <%= @listen == @bind ? "" : @listen %>
 <% end %>
 
-requirepass "<%= @password %>"
-
 tcp-keepalive <%= @keepalive %>
 timeout <%= @timeout %>
 loglevel <%= @loglevel %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-redis_lb-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-redis_lb-run.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec /opt/opscode/embedded/bin/veil-env-helper -s REDIS_PASSWORD=redis_lb.password chpst -P -o 131071 -u <%= node["private_chef"]["user"]["username"] %> -U <%= node["private_chef"]["user"]["username"] %> -o 100000 env HOME="<%= node["private_chef"]["redis_lb"]["dir"] %>" /opt/opscode/embedded/bin/redis-server <%= File.join(node["private_chef"]["redis_lb"]["dir"], "etc", "redis.conf") %>
+exec /opt/opscode/embedded/bin/veil-env-helper -s REDIS_PASSWORD=redis_lb.password -- chpst -P -o 131071 -u <%= node["private_chef"]["user"]["username"] %> -U <%= node["private_chef"]["user"]["username"] %> -o 100000 env HOME="<%= node["private_chef"]["redis_lb"]["dir"] %>" /opt/opscode/embedded/bin/redis-server <%= File.join(node["private_chef"]["redis_lb"]["dir"], "etc", "redis.conf") %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-redis_lb-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-redis_lb-run.erb
@@ -1,4 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -P -o 131071 -u <%= node["private_chef"]["user"]["username"] %> -U <%= node["private_chef"]["user"]["username"] %> -o 100000 env HOME="<%= node["private_chef"]["redis_lb"]["dir"] %>" /opt/opscode/embedded/bin/redis-server <%= File.join(node["private_chef"]["redis_lb"]["dir"], "etc", "redis.conf") %>
-
+exec /opt/opscode/embedded/bin/veil-env-helper -s REDIS_PASSWORD=redis_lb.password chpst -P -o 131071 -u <%= node["private_chef"]["user"]["username"] %> -U <%= node["private_chef"]["user"]["username"] %> -o 100000 env HOME="<%= node["private_chef"]["redis_lb"]["dir"] %>" /opt/opscode/embedded/bin/redis-server <%= File.join(node["private_chef"]["redis_lb"]["dir"], "etc", "redis.conf") %>


### PR DESCRIPTION
This uses a patched version of redis which can now read the password
from the environment.

Signed-off-by: Steven Danna <steve@chef.io>