### PR TITLE
Ingest user-supplied passwords

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -57,7 +57,11 @@ class PostgresqlPreflightValidator < PreflightValidator
     # These values must be explictly set in chef-server.rb:
     fail_with err_CSPG004_missing_external_host unless cs_pg_attr.has_key? 'vip'
     fail_with err_CSPG002_missing_superuser_id unless cs_pg_attr.has_key? 'db_superuser'
-    fail_with err_CSPG003_missing_superuser_password unless cs_pg_attr.has_key? 'db_superuser_password'
+    fail_with err_CSPG003_missing_superuser_password unless has_superuser_password?
+  end
+
+  def has_superuser_password?
+    PrivateChef.credentials.exists?("postgresql", "db_superuser_password") || cs_pg_attr.has_key?("db_superuser_password")
   end
 
   # We do not support changing from managed to external DB or vice-versa, so the

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -519,9 +519,9 @@ module PrivateChef
           credentials.add("postgresql", "db_superuser_password",
                           value: PrivateChef["postgresql"]["db_superuser_password"],
                           frozen: true, force: true)
-        else
-          credentials.add("postgresql", "db_superuser_password", length: 100)
         end
+      else
+        credentials.add("postgresql", "db_superuser_password", length: 100)
       end
     end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/warnings.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/warnings.rb
@@ -1,0 +1,26 @@
+module ChefServer
+  class Warnings
+    @@warnings = []
+
+    def self.warn(msg)
+      @@warnings << msg
+    end
+
+    def self.print_warnings
+      return if @@warnings.empty?
+
+      puts "\n" + "-"*70 + "\n"
+      puts <<EOF
+
+The following warnings were encountered during the reconfiguration of
+your Chef server:
+
+EOF
+      @@warnings.each do |msg|
+        puts "#{msg}\n"
+      end
+
+      puts "\n" + "-"*70 + "\n"
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -188,3 +188,9 @@ file "/etc/opscode/chef-server-running.json" do
 
   content Chef::JSONCompat.to_json_pretty(file_content)
 end
+
+ruby_block "print reconfigure warnings" do
+  block do
+    ChefServer::Warnings.print_warnings
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -36,7 +36,6 @@ rabbitmq = OmnibusHelper.new(node).rabbitmq_configuration
 actions_vip = rabbitmq['vip']
 actions_port = rabbitmq['node_port']
 actions_user = rabbitmq['actions_user']
-actions_password = rabbitmq['actions_password']
 actions_vhost = rabbitmq['actions_vhost']
 actions_exchange = rabbitmq['actions_exchange']
 
@@ -50,7 +49,6 @@ template erchef_config do
                                                                  :actions_vip => actions_vip,
                                                                  :actions_port => actions_port,
                                                                  :actions_user => actions_user,
-                                                                 :actions_password => actions_password,
                                                                  :actions_vhost => actions_vhost,
                                                                  :actions_exchange => actions_exchange,
                                                                  :ldap_encryption_type => ldap_encryption_type,

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/private_keys.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/private_keys.rb
@@ -28,11 +28,7 @@ unless PrivateChef.credentials.exist?('chef-server', 'superuser_key')
   PrivateChef.credentials.add('chef-server', 'superuser_key',
                               value: pivotal_key.to_pem,
                               frozen: true )
-  # Used only io chef_server_data_bootstrap.rb  to provide the key for pivotal
-  # user creation.  Setting it here so that we can keep the related OpenSSL call wrangling
-  # to one place.
-  # Setting at the top level so that we don't export this to chef-server-running.json
-  node.set['bootstrap']['superuser_public_key'] = pivotal_key.public_key.to_s
+
   # TODO 2017-02-28 mp: let's consider making this the default behavior
   # of any write to CredentialsCollection -
   PrivateChef.credentials.save

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -93,8 +93,6 @@
             {port, <%= node['private_chef']['ldap']['port'] || (@ssl_enabled ? 636 : 389) %> },
             {timeout, <%= node['private_chef']['ldap']['timeout'] || 60000 %> },
             {bind_dn, "<%= node['private_chef']['ldap']['bind_dn'] || "" %>" },
