### PR TITLE
Fix Chef 12 oc_id regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ matrix:
       before_script: cd oc-chef-pedant
       script: bundle exec rake chef_zero_spec
       env:
+        - "PEDANT_OPTS=\"--skip-oc_id\""
         - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v5.3.2' \""
       # Remove things only used by erlang
       install:
@@ -94,6 +95,7 @@ matrix:
       before_script: cd oc-chef-pedant
       script: bundle exec rake chef_zero_spec
       env:
+        - "PEDANT_OPTS=\"--skip-oc_id\""
         - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v5.3.2' \""
         - CHEF_FS=1
       # Remove things only used by erlang

--- a/oc-chef-pedant/lib/pedant/command_line.rb
+++ b/oc-chef-pedant/lib/pedant/command_line.rb
@@ -148,7 +148,7 @@ module Pedant
                 clients depsolver search knife validation authentication authorization
                 principals acl containers groups association omnibus organizations
                 usags controls keys cookbook-artifacts license headers server-api-version
-                policies pedantic self-test api-v0 api-v1 object-identifiers
+                policies pedantic self-test api-v0 api-v1 object-identifiers oc_id
                 multiuser universe chef-zero-quirks user-keys client-keys required-recipe)
       export_options(opts, tags)
     end

--- a/oc-chef-pedant/spec/api/oc_id_spec.rb
+++ b/oc-chef-pedant/spec/api/oc_id_spec.rb
@@ -1,0 +1,65 @@
+require 'pedant/rspec/common'
+
+describe "oc_id API", :oc_id do
+  context "status endpoint" do
+    let(:request_url) { "#{platform.server}/id/v1/status" }
+    let(:good_status) do
+      {"status" => "ok",
+       "erchef" => { "status" => "reachable" },
+       "postgres"=>{ "status" => "reachable" }}
+    end
+
+    context "GET /id/v1/status" do
+      it "retuns 200" do
+        get(request_url, platform.superuser).should look_like({:status => 200,
+                                                               :body => good_status})
+      end
+    end
+  end
+
+  context "signin" do
+    let(:username) { platform.non_admin_user.name }
+    let(:request_url) { "#{platform.server}/id/auth/chef/callback" }
+    let(:request_body) { "username=#{username}&password=#{password}&authenticity_token=#{CGI.escape(csrf[:token])}&commit=Sign+In" }
+    let(:request_headers) do
+      {
+        "Content-Type" => "application/x-www-form-urlencoded",
+        "Cookie" => csrf[:cookie]
+      }
+    end
+
+    let(:csrf) do
+      response = get("#{platform.server}/id/signin", platform.superuser, headers: {"Accept" => "text/html"})
+      cookie = response.headers[:set_cookie][1].split(";").first
+      # I KNOW. I'll leave it up to reviewers whether we should pull
+      # in nokogiri or hpricot just do to this
+      re = /<meta name="csrf-token" content="(.*)" \/>/
+      token = response.match(re)[1]
+      { cookie: cookie, token: token}
+    end
+
+    let(:response) { post(request_url, platform.superuser, headers: request_headers, payload: request_body) }
+
+    context "with correct password" do
+      let(:password) { "foobar" } #hardcoded at the platform layer
+      context "POST /id/auth/chef/callback" do
+        it "redirects us to authorized applications" do
+          expect(response.code).to eq(302)
+          expect(response.headers[:location]).to match(%r{/id/oauth/authorized_applications})
+        end
+      end
+    end
+
+    context "with incorrect password" do
+      let(:password) { "WRONGWRONGWRONG" }
+      context "POST /id/auth/chef/callback" do
+        it "redirects us to an error" do
+          expect(response.code).to eq(302)
+          expect(response.headers[:location]).to match(%r{/id/auth/failure\?message=invalid_credentials&strategy=chef})
+        end
+      end
+    end
+
+
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -27,7 +27,16 @@ end
 app_settings = {
   'chef' => {
     'endpoint' => "https://#{node['private_chef']['lb_internal']['vip']}",
-    'superuser' => 'pivotal'
+    'superuser' => 'pivotal',
+    #
+    # Why is this verify_none?
+    #
+    # Since we set the endpoint to 'localhost', even if we set the
+    # trusted_cert_dir to include the user-provided or self-signed
+    # cert in use by nginx, we will likely fail verification since
+    # those are certs for the api_fqdn and not localhost.
+    #
+    'ssl_verify_mode' => 'verify_none'
   },
   'doorkeeper' => {
     'administrators' => node['private_chef']['oc_id']['administrators'] || []

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -20,7 +20,7 @@ gem 'newrelic_rpm'
 gem 'doorkeeper', '~> 1.4.0'
 
 gem 'veil', git: 'https://github.com/chef/chef_secrets'
-gem 'omniauth-chef', git: 'https://github.com/chef/omniauth-chef', branch: 'ssd/POOL-581'
+gem 'omniauth-chef', git: 'https://github.com/chef/omniauth-chef'
 gem 'chef-web-core', git: 'https://github.com/chef/chef-web-core.git'
 
 #

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -13,14 +13,14 @@ gem 'unicorn-rails', '~> 1.1.0'
 gem 'omniauth', '~> 1.3.2'
 gem 'nokogiri', '>= 1.7.1'
 gem 'pg'
-gem 'mixlib-authentication', '~> 1.3.0'
+gem 'mixlib-authentication', '~> 1.3'
 gem 'sentry-raven'
 gem 'responders', '~> 2.0'
 gem 'newrelic_rpm'
 gem 'doorkeeper', '~> 1.4.0'
 
 gem 'veil', git: 'https://github.com/chef/chef_secrets'
-gem 'omniauth-chef', git: 'https://github.com/chef/omniauth-chef'
+gem 'omniauth-chef', git: 'https://github.com/chef/omniauth-chef', branch: 'ssd/POOL-581'
 gem 'chef-web-core', git: 'https://github.com/chef/chef-web-core.git'
 
 #

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -19,8 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omniauth-chef
-  revision: 7f336c33f0aebd362ab6b607d6d54a0c09486a65
-  branch: ssd/POOL-581
+  revision: 5bae8dd3e5f6afd2356672b745f29da210698d7d
   specs:
     omniauth-chef (0.3.0)
       chef (~> 12)
@@ -405,7 +404,7 @@ GEM
       eventmachine (~> 1.0.0)
       thin (>= 1.5, < 1.7)
     slop (3.6.0)
-    specinfra (2.67.8)
+    specinfra (2.67.9)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -19,7 +19,8 @@ GIT
 
 GIT
   remote: https://github.com/chef/omniauth-chef
-  revision: 795f299e579d17c2112e08acc7501c246e9bd1b5
+  revision: 7f336c33f0aebd362ab6b607d6d54a0c09486a65
+  branch: ssd/POOL-581
   specs:
     omniauth-chef (0.3.0)
       chef (~> 12)
@@ -80,6 +81,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (6.0.3)
     awesome_print (1.7.0)
     bcrypt (3.1.11)
@@ -99,31 +102,38 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    chef (12.6.0)
-      chef-config (= 12.6.0)
-      chef-zero (~> 4.2, >= 4.2.2)
+    chef (12.19.36)
+      addressable
+      bundler (>= 1.10)
+      chef-config (= 12.19.36)
+      chef-zero (>= 4.8)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
       ffi-yajl (~> 2.2)
       highline (~> 1.6, >= 1.6.9)
-      mixlib-authentication (~> 1.3)
-      mixlib-cli (~> 1.4)
+      iniparse (~> 1.4)
+      mixlib-archive (~> 0.4)
+      mixlib-authentication (~> 1.4)
+      mixlib-cli (~> 1.7)
       mixlib-log (~> 1.3)
       mixlib-shellout (~> 2.0)
-      net-ssh (~> 2.6)
-      net-ssh-multi (~> 1.1)
-      ohai (>= 8.6.0.alpha.1, < 9)
-      plist (~> 3.1.0)
+      net-sftp (~> 2.1, >= 2.1.2)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (>= 8.6.0.alpha.1, < 13)
+      plist (~> 3.2)
       proxifier (~> 1.0)
-      pry (~> 0.9)
-      rspec-core (~> 3.4)
-      rspec-expectations (~> 3.4)
-      rspec-mocks (~> 3.4)
+      rspec-core (~> 3.5)
+      rspec-expectations (~> 3.5)
+      rspec-mocks (~> 3.5)
       rspec_junit_formatter (~> 0.2.0)
       serverspec (~> 2.7)
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
-    chef-config (12.6.0)
+      uuidtools (~> 2.1.5)
+    chef-config (12.19.36)
+      addressable
+      fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     chef-zero (4.9.0)
@@ -185,6 +195,7 @@ GEM
     foundation-rails (5.5.1.1)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
+    fuzzyurl (0.9.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     grit (2.5.0)
@@ -196,6 +207,7 @@ GEM
     hike (1.2.3)
     hirb (0.7.3)
     i18n (0.8.1)
+    iniparse (1.4.2)
     ipaddress (0.8.3)
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
@@ -224,7 +236,9 @@ GEM
     mime-types (1.25.1)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    mixlib-authentication (1.3.0)
+    mixlib-archive (0.4.1)
+      mixlib-log
+    mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
@@ -234,9 +248,11 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.4)
-    net-ssh-gateway (1.3.0)
+    net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
+    net-ssh (4.1.0)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
@@ -261,7 +277,7 @@ GEM
       rack (>= 1.0, < 3)
     pbkdf2 (0.1.0)
     pg (0.18.4)
-    plist (3.1.0)
+    plist (3.2.0)
     posix-spawn (0.3.11)
     proxifier (1.0.3)
     pry (0.9.12.6)
@@ -286,6 +302,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    public_suffix (2.0.5)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.5)
@@ -388,7 +405,7 @@ GEM
       eventmachine (~> 1.0.0)
       thin (>= 1.5, < 1.7)
     slop (3.6.0)
-    specinfra (2.67.7)
+    specinfra (2.67.8)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -454,7 +471,7 @@ DEPENDENCIES
   jquery-rails
   jwt
   mailcatcher
-  mixlib-authentication (~> 1.3.0)
+  mixlib-authentication (~> 1.3)
   newrelic_rpm
   nokogiri (>= 1.7.1)
   omniauth (~> 1.3.2)
@@ -481,4 +498,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/src/oc-id/lib/chef_resource.rb
+++ b/src/oc-id/lib/chef_resource.rb
@@ -10,7 +10,8 @@ module ChefResource
   end
 
   def chef
-    ::Chef::ServerAPI.new endpoint, Settings.chef.superuser, nil, parameters
+    ::Chef::Config.ssl_verify_mode Settings.chef.ssl_verify_mode.to_sym || :verify_peer
+    ::Chef::ServerAPI.new endpoint, parameters
   end
 
   private
@@ -28,6 +29,9 @@ module ChefResource
   end
 
   def parameters
-    { headers: headers, raw_key: key }
+    { headers: headers,
+      client_name: Settings.chef.superuser,
+      client_key: nil,
+      raw_key: key }
   end
 end


### PR DESCRIPTION
The upgrade of oc_id to Chef 12 in commit

6824d90

introduced 2 issues:

(1) Incorrect arguments to ServrAPI.new
(2) A change in ssl verification behavior

This commit

- Fixes issue (1),
- Make the ssl_verify_mode configurable
- Updates omniauth-chef to a version that contains similar fixes.

* SSL Verify Mode

The ssl verify mode has been set to verify_none. This isn't a behavior
change from previous versions since this was the default in the old
version of Chef we were previously pinned to.

Because we want to talk to oc_id via 'localhost' to avoid cross-node
requests, changing this to verify_peer is problematic since, even if
we did the work to add /var/opt/opscode/nginx/ca (or the user-provided
cert location) to the trusted_cert_dir, the cert would likely still
mismatch since in the common case such certs ar for the `api_fqdn` and
not "localhost".