### PR TITLE
Add preflight check for half-disabled ipv6 systems

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -145,6 +145,7 @@ class PreflightChecks
       SolrPreflightValidator.new(node).run!
       SslPreflightValidator.new(node).run!
       BookshelfPreflightValidator.new(node).run!
+      Ipv6PreflightValidator.new(node).run!
     rescue PreflightValidationFailed => e
       # use of exit! prevents exit handlers from running, ensuring the last thing
       # the customer sees is the descriptive error we've provided.

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_ipv6_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_ipv6_validator.rb
@@ -1,0 +1,65 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative './preflight_checks.rb'
+
+class Ipv6PreflightValidator < PreflightValidator
+  def initialize(node)
+    super
+  end
+
+  def run!
+    verify_ipv6_for_lo
+  end
+
+  # When setting the environment variable ERL_EPMD_ADDRESS to _anything_, epmd
+  # will _also_ try to listen on 127.0.0.1 _and_ ::1:
+  # https://github.com/erlang/otp/blob/47e46069d019/erts/epmd/src/epmd_srv.c#L255-L261
+  #
+  # We set ERL_EPMD_ADDRESS=127.0.0.1 in each of our Erlang services' run files.
+  #
+  # If IPv6 is disabled completely, epmd's try to bind to ::1 fails with an
+  # error that is ignored:
+  # https://github.com/erlang/otp/blob/47e46069d019/erts/epmd/src/epmd_srv.c#L370-L372
+  #
+  # If IPv6 is not disabled completely, that bind fails more harshly, and causes
+  # epmd to not come up, making the service's bootup fail, too, as it cannot
+  # connect to epmd.
+  #
+  # See also http://erlang.org/pipermail/erlang-questions/2016-March/088427.html
+  def verify_ipv6_for_lo
+    if ipv6_enabled && !lo_has_ipv6_addr
+      fail_with <<EOF
+Your system has IPv6 enabled but its loopback interface has no IPv6
+address.
+
+You must either pass `ipv6.disable=1` to your kernel command line,
+to completely disable IPv6, or ensure the loopback interface has an
+`::1` address by running
+
+    sysctl net.ipv6.conf.lo.disable_ipv6=0
+EOF
+    end
+  end
+
+  def ipv6_enabled
+    # if kernel cmdline has ipv6.disable=1, this doesn't exist
+    ::File.exists?("/proc/sys/net/ipv6")
+  end
+
+  def lo_has_ipv6_addr
+    IO.read("/proc/sys/net/ipv6/conf/lo/disable_ipv6").chomp == "0"
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_ipv6_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_ipv6_validator_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../libraries/helper.rb'
+require_relative '../../libraries/preflight_checks.rb'
+require_relative '../../libraries/preflight_ipv6_validator.rb'
+
+describe Ipv6PreflightValidator do
+  let(:ipv6_preflight) do
+    i = Ipv6PreflightValidator.new({'private_chef' => {}})
+    allow(i).to receive(:fail_with).and_return(:i_failed)
+    i
+  end
+
+  before(:each) do
+    allow(File).to receive(:exists?).with("/proc/sys/net/ipv6").and_return(enabled)
+    allow(IO).to receive(:read).with("/proc/sys/net/ipv6/conf/lo/disable_ipv6").and_return(disable_ipv6)
+  end
+
+  context "when ipv6 is enabled" do
+    let(:enabled) { true }
+
+    context "the loopback interface has no ipv6 address" do
+      let(:disable_ipv6) { "1\n" }
+
+      it "raises an error" do
+        expect(ipv6_preflight.verify_ipv6_for_lo).to eq(:i_failed)
+      end
+    end
+
+    context "the loopback interface has an ipv6 address" do
+      let(:disable_ipv6) { "0\n" }
+
+      it "does not raise an error" do
+        expect(ipv6_preflight.verify_ipv6_for_lo).not_to eq(:i_failed)
+      end
+    end
+
+  end
+
+  context "when ipv6 is disabled" do
+    let(:enabled) { false }
+    let(:disable_ipv6) { "whatever\n" }
+
+    it "does not raise an error" do
+      expect(ipv6_preflight.verify_ipv6_for_lo).not_to eq(:i_failed)
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-rabbitmq-t.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-rabbitmq-t.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 exec 2>&1
 echo "received TERM from runit, invoking rabbitmqctl stop"
-exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /usr/bin/env HOME=<%= node['private_chef']['rabbitmq']['dir'] %> /opt/opscode/embedded/bin/rabbitmqctl stop
+exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /usr/bin/env ERL_EPMD_ADDRESS=127.0.0.1 HOME=<%= node['private_chef']['rabbitmq']['dir'] %> /opt/opscode/embedded/bin/rabbitmqctl stop


### PR DESCRIPTION
As @voroniys noticed with one of our add-ons (#1111), there's a
hard-to-debug system configuration issue around epmd on ipv6-enabled
systems lacking `::1` on their loopback interface.

This preflight checks tries to catch that, and inform the user of their
possible ways forward.