### PR TITLE
[oc-chef-pedant] Don't directly depend on veil

### DIFF
--- a/oc-chef-pedant/Gemfile
+++ b/oc-chef-pedant/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 gemspec
 gem 'rest-client', github: 'chef/rest-client'
 # For debugging in dvm
-# gem 'veil',path: '/host/external-deps/chef_secrets'
-gem 'veil', github: 'chef/chef_secrets'
 gem 'pry'
 gem 'rake'
 

--- a/oc-chef-pedant/Gemfile.lock
+++ b/oc-chef-pedant/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: git://github.com/chef/chef_secrets.git
-  revision: d9695b10fc05d10b6b32d79e82c568f13510888a
-  specs:
-    veil (0.1.0)
-      bcrypt (~> 3.1)
-      pbkdf2
-
-GIT
   remote: git://github.com/chef/rest-client.git
   revision: ba0d12258b77791d8f7d9776d008eb6fa3580ccc
   specs:
@@ -29,7 +21,6 @@ PATH
       rspec (~> 3.2)
       rspec-rerun (~> 1.0)
       rspec_junit_formatter (~> 0.2)
-      veil (>= 0.0.1)
 
 GEM
   remote: https://rubygems.org/
@@ -39,10 +30,9 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    bcrypt (3.1.11)
     builder (3.2.3)
     coderay (1.1.1)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.0.4)
     diff-lcs (1.3)
     erubis (2.7.0)
     i18n (0.8.1)
@@ -58,7 +48,6 @@ GEM
     mixlib-shellout (2.2.7)
     net-http-spy (0.2.1)
     netrc (0.7.9)
