### PR TITLE
Remove sensitive attributes

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -122,9 +122,7 @@ default['private_chef']['rabbitmq']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['rabbitmq']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['rabbitmq']['vhost'] = '/chef'
 default['private_chef']['rabbitmq']['user'] = 'chef'
-default['private_chef']['rabbitmq']['password'] = 'chefrocks'
 default['private_chef']['rabbitmq']['actions_user'] = 'actions'
-default['private_chef']['rabbitmq']['actions_password'] = 'changeme'
 default['private_chef']['rabbitmq']['actions_vhost'] = '/analytics'
 default['private_chef']['rabbitmq']['actions_exchange'] = 'actions'
 default['private_chef']['rabbitmq']['node_ip_address'] = '127.0.0.1'
@@ -140,7 +138,6 @@ default['private_chef']['rabbitmq']['ssl_versions'] = ['tlsv1.2', 'tlsv1.1']
 # RabbitMQ Management Plugin
 ####
 default['private_chef']['rabbitmq']['management_user'] = "rabbitmgmt"
-default['private_chef']['rabbitmq']['management_password'] = "chefrocks"
 default['private_chef']['rabbitmq']['management_port'] = 15672
 default['private_chef']['rabbitmq']['management_enabled'] = true
 
@@ -195,7 +192,6 @@ default['private_chef']['rabbitmq']['rabbit_mgmt_ibrowse_options'] =  "{connect_
 ####
 default['private_chef']['external-rabbitmq']['enable'] = false
 default['private_chef']['external-rabbitmq']['actions_user'] = 'actions'
-default['private_chef']['external-rabbitmq']['actions_password'] = 'changeme'
 default['private_chef']['external-rabbitmq']['actions_vhost'] = '/analytics'
 default['private_chef']['external-rabbitmq']['actions_exchange'] = 'actions'
 default['private_chef']['external-rabbitmq']['node_port'] = '5672'
@@ -282,9 +278,7 @@ default['private_chef']['opscode-erchef']['authz_pooler_timeout'] = '0'
 default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = nil
 default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
-default['private_chef']['opscode-erchef']['sql_password'] = "snakepliskin"
 default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
-default['private_chef']['opscode-erchef']['sql_ro_password'] = "shmunzeltazzen"
 #
 # Reindex configurables
 #
@@ -573,7 +567,6 @@ default['private_chef']['postgresql']['log_rotation']['file_maxbytes'] = 1048576
 default['private_chef']['postgresql']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['postgresql']['username'] = "opscode-pgsql"
 default['private_chef']['postgresql']['db_superuser'] = 'opscode-pgsql'
-default['private_chef']['postgresql']['db_superuser_password'] = 'doallthethings'
 default['private_chef']['postgresql']['shell'] = "/bin/sh"
 default['private_chef']['postgresql']['home'] = "/var/opt/opscode/postgresql"
 default['private_chef']['postgresql']['user_path'] = "/opt/opscode/embedded/bin:/opt/opscode/bin:$PATH"
@@ -631,7 +624,6 @@ default['private_chef']['oc_bifrost']['log_rotation']['max_messages_per_second']
 default['private_chef']['oc_bifrost']['vip'] = '127.0.0.1'
 default['private_chef']['oc_bifrost']['listen'] = '127.0.0.1'
 default['private_chef']['oc_bifrost']['port'] = 9463
-default['private_chef']['oc_bifrost']['superuser_id'] = '5ca1ab1ef005ba111abe11eddecafbad'
 default['private_chef']['oc_bifrost']['db_pool_size'] = '20'
 default['private_chef']['oc_bifrost']['db_pool_max'] = nil
 default['private_chef']['oc_bifrost']['db_pool_init'] = nil
@@ -640,9 +632,7 @@ default['private_chef']['oc_bifrost']['db_pooler_timeout'] = 2000
 default['private_chef']['oc_bifrost']['db_pool_queue_max'] = 20
 default['private_chef']['oc_bifrost']['udp_socket_pool_size'] = nil
 default['private_chef']['oc_bifrost']['sql_user'] = "bifrost"
