### PR TITLE
Enhance API to handle global groups in local contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ MODIFIED_COMPONENTS_CHANGELOG.md
 dev/*.deb
 src/oc_erchef/log
 compile_commands.json
+.kitchen
+

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -440,7 +440,7 @@ describe "ACL API", :acl do
 
       context "PUT /organizations/_acl/#{permission}" do
         let(:actors) { ["pivotal"] }
-        let(:groups) { ["admins" ] }
+        let(:groups) { ["admins"] }
         let(:read_groups) { ["admins", "users"] }
         let(:default_body) {{
             "create" => {"actors" => actors, "groups" => groups},
@@ -798,8 +798,6 @@ describe "ACL API", :acl do
 
       end
     end
-
-
   end
 
   context "/<type>/<name>/_acl endpoint" do
@@ -1434,7 +1432,7 @@ describe "ACL API", :acl do
                       }
                     }}
 
-                  it "returns 400", :validation  do
+                  it "returns 400", :validation do
                     response = put(permission_request_url, platform.admin_user,
                       :payload => update_body)
                     expect(response).to have_status_code 400

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -438,13 +438,6 @@ describe "ACL API", :acl do
       let(:acl_url) { api_url("organizations/_acl") }
       let(:request_url) { api_url("organizations/_acl/#{permission}") }
 
-      before :each do
-        platform.create_org(test_orgname2)
-      end
-      after :each do
-        delete("#{platform.server}/organizations/#{test_orgname2}", platform.superuser)
-      end
-
       context "PUT /organizations/_acl/#{permission}" do
         let(:actors) { ["pivotal"] }
         let(:groups) { ["admins" ] }
@@ -810,13 +803,6 @@ describe "ACL API", :acl do
   end
 
   context "/<type>/<name>/_acl endpoint" do
-
-    before do
-      platform.create_org(test_orgname2)
-    end
-    after do
-      delete("#{platform.server}/organizations/#{test_orgname2}", platform.superuser)
-    end
 
     # TODO: Sanity check: users don't seem to have any ACLs, or at least, nothing is
     # accessible from external API as far as I can tell:
@@ -1209,7 +1195,7 @@ describe "ACL API", :acl do
             context "PUT /#{type}/<name>/_acl/#{permission}" do
               let(:clients) { [platform.non_admin_client.name] }
               let(:users) {
-                  [platform.non_admin_user.name, platform.admin_user.name, "pivotal"]
+                [platform.non_admin_user.name, platform.admin_user.name, "pivotal"].uniq
               }
               let(:local_groups) { ["admins", "users", "clients"] }
 

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -19,11 +19,11 @@ describe "ACL API", :acl do
 
   before(:all) do
     @test_orgname2 = "test-org-#{rand_id}"
-    platform.create_org(@test_orgname2)
+    platform.create_org(@test_orgname2) if Pedant.config[:org][:create_me]
   end
 
   after(:all) do
-    platform.delete_org(@test_orgname2)
+    platform.delete_org(@test_orgname2) if Pedant.config[:org][:create_me]
   end
 
   # (temporarily?) deprecating /users/*/_acl endpoint due to its broken state and lack of usefulness

--- a/oc-chef-pedant/spec/api/account/account_group_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_group_spec.rb
@@ -417,13 +417,6 @@ describe "opscode-account groups", :groups do
     let(:test_group) { "test-group" }
     let(:test_orgname2) { "test-org-#{rand_id}-#{Process.pid}" }
 
-    before do
-      platform.create_org(test_orgname2)
-    end
-    after do
-      delete("#{platform.server}/organizations/#{test_orgname2}", platform.superuser)
-    end
-
     before :each do
       post(api_url("groups"), platform.admin_user,
         :payload => {"id" => test_group}).should look_like({:status => 201})

--- a/oc-chef-pedant/spec/api/account/account_group_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_group_spec.rb
@@ -417,6 +417,15 @@ describe "opscode-account groups", :groups do
     let(:test_group) { "test-group" }
     let(:test_orgname2) { "test-org-#{rand_id}-#{Process.pid}" }
 
+    before(:all) do
+      @test_orgname2 = "test-org-#{rand_id}"
+      platform.create_org(@test_orgname2) if Pedant.config[:org][:create_me]
+    end
+
+    after(:all) do
+      platform.delete_org(@test_orgname2) if Pedant.config[:org][:create_me]
+    end
+
     before :each do
       post(api_url("groups"), platform.admin_user,
         :payload => {"id" => test_group}).should look_like({:status => 201})
