### PR TITLE
[nginx] regression: proxied compliance requests get HTTP 404

### DIFF
--- a/oc-chef-pedant/lib/pedant/command_line.rb
+++ b/oc-chef-pedant/lib/pedant/command_line.rb
@@ -17,7 +17,7 @@ require 'optparse'
 
 module Pedant
 
-  class CommandLine < Struct.new(:junit_file, :config_file, :log_file, :include_internal, :only_internal,
+  class CommandLine < Struct.new(:junit_file, :config_file, :log_file, :include_internal, :only_internal, :compliance_proxy_tests,
                                  :run_all, :exclude_internal_orgs, :only_internal_orgs, :verify_error_messages,
                                  :bell_on_completion, :rerun, :seed, :use_default_org, :ssl_version, :server_api_version)
 
@@ -102,6 +102,10 @@ module Pedant
 
       opts.on("--all", "Run all tests.  Supersedes any other filtering-related arguments") do
         self.run_all = true
+      end
+
+      opts.on("--compliance-proxy-tests") do
+        self.compliance_proxy_tests = true
       end
 
       opts.on("--bell", "Emits a console bell after completing tests") do

--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -136,6 +136,12 @@ module Pedant
     # Error message verification is on by default
     verify_error_messages(true)
 
+    # Compliance proxy tests whether to start a fake compliance
+    # endpoint to test nginx proxying
+    compliance_proxy_tests(false)
+    # Port to start stub compliance proxy on
+    compliance_proxy_port(9998)
+
     # Emits a console bell when run finishes
     bell_on_completion(false)
 

--- a/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
+++ b/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
@@ -1,0 +1,73 @@
+describe "Compliance Proxy Tests", :compliance_proxy_tests do
+  if !Pedant.config.compliance_proxy_tests
+    it "Compliance Proxy Tests disabled since config.compliance_proxy_tests = false" do
+      expect(true).to eq(true)
+    end
+  else
+    before(:all) do
+      # Start stub compliance server in a thread
+      require 'webrick'
+      require 'webrick/https'
+      require 'openssl'
+      require 'thread'
+      cert_name = [
+        %w[CN localhost],
+      ]
+      puts "Starting stub compliance server on #{Pedant.config.compliance_proxy_port}"
+      Thread.new do
+        server = WEBrick::HTTPServer.new(:Port => Pedant.config.compliance_proxy_port,
+                                         :SSLEnable => true,
+                                         :SSLCertName => cert_name)
+        server.mount_proc '/' do |req, res|
+          if req.path =~ %r{/compliance/profiles/([^/]+)/?}
+            res.body = '{ "response": "ok" }'
+          elsif req.path =~ %r{/compliance/profiles/([^/]+)/([^/]+)/?}
+            res.body = '{ "response": "ok" }'
+          else
+            res.body = '{}'
+            res.status = 404
+          end
+        end
+        server.start
+      end
+    end
+
+    context "/organizations/ORG/owners/OWNER/compliance[/PROFILE]" do
+      let(:good_status) { {"response" => "ok"} }
+
+      context "GET /organizations/ORG/owners/OWNER/compliance" do
+        let(:request_url) { api_url("owners/foobar/compliance") }
+          it "retuns 200" do
+            get(request_url, admin_user).should look_like({:status => 200,
+                                                           :body => good_status})
+          end
+      end
+
+      context "GET /organizations/ORG/owners/OWNER/compliance/PROFILE" do
+        let(:request_url) { api_url("owners/foobar/compliance/testprofile") }
+        it "retuns 200" do
+          puts request_url
+          get(request_url, admin_user).should look_like({:status => 200,
+                                                         :body => good_status})
+        end
+      end
+
+      context "GET /compliance/organizations/ORG/owners/OWNER/compliance" do
+        let(:request_url) { "#{platform.server}/compliance/organizations/#{platform.test_org.name}/owners/foobar/compliance" }
+        it "retuns 200" do
+          puts request_url
+          get(request_url, admin_user).should look_like({:status => 200,
+                                                         :body => good_status})
+        end
+      end
+
+      context "GET /compliance/organizations/ORG/owners/OWNER/compliance/PROFILE" do
+        let(:request_url) { "#{platform.server}/compliance/organizations/#{platform.test_org.name}/owners/foobar/compliance/testprofile" }
+        it "retuns 200" do
+          get(request_url, admin_user).should look_like({:status => 200,
+                                                         :body => good_status})
+        end
+      end
+    end
+  end
+end

--- a/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
+++ b/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
@@ -32,41 +32,33 @@ describe "Compliance Proxy Tests", :compliance_proxy_tests do
       end
     end
 
-    context "/organizations/ORG/owners/OWNER/compliance[/PROFILE]" do
-      let(:good_status) { {"response" => "ok"} }
+    let(:response) { get(request_url, admin_user) }
 
-      context "GET /organizations/ORG/owners/OWNER/compliance" do
-        let(:request_url) { api_url("owners/foobar/compliance") }
-          it "retuns 200" do
-            get(request_url, admin_user).should look_like({:status => 200,
-                                                           :body => good_status})
-          end
+    context "GET /organizations/ORG/owners/OWNER/compliance" do
+      let(:request_url) { api_url("owners/foobar/compliance") }
+      it "returns 200" do
+          expect(response.code).to eq(200)
       end
+    end
 
-      context "GET /organizations/ORG/owners/OWNER/compliance/PROFILE" do
-        let(:request_url) { api_url("owners/foobar/compliance/testprofile") }
-        it "retuns 200" do
-          puts request_url
-          get(request_url, admin_user).should look_like({:status => 200,
-                                                         :body => good_status})
-        end
+    context "GET /organizations/ORG/owners/OWNER/compliance/PROFILE" do
+      let(:request_url) { api_url("owners/foobar/compliance/testprofile") }
+      it "returns 200" do
+        expect(response.code).to eq(200)
       end
+    end
 
-      context "GET /compliance/organizations/ORG/owners/OWNER/compliance" do
-        let(:request_url) { "#{platform.server}/compliance/organizations/#{platform.test_org.name}/owners/foobar/compliance" }
-        it "retuns 200" do
-          puts request_url
-          get(request_url, admin_user).should look_like({:status => 200,
-                                                         :body => good_status})
-        end
+    context "GET /compliance/organizations/ORG/owners/OWNER/compliance" do
+      let(:request_url) { "#{platform.server}/compliance/organizations/#{platform.test_org.name}/owners/foobar/compliance" }
+      it "returns 200" do
+        expect(response.code).to eq(200)
       end
+    end
 
-      context "GET /compliance/organizations/ORG/owners/OWNER/compliance/PROFILE" do
-        let(:request_url) { "#{platform.server}/compliance/organizations/#{platform.test_org.name}/owners/foobar/compliance/testprofile" }
-        it "retuns 200" do
-          get(request_url, admin_user).should look_like({:status => 200,
-                                                         :body => good_status})
-        end
+    context "GET /compliance/organizations/ORG/owners/OWNER/compliance/PROFILE" do
+      let(:request_url) { "#{platform.server}/compliance/organizations/#{platform.test_org.name}/owners/foobar/compliance/testprofile" }
+      it "returns 200" do
+        expect(response.code).to eq(200)
       end
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -159,7 +159,12 @@ end
     mode '0644'
     variables(lbconf.merge(
       :server_proto => server_proto,
-      :script_path => nginx_scripts_dir
+      :script_path => nginx_scripts_dir,
+      # Compliance endpoint to forward profiles calls to the Automate API:
+      #   /organizations/ORG/owners/OWNER/compliance[/PROFILE]
+      # Supports the legacy(chef-gate) URLs as well:
+      #   /compliance/organizations/ORG/owners/OWNER/compliance[/PROFILE]
+      :compliance_proxy_regex => '(?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*)'
       )
     )
     notifies :restart, 'runit_service[nginx]' unless backend_secondary?

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -101,12 +101,12 @@
     #   /organizations/ORG/owners/OWNER/compliance[/PROFILE]
     # Supports the legacy(chef-gate) URLs as well:
     #   /compliance/organizations/ORG/owners/OWNER/compliance[/PROFILE]
-    location ~ (?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*) {
+    location ~ <%= @compliance_proxy_regex -%> {
       set $request_org $1;
       access_by_lua_block { validator.validate("GET") }
       proxy_set_header x-data-collector-token $data_collector_token;
       proxy_set_header x-data-collector-auth "version=1.0";
-      rewrite ^ "/compliance/profiles/$2$3" break;
+      rewrite ^<%= @compliance_proxy_regex -%> "/compliance/profiles/$2$3" break;
       proxy_pass https://compliance-profiles;
     }
     <% end -%>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -106,7 +106,7 @@
       access_by_lua_block { validator.validate("GET") }
       proxy_set_header x-data-collector-token $data_collector_token;
       proxy_set_header x-data-collector-auth "version=1.0";
-      rewrite ^<%= @compliance_proxy_regex -%> "/compliance/profiles/$2$3" break;
+      rewrite ^<%= @compliance_proxy_regex -%> /compliance/profiles/$2$3 break;
       proxy_pass https://compliance-profiles;
     }
     <% end -%>


### PR DESCRIPTION
The compliance proxy no longer included the owner or profile name in
the upstream requests because of a bad rewrite rule.  This corrects
the rewrite rule.

*Testing*

Since there are no tests for this endpoint, I've tested it manually
using the following procedure:

1. Configure /etc/opscode/chef-server.rb as follows:

       data_collector['token'] = 'foobar'
       profiles['root_url'] = 'http://localhost:9998'

2. Use `socat` to start an SSL listener on 9998:

       socat OPENSSL-LISTEN:9998,reuseaddr,fork,verify=0,\
       cert=/var/opt/opscode/nginx/ca/api.chef-server.dev.crt,\
       key=/var/opt/opscode/nginx/ca/api.chef-server.dev.key,\
       dhparam=/var/opt/opscode/nginx/ca/dhparams.pem - | grep 'GET'

3. Use `knife raw` to make reqeusts and check the URL recieved by (2)

       knife raw /organizations/testorg/owners/foobar/compliance/bob -c /etc/opscode/pivotal.rb
       knife raw /compliance/organizations/testorg/owners/foobar/compliance/bob -c /etc/opscode/pivotal.rb

Before this change, the following two requests were recieved:

    GET /compliance/profiles/ HTTP/1.0
    GET /compliance/profiles/ HTTP/1.0

After this change:

    GET /compliance/profiles/foobar/bob HTTP/1.0
    GET /compliance/profiles/foobar/bob HTTP/1.0

Signed-off-by: Steven Danna <steve@chef.io>