### PR TITLE
Always render bookshelf route

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -77,9 +77,8 @@
     }
     <% end -%>
 
-    <% if node['private_chef']['bookshelf']['enable'] -%>
     # bookshelf
-      <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
+    <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
     location ~ "^/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/organization-.+" {
       set $destination @cached;
       if ($request_method !~ ^(GET)$) {
@@ -97,11 +96,10 @@
     location @uncached {
       proxy_pass http://bookshelf;
     }
-      <% else -%>
+    <% else -%>
     location ~ "^/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/organization-.+" {
       proxy_pass http://bookshelf;
     }
-      <% end -%>
     <% end -%>
 
     # erchef status endpoint


### PR DESCRIPTION
We mistakenly disabled the bookshelf route when bookshelf was
disabled.  While that sounds reasonable, in a tier configuration,
bookshelf is disabled on the frontends, but all requests still need to
route through the frontend nginx instance.

Signed-off-by: Steven Danna <steve@chef.io>