### PR TITLE
Don't log rabbitmq password during migration 1.31

### DIFF
--- a/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
+++ b/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
@@ -11,7 +11,8 @@ define_upgrade do
       [rmq["management_user"], "management_password"]
     ].each do |name, passname|
       pass = Partybus.config.secrets.get('rabbitmq', passname)
-      run_command("/opt/opscode/embedded/bin/rabbitmqctl change_password #{name} #{pass}")
+      run_command("/opt/opscode/embedded/bin/rabbitmqctl change_password #{name} #{pass}",
+                  log_msg: "rabbitmq password upgrade for user #{name}")
     end
 
     stop_services(["rabbitmq"])

--- a/omnibus/partybus/lib/partybus/migration_api/v1.rb
+++ b/omnibus/partybus/lib/partybus/migration_api/v1.rb
@@ -92,7 +92,8 @@ EOF
       end
 
       def run_command(command, options={})
-        log("\tRunning Command: #{command} with options #{options.inspect}")
+        log_msg = options[:log_msg] || "Running Command: #{command} with options #{options.inspect}"
+        log("\t#{log_msg}")
         runner = Partybus::CommandRunner.new
         runner.run_command(command, options)
       end


### PR DESCRIPTION
Signed-off-by: Steven Danna <steve@chef.io>