### PR TITLE
make rabbitmq password migration a noop if local rabbitmq is not enabled

### DIFF
--- a/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
+++ b/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
@@ -1,9 +1,10 @@
 define_upgrade do
   if Partybus.config.bootstrap_server # TODO: do we want this?
+    rmq = Partybus.config.running_server["private_chef"]["rabbitmq"]
+    return unless rmq["enable"]
 
     start_services(["rabbitmq"])
 
-    rmq = Partybus.config.running_server["private_chef"]["rabbitmq"]
     [
       [rmq["user"], "password"],
       [rmq["actions_user"], "actions_password"],


### PR DESCRIPTION
Signed-off-by: Stephan Renatus <srenatus@chef.io>