@@ -630,7 +639,7 @@ describe "opscode-account groups", :groups do
           "::server-admins"
         }
         let(:other_admins) {
-          "#{test_orgname2}::admins"
+          "#{@test_orgname2}::admins"
         }
         let(:new_group_payload_with_global) {{
           "groupname" => test_group,

--- a/oc-chef-pedant/spec/api/account/account_group_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_group_spec.rb
@@ -6,7 +6,6 @@ describe "opscode-account groups", :groups do
 
   context "/groups endpoint" do
     let(:request_url) { api_url("groups") }
-
     context "GET /groups" do
       # This is only a partial body -- there are other groups as well, but these
       # should all exist for an organization:
@@ -416,6 +415,14 @@ describe "opscode-account groups", :groups do
   context "/groups/<name> endpoint" do
     let(:request_url) { api_url("groups/#{test_group}") }
     let(:test_group) { "test-group" }
+    let(:test_orgname2) { "test-org-#{rand_id}-#{Process.pid}" }
+
+    before do
+      platform.create_org(test_orgname2)
+    end
+    after do
+      delete("#{platform.server}/organizations/#{test_orgname2}", platform.superuser)
+    end
 
     before :each do
       post(api_url("groups"), platform.admin_user,
@@ -598,8 +605,9 @@ describe "opscode-account groups", :groups do
         let(:new_group_payload) {{
             "groupname" => test_group,
             "actors" => {"clients" => [platform.non_admin_client.name],
-              "users" => [platform.non_admin_user.name],
-              "groups" => ["users"]}
+                         "users" => [platform.non_admin_user.name],
+                         "groups" => ["users"]
+                        },
           }}
 
         let(:modified_group_body) {{
@@ -624,6 +632,43 @@ describe "opscode-account groups", :groups do
               })
           end
         end
+
+        let(:server_admins) {
+          "::server-admins"
+        }
+        let(:other_admins) {
+          "#{test_orgname2}::admins"
+        }
+        let(:new_group_payload_with_global) {{
+          "groupname" => test_group,
+          "actors" => {"clients" => [platform.non_admin_client.name],
+                       "users" => [platform.non_admin_user.name],
+                       "groups" => ["users", server_admins, other_admins]
+                      },
+        }}
+        let(:modified_group_body_with_global) {{
+            "actors" => [platform.non_admin_user.name, platform.non_admin_client.name],
+            "users" => [platform.non_admin_user.name],
+            "clients" => [platform.non_admin_client.name],
+            "groups" => ["users", server_admins, other_admins],
+            "orgname" => org,
+            "name" => test_group,
+            "groupname" => test_group
+        }}
+
+        context "admin user can reference global group and other orgs" do
+          it "can update group" do
+            put(request_url, platform.admin_user,
+                :payload => new_group_payload_with_global).should look_like({
+                :status => 200
+              })
+            get(request_url, platform.admin_user).should look_like({
+                :status => 200,
+                :body_exact => modified_group_body_with_global
+            })
+          end
+        end
+
 
         context "admin user cannot remove self from group" do
           let(:initial_group_payload) {{

--- a/src/oc_erchef/apps/oc_chef_authz/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/oc_chef_authz/priv/pgsql_statements.config
@@ -191,6 +191,9 @@
  {find_user_name_in_authz_ids, <<"SELECT username, authz_id FROM users WHERE authz_id = ANY($1)">>}.
  {find_user_authz_id_in_names, <<"SELECT username AS name, authz_id FROM users WHERE username = ANY($1)">>}.
  {find_group_name_in_authz_ids, <<"SELECT name, authz_id FROM groups WHERE authz_id = ANY($1)">>}.
+
+ {find_scoped_group_name_in_authz_ids, <<"SELECT org_id, name, authz_id FROM groups WHERE authz_id = ANY($1)">>}.
+
  {find_group_authz_id_in_names, <<"SELECT name, authz_id FROM groups WHERE org_id = $1 AND name = ANY($2)">>}.
 
 
@@ -265,4 +268,3 @@
      FROM inputs
 LEFT JOIN user_org ON username = name_in
 LEFT JOIN clients ON clients.name = name_in AND clients.org_id = $1">>}.
-

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl_constraints.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl_constraints.erl
@@ -26,16 +26,16 @@
 -compile([export_all]).
 -endif.
 
--export([check_acl_constraints/4]).
+-export([check_acl_constraints/5]).
 
--spec check_acl_constraints(binary(), atom(), binary(),tuple()) -> ok | [atom(),...].
-check_acl_constraints(AuthzId, Type, AclPerm, Ace) ->
-  check_acl_constraints(AuthzId, Type, AclPerm, Ace, acl_checks()).
+-spec check_acl_constraints(binary(), binary(), atom(), binary(), tuple()) -> ok | [atom(),...].
+check_acl_constraints(OrgId, AuthzId, Type, AclPerm, Ace) ->
+  check_acl_constraints(OrgId, AuthzId, Type, AclPerm, Ace, acl_checks()).
 
 
--spec check_acl_constraints(binary(),atom(),binary(),tuple(), [fun()]) -> ok | [atom(),...].
-check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks) ->
-  case lists:filtermap(fun(Check) -> Check(AuthzId, Type, AclPerm, Ace) end, AclChecks) of
+-spec check_acl_constraints(binary(), binary(), atom(), binary(), tuple(), [fun()]) -> ok | [atom(),...].
+check_acl_constraints(OrgId, AuthzId, Type, AclPerm, Ace, AclChecks) ->
+  case lists:filtermap(fun(Check) -> Check(OrgId, AuthzId, Type, AclPerm, Ace) end, AclChecks) of
     [] ->
       ok;
     Failures ->
@@ -45,12 +45,12 @@ check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks) ->
 -spec acl_checks() -> [fun()].
 acl_checks() ->
   [
-    fun check_admins_group_removal_from_grant_ace/4
+    fun check_admins_group_removal_from_grant_ace/5
   ].
 
--spec check_admins_group_removal_from_grant_ace(binary(),atom(),binary(),tuple())
+-spec check_admins_group_removal_from_grant_ace(binary(),binary(), atom(),binary(),tuple())
       -> false | {true, attempted_admin_group_removal_grant_ace}.
-check_admins_group_removal_from_grant_ace(AuthzId, Type, AclPerm, NewAce) ->
+check_admins_group_removal_from_grant_ace(OrgId, AuthzId, Type, AclPerm, NewAce) ->
   %% It is necessary to pull the current ace and compare to the new ace.
   %% This is because there are some groups that don't have the admin
   %% group by default, such as billing-admins. This will have the effect
@@ -59,7 +59,7 @@ check_admins_group_removal_from_grant_ace(AuthzId, Type, AclPerm, NewAce) ->
   case AclPerm of
     <<"grant">> ->
       NewGroups = extract_acl_groups(AclPerm, NewAce),
-      CurrentAce = oc_chef_authz_acl:fetch(Type, AuthzId),
+      CurrentAce = oc_chef_authz_acl:fetch(Type, OrgId, AuthzId),
       CurrentGroups = extract_acl_groups(AclPerm, CurrentAce),
       case check_admins_group_removal(CurrentGroups, NewGroups) of
         not_removed ->
@@ -104,5 +104,3 @@ contains_admins_group(Groups) ->
 extract_acl_groups(AclPerm, Ace) ->
       ActorsAndGroups = ej:get({AclPerm}, Ace),
       ej:get({<<"groups">>}, ActorsAndGroups).
-
-

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -435,7 +435,7 @@ render_names_in_context(OrgId, ScopedNames, Context) ->
     GroupedScopedNames = group_by_key(ScopedNames),
     {Expanded, _Cache} = lists:foldl(fun(E, A) -> render_names_in_context_f(OrgId, E, A) end,
                                      {[], Context}, GroupedScopedNames),
-    lists:flatten(Expanded).
+    lists:sort(lists:flatten(Expanded)).
 
 %% We are in the same scope, omit qualifier
 render_names_in_context_f(OrgId, {OrgId, Names}, {Expanded, Context}) ->

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -460,7 +460,7 @@ lookup_org_id_cached(OrgName, Cache) ->
             case chef_sql:fetch_org_metadata(OrgName) of
                 not_found ->
                     %% negative results are worth caching
-                    {not_found, maps:update(OrgName, not_found, Cache)};
+                    {not_found, maps:put(OrgName, not_found, Cache)};
                 {OrgId, _AuthzId} ->
                     {OrgId, maps:put(OrgName, OrgId, Cache)}
             end

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -26,7 +26,6 @@
 -export([names_to_authz_id/3,
          initialize_context/2,
          initialize_context/1,
-         org_id_to_name/1,
          full_name/1,
 
          %% Used by oc_chef_group
@@ -302,7 +301,7 @@ is_ambiguous_actor({_, _, _}) ->
         {[binary()],[binary()]}.
 authz_id_to_names(group, AuthzIds, #context{org_id = OrgId, db_callback_fun = CallbackFun}) ->
     {ScopedNames, DiffedList} = query_and_diff_authz_ids(find_scoped_group_name_in_authz_ids, AuthzIds, CallbackFun),
-    {render_names_in_context(OrgId, ScopedNames), DiffedList};
+    {render_names_from_org_id(OrgId, ScopedNames), DiffedList};
 authz_id_to_names(client, AuthzIds, #context{db_callback_fun = CallbackFun}) ->
     query_and_diff_authz_ids(find_client_name_in_authz_ids, AuthzIds, CallbackFun);
 authz_id_to_names(user, AuthzIds, #context{db_callback_fun = CallbackFun}) ->
@@ -413,21 +412,21 @@ group_by_key(L) ->
 %% Expansion of authz ids into scoped names
 %% Takes {OrgName, Name} pairs in ScopedNames and returns
 %% list of names with scoping metacharacter inserted
--spec render_names_in_context(binary(),[{binary(), [binary()]}]) -> [binary()].
-render_names_in_context(OrgId, ScopedNames) ->
+-spec render_names_from_org_id(binary(),[{binary(), [binary()]}]) -> [binary()].
+render_names_from_org_id(OrgId, ScopedNames) ->
     GroupedScopedNames = group_by_key(ScopedNames),
-    Expanded = lists:foldl(fun(E, A) -> render_names_in_context_f(OrgId, E, A) end,
+    Expanded = lists:foldl(fun(E, A) -> render_names_from_org_id_f(OrgId, E, A) end,
                               [], GroupedScopedNames),
     lists:sort(lists:flatten(Expanded)).
 
 %% We are in the same scope, omit qualifier
-render_names_in_context_f(OrgId, {OrgId, Names}, Expanded) ->
+render_names_from_org_id_f(OrgId, {OrgId, Names}, Expanded) ->
     [Names | Expanded];
 %% we are in a different scope, but it's the global scope. Use abbreviated version.
-render_names_in_context_f(_OrgId, {?GLOBAL_PLACEHOLDER_ORG_ID, Names}, Expanded) ->
+render_names_from_org_id_f(_OrgId, {?GLOBAL_PLACEHOLDER_ORG_ID, Names}, Expanded) ->
     ENames = [ make_name(<<>>, Name) || Name <- Names],
     [ENames | Expanded];
-render_names_in_context_f(_OrgId, {AnotherOrgId, Names}, Expanded) ->
+render_names_from_org_id_f(_OrgId, {AnotherOrgId, Names}, Expanded) ->
     %% Design note: we drop missing orgs silently. Org deletion leaks many objects and we must
     %% be robust to that. Thought we will log a warning message to be transparent.
     case org_id_to_name(AnotherOrgId) of

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -313,7 +313,7 @@ query_and_diff_authz_ids(QueryName, AuthzIds, CallbackFun) ->
             {ResultNames, FoundAuthzIds} = lists:foldl(fun extract_maybe_scoped_name/2,
                                                        {[],[]}, Results),
             DiffedList = sets:to_list(sets:subtract(sets:from_list(AuthzIds), sets:from_list(FoundAuthzIds))),
-            {lists:reverse(ResultNames), DiffedList};
+            {lists:sort(ResultNames), DiffedList};
         _Other ->
             {[], []}
     end.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -1,0 +1,491 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%%
+%% ex: ts=4 sw=4 et
+%% @author Mark Anderson <mark@chef.io>
+%% Copyright 2016 Chef Software, Inc.
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(oc_chef_authz_scoped_name).
+
+-include("chef_types.hrl").
+-include("oc_chef_types.hrl").
+
+-export([names_to_authz_id/3,
+         filter_by_error_type/2,
+         authz_id_to_names/3]).
+
+-export([make_scoped_names/2,
+         parse_scoped_names/2,
+         parse_unscoped_names/2,
+         convert_ids_to_names/3,
+         find_client_authz_ids/2,
+         find_user_authz_ids/2,
+         find_group_authz_ids/2,
+
+         make_sql_callback/0,
+         initialize_context/1,
+         initialize_context/2,
+         make_name/2,
+         org_id_to_name/1
+        ]).
+
+-export([parse_scoped_name/3, fetch_authz_ids/2]).
+
+-ifdef(TEST).
+-compile([export_all]).
+-endif.
+
+%%
+%% Process names with scoping descriptor.
+%%
+
+%% This is derived from oc_chef_wm/src/oc_chef_wm_groups.erl; investigate what it will take to refactor this.
+-define(NAME, "[a-z0-9\-_]").
+
+-define(SCOPE_SEPARATOR, <<"::">>).
+-define(SCOPED_NAME_REGEX, "^(?:(" ?NAME "+)|(?:(" ?NAME "*)\\:\\:(" ?NAME "+)))$").
+
+-record(context, {org_id :: undefined,
+                  db_context :: undefined,
+                  db_callback_fun :: undefined
+                 }).
+
+-record(sname, {full :: undefined,
+                base :: undefined,
+                org :: undefined,
+                org_id :: undefined,
+                authz_id :: undefined
+               }).
+
+initialize_context(OrgId) ->
+    initialize_context(OrgId, make_sql_callback()).
+
+initialize_context(OrgId, CallBackFun) ->
+    initialize_context(OrgId, undefined, CallBackFun).
+
+initialize_context(OrgId, DbContext, CallBackFun) ->
+    #context{org_id = OrgId,
+             db_context = DbContext,
+             db_callback_fun = CallBackFun}.
+
+
+%%
+%% Takes scoped names to authz ids
+%%   Names: list of names as binary; can include scoping symbol
+%%   Type: The type of object to look for
+%%   OrgContext: The name of the org whose context is local or 'global'
+%%
+%% We perform a series of successive lowerings;
+%% * parsing the name into base and org components
+%%   (if the later is present, otherwise inserting the current in-context org)
+%% * Mapping the org name to id
+%% * Looking up the org id, name pair in the appropriate table(s)
+
+%%
+%% Output:
+%% { [{Name, AuthzId}, [{Name, ErrorType}] }
+%%
+%%
+names_to_authz_id(Type, Names, MapperContext) ->
+    %% Lower to fully qualified orgname, name
+    ScopedNames = parse_scoped_names(Names, is_scoped_type(Type), MapperContext),
+    {ProperNames, Errors} = lists:foldl(fun filter_errors/2, {[], []}, ScopedNames),
+
+    OrgCache = init_org_name_cache(),
+
+    %% Map org names to org ids
+    {NamesWithOrgIds, Errors2, _} =
+        lists:foldl(fun(Name, Acc) -> lookup_org_id(Name, Acc, MapperContext) end,
+                    {[], Errors, OrgCache}, ProperNames),
+
+    %% group by org id for efficiency (can't do it sooner because we don't know all the org ids
+    NamesGroupedByOrgIds = group_by_org_ids(NamesWithOrgIds),
+
+    %% Take the grouped records, and look them up
+    {AuthzIds, Errors3} = lists:foldl(fun(N, A) ->
+                                               scoped_names_to_authz_id(Type, N, A)
+                                       end,
+                                       {[], Errors2}, NamesGroupedByOrgIds),
+
+    {lists:flatten(AuthzIds), group_errors(Errors3)}.
+
+filter_errors(#sname{} = ScopedName, {Parsed, Errors}) ->
+    { [ScopedName | Parsed], Errors };
+filter_errors(Error, {Parsed, Errors}) ->
+    {Parsed, [Error | Errors]}.
+
+%% Lookup org_ids from orgnames
+%%
+%% already have id for orgname, skip
+%% Errors: orgname_not_found
+lookup_org_id(#sname{org_id = OrgId} = Name, {AccNames, Errors, Cache}, _Context) when OrgId =/= undefined ->
+    { [Name | AccNames], Errors, Cache };
+%% Need to lookup name
+lookup_org_id(#sname{org = OrgName} = Name, {AccNames, Errors, Cache}, _Context) ->
+    case lookup_org_id_cached(OrgName, Cache) of
+        {not_found, Cache1} ->
+            {AccNames, [{orgname_not_found, Name} | Errors], Cache1};
+        {OrgId, Cache1} ->
+            {[Name#sname{org_id = OrgId} | AccNames], Errors, Cache1}
+    end.
+
+%%
+%% Group by org id
+%%
+group_by_org_ids(Names) ->
+    NamesByOrgId = lists:foldl(fun group_by_org_ids/2, #{}, Names),
+    maps:to_list(NamesByOrgId).
+
+group_by_org_ids(#sname{org_id = OrgId} = Name, Acc) ->
+    Old = maps:get(OrgId, Acc, []),
+    maps:put(OrgId, [Name | Old], Acc).
+
+
+
+%%
+%% Actually lookup names
+%%
+%% Errors: not_found, ambiguous
+scoped_names_to_authz_id(Type, {OrgId, Names}, {AuthzIdAcc, Errors}) ->
+    BaseNames = [ Base || #sname{base = Base} <- Names],
+    {AuthzIds, Missing, Ambiguous} = authz_records_by_name(Type, OrgId, BaseNames),
+    MissingErrors = make_error_from_set(not_found, Names, Missing),
+    AmbiguousErrors = make_error_from_set(ambiguous, Names, Ambiguous),
+    {[AuthzIds | AuthzIdAcc],  [AmbiguousErrors | [MissingErrors | Errors]]}.
+
+make_error_from_set(ErrorName, ScopedNames, UnscopedNameSet) ->
+    [ {ErrorName, Name} || Name <- extract_full_names(ScopedNames, UnscopedNameSet) ].
+
+extract_full_names(ScopedNames, UnscopedNameSet) ->
+    [ Full || #sname{full = Full, base = Base} <- ScopedNames,
+              ordsets:is_element(Base, UnscopedNameSet) ].
+
+%%
+%% Abstract away difference in lookups between actors, clients, users and groups.
+%%
+%% Returns AuthzIds, missing names and names that are judged ambiguous
+authz_records_by_name(actor, OrgId, Names) ->
+    {ok, Actors} = oc_chef_authz_db:find_org_actors_by_name(OrgId, Names),
+    {Missing, Remaining} = lists:partition(fun is_missing_actor/1, Actors),
+    {Ambiguous, Valid} = lists:partition(fun is_ambiguous_actor/1, Remaining),
+    AuthzIds = ids_from_records(Valid),
+    {AuthzIds,
+     ordsets:from_list(names_from_records(Missing)),
+     ordsets:from_list(names_from_records(Ambiguous))};
+authz_records_by_name(Type, OrgId, Names) ->
+    Records = oc_chef_authz_db:authz_records_by_name(Type, OrgId, Names),
+    AuthzIds = ids_from_records(Records),
+    FoundNames = ordsets:from_list(names_from_records(Records)),
+    GivenNames = ordsets:from_list(Names),
+    Remaining = ordsets:subtract(GivenNames, FoundNames),
+    {AuthzIds, Remaining, ordsets:new()}.
+
+%% Helper functions for oc_chef_authz_db:authz_records_by_name and oc_chef_authz_db:find_org_actors_by_name
+names_from_records(Records) ->
+    [ name_from_record(R) || R  <- Records].
+
+name_from_record({Name, _,  _}) ->
+    Name;
+name_from_record({Name, _}) ->
+    Name.
+
+ids_from_records(Records) ->
+    [ id_from_record(R) || R <- Records ].
+
+id_from_record({_, AuthzId}) ->
+    AuthzId;
+id_from_record({_, UserAuthzId, null}) ->
+    UserAuthzId;
+id_from_record({_, null, ClientAuthzId}) ->
+    ClientAuthzId.
+
+is_missing_actor({_, null, null}) ->
+    true;
+is_missing_actor({_, _, _}) ->
+    false.
+
+is_ambiguous_actor({_, UserAZ, ClientAZ}) when UserAZ =/= null andalso
+                                               ClientAZ =/= null ->
+    true;
+is_ambiguous_actor({_, _, _}) ->
+    false.
+
+%%
+%% Some consumers of the name mapper want to split out errors by type
+%%
+filter_by_error_type(ErrorType, Errors) ->
+    %% ET is introduced to work around issue with shadowed variables in list comprehensions
+    [ Name || {ET, Name} <- Errors, ET =:= ErrorType ].
+
+group_errors(Errors) ->
+    group_by_key(lists:flatten(Errors)).
+
+%% Helper functions
+%%
+%% No error handling; we probably should generate an error when we have missing
+%%
+find_client_authz_ids(ClientNames, Context) ->
+    {AuthzIds, _Missing} = names_to_authz_id(client, ClientNames, Context),
+    AuthzIds.
+
+find_user_authz_ids(UserNames, Context) ->
+    {AuthzIds, _Missing} = names_to_authz_id(user, UserNames, Context),
+    AuthzIds.
+
+find_group_authz_ids(GroupNames, Context) ->
+    {AuthzIds, _Missing} = names_to_authz_id(group, GroupNames, Context),
+    AuthzIds.
+
+%%
+%%
+%%
+convert_ids_to_names(ActorAuthzIds, GroupAuthzIds, Context) ->
+    {ClientNames, RemainingAuthzIds} = authz_id_to_names(client, ActorAuthzIds,Context),
+    {UserNames, DefunctActorAuthzIds} = authz_id_to_names(user, RemainingAuthzIds, Context),
+    {GroupNames, DefunctGroupAuthzIds} = authz_id_to_names(group, GroupAuthzIds, Context),
+    oc_chef_authz_cleanup:add_authz_ids(DefunctActorAuthzIds, DefunctGroupAuthzIds),
+    {ClientNames, UserNames, GroupNames}.
+
+%%
+%% Takes authz ids to scoped names
+%%
+%% Returns {NamesFound, UnmappedAuthzIds} We can have UnmappedAuthzIds if an entity was
+%% deleted on the server but not in bifrost, or if we have a mix of clients and users
+%%
+
+
+%%
+%% Each type of object has different restrictions on its scope.
+%%
+authz_id_to_names(group, AuthzIds, #context{org_id = OrgId, db_callback_fun = CallbackFun} = Context) ->
+    {ScopedNames, DiffedList} = query_and_diff_authz_ids(find_scoped_group_name_in_authz_ids, AuthzIds, CallbackFun),
+    {render_names_in_context(OrgId, ScopedNames, Context), DiffedList};
+authz_id_to_names(client, AuthzIds, #context{db_callback_fun = CallbackFun}) ->
+    query_and_diff_authz_ids(find_client_name_in_authz_ids, AuthzIds, CallbackFun);
+authz_id_to_names(user, AuthzIds, #context{db_callback_fun = CallbackFun}) ->
+    query_and_diff_authz_ids(find_user_name_in_authz_ids, AuthzIds, CallbackFun).
+
+query_and_diff_authz_ids(_QueryName, [], _) ->
+    %% Sometimes the list of authz ids is empty; shortcut that and save a DB call.
+    {[], []};
+query_and_diff_authz_ids(QueryName, AuthzIds, CallbackFun) ->
+    case CallbackFun({QueryName, [AuthzIds]}) of
+        not_found ->
+            {[], AuthzIds};
+        Results when is_list(Results)->
+            {ResultNames, FoundAuthzIds} = lists:foldl(fun extract_maybe_scoped_name/2,
+                                                       {[],[]}, Results),
+            DiffedList = sets:to_list(sets:subtract(sets:from_list(AuthzIds), sets:from_list(FoundAuthzIds))),
+            {lists:reverse(ResultNames), DiffedList};
+        _Other ->
+            {[], []}
+    end.
+
+%extract_maybe_scoped_name([Name, AuthzId],  {Names, AuthzIds}) ->
+%    {[Name| Names], [AuthzId | AuthzIds]};
+%extract_maybe_scoped_name([OrgId, Name, AuthzId],  {Names, AuthzIds}) ->
+%    {[{OrgId, Name} | Names], [AuthzId | AuthzIds]}.
+
+%% Scoped names are triples with org_id, name, and authz_id
+extract_maybe_scoped_name([{_NameKey, Name}, {<<"authz_id">>, AuthzId}],
+                          {NamesIn, AuthzIdsIn}) ->
+    {[Name | NamesIn], [AuthzId | AuthzIdsIn]};
+extract_maybe_scoped_name([{<<"org_id">>, OrgId}, {_NameKey, Name}, {<<"authz_id">>, AuthzId}],
+                          {NamesIn, AuthzIdsIn}) ->
+    {[{OrgId, Name} | NamesIn], [AuthzId | AuthzIdsIn]}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Support routines
+%%
+is_scoped_type(group) ->
+    true;
+is_scoped_type(_) ->
+    false.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Tools for parsing/unparsing scoped names into {orgname, name} tuples
+%% These use a org name as 'context' to resove and emit scoped names
+%% Org names are either binaries, or they are the special atom global_org
+%%
+
+%% This simplifies testing
+make_regex() ->
+    {ok, Pattern} = re:compile(?SCOPED_NAME_REGEX),
+    Pattern.
+%% A scoped name is of the form scope::name. If scope is elided, then we are in the global
+%% scope. If there is no scope separator, then it is in the current context.
+%%
+%% Returns a #sname record, which fully qualifies the name to an org, or the special atom
+%% 'global_org'
+%%
+%% Errors:
+%%   ill_formed_name
+%%   inappropriate_scoped_name
+parse_scoped_name(Name, ScopedOk, Context) ->
+    Pattern = make_regex(),
+    maybe_parse_scoped_name(Name, Pattern, ScopedOk, Context).
+
+parse_scoped_names(Names, Context) ->
+    parse_scoped_names(Names, true, Context).
+
+parse_unscoped_names(Names, Context) ->
+    parse_scoped_names(Names, false, Context).
+
+parse_scoped_names(Names, ScopedOk, Context) ->
+    Pattern = make_regex(),
+    [ maybe_parse_scoped_name(Name, Pattern, ScopedOk, Context) || Name <- Names ].
+
+maybe_parse_scoped_name(Name, Pattern, ScopedOk, Context) ->
+    process_match(re:run(Name, Pattern, [{capture, all, binary}]), Name, Context, ScopedOk).
+
+%% Process the various formats, and expand them
+%%
+%% If no match, then we have bad name
+process_match(nomatch, Name, _Context, _ScopedOk) ->
+    {ill_formed_name, Name};
+%% If we only onl match the name, then it is an unscoped name, and we use the org context
+process_match({match, [Name, Name]}, Name, Context, _ScopedOk) ->
+    set_org_from_context(#sname{base = Name, full = Name}, Context);
+%% Anything not a simple, unqualified name should be rejected
+process_match({match, _}, Name, _, false) ->
+    {inappropriate_scoped_name, Name};
+%% If scope is omitted, assume global
+process_match({match, [_, <<>>, <<>>, BaseName]}, Name, _, true) ->
+    #sname{org = global_org, base = BaseName, full = Name};
+%% Fully qualified name
+process_match({match, [_, <<>>, OrgName, BaseName]}, Name, _, true) ->
+    #sname{org = OrgName, base = BaseName, full = Name}.
+
+set_org_from_context(#sname{} = ScopedName, #context{org_id = OrgId}) when OrgId =/= undefined ->
+    ScopedName#sname{org_id = OrgId}.
+
+%%
+%% Takes a list of {K, V} pairs, and regroups them. Use maps because the syntax is nice
+%%
+group_by_key(L) ->
+    Map = lists:foldl(fun({K, V}, Map) ->
+                              VL = maps:get(K, Map, []),
+                              maps:put(K, [V | VL], Map)
+                      end,
+                      #{}, L),
+    maps:to_list(Map).
+
+
+%%
+%%
+make_sql_callback() ->
+    fun chef_sql:select_rows/1.
+
+
+%%
+%% Helper function for working with unscoped names
+%%
+make_scoped_names(OrgName, Names) ->
+    [{OrgName, Name} || Name <- Names].
+
+%%
+%%
+%%
+fetch_authz_ids(Type, ScopedNames) ->
+    NamesByOrg = group_by_key(ScopedNames),
+    case fetch_ids_rec(Type, NamesByOrg, {[], []}) of
+        [Found, []] ->
+            Found;
+        [_, Missing] ->
+            throw({invalid, Type, Missing})
+    end.
+
+
+%%
+%%
+%%
+fetch_ids_rec(_type, [], {Found, Missing}) ->
+    {lists:flatten(Found), Missing};
+fetch_ids_rec(Type, [{OrgId, Names} | Remainder], {Found, Missing}) ->
+    Records = oc_chef_authz_db:authz_records_by_name(Type, OrgId, Names),
+    FoundNames = lists:sort(names_from_records(Records)), % Investigate if this sort is redundant (db may already sort)
+    Remaining = Names -- FoundNames, % --/++ on very large lists might be slow.
+    Missing1 = case Remaining of
+                  [] ->
+                      [{OrgId, Remaining} | Missing];
+                  _ ->
+                      Missing
+              end,
+    fetch_ids_rec(Type, Remainder, {[FoundNames | Found], Missing1}).
+
+
+%%
+%% Expansion of authz ids into scoped names
+%% Takes {OrgName, Name} pairs in ScopedNames and returns
+%% list of names with scoping metacharacter inserted
+render_names_in_context(OrgId, ScopedNames, Context) ->
+    GroupedScopedNames = group_by_key(ScopedNames),
+    {Expanded, _Cache} = lists:foldl(fun(E, A) -> render_names_in_context_f(OrgId, E, A) end,
+                                     {[], Context}, GroupedScopedNames),
+    lists:flatten(Expanded).
+
+%% We are in the same scope, omit qualifier
+render_names_in_context_f(OrgId, {OrgId, Names}, {Expanded, Context}) ->
+    { [Names | Expanded], Context};
+%% we are in a different scope, but it's the global scope. Use abbreviated version.
+render_names_in_context_f(_OrgId, {?GLOBAL_PLACEHOLDER_ORG_ID, Names}, {Expanded, Context}) ->
+    ENames = [ make_name(<<>>, Name) || Name <- Names],
+    { [ENames | Expanded], Context};
+render_names_in_context_f(_OrgId, {AnotherOrgId, Names}, {Expanded, Context}) ->
+    %% Design note: we drop missing orgs silently. Org deletion leaks many objects and we must
+    %% be robust to that.
+    case org_id_to_name(AnotherOrgId) of
+        not_found ->
+            {Expanded, Context};
+        OrgName ->
+            ENames = [ make_name(OrgName, Name) || Name <- Names ],
+            { [ENames, Expanded], Context }
+    end.
+
+make_name(OrgName, Name) ->
+    <<OrgName/binary, "::", Name/binary>>.
+
+%%
+%% Lookup org name
+%%
+org_id_to_name(OrgId) ->
+    %% TODO maybe rework this; it bypasses a bunch of our statistics gathering code.
+    case chef_sql:select_rows({find_organization_by_id, [OrgId]}) of
+        [Org|_Others] ->  proplists:get_value(<<"name">>, Org);
+        _ -> not_found
+    end.
+
+%%
+%% Memoize org id lookup
+%%
+init_org_name_cache() ->
+    #{ global_org => ?GLOBAL_PLACEHOLDER_ORG_ID }.
+
+lookup_org_id_cached(OrgName, Cache) ->
+    case Cache of
+        #{OrgName := OrgId} ->
+            %% it would be nice to do this in the fun head (OrgId,  #{OrgName := OrgId})
+            %% but erlang match and maps don't work that way.
+            {OrgId, Cache};
+        _ ->
+            case chef_sql:fetch_org_metadata(OrgName) of
+                not_found ->
+                    %% negative results are worth caching
+                    {not_found, maps:update(OrgName, not_found, Cache)};
+                {OrgId, _AuthzId} ->
+                    {OrgId, maps:put(OrgName, OrgId, Cache)}
+            end
+    end.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -381,7 +381,7 @@ maybe_parse_scoped_name(Name, Pattern, ScopedOk, Context) ->
 %% If no match, then we have bad name
 process_match(nomatch, Name, _Context, _ScopedOk) ->
     {ill_formed_name, Name};
-%% If we only onl match the name, then it is an unscoped name, and we use the org context
+%% If we only match the name, then it is an unscoped name, and we use the org context
 process_match({match, [Name, Name]}, Name, Context, _ScopedOk) ->
     set_org_from_context(#sname{base = Name, full = Name}, Context);
 %% Anything not a simple, unqualified name should be rejected
@@ -429,9 +429,10 @@ render_names_in_context_f(_OrgId, {?GLOBAL_PLACEHOLDER_ORG_ID, Names}, Expanded)
     [ENames | Expanded];
 render_names_in_context_f(_OrgId, {AnotherOrgId, Names}, Expanded) ->
     %% Design note: we drop missing orgs silently. Org deletion leaks many objects and we must
-    %% be robust to that.
+    %% be robust to that. Thought we will log a warning message to be transparent.
     case org_id_to_name(AnotherOrgId) of
         not_found ->
+            lager:warning("Unable to find organization with id '~p'~n", [AnotherOrgId]),
             Expanded;
         OrgName ->
             ENames = [ make_name(OrgName, Name) || Name <- Names ],

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -393,7 +393,11 @@ process_match({match, [_, <<>>, <<>>, BaseName]}, Name, _, true) ->
 process_match({match, [_, <<>>, OrgName, BaseName]}, Name, _, true) ->
     #sname{org = OrgName, base = BaseName, full = Name}.
 
-set_org_from_context(#sname{} = ScopedName, #context{org_id = OrgId}) when OrgId =/= undefined ->
+%% If our context is undefined, assume we are coming from a "global" endpoint such as
+%% /users/USERNAME/_acl/PERM.
+set_org_from_context(#sname{} = ScopedName, #context{org_id = undefined}) ->
+    ScopedName#sname{org_id = ?GLOBAL_PLACEHOLDER_ORG_ID};
+set_org_from_context(#sname{} = ScopedName, #context{org_id = OrgId}) ->
     ScopedName#sname{org_id = OrgId}.
 
 %%

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_constraints_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_acl_constraints_tests.erl
@@ -23,6 +23,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-define(ORGID, <<"some_org_id">>).
+
 %% Test generators that setup and run the tests
 oc_chef_authz_acl_constraints_test_() ->
   [
@@ -80,9 +82,9 @@ check_acl_constraints_no_failures() ->
   Type = group,
   AclPerm = <<"grant">>,
   Ace = {[{<<"grant">>,{[{<<"actors">>,[<<"pivotal">>]},{<<"groups">>,[]}]}}]},
-  AclChecks = [ fun(_AuthzId, _Type, _AclPerm, _Ace) -> false end ],
+  AclChecks = [ fun(_OrgId, _AuthzId, _Type, _AclPerm, _Ace) -> false end ],
   [
-    ?_assertEqual(ok, oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks))
+    ?_assertEqual(ok, oc_chef_authz_acl_constraints:check_acl_constraints(?ORGID, AuthzId, Type, AclPerm, Ace, AclChecks))
   ].
 
 check_acl_constraints_failures() ->
@@ -93,14 +95,14 @@ check_acl_constraints_failures() ->
   Type = group,
   AclPerm = <<"grant">>,
   Ace = {[{<<"grant">>,{[{<<"actors">>,[<<"pivotal">>]},{<<"groups">>,[]}]}}]},
-  AclChecks = [ fun(_AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_message_here} end ],
-  Test1 = ?_assertEqual([failure_message_here], oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks)),
+  AclChecks = [ fun(_OrgId, _AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_message_here} end ],
+  Test1 = ?_assertEqual([failure_message_here], oc_chef_authz_acl_constraints:check_acl_constraints(?ORGID, AuthzId, Type, AclPerm, Ace, AclChecks)),
   AclChecks2 = [
-                fun(_AuthzId, _Type, _AclPerm, _Ace) -> false end,
-                fun(_AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_one} end,
-                fun(_AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_two} end
+                fun(_OrgId, _AuthzId, _Type, _AclPerm, _Ace) -> false end,
+                fun(_OrgId, _AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_one} end,
+                fun(_OrgId, _AuthzId, _Type, _AclPerm, _Ace) -> {true, failure_two} end
                ],
-  Test2 = ?_assertEqual([failure_one, failure_two], oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, AclChecks2)),
+  Test2 = ?_assertEqual([failure_one, failure_two], oc_chef_authz_acl_constraints:check_acl_constraints(?ORGID, AuthzId, Type, AclPerm, Ace, AclChecks2)),
   [ Test1, Test2 ].
 
 check_acl_constraints_not_grant_ace() ->
@@ -118,7 +120,7 @@ check_acl_constraints_not_grant_ace() ->
   AclPerm = <<"create">>,
   Ace = {[{<<"create">>,{[{<<"actors">>,[<<"pivotal">>]},{<<"groups">>,[]}]}}]},
   [
-    ?_assertEqual(ok, oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, AclPerm, Ace, oc_chef_authz_acl_constraints:acl_checks()))
+    ?_assertEqual(ok, oc_chef_authz_acl_constraints:check_acl_constraints(?ORGID, AuthzId, Type, AclPerm, Ace, oc_chef_authz_acl_constraints:acl_checks()))
   ].
 
 

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
@@ -1,0 +1,395 @@
+%% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 92-*-
+%% ex: ts=4 sw=4 et
+%%
+%% @author Mark Anderson <mark@chef.io>
+%% Copyright 2017 Chef Software, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+-module(oc_chef_authz_scoped_name_tests).
+
+-compile([export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, oc_chef_authz_scoped_name).
+
+-define(GLOBAL_PLACEHOLDER_ORG_ID, <<"00000000000000000000000000000000">>).
+
+-define(ORG1, <<"the_org">>).
+-define(ORG1_ID, <<"ORG1_ID_AAAAA">>).
+-define(ORG2, <<"organization2">>).
+-define(ORG2_ID, <<"ORG2_ID_BBBBB">>).
+-define(PLAIN_NAME, <<"name">>).
+-define(GLOBAL_NAME, <<"::name">>).
+-define(PLAIN_GROUP, <<"a_group">>).
+-define(GLOBAL_GROUP, <<"::a_group">>).
+-define(ORGLOCAL_NAME, ?M:make_name(<<"organization2">>, ?PLAIN_GROUP)).
+-define(ORGLOCAL_GROUP, ?M:make_name(<<"organization2">>, ?PLAIN_GROUP)).
+-define(BARE_ORG_NAME, <<"organization::">>).
+-define(DEEP_NAME, <<"foo::bar::baz">>).
+-define(INVALID_NAME, <<"foo123AGAc">>).
+-define(PLAIN_GROUP_AUTHZ_ID, plain_group_authz_id).
+-define(GLOBAL_NAME_AUTHZ_ID, global_name_authz_id).
+-define(ORGLOCAL_NAME_AUTHZ_ID, orglocal_name_authz_id).
+
+-define(SCOPE_PERMUTATIONS, [{?ORG1_ID, ?PLAIN_GROUP}, {?ORG2_ID, ?PLAIN_GROUP}, {?GLOBAL_PLACEHOLDER_ORG_ID, ?PLAIN_GROUP}]).
+
+%% Copypast for oc_chef_authz_scoped_name.erl
+%-record(context, {org_name :: undefined,
+%                  org_id :: undefined,
+%                  db_context :: undefined,
+%                  db_callback_fun :: undefined
+%                 }).
+
+-record(sname, {full :: undefined,
+                base :: undefined,
+                org :: undefined,
+                org_id :: undefined,
+                authz_id :: undefined
+               }).
+
+stringtitle(Desc, Args) ->
+    erlang:iolist_to_binary(io_lib:format(Desc, Args)).
+
+mk_parse_scoped_name_test(true) ->
+    [{?PLAIN_NAME, mk_sname(?PLAIN_NAME, ?PLAIN_NAME, undefined, ?ORG1_ID)},
+     {?GLOBAL_NAME, mk_sname(?GLOBAL_NAME, ?PLAIN_NAME, global_org, undefined)},
+     {?ORGLOCAL_NAME, mk_sname(?ORGLOCAL_NAME, ?PLAIN_GROUP, ?ORG2, undefined)},
+     {?BARE_ORG_NAME, {ill_formed_name, ?BARE_ORG_NAME}},
+     {?DEEP_NAME, {ill_formed_name, ?DEEP_NAME}}];
+mk_parse_scoped_name_test(false) ->
+    [{?PLAIN_NAME, mk_sname(?PLAIN_NAME, ?PLAIN_NAME, undefined, ?ORG1_ID)},
+     {?GLOBAL_NAME, {inappropriate_scoped_name, ?GLOBAL_NAME}},
+     {?ORGLOCAL_NAME, {inappropriate_scoped_name, ?ORGLOCAL_NAME}},
+     {?BARE_ORG_NAME, {ill_formed_name, ?BARE_ORG_NAME}},
+     {?DEEP_NAME, {ill_formed_name, ?DEEP_NAME}}
+    ].
+
+parse_scoped_name_test_() ->
+    Subject = fun ?M:parse_scoped_name/3,
+
+    Context = mk_context(),
+    TestTuples = lists:flatten( [ [{N, S, R} || {N, R} <- mk_parse_scoped_name_test(S) ] || S <- [true,false] ] ),
+    TestFun = fun(Name, ScopedOk, Result) ->
+                      Title = stringtitle("Test ~s ~p ~p",[Name, ScopedOk, Result]),
+                      {Title,
+                       fun() ->
+                               Answer = Subject(Name, ScopedOk, Context),
+                               ?assertEqual(Result,  Answer)
+                       end
+                      }
+              end,
+    {foreach,
+     fun() ->
+             ok
+     end,
+     fun(_) ->
+              ok
+     end,
+     [ TestFun(N, S, R) || {N, S, R} <- TestTuples ]
+    }.
+
+parse_scoped_names_test_() ->
+    Subject = fun ?M:parse_scoped_names/3,
+    Context = mk_context(),
+    TestFun = fun(Scoped) ->
+                      Title = stringtitle("~s",[Scoped]),
+                      {Title,
+                       fun() ->
+                               Data = mk_parse_scoped_name_test(Scoped),
+                               {Input, Output} = lists:unzip(Data),
+                               Answer = Subject(Input, Scoped, Context),
+                               ?assertEqual(Output,  Answer)
+                       end
+                      }
+              end,
+
+    {foreach,
+     fun() ->
+             ok
+     end,
+     fun(_) ->
+             ok
+     end,
+     [
+      ?_assertEqual([mk_sname(?GLOBAL_NAME, ?PLAIN_NAME, global_org, undefined)],
+                    Subject([?GLOBAL_NAME], true, Context))
+      | [ TestFun(S) || S <- [true, false] ]
+     ]
+    }.
+
+
+empty_names_to_authz_id_test() ->
+    Context = mk_context(),
+    Subject = fun ?M:names_to_authz_id/3,
+    Answer = Subject(group, [], Context),
+    ?assertEqual({[], []}, Answer).
+
+%%
+%% Names to authz id
+%%
+names_to_authz_id_test_() ->
+    Context = mk_context(),
+    Subject = fun ?M:names_to_authz_id/3,
+
+    {foreach,
+     fun() ->
+             meck:new(chef_db),
+             meck:expect(chef_db, fetch_org_metadata, fun(_,?ORG1) ->
+                                                              {?ORG1_ID, dummyAuthzId}
+                                                      end ),
+
+             meck:new(oc_chef_authz_db),
+             meck:expect(oc_chef_authz_db, authz_records_by_name, mock_authz_records_by_name(group, make_simple_authz_record_data()) ),
+             ok
+     end,
+     fun(ok) ->
+             meck:unload(oc_chef_authz_db),
+             meck:unload(chef_db)
+     end,
+     [
+      {"empty list returns nothing and no errors",
+       fun() ->
+               Answer = Subject(group, [], Context),
+               ?assertEqual({[], []}, Answer)
+       end
+      },
+      {"simple list returns an authz id and no errors",
+       fun() ->
+               Answer = Subject(group, [?PLAIN_GROUP], Context),
+               ?assertEqual({[make_dummy_authz_id(?ORG1, ?PLAIN_GROUP)], []}, Answer)
+       end
+      }
+     ]
+    }.
+
+
+%% scoped_names_to_authz_id_test_() ->
+%%     Subject = fun ?M:scoped_names_to_authz_id/4,
+%%     {foreach,
+%%      fun() ->
+%%              meck:new(?M),
+%% %             meck:expect(?M),
+%%              ok
+%%      end,
+%%      fun(ok) ->
+%%              meck:unload(?M)
+%%      end,
+%%      [
+%%       {"empty list returns nothing and no errors",
+%%        ?_assertEqual({[], []},
+%%                      Subject(foo, {<<"TESTID">>, []}, {[], []}, {context}))
+%%       }
+%%      ]
+%%     }.
+
+
+authz_id_to_names_test_() ->
+
+    Context = mk_context_reverse(mk_lookup_map()),
+    OrgMap = mk_orgid_map(),
+    Subject = fun ?M:authz_id_to_names/3,
+
+    {foreach,
+     fun() ->
+             meck:new(chef_sql),
+
+             meck:expect(chef_sql, fetch_org_metadata, fun(?ORG1) -> {?ORG1_ID, dummyAuthzId} end ),
+             meck:expect(chef_sql, select_rows, mock_sql_org_lookup(OrgMap)),
+
+             meck:new(oc_chef_authz_db),
+             meck:expect(oc_chef_authz_db, authz_records_by_name, mock_authz_records_by_name(group, make_simple_authz_record_data()) ),
+             ok
+     end,
+     fun(ok) ->
+             meck:unload(oc_chef_authz_db),
+             meck:unload(chef_sql)
+     end,
+     [
+      {"empty list returns nothing and no errors",
+       fun() ->
+               Answer = Subject(group, [], Context),
+               ?assertEqual({[], []}, Answer)
+       end
+      },
+      {"simple list returns an id and no errors",
+       fun() ->
+               Answer = Subject(group, [?PLAIN_GROUP_AUTHZ_ID], Context),
+               ?assertEqual({[?PLAIN_GROUP], []}, Answer)
+       end
+      },
+      {"long list list returns an id and no errors",
+       fun() ->
+               {Found, Errors} = Subject(group, [?PLAIN_GROUP_AUTHZ_ID, ?ORGLOCAL_NAME_AUTHZ_ID, ?GLOBAL_NAME_AUTHZ_ID], Context),
+               ?assertEqual({[?GLOBAL_GROUP, ?PLAIN_GROUP, ?ORGLOCAL_GROUP], []},
+                            {lists:sort(Found), Errors})
+       end
+      }
+     ]
+    }.
+
+query_and_diff_authz_ids_test_() ->
+    Subject = fun ?M:query_and_diff_authz_ids/3,
+
+    LookupMap = mk_lookup_map(),
+    DbCallback = mk_db_callback_fn(LookupMap),
+
+    {foreach,
+     fun() ->
+             ok
+     end,
+     fun(_) ->
+             ok
+     end,
+     [
+      {"empty list returns nothing and no errors",
+       fun() ->
+               Answer = Subject(dummy_query, [], DbCallback),
+               ?assertEqual({[], []}, Answer)
+       end
+      },
+      {"simple list returns and and no errors",
+       fun() ->
+               Answer = Subject(dummy_query, [?PLAIN_GROUP_AUTHZ_ID], DbCallback),
+               ?assertEqual({[{?ORG1_ID, ?PLAIN_GROUP}],[]}, Answer)
+       end
+      },
+      {"longer list returns and and no errors",
+       fun() ->
+               Answer = Subject(dummy_query, [?PLAIN_GROUP_AUTHZ_ID, ?ORGLOCAL_NAME_AUTHZ_ID, ?GLOBAL_NAME_AUTHZ_ID], DbCallback),
+               ?assertEqual({?SCOPE_PERMUTATIONS,[]}, Answer)
+       end
+      }
+     ]
+    }.
+
+%%
+%%
+render_names_in_context_test_() ->
+    Subject = fun ?M:render_names_in_context/3,
+
+    Context = mk_context_reverse(mk_lookup_map()),
+    OrgMap = mk_orgid_map(),
+    {foreach,
+     fun() ->
+             meck:new(chef_sql),
+             meck:expect(chef_sql, select_rows, mock_sql_org_lookup(OrgMap)),
+             ok
+     end,
+     fun(_) ->
+             meck:unload(chef_sql),
+             ok
+     end,
+     [
+      {"empty list returns nothing and no errors",
+       fun() ->
+               Answer = Subject(?ORG1_ID, [], Context),
+               ?assertEqual([], Answer)
+       end
+      },
+      {"simple list returns and and no errors",
+       fun() ->
+               Answer = Subject(?ORG1_ID, [{?ORG1_ID,?PLAIN_GROUP}], Context),
+               ?assertEqual([?PLAIN_GROUP], Answer)
+       end
+      },
+      {"longer list returns and and no errors",
+       fun() ->
+               Answer = Subject(?ORG1_ID, ?SCOPE_PERMUTATIONS, Context),
+               ?assertEqual([?ORGLOCAL_GROUP,?PLAIN_GROUP, ?M:make_name(<<>>,?PLAIN_GROUP)],
+                            Answer)
+       end
+      }
+     ]
+    }.
+
+
+%%
+%% Utility functions
+%%
+
+mk_db_callback_fn(Map) ->
+    fun({_QueryName, [Ids]}) ->
+            R = [ X ||  X <- [maps:get(Id, Map, {}) || Id <- Ids], is_list(X)],
+            R
+
+    end.
+
+mk_lookup_map() ->
+    #{
+       ?PLAIN_GROUP_AUTHZ_ID => make_db_record(?PLAIN_GROUP, ?ORG1_ID, ?PLAIN_GROUP_AUTHZ_ID),
+       ?ORGLOCAL_NAME_AUTHZ_ID => make_db_record(?PLAIN_GROUP, ?ORG2_ID, ?ORGLOCAL_NAME_AUTHZ_ID),
+       ?GLOBAL_NAME_AUTHZ_ID => make_db_record(?PLAIN_GROUP, ?GLOBAL_PLACEHOLDER_ORG_ID, ?GLOBAL_NAME_AUTHZ_ID)
+     }.
+
+mk_orgid_map() ->
+     #{
+        ?ORG1_ID => ?ORG1,
+        ?ORG2_ID => ?ORG2,
+        ?GLOBAL_PLACEHOLDER_ORG_ID => global_org
+     }.
+
+mock_sql_org_lookup(OrgMap) ->
+    fun({find_organization_by_id, [OrgId]}) ->
+            OrgName = maps:get(OrgId, OrgMap, not_found),
+            [[{<<"name">>, OrgName}]]
+    end.
+
+mk_context() ->
+    ?M:initialize_context(?ORG1_ID, db_callback_fun).
+
+mk_context_reverse(Map) ->
+    Callback = mk_db_callback_fn(Map),
+    ?M:initialize_context(?ORG1_ID, Callback).
+
+make_dummy_authz_id(Org, Name) ->
+    <<"AUTHZ_", Org/binary, "__", Name/binary>>.
+
+make_dummy_authz_record_2(Org, Name) ->
+    {Name, make_dummy_authz_id(Org,Name)}.
+
+mock_authz_records_by_name(group, Map) ->
+    fun(group, OrgId, Names) ->
+            lists:foldl(fun(N, A) ->
+                                case maps:find(OrgId, Map) of
+                                    error -> A;
+                                    {ok, NMap} ->
+                                        case maps:find(N, NMap) of
+                                            error -> A;
+                                            {ok, AuthzId} -> [AuthzId | A ]
+                                        end
+                                end
+                        end,
+                        [], Names)
+    end.
+
+make_simple_authz_record_data() ->
+    #{ ?ORG1_ID =>
+           #{ ?PLAIN_GROUP => make_dummy_authz_record_2(?ORG1,?PLAIN_GROUP) },
+       ?GLOBAL_PLACEHOLDER_ORG_ID =>
+           #{ ?PLAIN_NAME => make_dummy_authz_record_2(<<"global">>,?PLAIN_NAME )} }.
+
+make_db_record(Name, AuthzId) ->
+    [{<<"name">>, Name}, {<<"authz_id">>, AuthzId}].
+
+make_db_record(Name, OrgId, AuthzId) ->
+    [{<<"org_id">>, OrgId}, {<<"group_name">>, Name}, {<<"authz_id">>, AuthzId}].
+
+mk_sname(Full, Base, Org, OrgId) ->
+    mk_sname(Full, Base, Org, OrgId, undefined).
+
+mk_sname(Full, Base, Org, OrgId, AuthzId) ->
+    #sname{full = Full, base = Base, org = Org, org_id = OrgId, authz_id = AuthzId}.

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
@@ -279,9 +279,8 @@ query_and_diff_authz_ids_test_() ->
 %%
 %%
 render_names_in_context_test_() ->
-    Subject = fun ?M:render_names_in_context/3,
+    Subject = fun ?M:render_names_in_context/2,
 
-    Context = mk_context_reverse(mk_lookup_map()),
     OrgMap = mk_orgid_map(),
     {foreach,
      fun() ->
@@ -296,19 +295,19 @@ render_names_in_context_test_() ->
      [
       {"empty list returns nothing and no errors",
        fun() ->
-               Answer = Subject(?ORG1_ID, [], Context),
+               Answer = Subject(?ORG1_ID, []),
                ?assertEqual([], Answer)
        end
       },
       {"simple list returns and and no errors",
        fun() ->
-               Answer = Subject(?ORG1_ID, [{?ORG1_ID,?PLAIN_GROUP}], Context),
+               Answer = Subject(?ORG1_ID, [{?ORG1_ID,?PLAIN_GROUP}]),
                ?assertEqual([?PLAIN_GROUP], Answer)
        end
       },
       {"longer list returns and and no errors",
        fun() ->
-               Answer = Subject(?ORG1_ID, ?SCOPE_PERMUTATIONS, Context),
+               Answer = Subject(?ORG1_ID, ?SCOPE_PERMUTATIONS),
                Expected = lists:sort([?ORGLOCAL_GROUP,?PLAIN_GROUP, ?M:make_name(<<>>,?PLAIN_GROUP)]),
                ?assertEqual(Expected,
                             Answer)

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
@@ -278,8 +278,8 @@ query_and_diff_authz_ids_test_() ->
 
 %%
 %%
-render_names_in_context_test_() ->
-    Subject = fun ?M:render_names_in_context/2,
+render_names_from_org_id_test_() ->
+    Subject = fun ?M:render_names_from_org_id/2,
 
     OrgMap = mk_orgid_map(),
     {foreach,

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_scoped_name_tests.erl
@@ -45,7 +45,7 @@
 -define(GLOBAL_NAME_AUTHZ_ID, global_name_authz_id).
 -define(ORGLOCAL_NAME_AUTHZ_ID, orglocal_name_authz_id).
 
--define(SCOPE_PERMUTATIONS, [{?ORG1_ID, ?PLAIN_GROUP}, {?ORG2_ID, ?PLAIN_GROUP}, {?GLOBAL_PLACEHOLDER_ORG_ID, ?PLAIN_GROUP}]).
+-define(SCOPE_PERMUTATIONS, lists:sort([{?ORG1_ID, ?PLAIN_GROUP}, {?ORG2_ID, ?PLAIN_GROUP}, {?GLOBAL_PLACEHOLDER_ORG_ID, ?PLAIN_GROUP}])).
 
 %% Copypast for oc_chef_authz_scoped_name.erl
 %-record(context, {org_name :: undefined,
@@ -309,7 +309,8 @@ render_names_in_context_test_() ->
       {"longer list returns and and no errors",
        fun() ->
                Answer = Subject(?ORG1_ID, ?SCOPE_PERMUTATIONS, Context),
-               ?assertEqual([?ORGLOCAL_GROUP,?PLAIN_GROUP, ?M:make_name(<<>>,?PLAIN_GROUP)],
+               Expected = lists:sort([?ORGLOCAL_GROUP,?PLAIN_GROUP, ?M:make_name(<<>>,?PLAIN_GROUP)]),
+               ?assertEqual(Expected,
                             Answer)
        end
       }

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl.erl
@@ -80,12 +80,12 @@ validate_request('GET', Req, #base_state{chef_db_context = DbContext,
 auth_info(Req, State) ->
     check_acl_auth(Req, State).
 
-to_json(Req, #base_state{resource_state = #acl_state{type = Type, authz_id = AuthzId}} = State) ->
+to_json(Req, #base_state{organization_guid = OrgId, resource_state = #acl_state{type = Type, authz_id = AuthzId}} = State) ->
     Granular = case wrq:get_qs_value("detail", Req) of
                    "granular" -> granular;
                    _ -> undefined
                end,
-    case oc_chef_authz_acl:fetch(Type, AuthzId, Granular) of
+    case oc_chef_authz_acl:fetch(Type, OrgId, AuthzId, Granular) of
         forbidden ->
             {{halt, 403}, Req, State#base_state{log_msg = requestor_access_failed}};
         Ejson ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
@@ -93,7 +93,7 @@ validate_request('PUT', Req, #base_state{chef_db_context = DbContext,
         %% they know what they are doing. With great power and all.
         {Req1, State1};
       false ->
-        case oc_chef_authz_acl_constraints:check_acl_constraints(AuthzId, Type, Part, Ace) of
+        case oc_chef_authz_acl_constraints:check_acl_constraints(OrgId, AuthzId, Type, Part, Ace) of
           ok ->
             {Req1, State1};
           [ Violation | _T ] ->


### PR DESCRIPTION
Support nonlocal group names

The server_admins group introduces an issue with ACLS and groups; we
have a global group in the context of a organization scoped
object. Not only do we have the potential of conflicts with a org
scoped group with the same name, we also lack a mechanisim to look up
groups that aren't in the org we're looking at.

This PR adds new syntax '::' to indicate scoping. ::GROUPNAME without
a prefix indicates a global (across multiple orgs) entity, while
ORGNAME::GROUPNAME refers to a group in an another org.

This should unblock the work around server admins, including improved
org creation.

There remain a few rough spots around error handling, and a few
opportunities to streamline and simplify the logic around 'lowering'
qualified names to authz_ids, but this should be enough to kickstart
the discussion.

This will need to be implemented in chef_zero to maintain feature parity.

**Ticket:** POOL-570