### PR TITLE
Use higher compression level for release builds

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -96,14 +96,17 @@ dependency "chef-ha-plugin-config"
 dependency "chef" # for embedded chef-client -z runs (built from master - build last)
 dependency "cleanup" # MUST BE LAST DO NOT MOVE
 
+# if this is a release build, use a higher compression level
+xz_level = ENV['PIPELINE_TRIGGER_JOB_NAME'] == 'chef-server-12-trigger-release' ? 6 : 1
+
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']
-  compression_level 1
+  compression_level xz_level
   compression_type :xz
 end
 
 package :deb do
-  compression_level 1
+  compression_level xz_level
   compression_type :xz
 end
 


### PR DESCRIPTION
When we've introduced xz compression for rpm and debs, level 1 was
picked as it took roughly as long as gz (which we had before), while
still giving us smaller artifacts.

However, if we do a release, it would make sense to use a higher level.
In general, the release build should come mostly from cache anyways, so
its build time should be smaller, so the inflation of that time would be
less terrible.

Level 6 is the default of the CLI tools for xz (xzcat etc).

Signed-off-by: Stephan Renatus <srenatus@chef.io>