### PR TITLE
Cleanup leftover secrets_file oc-id config

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -27,8 +27,7 @@ end
 app_settings = {
   'chef' => {
     'endpoint' => "https://#{node['private_chef']['lb_internal']['vip']}",
-    'superuser' => 'pivotal',
-    'secrets_file' => '/etc/opscode/private-chef-secrets.json'
+    'superuser' => 'pivotal'
   },
   'doorkeeper' => {
     'administrators' => node['private_chef']['oc_id']['administrators'] || []

--- a/src/oc-id/config/settings.yml
+++ b/src/oc-id/config/settings.yml
@@ -1,7 +1,6 @@
 chef:
   endpoint: https://192.168.33.100
   superuser: pivotal
-  secrets_file: <%= Rails.root %>/config/private-chef-secrets.json
 doorkeeper:
   administrators:
     - rainbowdash

--- a/src/oc-id/config/settings/production.yml
+++ b/src/oc-id/config/settings/production.yml
@@ -1,4 +1,3 @@
 chef:
   endpoint: https://api.opscode.us
   superuser: pivotal
-  secrets_file: /etc/opscode/private-chef-secrets.json


### PR DESCRIPTION
oc-id no longer needs direct access to the secrets file so this
configuration item should be unused.

Signed-off-by: Steven Danna <steve@chef.io>