### PR TITLE
Mp/oc id missing all.svg

### DIFF
--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -44,6 +44,8 @@ vm:
   # All settings below apply only to the chef-server vm
   cpus: 4
   memory: 4096
+  # nodejs is included here so that we can run asset compile phase of
+  # oc-id on load.
   packages: [ ntp, curl, wget, htop, uuid-dev, tmux, vim, iotop, zlib1g-dev, liblzma-dev ]
   omnibus-autoload: [] # see config.yml for details and to add components
   # Override this in config.yml to set a custom path for your dotfiles
@@ -91,6 +93,8 @@ vm:
        - config/database.yml # [oc-id] we'll need to use the one from omnibus
        - config/settings/production.yml # [oc-id] we'll need to use the one from omnibus
        - config/initializers/secret_token.rb # [oc-id] we'll need to use the one from omnibus
+       - oc-id/public/id
+       - oc-id/tmp
 
   cover:
     base_output_path: /vagrant/testdata/cover # maps to dev/testdata/cover
@@ -127,7 +131,8 @@ projects:
     type: rails
     install_options: --without development test doc
     build_steps:
-      - bundle exec --keep-file-descriptors rake assets:precompile db:migrate
+      - bundle exec rake assets:precompile --trace
+      - bundle exec --keep-file-descriptors rake db:migrate
     symlinks:
       config/database.yml: config/database.yml
       config/settings/production.yml: config/production.yml

--- a/dev/dvm/lib/dvm/tools.rb
+++ b/dev/dvm/lib/dvm/tools.rb
@@ -5,6 +5,12 @@ module DVM
       say desc if desc
       cmd = Mixlib::ShellOut.new(command, opts)
       cmd.run_command
+      unless no_raise || cmd.status.exitstatus > 0
+        #{command} failed"
+        puts "*** stdout: #{cmd.stdout}"
+        puts "*** stderr: #{cmd.stderr}"
+      end
+
       cmd.error! unless no_raise
       cmd
     end

--- a/src/oc-id/config/environments/production.rb
+++ b/src/oc-id/config/environments/production.rb
@@ -27,7 +27,7 @@ OcId::Application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Generate digests for assets URLs.
   config.assets.digest = true


### PR DESCRIPTION
enable compilation of missing assets, so that
requests to `all.svg` no longer 404.  This
dependency is defined and added in chef-web-core.
Building the assets in precompile generates everything including
all-FINGERPRINT.svg, however Rails is not using the fingerprint
in this case.

This is a simple fix after exploring the asset generation and
not finding a sane way to either a) get rails to use
the fingerprint for this resource ; or b) get it to load the
un-fingerprinted version out of the gem.

Since this is the only missing asset, no impact is expected by
enabling compilation of missing resources.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>