### PR TITLE
fix rabbit migration: start/stop rabbitmq

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/wait-for-rabbit.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/wait-for-rabbit.erb
@@ -18,4 +18,4 @@ done
 
 echo "waiting for rabbitmq..."
 HOME=/root PATH=/opt/opscode/embedded/bin:$PATH /opt/opscode/embedded/bin/rabbitmqctl wait <%= @config['data_dir'] %>/<%= @config['nodename'] %>.pid 2>/tmp/stderr
-echo "rabbbitmq might be up..."
+echo "rabbitmq might be up..."

--- a/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
+++ b/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
@@ -1,6 +1,8 @@
 define_upgrade do
   if Partybus.config.bootstrap_server # TODO: do we want this?
 
+    start_services(["rabbitmq"])
+
     rmq = Partybus.config.running_server["private_chef"]["rabbitmq"]
     [
       [rmq["user"], "password"],
@@ -10,5 +12,7 @@ define_upgrade do
       pass = Partybus.config.secrets.get('rabbitmq', passname)
       run_command("/opt/opscode/embedded/bin/rabbitmqctl change_password #{name} #{pass}")
     end
+
+    stop_services(["rabbitmq"])
   end
 end


### PR DESCRIPTION
When this migration was merged, the bug where `chef-server-ctl stop rabbitmq` wouldn't *really* stop it was still around, so this omission slipped in.