-            %% TODO: user-provided pass, what do?
-            {bind_password, "<%= @helper.escape_characters_in_string(node['private_chef']['ldap']['bind_password']) %>" },
             {base_dn, "<%= node['private_chef']['ldap']['base_dn'] || "" %>" },
             {group_dn, "<%= node['private_chef']['ldap']['group_dn'] || "" %>" },
             {login_attribute, "<%= node['private_chef']['ldap']['login_attribute'] || "samaccountname" %>" },

--- a/omnibus/files/private-chef-ctl-commands/secrets.rb
+++ b/omnibus/files/private-chef-ctl-commands/secrets.rb
@@ -1,4 +1,6 @@
 add_command_under_category "set-ldap-bind-password", "Secrets Management", "Add or change LDAP bind password", 2 do
+  require 'highline'
+
   ARGV.delete("--yes") # remove --yes so users can give it in all cases in automation
   bind_password = get_secret("BIND_PASSWORD", "LDAP bind password")
   set_secret("ldap", "bind_password", bind_password)
@@ -33,11 +35,13 @@ def get_secret(env_key, prompt='secret')
   elsif ENV[env_key]
     ENV[env_key]
   else
-    prompt_for_password(prompt)
+    pass1 = HighLine.ask("Enter #{prompt}: " ) { |q| q.echo = false }
+    pass2 = HighLine.ask("Re-enter #{prompt}: " ) { |q| q.echo = false }
+    if pass1 == pass2
+      pass2
+    else
+      STDERR.puts "ERROR: Passwords don't match"
+      exit(1)
+    end
   end
-end
-
-def prompt_for_password(prompt)
-  require 'highline'
-  HighLine.ask("Enter #{prompt}: " ) { |q| q.echo = "*" }
 end

--- a/omnibus/files/private-chef-ctl-commands/secrets.rb
+++ b/omnibus/files/private-chef-ctl-commands/secrets.rb
@@ -1,0 +1,43 @@
+add_command_under_category "set-ldap-bind-password", "Secrets Management", "Add or change LDAP bind password", 2 do
+  ARGV.delete("--yes") # remove --yes so users can give it in all cases in automation
+  bind_password = get_secret("BIND_PASSWORD", "LDAP bind password")
+  set_secret("ldap", "bind_password", bind_password)
+end
+
+add_command_under_category "set-db-superuser-password", "Secrets Management", "Add or change DB superuser password", 2 do
+  require 'highline'
+
+  if !ARGV.delete("--yes")
+    STDERR.puts "WARN: Manually setting the DB superuser password is only supported for external postgresql instances"
+    if !HighLine.agree("Would you like to continue (y/n)? ")
+      exit(0)
+    end
+  end
+
+  password = get_secret("DB_PASSWORD", "DB superuser password")
+  set_secret("postgresql", "db_superuser_password", password)
+end
+
+def set_secret(group, key, secret)
+  # TODO(ssd) 2017-03-07: We could just use veil directly here since we already require it other places
+  # in the -ctl commands...
+  require 'mixlib/shellout'
+  cmd = Mixlib::ShellOut.new("/opt/opscode/embedded/bin/veil-ingest-secret #{group}.#{key}", input: secret)
+  cmd.run_command
+end
+
+def get_secret(env_key, prompt='secret')
+  password_arg = ARGV[3]
+  if password_arg
+    password_arg
+  elsif ENV[env_key]
+    ENV[env_key]
+  else
+    prompt_for_password(prompt)
+  end
+end
+
+def prompt_for_password(prompt)
+  require 'highline'
+  HighLine.ask("Enter #{prompt}: " ) { |q| q.echo = "*" }
+end


### PR DESCRIPTION
The ldap bind_password and (potentially) the postgresql superuser password can be set by the user in the configuration file.  For users who have policies against passwords in plaintext configuration files, we offer 2 new commands:

    chef-server-ctl set-ldap-bind-password
    chef-server-ctl set-db-superuser-password

which can be used to set those passwords on the command line.

NOTE: The passwords are still stored in plain-test in the private-chef-secrets.json file.