### PR TITLE
Set SAN on generated SSL certificate

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -1,4 +1,5 @@
 require 'mixlib/shellout'
+require 'ipaddr'
 require 'uri'
 require "net/http"
 
@@ -26,6 +27,13 @@ class OmnibusHelper
 
     config['actions_password'] = PrivateChef.credentials.get("rabbitmq", "actions_password")
     config
+  end
+
+  def self.is_ip?(addr)
+    IPAddr.new addr
+    true
+  rescue IPAddr::InvalidAddressError
+    false
   end
 
   # Normalizes hosts. If the host part is an ipv6 literal, then it

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -56,13 +56,21 @@ if (node['private_chef']['nginx']['ssl_certificate'].nil? &&
    ssl_keyfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.key")
    ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
 
+   server_name = node['private_chef']['nginx']['server_name']
+   server_name_type = if OmnibusHelper.is_ip?(server_name)
+                        "IP"
+                      else
+                        "DNS"
+                      end
+
    openssl_x509 ssl_crtfile do
-     common_name node['private_chef']['nginx']['server_name']
+     common_name server_name
      org node['private_chef']['nginx']['ssl_company_name']
      org_unit node['private_chef']['nginx']['ssl_organizational_unit_name']
      country node['private_chef']['nginx']['ssl_country_name']
      key_length node['private_chef']['nginx']['ssl_key_length']
      expire node['private_chef']['nginx']['ssl_duration']
+     subject_alt_name [ "#{server_name_type}:#{server_name}" ]
      owner 'root'
      group 'root'
      mode '0644'

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
@@ -1,12 +1,25 @@
 require_relative '../../libraries/helper.rb'
 
-describe OmnibusHelper, :es5 do
-
+describe OmnibusHelper do
   before do
     # suppress log output
     allow(Chef::Log).to receive(:info)
     allow(Chef::Log).to receive(:error)
     allow(Chef::Log).to receive(:warn)
+  end
+
+  describe "#is_ip?" do
+    it "returns true for an IPv4 address" do
+      expect(OmnibusHelper.is_ip?("192.168.33.10")).to eq(true)
+    end
+
+    it "returns true for an IPv6 address" do
+      expect(OmnibusHelper.is_ip?("::1")).to eq(true)
+    end
+
+    it "returns false for a hostname" do
+      expect(OmnibusHelper.is_ip?("1.example.com")).to eq(false)
+    end
   end
 
   describe '#bookshelf_s3_url' do
@@ -75,7 +88,7 @@ describe OmnibusHelper, :es5 do
           'opscode-solr4' => {
             'external' => external,
             'external_url' => external_url
-          }, 
+          },
           'opscode-erchef' => {
             'search_provider' => provider
           }
@@ -128,22 +141,22 @@ describe OmnibusHelper, :es5 do
 
     context 'when elastic search is unavailable' do
       context 'should return 2 but the request fails first time only' do
-        let(:times) {1}  
+        let(:times) { 1 }
         it_behaves_like "elastic search version request fails"
       end
 
       context 'should return 2 but the request fails the first two times' do
-        let(:times) {2}  
+        let(:times) { 2 }
         it_behaves_like "elastic search version request fails"
       end
 
       context 'should return 2 but the request fails the first three times' do
-        let(:times) {3}  
+        let(:times) { 3 }
         it_behaves_like "elastic search version request fails"
       end
-      
+
       context 'should return 2 but the request fails the first four times' do
-        let(:times) {4}  
+        let(:times) { 4 }
         it_behaves_like "elastic search version request fails"
       end
 


### PR DESCRIPTION
This sets a Subject Alternative Name for newly-generated SSL
certificates. Newer browsers require that the SubjectAltName is set in
addition to the CommonName.

Fixes #1260

Signed-off-by: Steven Danna <steve@chef.io>