### PR TITLE
Fix regression in bookshelf preflight check

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bookshelf_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bookshelf_validator.rb
@@ -38,7 +38,7 @@ class BookshelfPreflightValidator < PreflightValidator
       true
     else
       previous_value = previous_run['bookshelf']['storage_type']
-      current_value = user_attrs['storage_type'] || 'filesystem'
+      current_value = (user_attrs['storage_type'] || 'filesystem').to_s
 
       if previous_value.nil? && current_value == 'filesystem' # case (2)
         true
@@ -56,7 +56,7 @@ bookshelf['storage_type'] = 'filesystem'
 
 in /etc/opscode/chef-server.rb or leave it unset.
 EOM
-      elsif previous_value == current_value # case (5)
+      elsif previous_value.to_s == current_value # case (5)
         true
       else # everything else is invalid, including case 4 above
         fail_with <<EOM

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bookshelf_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bookshelf_validator_spec.rb
@@ -47,6 +47,11 @@ describe BookshelfPreflightValidator do
         expect(subject.verify_storage_type_unchanged).to eq(true)
       end
 
+      it "succeeds if set to :filesystem" do
+        expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({'storage_type' => :filesystem})
+        expect(subject.verify_storage_type_unchanged).to eq(true)
+      end
+
       it "succeeds if not set" do
         expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({})
         expect(subject.verify_storage_type_unchanged).to eq(true)
@@ -74,6 +79,11 @@ describe BookshelfPreflightValidator do
 
       it "succceds if set to the same value as before" do
         expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({'storage_type' => 'sql'})
+        expect(subject.verify_storage_type_unchanged).to eq(true)
+      end
+
+      it "succeeds if set to the same value but as symbol" do
+        expect(PrivateChef).to receive(:[]).with('bookshelf').and_return({'storage_type' => :sql})
         expect(subject.verify_storage_type_unchanged).to eq(true)
       end
 


### PR DESCRIPTION
The commit 0f4ded20d740d2a771da13d7b095d4575577cbc2 removed the to_s
coercion from the Bookshelf preflight checks. However, those checks
happen *before* the type coercion in the library, so we still need the
string coercion there since some configs have symbols in them.

Signed-off-by: Steven Danna <steve@chef.io>