### PR TITLE
Fix chef-server-ctl test for opsworks

### DIFF
--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -118,8 +118,8 @@ module Pedant
     maximum_search_time 65
 
     # Default URL for to commit/refresh before a search
-    search_commit_url "/solr/update?commit=true"
-    search_url_fmt "/solr/select?fq=+X_CHEF_type_CHEF_X:%{type}&q=%{query}&wt=json"
+    search_commit_url "/update?commit=true"
+    search_url_fmt "/select?fq=+X_CHEF_type_CHEF_X:%{type}&q=%{query}&wt=json"
 
     # Amout of time to sleep (in seconds) after performing a direct
     # Solr query (rather than via the Chef API).  This is used, e.g.,

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
@@ -46,7 +46,7 @@ template pedant_config do
   variables({
     :actions_enabled => node['private_chef']['dark_launch']['actions'],
     :api_url  => OmnibusHelper.new(node).nginx_ssl_url,
-    :solr_url => OmnibusHelper.new(node).solr_root,
+    :solr_url => OmnibusHelper.new(node).solr_url,
     :opscode_account_internal_url => node['private_chef']['lb_internal']['vip'],
     :opscode_account_internal_port => node['private_chef']['lb_internal']['account_port'],
     :erchef_internal_vip => node['private_chef']['opscode-erchef']['vip'],


### PR DESCRIPTION
Passes pedant in the CI environment. Should be good to merge.

The AWS Opsworks Automate offering has Chef Server using Automate's
elasticsearch instead of the built in Solr. This is done via the
external database feature of Chef Server.

This is implemented by setting the following in chef_server.rb:
opscode_solr4['external_url'] = http://localhost:8080/elasticsearch'

And then having nginx proxy that to the elasticsearch backend.

However that breaks pedant because  it uses the solr_root helper, which
would take the above external_url and render http://localhost:8080.

If we use the solr_url helper instead, the full URI is rendered, and
the tests work.

Signed-off-by: Mark Anderson <mark@chef.io>