### PR TITLE
[oc-id] Use the v0 API for all chef interactions

### DIFF
--- a/oc-chef-pedant/spec/api/oc_id_spec.rb
+++ b/oc-chef-pedant/spec/api/oc_id_spec.rb
@@ -49,7 +49,7 @@ describe "oc_id API", :oc_id do
     let(:response) { post(request_url, platform.superuser, headers: request_headers, payload: request_body) }
     it "returns a non-zero file" do
       expect(response.code).to eq(200)
-      expect(response.body.length).to_not be(0)
+      expect(response.body.length).to_not eq(0)
     end
 
     it "returns a valid key" do

--- a/oc-chef-pedant/spec/api/oc_id_spec.rb
+++ b/oc-chef-pedant/spec/api/oc_id_spec.rb
@@ -1,4 +1,5 @@
 require 'pedant/rspec/common'
+require 'openssl'
 
 describe "oc_id API", :oc_id do
   context "status endpoint" do
@@ -45,10 +46,16 @@ describe "oc_id API", :oc_id do
 
     let(:request_url) { "#{platform.server}/id/profile/regen_key" }
     let(:request_body) { "authenticity_token=#{CGI.escape(csrf[:token])}&commit=Get+a+New+Key" }
+    let(:response) { post(request_url, platform.superuser, headers: request_headers, payload: request_body) }
     it "returns a non-zero file" do
-      response = post(request_url, platform.superuser, headers: request_headers, payload: request_body)
       expect(response.code).to eq(200)
       expect(response.body.length).to_not be(0)
+    end
+
+    it "returns a valid key" do
+      expect(response.code).to eq(200)
+      # This will raise if it isn't a valid key
+      expect(OpenSSL::PKey::RSA.new(response.body).class).to eq(OpenSSL::PKey::RSA)
     end
   end
 

--- a/src/oc-id/lib/chef_resource.rb
+++ b/src/oc-id/lib/chef_resource.rb
@@ -32,6 +32,7 @@ module ChefResource
     { headers: headers,
       client_name: Settings.chef.superuser,
       client_key: nil,
+      api_version: "0",
       raw_key: key }
   end
 end


### PR DESCRIPTION
oc-id is currently still expecting v0-style key interactions, but our
bump to Chef 12 moved us to v1 inadvertently.

Signed-off-by: Steven Danna <steve@chef.io>