### PR TITLE
Tests run in proxied systems

### DIFF
--- a/oc-chef-pedant/pedant_config.rb
+++ b/oc-chef-pedant/pedant_config.rb
@@ -8,6 +8,7 @@
 # contexts as long as the Chef Server is running on localhost.
 #
 ################################################################################
+base_resource_url "https://localhost"
 
 # A unique identification string used to create orgs and users specific
 # to a each single chef server's nodes' OS. Simply using "Process.pid"

--- a/oc-chef-pedant/spec/api/account/account_association_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_association_spec.rb
@@ -125,10 +125,11 @@ describe "opscode-account user association", :association do
 
   def invite_user(orgname, username, inviter)
     url = "#{platform.server}/organizations/#{orgname}/association_requests"
+    resource_url = platform.resource_url("association_requests", orgname)
     post(url, inviter, :payload=>make_invite_payload(username)) do |response|
       response.should look_like({ :status => 201 })
       uri = parse(response)['uri']
-      uri.split('/')[0..-2].should == url.split('/')
+      uri.split('/')[0..-2].should == resource_url.split('/')
       return uri.split('/')[-1]
     end
     return nil

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
@@ -108,7 +108,7 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
       it 'should respond with a cookbook collection containing all versions of each cookbook' do
         list_response = get(request_url, requestor)
         expect(list_response.code).to eq(200)
-        expect(parse(list_response)).to eq(expected_cookbook_artifact_collection)
+        expect(parse(list_response)).to strictly_match(expected_cookbook_artifact_collection)
       end
 
     end

--- a/oc-chef-pedant/spec/api/policies/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/policies/complete_endpoint_spec.rb
@@ -189,14 +189,14 @@ describe "Policies API endpoint", :policies do
         expect(list_policies.code).to eq(200)
         response_obj = parse(list_policies.body)
         expect(response_obj).to be_a_kind_of(Hash)
-        expect(response_obj).to eq(expected_policies_list)
+        expect(response_obj).to strictly_match(expected_policies_list)
       end
 
       it "GET /policy_groups returns a data structure with the groups assigned policy revision", :policy_groups do
         expect(list_policy_groups.code).to eq(200)
         response_obj = parse(list_policy_groups.body)
         expect(response_obj).to be_a_kind_of(Hash)
-        expect(response_obj).to eq(expected_policy_group_list)
+        expect(response_obj).to strictly_match(expected_policy_group_list)
       end
     end
 
@@ -230,14 +230,14 @@ describe "Policies API endpoint", :policies do
         expect(list_policies.code).to eq(200)
         response_obj = parse(list_policies.body)
         expect(response_obj).to be_a_kind_of(Hash)
-        expect(response_obj).to eq(expected_policy_list)
+        expect(response_obj).to strictly_match(expected_policy_list)
       end
 
       it "GET /policy_groups returns a data structure with the groups assigned policy revision", :policy_groups do
         expect(list_policy_groups.code).to eq(200)
         response_obj = parse(list_policy_groups.body)
         expect(response_obj).to be_a_kind_of(Hash)
-        expect(response_obj).to eq(expected_policy_group_list)
+        expect(response_obj).to strictly_match(expected_policy_group_list)
       end
     end
 
@@ -383,16 +383,16 @@ describe "Policies API endpoint", :policies do
         expect(list_policies.code).to eq(200)
         response_obj = parse(list_policies.body)
         expect(response_obj).to be_a_kind_of(Hash)
-        expect(response_obj).to eq(expected_policies_list)
+        expect(response_obj).to strictly_match(expected_policies_list)
       end
 
       it "GET /policy_groups returns a data structure with all policy group->policy rev associations", :policy_groups do
         expect(list_policy_groups.code).to eq(200)
         response_obj = parse(list_policy_groups.body)
         expect(response_obj).to be_a_kind_of(Hash)
-        expect(response_obj["dev"]).to eq(expected_dev_group_data)
-        expect(response_obj["test"]).to eq(expected_test_group_data)
-        expect(response_obj["prod"]).to eq(expected_prod_group_data)
+        expect(response_obj["dev"]).to strictly_match(expected_dev_group_data)
+        expect(response_obj["test"]).to strictly_match(expected_test_group_data)
+        expect(response_obj["prod"]).to strictly_match(expected_prod_group_data)
       end
 
     end
@@ -443,13 +443,13 @@ describe "Policies API endpoint", :policies do
         it "GET /policy_groups/:policy_group_name returns 200 with an empty JSON Object" do
           response = get(named_policy_group_url, requestor)
           expect(response.code).to eq(200)
