### PR TITLE
Use before notification to ensure haproxy is started

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
@@ -112,6 +112,7 @@ ruby_block "wait for haproxy status socket" do
       Kernel.exit! 1
     end
   end
+  notifies :start, 'runit_service[haproxy]', :before
 end
 
 ruby_block "wait for backend leader to stabilize" do


### PR DESCRIPTION
During upgrades, haproxy may be down, but we require it to be up for
this test to pass.

Signed-off-by: Steven Danna <steve@chef.io>