### PR TITLE
Run oc_id's svlogd as user opscode

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-log-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-log-run.erb
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec svlogd -tt <%= @options[:log_directory] %>
+exec chpst -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> \
+  svlogd -tt <%= @options[:log_directory] %>

--- a/omnibus/files/private-chef-upgrades/001/032_oc_id_logdir_perms.rb
+++ b/omnibus/files/private-chef-upgrades/001/032_oc_id_logdir_perms.rb
@@ -1,0 +1,12 @@
+# oc_id's svlogd process running as root looks like a leftover of migration
+# 008_fix_logging.rb -- so we do the same thing for oc_id's log dir
+define_upgrade do
+  service = "oc_id"
+  if File.exist?("/var/log/opscode/#{service}/")
+    # ensure logs are all owned by the opscode user
+    run_command("chown opscode:opscode /var/log/opscode/#{service}/*")
+
+    # restart log service
+    run_command("/opt/opscode/embedded/bin/sv force-restart /opt/opscode/sv/#{service}/log")
+  end
+end


### PR DESCRIPTION
Running this as root is probably not necessary. This includes the
migration similar to what was happened in 008_fix_logging.rb.