### PR TITLE
Clean up redis_password from lua configuration

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -115,7 +115,6 @@ nginx_vars = nginx_vars.merge(:helper => NginxErb.new(node))
 lbconf = node['private_chef']['lb'].to_hash.merge(nginx_vars).merge(
   :redis_host => node['private_chef']['redis_lb']['vip'],
   :redis_port => node['private_chef']['redis_lb']['port'],
-  :redis_password => node['private_chef']['redis_lb']['password'],
   :omnihelper => OmnibusHelper.new(node)
 )
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-chef-mover.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-chef-mover.rb
@@ -35,7 +35,9 @@ template mover_config do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
-  variables(node['private_chef']['opscode-chef-mover'].to_hash.merge({:helper => OmnibusHelper.new(node)}))
+  variables(node['private_chef']['opscode-chef-mover'].to_hash.merge({:helper => OmnibusHelper.new(node),
+                                                                      :redis_password => PrivateChef.credentials.get("redis_lb", "password")
+                                                                     }))
 end
 
 link "/opt/opscode/embedded/service/opscode-chef-mover/sys.config" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
@@ -109,7 +109,7 @@ ruby_block "set_lb_redis_values" do
     require "redis"
     redis = Redis.new(:host => redis_data.vip,
                       :port => redis_data.port,
-                      :password => redis_data.password)
+                      :password => PrivateChef.credentials.get("redis_lb", "password"))
     xdl = node['private_chef']['lb']['xdl_defaults']
     banned_ips = PrivateChef['banned_ips']
     maint_mode_ips = PrivateChef['maint_mode_whitelist_ips']

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -1,7 +1,7 @@
 user <%= node['private_chef']['user']['username'] %> <%= node['private_chef']['user']['username']%>;
 worker_processes <%= @worker_processes %>;
 error_log /var/log/opscode/nginx/error.log<%= node['private_chef']['lb']['debug'] ? " debug" : "" %>;
-
+env REDIS_PASSWORD;
 daemon off;
 
 events {

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
@@ -52,15 +52,20 @@ local function connect_redis()
       ngx.log(ngx.ERR, "failed to connect redis: ", err)
    end
 
-   local ok, err = red:auth("<%= @redis_password %>")
-   if not ok then
-      if auth_not_required(err) then
-         ok = true
-      else
-         ngx.log(ngx.ERR, "failed to authenticate to redis: ", err)
+   local redis_password = os.getenv("REDIS_PASSWORD")
+   if redis_password == nil then
+      ngx.log(ngx.ERR, "REDIS_PASSWORD not found in the environment")
+      ok = false
+   else
+      local ok, err = red:auth(redis_password)
+      if not ok then
+         if auth_not_required(err) then
+            ok = true
+         else
+            ngx.log(ngx.ERR, "failed to authenticate to redis: ", err)
+        end
       end
    end
-
    return ok, red
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -164,7 +164,7 @@
           % If dry_run is true, eredis host and port will be ignored.
           {eredis_host, "127.0.0.1"},
           {eredis_port, 16379},
-          {eredis_password, "<%= node['private_chef']['redis_lb']['password'] %>"},
+          {eredis_password, "<%= @redis_password %>"},
           {solr_url, "<%= node['private_chef']['opscode-solr4']['url'] %>"}
          ]},
  {chef_reindex, [

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-nginx-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-nginx-run.erb
@@ -1,4 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec chpst -P /opt/opscode/embedded/sbin/nginx -c <%= File.join(node['private_chef']['nginx']['dir'], "etc", "nginx.conf") %>
-
+exec /opt/opscode/embedded/bin/veil-env-helper -s REDIS_PASSWORD=redis_lb.password -- chpst -P /opt/opscode/embedded/sbin/nginx -c <%= File.join(node['private_chef']['nginx']['dir'], "etc", "nginx.conf") %>

--- a/omnibus/files/private-chef-ctl-commands/reindex.rb
+++ b/omnibus/files/private-chef-ctl-commands/reindex.rb
@@ -19,6 +19,7 @@ require 'chef/config'
 require 'chef/rest'
 require 'chef/org'
 require 'redis'
+require 'veil'
 
 def all_orgs
   Chef::Config.from_file("/etc/opscode/pivotal.rb")
@@ -61,12 +62,16 @@ def enqueue_data_for_org(org)
   end
 end
 
+def veil
+  @veil ||= Veil::CredentialCollection::ChefSecretsFile.from_file("/etc/opscode/private-chef-secrets.json")
+end
+
 def redis
   @redis ||= begin
-                 vip = running_config["private_chef"]["redis_lb"]["vip"]
-                 port = running_config["private_chef"]["redis_lb"]["port"]
-                 password = running_config["private_chef"]["redis_lb"]["password"]
-                 Redis.new(port: port, ip: vip, password: password)
+               vip = running_config["private_chef"]["redis_lb"]["vip"]
+               port = running_config["private_chef"]["redis_lb"]["port"]
+               password = veil.get('redis_lb', 'password')
+               Redis.new(port: port, ip: vip, password: password)
              end
 end
 


### PR DESCRIPTION
The main change here is cleaning up the redis password from the nginx
lua scripts. It also ensures all access to the redis password happens
via veil.