### PR TITLE
rabbitmq: add runit control script for termination

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
@@ -107,7 +107,9 @@ template "/opt/opscode/bin/wait-for-rabbit" do
   variables( config: rabbitmq )
 end
 
-component_runit_service "rabbitmq"
+component_runit_service "rabbitmq" do
+  control ['t']
+end
 
 if is_data_master?
   rmq_ctl = "/opt/opscode/embedded/bin/rabbitmqctl"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/rabbitmq-defaults.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/rabbitmq-defaults.erb
@@ -35,3 +35,5 @@ ENABLED_PLUGINS_FILE=${SYS_PREFIX}/etc/enabled_plugins
 PLUGINS_DIR="${RABBITMQ_HOME}/plugins"
 
 CONF_ENV_FILE=<%= @config_file %>
+# stay in foreground, don't proxy signals
+RUNNING_UNDER_SYSTEMD=true

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-rabbitmq-t.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-rabbitmq-t.erb
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+echo "received TERM from runit, invoking rabbitmqctl stop"
+exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /usr/bin/env HOME=<%= node['private_chef']['rabbitmq']['dir'] %> /opt/opscode/embedded/bin/rabbitmqctl stop


### PR DESCRIPTION
Some upstream change brought in by the upgrade has inhibited
chef-server-ctl stop rabbitmq from stopping the service, leaving the
beam process re-parented.

This change tells rabbitmq-server it was running under systemd, such
that it will not fork in to the background.

To ensure we don't kill the beam process brutally, a script was added
mimicking what the rabbitmq-server script unsuccessfully tried to do.

Signed-off-by: Stephan Renatus <srenatus@chef.io>