-          expect(parse(response.body)).to eq(expected_body)
+          expect(parse(response.body)).to strictly_match(expected_body)
         end
 
         it "DELETE /policy_groups/:policy_group_name returns 200 with an empty JSON Object" do
           response = delete(named_policy_group_url, requestor)
           expect(response.code).to eq(200)
-          expect(parse(response.body)).to eq(expected_body)
+          expect(parse(response.body)).to strictly_match(expected_body)
         end
 
       end
@@ -468,13 +468,13 @@ describe "Policies API endpoint", :policies do
         it "GET /policy_groups/:policy_group_name returns 200 with a JSON Object showing associated policies" do
           response = get(named_policy_group_url, requestor)
           expect(response.code).to eq(200)
-          expect(parse(response.body)).to eq(expected_body)
+          expect(parse(response.body)).to strictly_match(expected_body)
         end
 
         it "DELETE /policy_groups/:policy_group_name returns 200 with a JSON Object showing associated policies" do
           response = delete(named_policy_group_url, requestor)
           expect(response.code).to eq(200)
-          expect(parse(response.body)).to eq(expected_body)
+          expect(parse(response.body)).to strictly_match(expected_body)
         end
 
         it "DELETE /policy_groups/:policy_group_name deletes policy associations" do

--- a/oc-chef-pedant/spec/api/universe_spec.rb
+++ b/oc-chef-pedant/spec/api/universe_spec.rb
@@ -78,7 +78,7 @@ describe 'Universe API Endpoint', :universe do
     it "returns the expected results" do
       response_obj = parse(universe.body)
       expect(response_obj).to be_a_kind_of(Hash)
-      expect(response_obj).to eq(expected_response)
+      expect(response_obj).to strictly_match(expected_response)
     end
   end
 end

--- a/oc-chef-pedant/spec/org_creation/validate_containers_spec.rb
+++ b/oc-chef-pedant/spec/org_creation/validate_containers_spec.rb
@@ -19,7 +19,7 @@ describe "Org Creation", :org_creation do
 
     it 'should have default containers' do
       # This also tests to make sure there are no extraneous containers in the response
-      expect(parsed_response).to eql(default_container_hash)
+      expect(parsed_response).to strictly_match(default_container_hash)
     end
 
     def self.should_have_container_for(resource)

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
@@ -46,6 +46,7 @@ template pedant_config do
   variables({
     :actions_enabled => node['private_chef']['dark_launch']['actions'],
     :api_url  => OmnibusHelper.new(node).nginx_ssl_url,
+    :base_resource_url => node['private_chef']['opscode-erchef']['base_resource_url'],
     :solr_url => OmnibusHelper.new(node).solr_url,
     :opscode_account_internal_url => node['private_chef']['lb_internal']['vip'],
     :opscode_account_internal_port => node['private_chef']['lb_internal']['account_port'],

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -4,6 +4,16 @@
 # defaults, and not all settings are appropriate in all settings.
 
 ################################################################################
+#
+
+# The base_resource_url gets set whenever we are operating behind a proxy,
+# notably in the automate-chef-server all in one installation
+#
+<%- if @base_resource_url && @base_resource_url.to_s != "host_header" %>
+base_resource_url "<%= @base_resource_url %>"
+<%- else %>
+# base_resource_url "<%= @base_resource_url %>"
+<%- end %>
 
 # A unique identification string used to create orgs and users specific
 # to a each single chef server's nodes' OS. Simply using "Process.pid"


### PR DESCRIPTION
NOTE: Rebase and merge after CLOUD-294/fix_solr_for_pedant (#1233) lands, as it contains and depends on it.

Passes pedant in the CI environment. (But we have some intermittent test failures on ppc64le Ubuntu 12 testers)

This PR encompasses a series of changes to allow chef-server-ctl test to operate when the main chef-server endpoint is proxied behind another name, such as the automate/chef server all in one install. 

When opscode-erchef base_resource_url is set differently from the server address that nginx is listening at (as is often the case when proxying) we construct the expected values in pedant incorrectly, using the server address when we should be using base_resource_url

In some cases :host_headers isn't sufficient, and we need to be flexible on what we accept for input.

I've broken it up into a series of commits for readability. I'd especially like feedback on the approach of modifying PedantHashComparator; the alternate seems to be modifying a large number of tests to disambiguate the URI we use to access the system and the resource we expect to return. See the CLOUD-294/fix_tests_mechanical branch for a sense of what that might look like. 