### PR TITLE
Do not set secrets ownership until after the owning user exists

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -451,13 +451,11 @@ module PrivateChef
     end
 
     def credentials
-      owner = OmnibusHelper.new(node).ownership
-      owner_opts = { user: owner['owner'], group: owner['group'] }
       @credentials ||=
         if File.exist?(secrets_json)
-          Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_json, owner_opts)
+          Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_json)
         else
-          Veil::CredentialCollection::ChefSecretsFile.new(owner_opts.merge(path: secrets_json))
+          Veil::CredentialCollection::ChefSecretsFile.new(path: secrets_json)
         end
     end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/private_keys.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/private_keys.rb
@@ -48,6 +48,15 @@ end
 
 webui_key = OpenSSL::PKey::RSA.new(PrivateChef.credentials.get('chef-server', 'webui_key'))
 
+# This file gets created before the opscode user exists -
+# we'll need to change ownership after the fact.
+helper = OmnibusHelper.new(node).ownership
+file "/etc/opscode/private-chef-secrets.json" do
+  owner helper['owner']
+  group helper['group']
+  mode "0600"
+end
+
 file "/etc/opscode/webui_pub.pem" do
   owner "root"
   group "root"


### PR DESCRIPTION
When we initialize Veil on a new installation of Chef Server,
the opscode user has not yet been created.  For the time being,
we'll skip setting the ownership on calling Veil, and explicitly
set it as a file resource in recipe execution.

Important Note: this introduces a non-obvious ordering change.
If credentials.save is called after the private_keys.rb recipe,
the ownership will get reverted by veil.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>