### PR TITLE
Fix Pedant to run in 12.14 world

### DIFF
--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -232,6 +232,12 @@ projects:
     path: oc-chef-pedant
     database: opscode_chef
     run: bin/oc-chef-pedant -c /var/opt/opscode/oc-chef-pedant/etc/pedant_config.rb
+    service:
+      secrets:
+        args:
+        list:
+          - chef-server.webui_key
+          - chef-server.superuser_key
 
   #
   # External Components

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -76,8 +76,8 @@ module Pedant
   end
 
   def self.create_platform
-    superuser_key = ENV['SUPERUSER_KEY']
-    webui_key = ENV['WEBUI_KEY']
+    superuser_key = ENV['CHEF_SECRET_CHEF-SERVER.SUPERUSER_KEY'] || ENV['SUPERUSER_KEY']
+    webui_key = ENV['CHEF_SECRET_CHEF-SERVER.WEBUI_KEY'] || ENV['WEBUI_KEY']
     config.pedant_platform = Pedant::Platform.new(config.chef_server,
                                                   superuser_key,
                                                   webui_key,


### PR DESCRIPTION
Minor missing config to work with secrets (thanks to Marc Paradise for
helping me fix these).

Signed-off-by: Mark Anderson <mark@chef.io>