### PR TITLE
Fix pedant compare

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/matchers.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/matchers.rb
@@ -74,20 +74,7 @@ module RSpec
           when Regexp
             spec =~ value
           when Array
-            # we care about contents, not order; i.e., treat them
-            # (kind of) like sets
-            return true if spec == value
-            return false if value.length < spec.length
-            return false if strict? and value.length != spec.length
-            # Note this is going to be slow for large arrays,
-            # though our actual usage shows we don't have any arrays on a
-            # scale that would matter.
-            return true if spec.all? { |s| value.include? s }
-            # Our comparisons are more complex than simple value
-              spec.each_with_index  do |newspec, x|
-                return false unless PedantHashComparator.new(newspec, @mode).matches? value[x]
-              end
-              return true
+            array_matches?(spec, value)
           when Hash
             PedantHashComparator.new(spec, @mode).matches?(value)
           when Proc then
@@ -97,6 +84,23 @@ module RSpec
           end
         end
 
+      end
+
+      def array_matches?(spec, value)
+        # we care about contents, not order; i.e., treat them
+        # (kind of) like sets
+        return true if spec == value
+        return false if value.length < spec.length
+        return false if strict? and value.length != spec.length
+        # Note this is going to be slow for large arrays,
+        # though our actual usage shows we don't have any arrays on a
+        # scale that would matter.
+        return true if spec.all? { |s| value.include? s }
+        # Our comparisons are more complex than simple value
+        spec.each_with_index  do |newspec, x|
+          return false unless PedantHashComparator.new(newspec, @mode).matches? value[x]
+        end
+        return true
       end
 
       def friendly_actual

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -931,6 +931,8 @@ describe "ACL API", :acl do
               }
             }
           }}
+          let(:groups) { ["users", "admins"] }
+          let(:read_groups) { ["users", "clients", "admins"] }
         when "policy_groups"
           let(:creation_url) {
             api_url("#{type}/#{new_object}/policies/acl_test_policy")
@@ -946,6 +948,8 @@ describe "ACL API", :acl do
               }
             }
           }}
+          let(:groups) { ["users", "admins"] }
+          let(:read_groups) { ["users", "clients", "admins"] }
         end
 
         before :each do


### PR DESCRIPTION
When comparing elements of a hash, if an element is an array we exit
if it matches, rather than continuing on to check the other keys.

This is because we used 'return true' in the body of an all? loop,
apparently intending to move to the next iteration of the loop, but
instead exiting the whole function with an incorrect 'true'.