### PR TITLE
support HEAD http request on named node endpoint

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -173,6 +173,10 @@ module Pedant
       authenticated_request :GET, url, requestor, opts, &validator
     end
 
+    def head(url, requestor, opts={}, &validator)
+      authenticated_request :HEAD, url, requestor, opts, &validator
+    end
+
     def put(url, requestor, opts={}, &validator)
       authenticated_request :PUT, url, requestor, opts, &validator
     end

--- a/oc-chef-pedant/lib/pedant/rspec/node_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/node_util.rb
@@ -202,6 +202,12 @@ module Pedant
         }
       end
 
+      let(:head_success_response) do
+        {
+          :status => 200
+        }
+      end
+
       let(:fetch_node_list_empty_response) do
         {
           :status => 200,

--- a/oc-chef-pedant/spec/api/nodes/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/nodes/complete_endpoint_spec.rb
@@ -85,6 +85,25 @@ describe "Testing the Nodes API endpoint", :nodes do
     end
   end # GET /nodes/<name>
 
+  context 'HEAD /nodes/<name>' do
+    let(:request_method) { :HEAD }
+    let(:request_url)    { api_url("/nodes/#{node_name}") }
+
+    context 'for a nonexistent node' do
+      let(:node_name){nonexistent_node_name}
+      it 'returns a 404', :smoke do
+        should look_like http_404_response
+      end
+    end
+
+    context 'for an existing node' do
+      include_context 'with temporary testing node'
+      it 'returns a 200', :smoke do
+        should look_like head_success_response
+      end
+    end
+  end # HEAD /nodes/<name>
+
   context 'GET /environments/<environment_name>/nodes' do
     let(:request_method) { :GET }
     let(:request_url)    { api_url("/environments/#{environment_name}/nodes") }

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
@@ -73,6 +73,8 @@ log_action(Req, #base_state{resource_state = ResourceState,
     case wrq:method(Req) of
         'GET' ->
             ok;
+        'HEAD' ->
+            ok;
         _ElseMethod -> %% POST, PUT, DELETE
             case ResourceMod of
                 oc_chef_wm_authenticate_user ->  %% POST to authenticate_user should not be an action.

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -539,6 +539,8 @@ http_method_to_authz_perm(#wm_reqdata{}=Req) ->
     http_method_to_authz_perm(wrq:method(Req));
 http_method_to_authz_perm('DELETE') ->
     delete;
+http_method_to_authz_perm('HEAD') ->
+    read;
 http_method_to_authz_perm('GET') ->
     read;
 http_method_to_authz_perm('POST') ->


### PR DESCRIPTION
This PR adds support for the HEAD HTTP verb on the named node endpoint.
Since node objects can be quite large, querying for their existence via GET can be expensive.

The benefits:
 * less expensive checks for node existence
 * potential optimization to incorporate into Chef::ChefFS

Existing node:
```
/Devel/ChefProject/chef-server/dev (jeremymv2/node_http_head $%)$ knife raw -m HEAD "/nodes/foo" -VV
INFO: Using configuration from /Users/jmiller/Devel/ChefProject/chef-server/dev/.chef/knife.rb
DEBUG: Chef::HTTP calling Chef::HTTP::JSONOutput#handle_request
DEBUG: Chef::HTTP calling Chef::HTTP::CookieManager#handle_request
DEBUG: Chef::HTTP calling Chef::HTTP::Decompressor#handle_request
DEBUG: Chef::HTTP calling Chef::HTTP::Authenticator#handle_request
DEBUG: Signing the request as admin
DEBUG: Chef::HTTP calling Chef::HTTP::RemoteRequestID#handle_request
DEBUG: Initiating HEAD to https://api.chef-server.dev/organizations/test/nodes/foo
DEBUG: ---- HTTP Request Header Data: ----
DEBUG: Content-Type: application/json
DEBUG: Accept: application/json
DEBUG: Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
DEBUG: X-Ops-Server-API-Version: 1
DEBUG: X-OPS-SIGN: algorithm=sha1;version=1.1;
DEBUG: X-OPS-USERID: admin
DEBUG: X-OPS-TIMESTAMP: 2017-04-05T18:32:26Z
DEBUG: X-OPS-CONTENT-HASH: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
DEBUG: X-OPS-AUTHORIZATION-1: wyHnZ29GHvHD6Q0ACgnSqroxw9PjQJFCEsA1+s4S/6EHFTnijkTjqDQDg38h
DEBUG: X-OPS-AUTHORIZATION-2: xTWWrLtS8/Ax07kZAUleGna83/WXdDeoaBRmug0XmN9Uucn180b0AN25imGG
DEBUG: X-OPS-AUTHORIZATION-3: 5JGWETXe5ZtSR5+IaBPyIRezJu8CGwjXTrowBRgxqS0p9oZ3vyK/odDgxTzV
DEBUG: X-OPS-AUTHORIZATION-4: pYrTpWgt0ZvzzJrEoG2VdBgpOtCgSMPfeRpRWNem0wyI/VyFZ1pvlsCPNOAj
DEBUG: X-OPS-AUTHORIZATION-5: WxPiiOjhpCEep3OyQoynn1iu6egd35pOpCIvXNab6X7PBJlTD8NDi/CuApwN
DEBUG: X-OPS-AUTHORIZATION-6: nvhnQSaypa0Ilu7gaasTE1UDpc6qhSt6E8RS75ZlXg==
DEBUG: HOST: api.chef-server.dev:443
DEBUG: X-REMOTE-REQUEST-ID: 740ffd42-4ac4-495d-b1aa-02af91fb83d0
DEBUG: ---- End HTTP Request Header Data ----
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 200 OK
DEBUG: server: openresty/1.11.2.1
DEBUG: date: Wed, 05 Apr 2017 18:32:26 GMT
DEBUG: content-type: application/json
DEBUG: content-length: 0
DEBUG: connection: close
DEBUG: x-ops-server-api-version: {"min_version":"0","max_version":"1","request_version":"1","response_version":"1"}
DEBUG: x-ops-api-info: flavor=cs;version=12.0.0;oc_erchef=12.14.0-7467208
DEBUG: ---- End HTTP Status/Header Data ----
DEBUG: Chef::HTTP calling Chef::HTTP::RemoteRequestID#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::Authenticator#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::Decompressor#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::CookieManager#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::JSONOutput#handle_response
null
~/Devel/ChefProject/chef-server/dev (jeremymv2/node_http_head $%)$
```

Non-existent node:
```
~/Devel/ChefProject/chef-server/dev (jeremymv2/node_http_head $%)$ knife raw -m HEAD "/nodes/bar" -VV
INFO: Using configuration from /Users/jmiller/Devel/ChefProject/chef-server/dev/.chef/knife.rb
DEBUG: Chef::HTTP calling Chef::HTTP::JSONOutput#handle_request
DEBUG: Chef::HTTP calling Chef::HTTP::CookieManager#handle_request
DEBUG: Chef::HTTP calling Chef::HTTP::Decompressor#handle_request
DEBUG: Chef::HTTP calling Chef::HTTP::Authenticator#handle_request
DEBUG: Signing the request as admin
DEBUG: Chef::HTTP calling Chef::HTTP::RemoteRequestID#handle_request
DEBUG: Initiating HEAD to https://api.chef-server.dev/organizations/test/nodes/bar
DEBUG: ---- HTTP Request Header Data: ----
DEBUG: Content-Type: application/json
DEBUG: Accept: application/json
DEBUG: Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
DEBUG: X-Ops-Server-API-Version: 1
DEBUG: X-OPS-SIGN: algorithm=sha1;version=1.1;
DEBUG: X-OPS-USERID: admin
DEBUG: X-OPS-TIMESTAMP: 2017-04-05T18:33:14Z
DEBUG: X-OPS-CONTENT-HASH: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
DEBUG: X-OPS-AUTHORIZATION-1: UKXK4zIpcQ4zpIRSV5ne9pxOKY2+9llxya9LcWAI1Dp6yxaZmoYYIi8GS+KF
DEBUG: X-OPS-AUTHORIZATION-2: ReWxpMG7TK4DnnhTR+dx6mbu5Hoe4fcGg71Gbzwwr4sZZFn7ArDzjenMBHjg
DEBUG: X-OPS-AUTHORIZATION-3: BHZqRDGTsBDYxyGU2+kXDpmWvWbtJwXO7ZAWLpy4v8zjUkL4tyteQcFjbKVU
DEBUG: X-OPS-AUTHORIZATION-4: lE33vukZkcRT+MQ9WTNpcSx/xGWucYrwBAZZeWSdMFp/RAgWZSbEUS6kEPRL
DEBUG: X-OPS-AUTHORIZATION-5: 9ipwcUv9pWeV+2PgdZ05zblzPEWv6ipkMNIfwD0i9Kqw3KiW/jsn2m5w/sd3
DEBUG: X-OPS-AUTHORIZATION-6: 96C+zVJnRWUxSU2VvZgO1ETekR34HcN6zsHim4raAw==
DEBUG: HOST: api.chef-server.dev:443
DEBUG: X-REMOTE-REQUEST-ID: ceeb40b5-f01f-48db-815f-9dea1764da34
DEBUG: ---- End HTTP Request Header Data ----
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 404 Object Not Found
DEBUG: server: openresty/1.11.2.1
DEBUG: date: Wed, 05 Apr 2017 18:33:14 GMT
DEBUG: content-length: 34
DEBUG: connection: close
DEBUG: x-ops-server-api-version: {"min_version":"0","max_version":"1","request_version":"1","response_version":"1"}
DEBUG: x-ops-api-info: flavor=cs;version=12.0.0;oc_erchef=12.14.0-7467208
DEBUG: ---- End HTTP Status/Header Data ----
DEBUG: Chef::HTTP calling Chef::HTTP::RemoteRequestID#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::Authenticator#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::Decompressor#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::CookieManager#handle_response
DEBUG: Chef::HTTP calling Chef::HTTP::JSONOutput#handle_response
DEBUG: Expected JSON response, but got content-type ''
INFO: HTTP Request Returned 404 Object Not Found:
ERROR: Server responded with error 404 "Object Not Found"
~/Devel/ChefProject/chef-server/dev (jeremymv2/node_http_head $%)$
```

Logs for a successful query:
```
==> /var/log/opscode/nginx/access.log <==
192.168.33.1 - - [05/Apr/2017:14:35:12 -0400]  "HEAD /organizations/test/nodes/foo HTTP/1.1" 200 "0.013" 0 "-" "Chef Knife/12.18.31 (ruby-2.3.1-p112; ohai-8.23.0; x86_64-darwin14; +https://chef.io)" "127.0.0.1:8000" "200" "0.012" "12.18.31" "algorithm=sha1;version=1.1;" "admin" "2017-04-05T18:35:12Z" "2jmj7l5rSw0yVb/vlWAYkK/YBwk=" 1071

==> /var/log/opscode/opscode-erchef/requests.log.1 <==
2017-04-05T18:35:12Z oc_erchef@api method=HEAD; path=/organizations/test/nodes/foo; status=200; req_id=g3IAA2QADW9jX2VyY2hlZkBhcGkCAANAJwEAAAEAAAAA; org_name=test; couchdb_groups=false; couchdb_organizations=false; couchdb_containers=false; couchdb_acls=false; 503_mode=false; couchdb_associations=false; couchdb_association_requests=false; req_time=10; rdbms_time=2; rdbms_count=4; authz_time=4; authz_count=1; user=admin; req_api_version=1;

==> /var/log/opscode/oc_bifrost/requests.log.1 <==
2017-04-05T18:35:12Z oc_bifrost@127.0.0.1 method=GET; path=/objects/cbcfda915a4f56e22b9141099391cd2c/acl/read/actors/faeeb8cdf9da7fa8dee11a80f32fcf61; status=200; requestor_id=faeeb8cdf9da7fa8dee11a80f32fcf61; req_time=1; rdbms.bifrost_db.has_permission_time=0; rdbms.bifrost_db.has_permission_count=1; rdbms.bifrost_db.exists_time=0; rdbms.bifrost_db.exists_count=1;
```