### PR TITLE
Fix "chef-server-ctl reconfigure" for ldap configuration changes

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -190,8 +190,7 @@ class OmnibusHelper
   end
 
   def ldap_authentication_enabled?
-    node['private_chef'].attribute?('ldap') &&
-      !(node['private_chef']['ldap'].nil? || node['private_chef']['ldap'].empty?)
+    node['private_chef']["ldap"] && node['private_chef']['ldap']['enabled']
   end
 
   def platform_package_suffix

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -780,9 +780,13 @@ EOF
       credentials.save if did_something
     end
 
+    def set_ldap_enabled
+      PrivateChef["ldap"]["enabled"] = !( PrivateChef["ldap"].nil? || PrivateChef["ldap"].empty? )
+    end
 
     def generate_config(node_name)
       assert_server_config(node_name) if server_config_required?
+      set_ldap_enabled
       gen_secrets(node_name)
       migrate_keys
 
@@ -810,9 +814,7 @@ EOF
 
       generate_config_for_topology(PrivateChef["topology"], node_name)
 
-      unless PrivateChef["ldap"].nil? || PrivateChef["ldap"].empty?
-        gen_ldap
-      end
+      gen_ldap if PrivateChef["ldap"]["enabled"]
 
       generate_hash
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -780,6 +780,12 @@ EOF
       credentials.save if did_something
     end
 
+    # When insecure_addon_compat is true, PrivateChef["ldap"] may be
+    # non-empty after the secrets from veil are merged into the
+    # configuration. The user may have inadvertantly left the password
+    # in the secrets file, even when all other LDAP configuration has
+    # been removed. This function is called before the secrets merge
+    # allowing us to detect whether the user wants ldap or not.
     def set_ldap_enabled
       PrivateChef["ldap"]["enabled"] = !PrivateChef["ldap"].empty?
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -781,7 +781,7 @@ EOF
     end
 
     def set_ldap_enabled
-      PrivateChef["ldap"]["enabled"] = !( PrivateChef["ldap"].nil? || PrivateChef["ldap"].empty? )
+      PrivateChef["ldap"]["enabled"] = !PrivateChef["ldap"].empty?
     end
 
     def generate_config(node_name)

--- a/omnibus/files/private-chef-ctl-commands/password.rb
+++ b/omnibus/files/private-chef-ctl-commands/password.rb
@@ -70,5 +70,5 @@ def run_knife_opc_cmd(cmd, message)
 end
 
 def ldap_authentication_enabled?
-  running_config['private_chef']['ldap'] && !running_config['private_chef']['ldap'].empty?
+  running_config['private_chef']['ldap'] && running_config['private_chef']['ldap']['enabled']
 end


### PR DESCRIPTION
Worked with @stevendanna on this to create the set_ldap_enabled
validation check before generating the config.

Tested this successfully in a local dev environment

Signed-off-by: Jaymala Sinha <jsinha@chef.io>
@stevendanna 