### PR TITLE
don't include erts in relx releases

### DIFF
--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -131,6 +131,7 @@
      {sqerl, load}
   ]},
 
+  {include_erts, false},
   {include_src, false},
   {extended_start_script,true},
   {overlay,[{template,"config/app.config","sys.config"},

--- a/src/chef-mover/rebar.config
+++ b/src/chef-mover/rebar.config
@@ -162,6 +162,7 @@
             eper
             ]},
 
+    {include_erts, false},
     {include_src, false},
     {lib_dirs,["_build/default/lib/oc_erchef/apps"]},
     {extended_start_script,true},

--- a/src/oc_bifrost/rebar.config
+++ b/src/oc_bifrost/rebar.config
@@ -95,6 +95,7 @@
         bifrost
    ]},
 
+  {include_erts, false},
   {include_src, false},
   {extended_start_script,true},
   {overlay,[{template,"config/vm.args","vm.args"},

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -144,6 +144,7 @@
         efast_xs
     ]},
 
+    {include_erts, false},
     {include_src, false},
     {extended_start_script,true},
     {overlay_vars,"config/vars.config"},


### PR DESCRIPTION
It seems like we could maybe do without those extra copies -- we ship
the erlang runtime environment and the extended_bin script created by
relx should just fine its erts (as long as the versions match, but they
do).

Signed-off-by: Stephan Renatus <srenatus@chef.io>