### PR TITLE
Fix private-chef specs to work with recent veil changes

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -451,17 +451,12 @@ module PrivateChef
     end
 
     def credentials
-      @credentials ||=
-        if File.exist?(secrets_json)
-          Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_json)
-        else
-          Veil::CredentialCollection::ChefSecretsFile.new(path: secrets_json)
-        end
+      @credentials ||= Veil::CredentialCollection::ChefSecretsFile.new(path: secrets_json)
     end
 
     def gen_secrets_default(node_name)
       # Sanity check:  don't generate secrets if we're in an HA cluster and are not the bootstap node.
-      unless File.exist? secrets_json
+      unless File.exists? secrets_json
         if  PrivateChef["topology"] == "ha" && !PrivateChef["servers"][node_name]["bootstrap"]
           Chef::Log.fatal("In an H/A topology the secrets must be created on the bootstrap node. "\
                           "Please copy the contents of /etc/opscode/ from your bootstrap Server " \

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -2,9 +2,10 @@ require_relative '../../libraries/private_chef.rb'
 require 'chef/log'
 
 def expect_existing_secrets
-  allow(File).to receive(:exist?).and_call_original
-  allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
-  allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
+  allow(File).to receive(:exists?).and_call_original
+  allow(File).to receive(:exists?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+  allow(File).to receive(:size).with("/etc/opscode/private-chef-secrets.json").and_return(1)
+  allow(File).to receive(:exists?).with("/etc/opscode/pivotal.pem").and_return(false)
   allow(IO).to receive(:read).and_call_original
   allow(IO).to receive(:read).with("/etc/opscode/private-chef-secrets.json").and_return(secrets)
 end
@@ -36,8 +37,7 @@ describe PrivateChef do
     allow(PrivateChef).to receive(:node).and_return(node)
     allow(PrivateChef).to receive(:exit!).and_raise(SystemExit)
     allow_any_instance_of(Veil::CredentialCollection::ChefSecretsFile).to receive(:save).and_return(true)
-    allow_any_instance_of(Kernel).to receive(:system).with("chmod 0600 /etc/opscode/private-chef-secrets.json").and_return(true)
-    allow_any_instance_of(Kernel).to receive(:system).with("chown opscode /etc/opscode/private-chef-secrets.json").and_return(true)
+    allow(File).to receive(:exists?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
   }
 
   # Example content of /etc/opscode/private-chef-secrets.json
@@ -140,7 +140,7 @@ EOF
     }
 
     before  do
-      allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return false
+      allow(File).to receive(:exists?).with("/etc/opscode/private-chef-secrets.json").and_return false
     end
 
 


### PR DESCRIPTION
With https://github.com/chef/chef_secrets/commit/e6b3d4300a8797283
we've changed the behaviour of new, requiring an extra mock.

Roughly twenty minutes were wasted on File.exist? vs File.exists?