### PR TITLE
Set insecure_addon_compat to true by default

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -107,7 +107,7 @@ module PrivateChef
 
   registered_extensions Mash.new
 
-  insecure_addon_compat false
+  insecure_addon_compat true
 
   class << self
     def from_file(filename)
@@ -571,7 +571,8 @@ WARN
     #
     def save_credentials_to_config
       credentials.legacy_credentials_hash.each do |service, creds|
-        next if service == "chef-server"
+        # Ignore secrets added by add-ons and the keys
+        next if PrivateChef[service].nil?
         creds.each do |name, value|
           PrivateChef[service][name] ||= value
         end


### PR DESCRIPTION
This change has the potential to break a lot of existing automation.
Setting this to true for now will give users time to update.

Signed-off-by: Steven Danna <steve@chef.io>