### PR TITLE
[nginx] Only access the REDIS_PASSWORD env variable once

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
@@ -5,6 +5,8 @@ module("config", package.seeall)
 -- NOTE: assumption that the following is defined globally:
 -- redis = require("resty/redis")
 
+local redis_password = os.getenv("REDIS_PASSWORD")
+
 local failsafe_config = {}
 failsafe_config["dl_default"] = { }
 failsafe_config["dl_default"][1] = "503_mode"
@@ -52,7 +54,6 @@ local function connect_redis()
       ngx.log(ngx.ERR, "failed to connect redis: ", err)
    end
 
-   local redis_password = os.getenv("REDIS_PASSWORD")
    if redis_password == nil then
       ngx.log(ngx.ERR, "REDIS_PASSWORD not found in the environment")
       ok = false


### PR DESCRIPTION
We've hoisted the getenv call to the top level of config.lua in an
attempt to see if this new call is the cause of recent build failures.
The build failures appear correlated with the following new errors in
nginx/error.log:

    ../ngx_lua-0.10.6/src/ngx_http_lua_util.c:1003: ngx_http_lua_run_thread:
    Assertion `orig_coctx->co_top + nrets == lua_gettop(orig_coctx->co)' failed.
    2017/03/06 09:15:12 [alert] 30132#0: worker process 30148 exited on signal 6

Signed-off-by: Steven Danna <steve@chef.io>