### PR TITLE
[dvm] use veil-env-helper where necessary

### DIFF
--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -106,6 +106,20 @@ projects:
       name: opscode-erchef
       cookie: erchef
       node: erchef@127.0.0.1
+      secrets:
+        args: --use-file
+        list:
+          - chef-server.webui_pub_key
+          - opscode_erchef.sql_password
+          - bookshelf.access_key_id
+          - bookshelf.secret_access_key
+          - rabbitmq.password
+          - rabbitmq.management_password
+          - rabbitmq.actions_password
+          - oc_bifrost.superuser_id
+        optional:
+          - data_collector.token
+          - ldap.bind_password
   oc-id:
     type: rails
     install_options: --without development test doc
@@ -118,6 +132,12 @@ projects:
     service:
       name: oc_id
       port: 9090
+      secrets:
+        args: --use-file
+        list:
+          - chef-server.webui_key
+          - oc_id.sql_password
+          - oc_id.secret_key_base
   oc_bifrost:
     type: erlang
     database: bifrost
@@ -126,16 +146,28 @@ projects:
       name:  oc_bifrost
       cookie: oc_bifrost
       node: oc_bifrost@127.0.0.1
+      secrets:
+        args: --use-file
+        list:
+          - oc_bifrost.sql_password
+          - oc_bifrost.superuser_id
   oc_reporting:
     type:  erlang
     external: true
     database: opscode_reporting
     omnibus-project: opscode-reporting
     service:
-     rel-type: rebar3
-     name: opscode-reporting
-     cookie: oc_reporting
-     node: oc_reporting@127.0.0.1
+      rel-type: rebar3
+      name: opscode-reporting
+      cookie: oc_reporting
+      node: oc_reporting@127.0.0.1
+      secrets:
+        args: --pack
+        list:
+          - chef-server.superuser_key
+          - chef-server.webui_pub_key
+          - opscode-reporting.sql_password
+          - rabbitmq.actions_password
   chef-mover:
     type: erlang
     service:
@@ -144,6 +176,12 @@ projects:
       name:  opscode-chef-mover
       cookie: mover
       node: mover@127.0.0.1
+      secrets:
+        args: --use-file
+        list:
+          - opscode_erchef.sql_password
+          - oc_bifrost.superuser_id
+          - redis_lb.password
   bookshelf:
     type: erlang
     service:
@@ -151,6 +189,13 @@ projects:
       name: bookshelf
       cookie: bookshelf
       node: bookshelf@127.0.0.1
+      secrets:
+        args: --use-file
+        list:
+          - bookshelf.access_key_id
+          - bookshelf.secret_access_key
+        optional:
+          - bookshelf.sql_password
   omnibus:
     path: "omnibus"
     name: opscode-omnibus

--- a/dev/dvm/lib/dvm/project/erlang.rb
+++ b/dev/dvm/lib/dvm/project/erlang.rb
@@ -49,9 +49,9 @@ module DVM
       # Ensure that our packaged installation isn't running, thereby preventing spewage of startup errors.
       disable_service
       if background
-        run_command("bin/#{relname} start", "Starting #{name}", cwd: relpath, env: { "DEVVM" => "1" } )
+        run_command("#{helper} -- bin/#{relname} start", "Starting #{name}", cwd: relpath, env: { "DEVVM" => "1" } )
       else
-        exec "cd #{relpath} && bin/#{relname} console", close_others: false
+        exec "cd #{relpath} && #{helper} -- bin/#{relname} console", close_others: false
       end
     end
 

--- a/dev/dvm/lib/dvm/project/project.rb
+++ b/dev/dvm/lib/dvm/project/project.rb
@@ -24,6 +24,26 @@ module DVM
       @service = @project['service']
     end
 
+    def helper
+      veil = service['secrets']
+      return '' unless veil
+
+      "veil-env-helper #{veil['args']} #{secrets_params} #{optional_params}"
+    end
+
+    def secrets_params
+      return '' unless service['secrets']['list']
+      service['secrets']['list'].map do |secret|
+        "-s #{secret}"
+      end.join(' ')
+    end
+
+    def optional_params
+      return '' unless service['secrets']['optional']
+      service['secrets']['optional'].map do |secret|
+        "-o #{secret}"
+      end.join(' ')
+    end
 
     def start(args, detach)
       raise DVM::DVMArgumentError, "Start not supported for #{name}"

