### PR TITLE
fix preflight check error message boot007, add fixture key removal to cleanup

### DIFF
--- a/omnibus/config/software/cleanup.rb
+++ b/omnibus/config/software/cleanup.rb
@@ -11,4 +11,7 @@ build do
   delete "#{install_dir}/embedded/nodejs"
   # strip shared object files related to gecode installs
   command "strip #{install_dir}/embedded/lib/libgecode*.so.32.0"
+
+  # remove any test fixture pivotal keys to avoid user confusion
+  command "find #{install_dir} -name pivotal.pem -delete"
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
@@ -78,27 +78,50 @@ class BootstrapPreflightValidator < PreflightValidator
     first_run? && all_creds_exist? && PrivateChef["postgresql"]["external"]
   end
 
+  def validate_sane_state
+    # If nothing is there, this is probably a first run
+    return true unless (secrets_file_exists? || pivotal_pem_exists?)
+
+    unless (new_secrets_layout? || old_secrets_info? || valid_mixed_state?)
+      fail_with err_BOOT006_invalid_secrets_state
+    end
+
+    true
+  end
+
   private
 
   def all_creds_exist?
     pivotal_key_exists? && secrets_exists?
   end
 
-  def pivotal_key_exists?
-    # on upgrades, we haven't had a chance to ingest the pivotal key, so we
-    # still need to check if the file is on disk
-    ::File.exist?("/etc/opscode/pivotal.pem") ||
-      PrivateChef.credentials.exist?('chef-server', 'superuser_key')
+
+  def new_secrets_layout?
+    secrets_exists? && secrets_contains_pivotal?
   end
 
-  def validate_sane_state
-    if pivotal_key_exists?
-      unless secrets_exists?
-        fail_with err_BOOT006_pivotal_with_no_secrets
-      end
-    elsif secrets_exists?
-      fail_with err_BOOT007_secrets_with_no_pivotal
-    end
+  def old_secrets_info?
+    secrets_file_exists? && pivotal_pem_exists?
+  end
+
+  def valid_mixed_state?
+    secrets_exists? && pivotal_pem_exists?
+  end
+
+  def secrets_file_exists?
+    ::File.exist?("/etc/opscode/private-chef-secrets.json")
+  end
+
+  def pivotal_pem_exists?
+    ::File.exist?("/etc/opscode/pivotal.pem")
+  end
+
+  def secrets_contains_pivotal?
+    PrivateChef.credentials.exist?('chef-server', 'superuser_key')
+  end
+
+  def pivotal_key_exists?
+    secrets_contains_pivotal? || pivotal_pem_exists?
   end
 
   def pivotal_user_exists?
@@ -170,34 +193,25 @@ BOOT005: Your configuration indicates that you may be starting this node
 EOM
   end
 
-  def err_BOOT006_pivotal_with_no_secrets
+  def err_BOOT006_invalid_secrets_state
 <<EOM
-BOOT006: The superuser key is present in the key store,
-         but the other expected credentials are missing.
+BOOT006: The secrets data in /etc/opscode appears invalid.
 
-         Ensure that the secrets file has been copied into /etc/opscode from the
-         first Chef Server node that you brought online, then run
-         'chef-server-ctl reconfigure' again.
+         Please ensure you have copied
+
+            /etc/opscode/private-chef-secrets.json
+
+         from the existing Chef Server to this chef-server.
+
+         If you are upgrading from Chef Server 12.13.0 or older,
+         please also copy the following files:
+
+            /etc/opscode/webui_priv.pem
+            /etc/opscode/pivotal.pem
+
+         Once copied run 'chef-server-ctl reconfigure' again.
 EOM
 
-  end
-
-  def err_BOOT007_secrets_with_no_pivotal
-# TODO 2017-02-28 mp: we'll want to replace pc-secrets references with the configured
-    # path supplied by user
-# TODO 2017-02-28 mp: I think there are doc updates to go with this wording change.
-<<EOM
-BOOT007: The secrets file (/etc/opscode/private-chef-secrets.json) is
-         present but it does not contain the superuser key and no
-         pivotal.pem could be found on disk.
-
-         Please check that private-chef-secrets.json has been copied
-         from the first Chef Server node that you brought online. If
-         you are upgrading from 12.13.0 or older, also check that
-         pivotal.pem and webui_priv.pem have been copied as well.
-
-         Then run 'chef-server-ctl reconfigure' again.
-EOM
   end
 
   def err_BOOT008_pivotal_public_key_mismatch

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
@@ -96,10 +96,8 @@ class BootstrapPreflightValidator < PreflightValidator
       unless secrets_exists?
         fail_with err_BOOT006_pivotal_with_no_secrets
       end
-    else
-      if secrets_exists?
-        fail_with err_BOOT007_secrets_with_no_pivotal
-      end
+    elsif secrets_exists?
+      fail_with err_BOOT007_secrets_with_no_pivotal
     end
   end
 
@@ -172,17 +170,14 @@ BOOT005: Your configuration indicates that you may be starting this node
 EOM
   end
 
