### PR TITLE
Enable analytics when insecure-addon mode is enabled.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -763,7 +763,7 @@ EOF
     # If known private keys are on disk, add them to Veil and commit them.
     def migrate_keys
       did_something = add_key_from_file_if_present("chef-server", "superuser_key", "/etc/opscode/pivotal.pem")
-      did_something ||= add_key_from_file_if_present("chef-server", "webui_key", "/etc/opscode/webui_priv.pem")
+      did_something |= add_key_from_file_if_present("chef-server", "webui_key", "/etc/opscode/webui_priv.pem")
       # Ensure these are committed to disk before continuing -
       # the secrets recipe will delete the old files.
       credentials.save if did_something

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/actions.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/actions.rb
@@ -1,0 +1,52 @@
+if is_data_master?
+  # Contents of the OC ID app's JSON data, to be called later
+  oc_id_app = proc do
+    begin
+      Chef::JSONCompat.from_json(
+        open('/etc/opscode/oc-id-applications/analytics.json').read
+      )
+    rescue Errno::ENOENT
+      Chef::Log.warn('No analytics oc-id-application present. Skipping')
+      {}
+    end
+  end
+
+  directory "/etc/opscode-analytics" do
+    owner OmnibusHelper.new(node).ownership['owner']
+    group OmnibusHelper.new(node).ownership['group']
+    mode '0775'
+    recursive true
+  end
+
+  # Write out the config files for actions to load in order to interface with this EC
+  # instance
+  #
+  file "/etc/opscode-analytics/webui_priv.pem" do
+    owner OmnibusHelper.new(node).ownership['owner']
+    group "root"
+    mode "0600"
+    content lazy {::File.open('/etc/opscode/webui_priv.pem').read}
+  end
+
+  rabbitmq = OmnibusHelper.new(node).rabbitmq_configuration
+
+  file "/etc/opscode-analytics/actions-source.json" do
+    owner 'root'
+    mode '0600'
+    sensitive true
+    content lazy {
+      Chef::JSONCompat.to_json_pretty(
+        private_chef: {
+          api_fqdn:           node['private_chef']['lb']['api_fqdn'],
+          oc_id_application:  oc_id_app.call,
+          rabbitmq_host:      rabbitmq['vip'],
+          rabbitmq_port:      rabbitmq['node_port'],
+          rabbitmq_vhost:     rabbitmq['actions_vhost'],
+          rabbitmq_exchange:  rabbitmq['actions_exchange'],
+          rabbitmq_user:      rabbitmq['actions_user'],
+          rabbitmq_password:  rabbitmq['actions_password']
+        }
+      )
+    }
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -160,6 +160,10 @@ end
 
 include_recipe "private-chef::cleanup"
 
+if darklaunch_values["actions"] && node['private_chef']['insecure_addon_compat']
+  include_recipe "private-chef::actions"
+end
+
 include_recipe "private-chef::private-chef-sh"
 include_recipe "private-chef::oc-chef-pedant"
 include_recipe "private-chef::log_cleanup"


### PR DESCRIPTION
This reverts an earlier change which removes support for analytics
in newer versions of Chef Server, and instead enables it only
when insecure addon mode is enabled.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>