### PR TITLE
[CLOUD-296] Add required_recipe endpoint

### DIFF
--- a/oc-chef-pedant/lib/pedant/command_line.rb
+++ b/oc-chef-pedant/lib/pedant/command_line.rb
@@ -149,7 +149,7 @@ module Pedant
                 principals acl containers groups association omnibus organizations
                 usags controls keys cookbook-artifacts license headers server-api-version
                 policies pedantic self-test api-v0 api-v1 object-identifiers
-                multiuser universe chef-zero-quirks user-keys client-keys)
+                multiuser universe chef-zero-quirks user-keys client-keys required-recipe)
       export_options(opts, tags)
     end
 

--- a/oc-chef-pedant/spec/api/required_recipe_spec.rb
+++ b/oc-chef-pedant/spec/api/required_recipe_spec.rb
@@ -1,0 +1,96 @@
+# Author:: Ryan Cragun <me@ryan.ec>
+# Copyright:: Copyright (c) 2017 Chef, Inc.
+
+require "pedant/rspec/common"
+
+describe "Required Recipe Endpoint", :required_recipe do
+  if Pedant::Config.required_recipe_enabled
+    describe "when required_recipe is enabled" do
+      describe "with a valid client" do
+        it "POST to /required_recipe returns 405" do
+          post(api_url("/required_recipe"), normal_client, payload: {}) do |response|
+            response.should look_like(status: 405)
+          end
+        end
+
+        it "GET to /required_recipe returns 200" do
+          get(api_url("/required_recipe"), normal_client) do |response|
+            response.should look_like(status: 200)
+          end
+        end
+      end
+
+      describe "with an invalid client" do
+        it "POST to /required_recipe returns 405" do
+          post(api_url("/required_recipe"), platform.bad_client, payload: {}) do |response|
+            response.should look_like(status: 405)
+          end
+        end
+
+        it "GET to /required_recipe returns 401" do
+          get(api_url("/required_recipe"), platform.bad_client, {}) do |response|
+            response.should look_like(status: 401)
+          end
+        end
+      end
+
+      describe "with a bad request" do
+        it "POST to /required_recipe returns 405" do
+          do_request(:POST, api_url("/required_recipe"), {}, payload: {}) do |response|
+            response.should look_like(status: 405)
+          end
+        end
+
+        it "GET to /required_recipe returns 400" do
+          do_request(:GET, api_url("/required_recipe"), {}, {}) do |response|
+            response.should look_like(status: 400)
+          end
+        end
+      end
+    end
+  else
+    describe "when required_recipe is disabled" do
+      describe "with a valid client" do
+        it "POST to /required_recipe returns 404" do
+          post(api_url("/required_recipe"), normal_client, payload: {}) do |response|
+            response.should look_like(status: 404)
+          end
+        end
+
+        it "GET to /required_recipe returns 404" do
+          get(api_url("/required_recipe"), normal_client, {}) do |response|
+            response.should look_like(status: 404)
+          end
+        end
+      end
+
+      describe "with an invalid client" do
+        it "POST to /required_recipe returns 404" do
+          post(api_url("/required_recipe"), platform.bad_client, payload: {}) do |response|
+            response.should look_like(status: 404)
+          end
+        end
+
+        it "GET to /required_recipe returns 404" do
+          get(api_url("/required_recipe"), platform.bad_client, {}) do |response|
+            response.should look_like(status: 404)
+          end
+        end
+      end
+
+      describe "with a bad request" do
+        it "POST to /required_recipe returns 404" do
+          do_request(:POST, api_url("/required_recipe"), {}, {}) do |response|
+            response.should look_like(status: 404)
+          end
+        end
+
+        it "GET to /required_recipe returns 404" do
+          do_request(:GET, api_url("/required_recipe"), {}, {}) do |response|
+            response.should look_like(status: 404)
+          end
+        end
+      end
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -41,6 +41,9 @@ default['private_chef']['default_orgname'] = nil
 
 default['private_chef']['fips_enabled'] = ChefConfig.fips?
 
+default['private_chef']['required_recipe']['enable'] = false
+default['private_chef']['required_recipe']['path'] = nil
+
 ###
 # Options for installing addons
 ###

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -146,6 +146,7 @@ class PreflightChecks
       SslPreflightValidator.new(node).run!
       BookshelfPreflightValidator.new(node).run!
       Ipv6PreflightValidator.new(node).run!
+      RequiredRecipePreflightValidator.new(node).run!
     rescue PreflightValidationFailed => e
       # use of exit! prevents exit handlers from running, ensuring the last thing
       # the customer sees is the descriptive error we've provided.

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_required_recipe_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_required_recipe_validator.rb
@@ -1,0 +1,84 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative './preflight_checks.rb'
+
+class RequiredRecipePreflightValidator < PreflightValidator
+  def initialize(node)
+    super
+    @required_recipe = PrivateChef['required_recipe']
+  end
+
+  def run!
+    return unless @required_recipe['enable']
+
+    verify_required_recipe_exists
+    verify_required_recipe_owner
+    verify_required_recipe_group
+    verify_required_recipe_mode
+  end
+
+  def stat
+    @stat ||= ::File.stat(@required_recipe['path'])
+  end
+
+  def verify_required_recipe_exists
+    unless ::File.exist?(@required_recipe['path'])
+      fail_with <<EOF
+Server enforced required recipe is enabled but the recipe file does not exist or
+is misconfigured. Please set the `required_recipe["path"] = /path/to/recipe` in
+`/etc/opscode/chef-server.rb` and run:
+
+    chef-server-ctl reconfigure
+EOF
+    end
+  end
+
+  def verify_required_recipe_owner
+    unless stat.uid == 0
+      fail_with <<EOF
+The required_recipe file must be owned by root. Please change the owner to root
+and reconfigure the Chef server:
+
+    chown root:root #{@required_recipe['path']}
+    chef-server-ctl reconfigure
+EOF
+    end
+  end
+
+  def verify_required_recipe_group
+    unless stat.gid == 0
+      fail_with <<EOF
+The required_recipe file must be in the root group. Please change the group to
+root and reconfigure the Chef server:
+
+    chown root:root #{@required_recipe['path']}
+    chef-server-ctl reconfigure
+EOF
+    end
+  end
+
+  def verify_required_recipe_mode
+    unless %w(600 644).include?(format('%o', stat.mode)[3..-1])
+      fail_with <<"EOF"
+The required_recipe must have a mode of 644 or 600. Please set a compatible mode
+and reconfigure the Chef server:
+
+    chmod 600 #{@required_recipe['path']}
+    chef-server-ctl reconfigure
+EOF
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -93,6 +93,7 @@ module PrivateChef
   backup["strategy"] = "tar"
 
   data_collector Mash.new