-default['private_chef']['oc_bifrost']['sql_password'] = "challengeaccepted"
 default['private_chef']['oc_bifrost']['sql_ro_user'] = "bifrost_ro"
-default['private_chef']['oc_bifrost']['sql_ro_password'] = "foreveralone"
 default['private_chef']['oc_bifrost']['sql_db_timeout'] = 5000
 # Enable extended performance logging data for bifrost.  Setting this to false
 # will cut bifrost request log size approximately in half.
@@ -676,8 +666,6 @@ default['private_chef']['bookshelf']['vip_port'] = 443
 default['private_chef']['bookshelf']['listen'] = '127.0.0.1'
 default['private_chef']['bookshelf']['port'] = 4321
 default['private_chef']['bookshelf']['stream_download'] = true
-default['private_chef']['bookshelf']['access_key_id'] = "generated-by-default"
-default['private_chef']['bookshelf']['secret_access_key'] = "generated-by-default"
 # Default: set to Host: header. Override to hardcode a url, "http://..."
 default['private_chef']['bookshelf']['external_url'] = :host_header
 default['private_chef']['bookshelf']['storage_type'] = :filesystem
@@ -692,9 +680,7 @@ default['private_chef']['bookshelf']['db_pool_queue_max'] = 200
 default['private_chef']['bookshelf']['db_pooler_timeout'] = 2000
 default['private_chef']['bookshelf']['sql_db_timeout'] = 5000
 default['private_chef']['bookshelf']['sql_ro_user'] = 'bookshelf_ro'
-default['private_chef']['bookshelf']['sql_ro_password'] = 'should_never_be_used'
 default['private_chef']['bookshelf']['sql_user'] = 'bookshelf'
-default['private_chef']['bookshelf']['sql_password'] = 'should_never_be_used'
 
 ###
 # Chef Identity
@@ -710,9 +696,7 @@ default['private_chef']['oc_id']['vip'] = "127.0.0.1"
 default['private_chef']['oc_id']['port'] = 9090
 default['private_chef']['oc_id']['sql_database'] = "oc_id"
 default['private_chef']['oc_id']['sql_user'] = "oc_id"
-default['private_chef']['oc_id']['sql_password'] = "snakepliskin"
 default['private_chef']['oc_id']['sql_ro_user'] = "oc_id_ro"
-default['private_chef']['oc_id']['sql_ro_password'] = "look-but-don't-touch"
 default['private_chef']['oc_id']['db_pool_size'] = '20'
 default['private_chef']['oc_id']['sentry_dsn'] = nil
 default['private_chef']['oc_id']['sign_up_url'] = nil
@@ -808,6 +792,7 @@ default['private_chef']['keepalived']['vrrp_instance_interface'] = "eth0"
 default['private_chef']['keepalived']['vrrp_instance_virtual_router_id'] = "1"
 default['private_chef']['keepalived']['vrrp_instance_priority'] = "100"
 default['private_chef']['keepalived']['vrrp_instance_advert_int'] = "1"
+# TODO mp 2017-03-10 this one too
 default['private_chef']['keepalived']['vrrp_instance_password'] = "sneakybeaky"
 default['private_chef']['keepalived']['vrrp_instance_ipaddress'] = node['ipaddress']
 default['private_chef']['keepalived']['vrrp_instance_ipaddress_dev'] = 'eth0'

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -260,6 +260,7 @@ default['private_chef']['opscode-expander']['consumer_id'] = "default"
 default['private_chef']['opscode-expander']['nodes'] = 2
 default['private_chef']['opscode-expander']['max_retries'] = 1
 default['private_chef']['opscode-expander']['retry_wait'] = 1
+
 ####
 # Erlang Chef Server API
 ####
@@ -279,6 +280,7 @@ default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = nil
 default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
 default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
+
 #
 # Reindex configurables
 #

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -49,8 +49,11 @@ class ChefServerDataBootstrap
     # objects in erchef.  By separating them, we increase the chance that a
     # bootstrap failed due to an error out of bifrost can be recovered
     # by re-running it.
