### PR TITLE
Restrict knife ec backup to use local gems.

### DIFF
--- a/omnibus/config/software/knife-ec-backup-gem.rb
+++ b/omnibus/config/software/knife-ec-backup-gem.rb
@@ -31,7 +31,7 @@ dependency "sequel-gem"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --without development", env: env
+  bundle "install --local --without development", env: env
 
   gem "build knife-ec-backup.gemspec", env: env
   gem "install knife-ec-backup*.gem --no-rdoc --no-ri --without development", env: env

--- a/omnibus/config/software/server-complete.rb
+++ b/omnibus/config/software/server-complete.rb
@@ -63,6 +63,9 @@ dependency "logrotate"
 # partybus and upgrade scripts
 dependency "partybus"
 
+# this gem is needed by knife-ec-backup
+dependency "chef" # for embedded chef-client -z runs (built from master - build last)
+
 # used in osc to ec upgrade path
 dependency "knife-ec-backup-gem"
 
@@ -78,4 +81,3 @@ dependency "oc-chef-pedant"
 dependency "private-chef-upgrades"
 dependency "private-chef-cookbooks"
 dependency "chef-ha-plugin-config"
-dependency "chef" # for embedded chef-client -z runs (built from master - build last)


### PR DESCRIPTION
This ensures that it will used cached gems (including the
same version of Chef that the rest of our components are using)
and will not pull in chef 13.0 before we've updated for it.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