-    pbkdf2 (0.1.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -96,7 +85,6 @@ DEPENDENCIES
   pry
   rake
   rest-client!
-  veil!
 
 BUNDLED WITH
    1.14.5

--- a/oc-chef-pedant/Rakefile
+++ b/oc-chef-pedant/Rakefile
@@ -3,15 +3,12 @@ require 'tempfile'
 require 'bundler'
 require 'json'
 require 'openssl'
-require 'veil'
 
 CURRENT_GEM_NAME = 'oc-chef-pedant'
 CURRENT_GEM_PATH = File.expand_path('../..', __FILE__)
 
 task :chef_zero_spec do
-  tmp_file = Tempfile.new("secrets").path
-  create_secrets_file(tmp_file)
-  @secrets_path = tmp_file
+  populate_secrets_env
   bundle_exec_with_chef("chef-zero", "rake pedant")
 end
 
@@ -53,15 +50,15 @@ def bundle_exec_with_chef(test_gem, commands)
 end
 
 def bundler_env
-  { "BUNDLE_GEMFILE" => @gemfile_path, "RUBYOPT" => nil, "GEMFILE_MOD" => nil,
-    "SECRETS_FILE" => @secrets_path }
+  { "BUNDLE_GEMFILE" => @gemfile_path,
+    "RUBYOPT" => nil,
+    "GEMFILE_MOD" => nil,
+    "SUPERUSER_KEY" => @superuser_key,
+    "WEBUI_KEY" => @webui_key
+  }
 end
 
-def create_secrets_file(file_path)
-  credentials = Veil::CredentialCollection::ChefSecretsFile.new(path: file_path)
-  key = OpenSSL::PKey::RSA.new(2048).to_pem
-  webui_key = OpenSSL::PKey::RSA.new(2048).to_pem
-  credentials.add("chef-server", "superuser_key", value: key)
-  credentials.add("chef-server", "webui_key", value: webui_key)
-  credentials.save
+def populate_secrets_env
+  @superuser_key = OpenSSL::PKey::RSA.new(2048).to_pem
+  @webui_key = OpenSSL::PKey::RSA.new(2048).to_pem
 end

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -37,8 +37,6 @@ require 'pedant/ui'
 require 'pedant/rspec/matchers'
 require 'pedant/rspec/common'
 
-require 'veil'
-
 module Pedant
   def self.config
     # This is a bit of a hack: for some reason, we have UTF-8/US-ASCII encoding
@@ -78,14 +76,11 @@ module Pedant
   end
 
   def self.create_platform
-    # Let's not expose the secrets store by default
-
-    # TODO 2017-02-28 mp:  configurable location:
-    path = ENV['SECRETS_FILE'] || "/etc/opscode/private-chef-secrets.json"
-    credentials = Veil::CredentialCollection::ChefSecretsFile.from_file(path)
-
+    superuser_key = ENV['SUPERUSER_KEY']
+    webui_key = ENV['WEBUI_KEY']
     config.pedant_platform = Pedant::Platform.new(config.chef_server,
-                                                  credentials,
+                                                  superuser_key,
+                                                  webui_key,
                                                   config.superuser_name)
   end
 

--- a/oc-chef-pedant/lib/pedant/platform.rb
+++ b/oc-chef-pedant/lib/pedant/platform.rb
@@ -31,12 +31,12 @@ module Pedant
                 :server, :superuser, :superuser_key_data, :webui_key
 
     # Create a Platform object for a given server (specified by
-    # protocol, hostname, and port ONLY).  You must supply the
+    # protocol, hostname, and port ONLY). You must supply the
     # superuser's key data in PEM form.
     #
-    def initialize(server, creds_or_key_data , superuser_name='pivotal')
-      load_credentials(creds_or_key_data)
-
+    def initialize(server, superuser_key, webui_key, superuser_name='pivotal')
+      @superuser_key_data = superuser_key
+      @webui_key = webui_key
       @server = (Pedant.config.explicit_port_url ? explicit_port_url(server) : server )
       puts "Configured URL: #{@server}"
       @superuser = Pedant::Requestor.new(superuser_name, @superuser_key_data, platform: self)
@@ -47,19 +47,6 @@ module Pedant
       @ldap_testing = Pedant::Config[:ldap_testing]
       self.pedant_run_timestamp # Cache the global timestamp at initialization
       self
-    end
-
-    def load_credentials(creds_or_key_data)
-      case creds_or_key_data
-      when String
-        @superuser_key_data = creds_or_key_data
-      else
-        creds = creds_or_key_data
-        @superuser_key_data = creds.get('chef-server', 'superuser_key')
-        if creds.exist?('chef-server', 'webui_key')
-          @webui_key = creds.get('chef-server', 'webui_key')
-        end
-      end
     end
 
     DEFAULT_ORG_REWRITE = /^\/?(search|nodes|cookbooks|data|roles|sandboxes|environments|clients|principals|runs|groups|containers|keys)/

--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |s|
   s.add_dependency('net-http-spy', '~> 0.2')
   s.add_dependency('erubis', '~> 2.7')
   s.add_dependency('rspec-rerun', '~> 1.0')
-  s.add_dependency('veil', '>= 0.0.1')
 end

--- a/omnibus/files/private-chef-ctl-commands/test.rb
+++ b/omnibus/files/private-chef-ctl-commands/test.rb
@@ -5,6 +5,12 @@
 #
 
 add_command_under_category "test", "general", "Run the API test suite against localhost.", 2 do
+  require 'veil'
+
+  veil = Veil::CredentialCollection::ChefSecretsFile.from_file("/etc/opscode/private-chef-secrets.json")
+  ENV['SUPERUSER_KEY'] = veil.get("chef-server", "superuser_key")
+  ENV['WEBUI_KEY'] = veil.get("chef-server", "webui_key")
+
   pedant_args = ARGV[3..-1]
   pedant_args = ["--smoke"] unless pedant_args.any?
   Dir.chdir(File.join(base_path, "embedded", "service", "oc-chef-pedant"))


### PR DESCRIPTION
Because oc-chef-pedant has a number of downstream dependencies, the
direct dependency on veil meant that veil was going to start leaking
into a number of other repositories and packages. I don't think we
want that until the API stabilizes a bit more and until it is a more
robust libary.

Signed-off-by: Steven Danna <steve@chef.io>