-
-    EcPostgres.with_service_connection(node, 'opscode_chef', 'opscode-erchef') do |conn|
+    username = node['private_chef']['opscode-erchef']['sql_user']
+    password = PrivateChef.credentials.get('opscode_erchef', 'sql_password')
+    EcPostgres.with_connection(node, 'opscode_chef',
+                               'db_superuser' => username,
+                               'db_superuser_password' => password) do |conn|
       create_superuser_in_erchef(conn)
       create_server_admins_global_group_in_erchef(conn)
       create_global_container_in_erchef(conn, 'organizations', orgs_authz_id)

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -20,7 +20,7 @@ class EcPostgres
     begin
       connection = ::PGconn.open('user' => postgres['db_superuser'],
                                  'host' => postgres['vip'],
-                                 'password' => postgres['db_superuser_password'],
+                                 'password' => PrivateChef.credentials.get('postgresql', 'db_superuser_password'),
                                  'port' => postgres['port'],
                                  'dbname' => database)
     rescue => e
@@ -48,10 +48,12 @@ class EcPostgres
   end
 
   def self.with_service_connection(node, database, service_name)
+
     service = node['private_chef'][service_name]
+    service_name = "opscode_erchef" if service_name == "opscode-erchef"
     with_connection(node, database,
                     db_superuser: service['sql_user'],
-                    db_superuser_password: service['sql_password']) do |connection|
+                    db_superuser_password: PrivateChef.credentials.get(service_name, 'sql_password')) do |connection|
       yield connection
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -81,7 +81,7 @@ class OmnibusHelper
   def db_connection_uri
     db_protocol = "postgres"
     db_user     = node['private_chef']['opscode-erchef']['sql_user']
-    db_password = node['private_chef']['opscode-erchef']['sql_password']
+    db_password = PrivateChef.credentials.get('opscode_erchef', 'sql_password')
     db_vip      = vip_for_uri('postgresql')
     db_name     = "opscode_chef"
 
@@ -91,7 +91,7 @@ class OmnibusHelper
   def bifrost_db_connection_uri
     db_protocol = "postgres"
     db_user     = node['private_chef']['oc_bifrost']['sql_user']
-    db_password = node['private_chef']['oc_bifrost']['sql_password']
+    db_password = PrivateChef.credentials.get('oc_bifrost', 'sql_password')
     db_vip      = vip_for_uri('postgresql')
     db_name     = "bifrost"
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -61,7 +61,7 @@ class PostgresqlPreflightValidator < PreflightValidator
   end
 
   def has_superuser_password?
-    PrivateChef.credentials.exists?("postgresql", "db_superuser_password") || cs_pg_attr.has_key?("db_superuser_password")
+    PrivateChef.credentials.exists?("postgresql", "db_superuser_password")
   end
 
   # We do not support changing from managed to external DB or vice-versa, so the

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -213,9 +213,9 @@ EOM
   def err_CSPG002_missing_superuser_id
 <<EOM
 CSPG002: You have not set a database superuser name under
-         "postgresql['db_superuser'] in
-         chef-server.rb.  This is required for external database support - please set
-         it now and then re-run 'chef-server-ctl reconfigure'.
+         "postgresql['db_superuser']" in chef-server.rb.  This is required
+         for external database support - please set it now and
+         then re-run 'chef-server-ctl reconfigure'.
 
          See https://docs.chef.io/server_components.html#postgresql-settings
          for more information.
@@ -224,9 +224,9 @@ EOM
 
   def err_CSPG003_missing_superuser_password
 <<EOM
-CSPG003: You have not set a database superuser password under
-         "postgresql['db_superuser_password']" in chef-server.rb.  This is
-         required for external database support - please set it now and then
+CSPG003: You have not set a database superuser password using
+         chef-server-ctl set-db-superuser-password. This is required
+         for external database support - please run this now, then
          re-run 'chef-server-ctl reconfigure'.
 
          See https://docs.chef.io/server_components.html#postgresql-settings

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -481,8 +481,8 @@ module PrivateChef
       credentials.add("rabbitmq", "management_password", length: 100)
       credentials.add("drbd", "shared_secret", length: 60)
       credentials.add("keepalived", "vrrp_instance_password", length: 100)