+  required_recipe Mash.new
 
   # - legacy config mashes -
   # these config values are here so that if any config has been previously
@@ -231,6 +232,7 @@ module PrivateChef
         "license",
         "backup",
         "data_collector",
+        "required_recipe",
 
         # keys for cleanup and back-compat
         "couchdb",
@@ -244,6 +246,7 @@ module PrivateChef
           use_chef_backend
           chef_backend_members
           data_collector
+          required_recipe
         }.include?(key)
           key
         else

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -49,8 +49,6 @@ end
   end
 end
 
-
-
 # Generate self-signed SSL certificate unless the user has provided one
 if (node['private_chef']['nginx']['ssl_certificate'].nil? &&
     node['private_chef']['nginx']['ssl_certificate_key'].nil?)
@@ -72,6 +70,17 @@ if (node['private_chef']['nginx']['ssl_certificate'].nil? &&
 
   node.default['private_chef']['nginx']['ssl_certificate'] = ssl_crtfile
   node.default['private_chef']['nginx']['ssl_certificate_key'] = ssl_keyfile
+end
+
+# Copy the required_recipe source into the nginx static root directory and
+# ensure that it's only modifiable by root.
+if node['private_chef']['required_recipe']['enable']
+  remote_file ::File.join(nginx_html_dir, 'required_recipe') do
+    source "file://#{node['private_chef']['required_recipe']['path']}"
+    owner 'root'
+    group 'root'
+    mode '0644'
+  end
 end
 
 # Generate dhparam.pem unless the user has provided a dhparam file

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
@@ -54,6 +54,7 @@ template pedant_config do
     :default_orgname => node['private_chef']['default_orgname'],
     :hostname => node['hostname'],
     :ssl_version =>  ssl_version,
-    :reindex_endpoint => reindex_endpoint
+    :reindex_endpoint => reindex_endpoint,
+    :required_recipe_enabled => node['private_chef']['required_recipe']['enable']
   }.merge(node['private_chef']['oc-chef-pedant'].to_hash))
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -76,6 +76,26 @@
     }
     <% end -%>
 
+    location ~ "^/organizations/([^/]+)/required_recipe$" {
+    <% if node['private_chef']['required_recipe']['enable'] -%>
+      set $request_org $1;
+      access_by_lua_block { validator.validate("GET") }
+      types { }
+      default_type text/plain;
+      add_header Content-MD5 <%= Digest::MD5.base64digest(::File.read(node['private_chef']['required_recipe']['path'])) %>;
+      alias <%= ::File.join(@dir, "html", "required_recipe") %>;
+    <% else -%>
+      # This endpoint is unique because it is defined via nginx and is not
+      # handled by an upstream like oc_erchef. In order to make responses
+      # consistent between Chef server and chef-zero we'll always enable
+      # the location but explicitly return a 404 when the feature is disabled,
+      # rather than leave it undefined. If we were to leave it undefined any
+      # non-signed requests would be routed to the main index page and return
+      # a 200 instead of 404.
+      return 404;
+    <% end -%>
+    }
+
     <% if node['private_chef']['profiles']['root_url'] && node['private_chef']['data_collector']['token'] -%>
     # Compliance endpoint to forward profiles calls to the Automate API:
     #   /organizations/ORG/owners/OWNER/compliance[/PROFILE]

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -175,6 +175,9 @@ server_api_version         <%= node['private_chef']['server-api-version'] %>
 # actions aren't available.
 actions_enabled <%= @actions_enabled %>
 
+# Enable/Disable tests if the required_recipe endpoint is turned on
+required_recipe_enabled <%= @required_recipe_enabled %>
+
 # Log HTTP Requests
 log_file "<%= File.join(@log_directory, "http-traffic.log") %>"
 <%- end %>


### PR DESCRIPTION
See [Chef RFC 89](https://github.com/chef/chef-rfc/blob/master/rfc089-server-enforced-recipe.md) for context.

Add the ability to serve a required recipe file to chef-clients.

* `/organizations/<orgname>/required_recipe` returns `404` for all organizations
  by default.
* `/organizations/<orgname>/required_recipe` returns `401` when the request is
  not made by a client from the requested org and the feature is enabled.
* `/organizations/<orgname>/required_recipe` returns the required recipe and
  `200` when the endpoint is enabled and requested by an authorized client.
* `required_recipe["enable"]` in `chef-server.rb` enables the required recipe
  feature.
* `required_recipe["path"]` in `chef-server.rb` specifies the recipe file to
  serve.