### PR TITLE
[pedant] Enable compliance-proxy-tests, wait for listener

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -evx
 
-sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --all
+sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --all --compliance-proxy-tests
 
 if [ "$OMNIBUS_FIPS_MODE" == "true" ]
 then

--- a/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
+++ b/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
@@ -15,9 +15,9 @@ def wait_for_http_listener(uri_string, retries = 10)
     if retries <= 0
       raise e
     else
-      puts "GET #{uri_string} failed: #{e} retrying in 1 seconds (#{retries} retries remaining)"
+      puts "GET #{uri_string} failed: #{e} retrying in 0.1 seconds (#{retries} retries remaining)"
       retries -= 1
-      sleep 1
+      sleep 0.1
       retry
     end
   end
@@ -35,9 +35,10 @@ def start_compliance_stub(port)
                                      :SSLVerifyClient => OpenSSL::SSL::VERIFY_NONE,
                                      :SSLCertName => [%w[CN localhost]])
     server.mount_proc '/' do |req, res|
-      if req.path =~ %r{/compliance/profiles/([^/]+)/?}
+      case req.path
+      when %r{/compliance/profiles/([^/]+)/?}
         res.body = '{ "response": "ok" }'
-      elsif req.path =~ %r{/compliance/profiles/([^/]+)/([^/]+)/?}
+      when %r{/compliance/profiles/([^/]+)/([^/]+)/?}
         res.body = '{ "response": "ok" }'
       else
         res.body = '{}'

--- a/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
+++ b/oc-chef-pedant/spec/api/compliance_proxy_spec.rb
@@ -1,3 +1,53 @@
+def wait_for_http_listener(uri_string, retries = 10)
+  require 'net/http'
+  require 'openssl'
+  require 'uri'
+  uri = URI(uri_string)
+  begin
+    puts "Trying GET #{uri_string}"
+    Net::HTTP.start(uri.host, uri.port, :use_ssl => true,
+                    verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+      request = Net::HTTP::Get.new uri
+      http.request request
+    end
+    puts "Succesfully made GET to #{uri_string}"
+  rescue StandardError => e
+    if retries <= 0
+      raise e
+    else
+      puts "GET #{uri_string} failed: #{e} retrying in 1 seconds (#{retries} retries remaining)"
+      retries -= 1
+      sleep 1
+      retry
+    end
+  end
+end
+
+def start_compliance_stub(port)
+  # Start stub compliance server in a thread
+  require 'webrick'
+  require 'webrick/https'
+  require 'openssl'
+  require 'thread'
+  Thread.new do
+    server = WEBrick::HTTPServer.new(:Port => port,
+                                     :SSLEnable => true,
+                                     :SSLVerifyClient => OpenSSL::SSL::VERIFY_NONE,
+                                     :SSLCertName => [%w[CN localhost]])
+    server.mount_proc '/' do |req, res|
+      if req.path =~ %r{/compliance/profiles/([^/]+)/?}
+        res.body = '{ "response": "ok" }'
+      elsif req.path =~ %r{/compliance/profiles/([^/]+)/([^/]+)/?}
+        res.body = '{ "response": "ok" }'
+      else
+        res.body = '{}'
+        res.status = 404
+      end
+    end
+    server.start
+  end
+end
+
 describe "Compliance Proxy Tests", :compliance_proxy_tests do
   if !Pedant.config.compliance_proxy_tests
     it "Compliance Proxy Tests disabled since config.compliance_proxy_tests = false" do
@@ -5,31 +55,11 @@ describe "Compliance Proxy Tests", :compliance_proxy_tests do
     end
   else
     before(:all) do
-      # Start stub compliance server in a thread
-      require 'webrick'
-      require 'webrick/https'
-      require 'openssl'
-      require 'thread'
-      cert_name = [
-        %w[CN localhost],
-      ]
-      puts "Starting stub compliance server on #{Pedant.config.compliance_proxy_port}"
-      Thread.new do
-        server = WEBrick::HTTPServer.new(:Port => Pedant.config.compliance_proxy_port,
-                                         :SSLEnable => true,
-                                         :SSLCertName => cert_name)
-        server.mount_proc '/' do |req, res|
-          if req.path =~ %r{/compliance/profiles/([^/]+)/?}
-            res.body = '{ "response": "ok" }'
-          elsif req.path =~ %r{/compliance/profiles/([^/]+)/([^/]+)/?}
-            res.body = '{ "response": "ok" }'
-          else
-            res.body = '{}'
-            res.status = 404
-          end
-        end
-        server.start
-      end
+      port = Pedant.config.compliance_proxy_port
+      puts "Starting stub compliance server on #{port}"
+      start_compliance_stub(port)
+      puts "Waiting for listener on #{port}"
+      wait_for_http_listener("https://localhost:#{port}/compliance/profiles/conn_test")
     end
 
     let(:response) { get(request_url, admin_user) }
@@ -37,7 +67,7 @@ describe "Compliance Proxy Tests", :compliance_proxy_tests do
     context "GET /organizations/ORG/owners/OWNER/compliance" do
       let(:request_url) { api_url("owners/foobar/compliance") }
       it "returns 200" do
-          expect(response.code).to eq(200)
+        expect(response.code).to eq(200)
       end
     end
 


### PR DESCRIPTION
We disabled these tests because occasionally the threaded compliance
stub server wouldn't start fast enough. This adds a simple function to
wait for the HTTP listener to be started before starting the tests.

Signed-off-by: Steven Danna <steve@chef.io>