--- a/dev/dvm/lib/dvm/project/rails.rb
+++ b/dev/dvm/lib/dvm/project/rails.rb
@@ -71,7 +71,7 @@ EOM
 
     def do_build
       build_steps.each do |step|
-        run_command("#{step}", "Build Step: '#{step}'", cwd: project_dir, env: {'RAILS_ENV' => 'production'})
+        run_command("#{helper} -- #{step}", "Build Step: '#{step}'", cwd: project_dir, env: {'RAILS_ENV' => 'production'})
       end
     end
 
@@ -85,7 +85,7 @@ EOM
     end
 
     def server_start_cmd
-      "cd #{project_dir} && bundle exec --keep-file-descriptors bin/rails server -p #{port} -b #{host} -e production"
+      "cd #{project_dir} && #{helper} -- bundle exec --keep-file-descriptors bin/rails server -p #{port} -b #{host} -e production"
     end
 
     def enable_service

--- a/dev/dvm/lib/dvm/project/ruby.rb
+++ b/dev/dvm/lib/dvm/project/ruby.rb
@@ -6,12 +6,14 @@ module DVM
   # TODO: support for 'system' in another system - like omnibus-reporting env...
   class RubyProject < Project
     attr_reader :gem_path, :with_binstubs
+
     def initialize(project_name, config)
       super
       @gem_path = project['gem-path'] || "/opt/opscode/embedded/service/gem"
       @with_binstubs = project.has_key?('with-binstubs') ? project['with-binstubs'] : false
 
     end
+
     def do_load(options)
       if @project['system']
         load_system_ruby_project
@@ -19,11 +21,13 @@ module DVM
         load_ruby_project
       end
     end
+
     def load_system_ruby_project
       # For now we're not loading further gem deps - we can revisit that
       # if/when we have a need to.
       bind_mount(project_dir,   system_gem_path(name))
     end
+
     def load_ruby_project
       # ruby projects that can be run as commands will be updated with a new bundler file in place,
       # so that they can just be run via `dvm run #{name}` without having to mess around
@@ -33,9 +37,11 @@ module DVM
       path = gem_path == "none" ? "" : "--path #{gem_path}"
       run_command("bundle install #{path} #{binstubs}", "Installing in-place...", cwd: project_dir)
     end
+
     def unload
       unmount(@project_dir)
     end
+
     def loaded?
       if project['system']
         path_mounted?(project_dir)
@@ -45,11 +51,12 @@ module DVM
         false
       end
     end
+
     def run(args)
       if @project['system']
         raise DVM::DVMArgumentError, 'Run not supported for system ruby projects - just use it normally via chef-server-ctl or otherwise, as it has been loaded into the server gemset.'
       else
-        exec "cd #{@project_dir} && #{@project['run']} #{args.join(" ")}", close_others: false
+        exec "cd #{@project_dir} && #{helper} -- #{@project['run']} #{args.join(" ")}", close_others: false
       end
     end
   end

--- a/dev/dvm/lib/dvm/tools.rb
+++ b/dev/dvm/lib/dvm/tools.rb
@@ -1,18 +1,12 @@
 module DVM
   module Tools
     def run_command(command, desc = nil, opts = {})
-      dir = opts[:cwd] || Dir.pwd
-      status = system(opts[:env] || {}, command,
-                      chdir: dir,
-                      close_others: false)
-
       no_raise = opts.delete(:no_raise)
-
-      unless no_raise
-        raise "Command Failed" if !status
-      end
-
-      status
+      say desc if desc
+      cmd = Mixlib::ShellOut.new(command, opts)
+      cmd.run_command
+      cmd.error! unless no_raise
+      cmd
     end
 
     def bind_mount(from, to)


### PR DESCRIPTION
It's tedius to always prefix your invocations of `dvm start SRV` with
veil-env-helper, and it's even hard to remember which secrets are needed
for which service.

Also, this reverts the removal of Mixlib::ShellOut for #run_command,
since we now don't need to pass file descriptors through dvm calls.
However, the fixed calls to #exec have been kept as-is (there's no
harm in these).

Signed-off-by: Stephan Renatus <srenatus@chef.io>