### PR TITLE
[travis] remove veil from on-the-flight Gemfile generation

### DIFF
--- a/oc-chef-pedant/Rakefile
+++ b/oc-chef-pedant/Rakefile
@@ -33,8 +33,6 @@ def bundle_exec_with_chef(test_gem, commands)
       gemfile.puts(line)
     end
     gemfile.puts("gem #{CURRENT_GEM_NAME.inspect}, path: #{CURRENT_GEM_PATH.inspect}")
-    # veil is not on rubygems
-    gemfile.puts("gem 'veil', github: 'chef/chef_secrets'")
     gemfile.puts("gemspec path: #{gem_path.inspect}")
     gemfile.close
     Dir.chdir(gem_path) do


### PR DESCRIPTION
Since veil now is a proper dependency of chef-zero, we no longer need
this.