-  # TODO 2017-02-28 mp:  actually this path is no longer possible.  If chef secrets is not there
-  # then the pivotal key cannot be.
   def err_BOOT006_pivotal_with_no_secrets
 <<EOM
 BOOT006: The superuser key is present in the key store,
-         but the file /etc/opscode/private-chef-secrets.json is missing.
+         but the other expected credentials are missing.
 
          Ensure that the secrets file has been copied into /etc/opscode from the
          first Chef Server node that you brought online, then run
          'chef-server-ctl reconfigure' again.
-
 EOM
 
   end
@@ -192,12 +187,16 @@ EOM
     # path supplied by user
 # TODO 2017-02-28 mp: I think there are doc updates to go with this wording change.
 <<EOM
-BOOT007: The secrets file (/etc/opscode/private-chef-secrets.json) is present
-         but it does not contain the superuser key.
+BOOT007: The secrets file (/etc/opscode/private-chef-secrets.json) is
+         present but it does not contain the superuser key and no
+         pivotal.pem could be found on disk.
 
-         Ensure that private-chef-secrets.json is copied into /etc/opscode from the
-         first Chef Server node that you brought online, then run
-         'chef-server-ctl reconfigure' again.
+         Please check that private-chef-secrets.json has been copied
+         from the first Chef Server node that you brought online. If
+         you are upgrading from 12.13.0 or older, also check that
+         pivotal.pem and webui_priv.pem have been copied as well.
+
+         Then run 'chef-server-ctl reconfigure' again.
 EOM
   end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
@@ -19,7 +19,99 @@ require_relative '../../libraries/helper.rb'
 
 
 describe BootstrapPreflightValidator do
+  let(:node_object) { { "private_chef" => {}, "previous_run" => {} } }
+
   let(:subject) { BootstrapPreflightValidator.new(node_object) }
+
+  describe "#validate_sane_state" do
+    let(:veil) { double() }
+    before do
+      allow(PrivateChef).to receive(:credentials).and_return(veil)
+    end
+
+    context "when nothing exists" do
+      before do
+        allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
+        allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
+      end
+
+      it "returns true" do
+        expect(subject.validate_sane_state).to eq(true)
+      end
+    end
+
+    context "when the secrets exist in the Chef 12.14.0+ format" do
+      before do
+        allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+        allow(veil).to receive(:length).and_return(10)
+        allow(veil).to receive(:exist?).with('chef-server', 'superuser_key').and_return(true)
+        allow(veil).to receive(:exist?).with('chef-server', 'webui_key').and_return(true)
+      end
+
+      it "returns true" do
+        expect(subject.validate_sane_state).to eq(true)
+      end
+    end
+
+    context "when the secrets exist in the Chef 12.13.0 and prev format" do
+      before do
+        allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+        allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(true)
+        allow(veil).to receive(:length).and_return(10)
+        allow(veil).to receive(:exist?).with('chef-server', 'superuser_key').and_return(false)
+        allow(veil).to receive(:exist?).with('chef-server', 'webui_key').and_return(false)
+      end
+
+      it "returns true" do
+        expect(subject.validate_sane_state).to eq(true)
+      end
+    end
+
+    context "when the secrets exist in an odd but recoverable mashup of those two formats" do
+      before do
+        allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+        allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(true)
+        allow(veil).to receive(:exist?).with('chef-server', 'webui_key').and_return(false)
+        allow(veil).to receive(:exist?).with('chef-server', 'superuser_key').and_return(false)
+        allow(veil).to receive(:length).and_return(10)
+      end
+
+      it "returns true" do
+        expect(subject.validate_sane_state).to eq(true)
+      end
+    end
+
+    context "invalid state:" do
+      context "pivotal.pem without private-chef-secrets.json" do
+        before do
+          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(false)
+          allow(veil).to receive(:length).and_return(0)
+          allow(veil).to receive(:exist?).with('chef-server', 'superuser_key').and_return(false)
+          allow(veil).to receive(:exist?).with('chef-server', 'webui_key').and_return(false)
+          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(true)
+        end
+
+        it "raises an error" do
+          expect{subject.validate_sane_state}.to raise_error(PreflightValidationFailed)
+        end
+      end
+
+      context "private-chef-secrets.json with no pivotal key anywhere" do
+        before do
+          allow(File).to receive(:exist?).with("/etc/opscode/private-chef-secrets.json").and_return(true)
+          allow(veil).to receive(:length).and_return(10)
+          allow(veil).to receive(:exist?).with('chef-server', 'superuser_key').and_return(false)
+          allow(veil).to receive(:exist?).with('chef-server', 'webui_key').and_return(false)
+          allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
+        end
+
+        it "raises an error" do
+          expect{subject.validate_sane_state}.to raise_error(PreflightValidationFailed)
+        end
+      end
+    end
+  end
+
 
   describe "#bypass_bootstrap?" do
     let(:superuser_key_exists) { true }


### PR DESCRIPTION
This is to reduce the potential for confusion (see for example #727).

While this preflight check will probably change soon (there will be no need for copying the `pivotal.pem`), this is a small change, let's just get this merged anyways (if only for the cleanup addition).