### PR TITLE
Do not return 400 for valid /users/USERNAME/_acl/PERM calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
       script: bundle exec rake chef_zero_spec
       env:
         - "PEDANT_OPTS=\"--skip-oc_id\""
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v5.3.2' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: '5-stable' \""
       # Remove things only used by erlang
       install:
       after_failure:
@@ -96,7 +96,7 @@ matrix:
       script: bundle exec rake chef_zero_spec
       env:
         - "PEDANT_OPTS=\"--skip-oc_id\""
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v5.3.2' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: '5-stable' \""
         - CHEF_FS=1
       # Remove things only used by erlang
       install:

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -9,12 +9,8 @@ describe "ACL API", :acl do
     "#{Process.pid}_#{rand(10**7...10**8).to_s}"
   end
 
-  let(:server_admins) {
-    "::server-admins"
-  }
-  let(:other_admins) {
-    "#{@test_orgname2}::admins"
-  }
+  let(:server_admins) { "::server-admins" }
+  let(:other_admins) { "#{@test_orgname2}::admins" }
   let(:nonlocal_groups) { [server_admins, other_admins ] }
 
   before(:all) do
@@ -26,25 +22,25 @@ describe "ACL API", :acl do
     platform.delete_org(@test_orgname2) if Pedant.config[:org][:create_me]
   end
 
-  # (temporarily?) deprecating /users/*/_acl endpoint due to its broken state and lack of usefulness
-  skip "/users/<name>/_acl endpoint" do
+  context "/users/<name>/_acl endpoint" do
     let(:username) { platform.admin_user.name }
     let(:request_url) { "#{platform.server}/users/#{username}/_acl" }
 
-    let(:read_access_group) { platform.test_org.name + "_read_access_group"}
-    let(:read_groups) { [read_access_group] }
+    let(:read_access_group) { "::" + platform.test_org.name + "_read_access_group"}
+    let(:read_groups) { [read_access_group, server_admins] }
+    let(:grant_groups) { [] }
 
     context "GET /users/<user>/_acl"  do
 
       let(:actors) { ["pivotal", username].uniq }
-      let(:groups) { [] }
+      let(:groups) { [ server_admins ] }
 
       let(:acl_body) {{
           "create" => {"actors" => actors, "groups" => groups},
           "read" => {"actors" => actors, "groups" => read_groups},
           "update" => {"actors" => actors, "groups" => groups},
           "delete" => {"actors" => actors, "groups" => groups},
-          "grant" => {"actors" => actors, "groups" => groups}
+          "grant" => {"actors" => actors, "groups" => grant_groups}
         }}
 
       context "superuser" do
@@ -178,17 +174,18 @@ describe "ACL API", :acl do
           # Nonexistent users are just dropped (perhaps this should be a 400, to match
           # organizations/<object>/_acl
           context "malformed requests" do
-            context "invalid actor" do
+            context "invalid actor", :validation do
               let(:request_body) {{
                   permission => {
                     "actors" => ["pivotal", "bogus", platform.admin_user.name],
                     "groups" => permission == "read" ? read_groups : groups
                   }
                 }}
-              it "returns 200" do
+
+              it "returns 400" do
                 put(request_url, platform.admin_user,
                     :payload => request_body).should look_like({
-                                                                 :status => 200
+                                                                 :status => 400
                                                                })
                 get(acl_url, platform.admin_user).should look_like({
                                                                      :status => 200,

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -30,7 +30,7 @@ describe "ACL API", :acl do
     let(:read_groups) { [read_access_group, server_admins] }
     let(:grant_groups) { [] }
 
-    context "GET /users/<user>/_acl"  do
+    context "GET /users/<user>/_acl",  :chef_zero_quirks do
 
       let(:actors) { ["pivotal", username].uniq }
       let(:groups) { [ server_admins ] }
@@ -62,7 +62,7 @@ describe "ACL API", :acl do
     end
 
     %w(create read update delete grant).each do |permission|
-      context "/users/<user>/_acl/#{permission} endpoint" do
+      context "/users/<user>/_acl/#{permission} endpoint",  :chef_zero_quirks do
         if (permission == "read")
           smoketest = :smoke
         else

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
@@ -285,10 +285,11 @@ fetch_actors(Context, ActorNames) ->
             AuthzIds;
         {_, [{Error, Names} | _]}
           when Error =:= ill_formed_name orelse
-               Error =:= inappropriate_scoped_name orelse
                Error =:= orgname_not_found orelse
                Error =:= not_found ->
             throw({bad_actor, Names});
+        {_, [{inappropriate_scoped_name, Names} | _]} ->
+            throw({inappropriate_scoped_name, Names});
         {_, [{ambiguous, Names} | _]} ->
             throw({ambiguous_actor, Names})
     end.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -103,11 +103,9 @@ initialize_context(OrgId, DbContext, CallBackFun) ->
 %%   (if the later is present, otherwise inserting the current in-context org)
 %% * Mapping the org name to id
 %% * Looking up the org id, name pair in the appropriate table(s)
-
 %%
 %% Output:
 %% { [{Name, AuthzId}, [{Name, ErrorType}] }
-%%
 %%
 -spec names_to_authz_id(lookup_type() ,[binary()], #context{}) -> { [binary()],[{atom(),binary()}] }.
 names_to_authz_id(Type, Names, MapperContext) ->
@@ -238,6 +236,14 @@ extract_full_names(ScopedNames, UnscopedNameSet) ->
 %% Abstract away difference in lookups between actors, clients, users and groups.
 %%
 %% Returns AuthzIds, missing names and names that are judged ambiguous
+%%
+
+%% The first two function heads are for cases where this is called from a global context
+%% where no organization_id set in the request.
+authz_records_by_name(actor, undefined, Names) ->
+    authz_records_by_name(user, undefined, Names);
+authz_records_by_name(actor, ?GLOBAL_PLACEHOLDER_ORG_ID, Names) ->
+    authz_records_by_name(user, undefined, Names);
 authz_records_by_name(actor, OrgId, Names) ->
     {ok, Actors} = oc_chef_authz_db:find_org_actors_by_name(OrgId, Names),
     {Missing, Remaining} = lists:partition(fun is_missing_actor/1, Actors),


### PR DESCRIPTION
Previously, if PUT was made to update a user ACL, the request would
return 400 if the request body contained a user. This was because the
code expected an OrgId to be set. Now, we assume that requests in the
global context (no org id), can only refer to users.

An alternative approach would be to extend the implementation of the
new scoping syntax so that it works everywhere.

A number of disabled pedant tests have been re-enabled.

Signed-off-by: Steven Danna <steve@chef.io>