### PR TITLE
[pedant] Downcase chef_server_uid

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -21,7 +21,7 @@ base_resource_url "<%= @base_resource_url %>"
 # on multiple nodes of the same chef server when the generated pedant
 # config file could have been copied across during the setup of that
 # chef server.
-chef_server_uid = "<%= @hostname %>_#{Process.pid}"
+chef_server_uid = "<%= @hostname %>_#{Process.pid}".downcase
 
 # Specify a testing organization if you are testing a multi-tenant
 # instance of a Chef Server (e.g., Private Chef, Hosted Chef).  If you


### PR DESCRIPTION
Since some objects (like orgs) only accept lowercase names, we need to
make sure that the chef_server_uid is always lowercase.

Signed-off-by: Steven Danna <steve@chef.io>