### PR TITLE
[oc-id] Don't write application configuration to disk by default

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_provider.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_provider.rb
@@ -11,17 +11,19 @@ class Chef
         converge_by "create oc-id application '#{new_resource.name}'" do
           attributes = create!
 
-          directory '/etc/opscode/oc-id-applications' do
-            owner 'root'
-            group 'root'
-            mode '0755'
-          end
+          if new_resource.write_to_disk
+            directory '/etc/opscode/oc-id-applications' do
+              owner 'root'
+              group 'root'
+              mode '0755'
+            end
 
-          file "/etc/opscode/oc-id-applications/#{new_resource.name}.json" do
-            content Chef::JSONCompat.to_json_pretty(attributes)
-            owner 'root'
-            group 'root'
-            mode '0600'
+            file "/etc/opscode/oc-id-applications/#{new_resource.name}.json" do
+              content Chef::JSONCompat.to_json_pretty(attributes)
+              owner 'root'
+              group 'root'
+              mode '0600'
+            end
           end
         end
       end
@@ -30,25 +32,25 @@ class Chef
 
       def create!
         @attributes ||= begin
-          rails_script = <<EOF
+                          rails_script = <<EOF
 app = Doorkeeper::Application.find_or_create_by(:name => "#{new_resource.name}");
 app.update_attributes(:redirect_uri => "#{new_resource.redirect_uri}");
 puts app.to_json
 EOF
-          # in order to account for rails logging, we take only the last line of output
-          # from the rails runner script. if the logging is parsed as json, we end up
-          # with a difficult-to-comprehend error message that looks like:
-          #
-          # ```
-          # Chef::Exceptions::JSON::ParseError: lexical error: invalid char in json text.
-          #                            I, [2015-05-07T18:26:37.236655
-          #          (right here) ------^
-          # ```
-          json = shell_out!("bin/rails runner -e production '#{rails_script}'",
-                            :cwd => '/opt/opscode/embedded/service/oc_id').stdout.lines.last.chomp
+                          # in order to account for rails logging, we take only the last line of output
+                          # from the rails runner script. if the logging is parsed as json, we end up
+                          # with a difficult-to-comprehend error message that looks like:
+                          #
+                          # ```
+                          # Chef::Exceptions::JSON::ParseError: lexical error: invalid char in json text.
+                          #                            I, [2015-05-07T18:26:37.236655
+                          #          (right here) ------^
+                          # ```
+                          json = shell_out!("bin/rails runner -e production '#{rails_script}'",
+                                            :cwd => '/opt/opscode/embedded/service/oc_id').stdout.lines.last.chomp
 
-          Chef::JSONCompat.from_json(json).delete_if { |key| %w[ id created_at updated_at].include? key }
-        end
+                          Chef::JSONCompat.from_json(json).delete_if { |key| %w[ id created_at updated_at].include? key }
+                        end
       end
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_resource.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_resource.rb
@@ -9,6 +9,7 @@ class Chef
       default_action :create
 
       attribute :name, :kind_of => String, :name_attribute => true
+      attribute :write_to_disk, :kind_of => [TrueClass, FalseClass], :default => false
       attribute :redirect_uri, :kind_of => String, :required => true
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -93,6 +93,7 @@ file settings_file do
   action :delete
   not_if  { File.symlink?(settings_file) }
 end
+
 link settings_file do
   to "#{oc_id_config_dir}/production.yml"
 end
@@ -104,11 +105,13 @@ template "#{oc_id_config_dir}/secret_token.rb" do
   mode '640'
   notifies :restart, 'runit_service[oc_id]' unless backend_secondary?
 end
+
 secrets_file = "/opt/opscode/embedded/service/oc_id/config/initializers/secret_token.rb"
 file secrets_file do
   action :delete
   not_if  { File.symlink?(secrets_file) }
 end
+
 link secrets_file do
   to "#{oc_id_config_dir}/secret_token.rb"
 end
@@ -120,11 +123,13 @@ template "#{oc_id_config_dir}/database.yml" do
   mode '640'
   notifies :restart, 'runit_service[oc_id]' unless backend_secondary?
 end
+
 database_file = "/opt/opscode/embedded/service/oc_id/config/database.yml"
 file database_file do
   action :delete
   not_if  { File.symlink?(database_file) }
 end
+
 link database_file do
   to "#{node['private_chef']['oc_id']['dir']}/config/database.yml"
 end
@@ -163,6 +168,7 @@ end
 # exist in the database, and dump their data to /etc/opscode/oc-id-applications.
 node['private_chef']['oc_id']['applications'].each do |name, app|
   oc_id_application name do
+    write_to_disk node['private_chef']['insecure_addon_compat']
     redirect_uri app['redirect_uri']
     only_if { is_data_master? }
   end

--- a/omnibus/files/private-chef-ctl-commands/oc_id_show_app.rb
+++ b/omnibus/files/private-chef-ctl-commands/oc_id_show_app.rb
@@ -1,0 +1,27 @@
+add_command_under_category "oc-id-show-app", "Secrets Management", "Show configuration for oc-id applications", 2 do
+  require 'mixlib/shellout'
+  require 'json'
+
+  app_name = ARGV[3]
+  if !app_name
+    STDERR.puts "No app name provided"
+    exit(1)
+  end
+
+  rails_script = <<EOF
+app = Doorkeeper::Application.find_by(:name => "#{app_name}");
+puts app.to_json
+EOF
+
+  cmd = Mixlib::ShellOut.new("bin/rails runner -e production '#{rails_script}'",
+                          :cwd => '/opt/opscode/embedded/service/oc_id')
+  cmd.run_command
+  json = cmd.stdout.lines.last.chomp
+  if json == "null"
+    STDERR.puts "Could not find app #{app_name}"
+    exit(1)
+  end
+
+  hash = JSON.parse(json).delete_if { |key| %w[ id created_at updated_at].include? key }
+  puts JSON.pretty_generate(hash)
+end


### PR DESCRIPTION
The user-configured applications previously resulted in files written
to disk with the oauth2 secret for that application.  These files are
how users currently integrate supermarket, compliance, and other
applications with oc-id.

To replace them, we've provided an oc-id-show-app ctl command that
will emit the same JSON that would have been in the file.

Signed-off-by: Steven Danna <steve@chef.io>