### PR TITLE
Enable the new compliance-proxy-tests in run_test.sh

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -evx
 
-sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --all
+sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --compliance-proxy-tests
 
 if [ "$OMNIBUS_FIPS_MODE" == "true" ]
 then
@@ -11,5 +11,5 @@ then
   echo "Sleeping 120 seconds to allow the Chef Server to reconfigure in FIPS mode"
   echo ""
   sleep 120
-  sudo chef-server-ctl test -J $WORKSPACE/pedant-fips.xml --smoke
+  sudo chef-server-ctl test -J $WORKSPACE/pedant-fips.xml --smoke --compliance-proxy-tests
 fi


### PR DESCRIPTION
Related change in opscode-ci #707 was merged and released in v5.15.70 of opscode-ci

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

TODO:  renable --all before merging

Paired with @marcparadise on this change. 