### PR TITLE
Pin the oc-chef-pedant chef-zero based tests to chef 12.x

### DIFF
--- a/oc-chef-pedant/Rakefile
+++ b/oc-chef-pedant/Rakefile
@@ -22,6 +22,8 @@ def bundle_exec_with_chef(test_gem, commands)
         next
       elsif line =~ /^\s*gem '#{CURRENT_GEM_NAME}'|\s*gem "#{CURRENT_GEM_NAME}"/
         next
+      elsif line =~ /^\s*gem 'chef'|\s*gem "chef"/
+        line = "gem 'chef', '~>12'"
       elsif line =~ /^\s*dev_gem\s*['"](.+)['"]\s*$/
         line = "gem '#{$1}', github: 'poise/#{$1}'"
       elsif line =~ /\s*gem\s*['"]#{test_gem}['"]/ # foodcritic      end


### PR DESCRIPTION
Pedant is _not_ compatible chef 13.x. There are 70 failures that will
need to be resolved before the chef-zero based tests will complete
successfully. When the oc-chef-pedant chef-zero test bundles the
`chef-zero v5.3.2` dependencies it'll pull in chef 13.x. This change
modifies `chef-zero`'s embedded chef dependency to 12.x.

Signed-off-by: Ryan Cragun <me@ryan.ec>