-      credentials.add("opscode_erchef", "sql_password", length: 60)
-      credentials.add("opscode_erchef", "sql_ro_password", length: 60)
+      credentials.add("opscode_erchef", "sql_password", length: 100)
+      credentials.add("opscode_erchef", "sql_ro_password", length: 100)
       # Freeze oc_bifrost superuser_id so it will not be rotated
       credentials.add("oc_bifrost", "superuser_id", length: 32, frozen: true)
       credentials.add("oc_bifrost", "sql_password", length: 100)
@@ -492,8 +492,9 @@ module PrivateChef
       credentials.add("oc_id", "sql_ro_password", length: 100)
       credentials.add("bookshelf", "access_key_id", length: 40)
       credentials.add("bookshelf", "secret_access_key", length: 80)
-      credentials.add("bookshelf", "sql_password", length: 80)
-      credentials.add("bookshelf", "sql_ro_password", length: 80)
+      credentials.add("bookshelf", "sql_password", length: 100)
+      credentials.add("bookshelf", "sql_ro_password", length: 100)
+      # First attempt to pull in any configured token,
 
       generate_rabbit_actions_password
       migrate_and_check_db_superuser_password

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -466,6 +466,7 @@ module PrivateChef
         end
       end
 
+      # TODO
       # Transition from erchef's sql_user/password etc living under 'postgresql'
       # in older versions to 'opscode_erchef' in newer versions
       if credentials["postgresql"] && credentials["postgresql"]["sql_password"]
@@ -498,10 +499,7 @@ module PrivateChef
       migrate_and_check_db_superuser_password
       migrate_and_check_ldap_bind_password
       migrate_and_check_data_collector_token
-      # TODO 2017-03-03 sr: remove "|| true" when we can cope with secrets not
-      #                     being in node attrs
-      save_credentials_to_config if (PrivateChef["insecure_addon_compat"] || true)
-
+      save_credentials_to_config if (PrivateChef["insecure_addon_compat"])
       credentials.save
     end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -8,12 +8,12 @@ postgres_attrs = node['private_chef']['postgresql']
 # create users
 
 private_chef_pg_user bifrost_attrs['sql_user'] do
-  password bifrost_attrs['sql_password']
+  password PrivateChef.credentials.get('oc_bifrost', 'sql_password')
   superuser false
 end
 
 private_chef_pg_user bifrost_attrs['sql_ro_user'] do
-  password bifrost_attrs['sql_ro_password']
+  password PrivateChef.credentials.get('oc_bifrost', 'sql_ro_password')
   superuser false
 end
 
@@ -43,7 +43,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
   username  postgres_attrs['db_superuser']
-  password  postgres_attrs['db_superuser_password']
+  password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bifrost"
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
@@ -3,12 +3,12 @@ postgres_attrs = node['private_chef']['postgresql']
 
 # create users
 private_chef_pg_user bookshelf_attrs['sql_user'] do
-  password bookshelf_attrs['sql_password']
+  password PrivateChef.credentials.get('bookshelf', 'sql_password')
   superuser false
 end
 
 private_chef_pg_user bookshelf_attrs['sql_ro_user'] do
-  password bookshelf_attrs['sql_ro_password']
+  password PrivateChef.credentials.get('bookshelf', 'sql_ro_password')
   superuser false
 end
 
@@ -38,7 +38,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/bookshelf/schema" do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
   username  postgres_attrs['db_superuser']
-  password  postgres_attrs['db_superuser_password']
+  password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bookshelf"
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -5,6 +5,10 @@ erchef = node['private_chef']['opscode-erchef']
 private_chef_pg_user erchef['sql_user'] do
   password PrivateChef.credentials.get('opscode_erchef', 'sql_password')
   superuser false
+  not_if {
+    puts "Starting with: #{erchef['sql_user']} #### #{PrivateChef.credentials.get('opscode_erchef', 'sql_password')}"
+    false
+  }
 end
 
 private_chef_pg_user erchef['sql_ro_user'] do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -5,10 +5,6 @@ erchef = node['private_chef']['opscode-erchef']
 private_chef_pg_user erchef['sql_user'] do
   password PrivateChef.credentials.get('opscode_erchef', 'sql_password')
   superuser false
