### PR TITLE
Exclude ldap in -running.json if disabled.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -175,21 +175,7 @@ file "/etc/opscode/chef-server-running.json" do
   owner OmnibusHelper.new(node).ownership['owner']
   group "root"
   mode "0600"
-
-  file_content = {
-    "private_chef" => node['private_chef'].to_hash,
-    "run_list" => node.run_list,
-    "runit" => node['runit'].to_hash
-  }
-  # back-compat fixes for opscode-reporting
-  # reporting uses the opscode-solr key for determining the location of the solr host,
-  # so we'll copy the contents over from opscode-solr4
-  file_content['private_chef']['opscode-solr'] ||= {}
-  %w{vip port}.each do |key|
-    file_content['private_chef']['opscode-solr'][key] = file_content['private_chef']['opscode-solr4'][key]
-  end
-
-  content Chef::JSONCompat.to_json_pretty(file_content)
+  content lazy { OmnibusHelper.chef_server_running_content(node) }
 end
 
 ruby_block "print reconfigure warnings" do


### PR DESCRIPTION
This ensures that addons can continue to rely on the presence of the ldap key instead of 
the internals to indicate whether ldap is enabled.

* Added a helper function to generate the chef-server running content to
  OmnibusHelper
* Moved solr attribute compat logic there
* made the content lazy so that it's not evaluated until we're done.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>