-  not_if {
-    puts "Starting with: #{erchef['sql_user']} #### #{PrivateChef.credentials.get('opscode_erchef', 'sql_password')}"
-    false
-  }
 end
 
 private_chef_pg_user erchef['sql_ro_user'] do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -3,12 +3,12 @@ postgres = node['private_chef']['postgresql']
 erchef = node['private_chef']['opscode-erchef']
 
 private_chef_pg_user erchef['sql_user'] do
-  password erchef['sql_password']
+  password PrivateChef.credentials.get('opscode_erchef', 'sql_password')
   superuser false
 end
 
 private_chef_pg_user erchef['sql_ro_user'] do
-  password erchef['sql_ro_password']
+  password PrivateChef.credentials.get('opscode_erchef', 'sql_ro_password')
   superuser false
 end
 
@@ -34,7 +34,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/base
   hostname  postgres['vip']
   port      postgres['port']
   username  postgres['db_superuser']
-  password  postgres['db_superuser_password']
+  password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database  "opscode_chef"
   action :nothing
   notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema]", :immediately
@@ -44,7 +44,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
   hostname  postgres['vip']
   port      postgres['port']
   username  postgres['db_superuser']
-  password  postgres['db_superuser_password']
+  password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "opscode_chef"
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id_database.rb
@@ -20,11 +20,11 @@ id_attrs = node['private_chef']['oc_id']
 
 # create users
 private_chef_pg_user id_attrs['sql_user'] do
-  password id_attrs['sql_password']
+  password PrivateChef.credentials.get('oc_id', 'sql_password')
 end
 
 private_chef_pg_user id_attrs['sql_ro_user'] do
-  password id_attrs['sql_ro_password']
+  password PrivateChef.credentials.get('oc_id', 'sql_ro_password')
 end
 
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -153,7 +153,7 @@ ERR
 
   # Update the postgresql superuser  with a password for tcp-based access.
   private_chef_pg_user node['private_chef']['postgresql']['db_superuser'] do
-    password node['private_chef']['postgresql']['db_superuser_password']
+    password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
     # This initial password set must be done over local socket:
     local_connection true
     # Don't make superuser into a non-superuser...

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -110,13 +110,13 @@ EOF
 
     it "generates secrets" do
       rendered_config = config_for("api.chef.io")
-      expect(rendered_config["private_chef"]["rabbitmq"]).to have_key("password")
+      expect(PrivateChef.credentials.exist?("rabbitmq", "password")).to eq(true)
     end
 
     it "does not regenerate a secret if it already exists" do
       expect_existing_secrets
-      rendered_config = config_for("api.chef.io")
-      expect(rendered_config["private_chef"]["rabbitmq"]["password"]).to eq("a866861140c2c7bc2dc67c9f7696be2b2108321e18acb08922c28a075a8dbb8e773d82142e9cc52c96fdf6928c901c3ab360")
+      config_for("api.chef.io")
+      expect(PrivateChef.credentials.get("rabbitmq", "password")).to eq("a866861140c2c7bc2dc67c9f7696be2b2108321e18acb08922c28a075a8dbb8e773d82142e9cc52c96fdf6928c901c3ab360")
     end
   end
 
@@ -145,8 +145,8 @@ EOF
 
 
     it "generates secrets on the backend bootstrap node" do
-      rendered_config = config_for("backend-active.chef.io")
-      expect(rendered_config["private_chef"]["rabbitmq"]).to have_key("password")
+      config_for("backend-active.chef.io")
+      expect(PrivateChef.credentials.exist?("rabbitmq", "password")).to eq(true)
     end
 
     it "enables opscode-chef-mover on the bootstrap node" do


### PR DESCRIPTION
This PR is the result of the first passa through chef-server to identify and remove all secrets stored as node attributes, and any references to them.

Note: Merging this will break nightlies of reporting, which still expects at least some of this info in chef-server-running.json