### PR TITLE
[ctl-commands] Call reindex escript with absolute path

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/reindex.rb
+++ b/omnibus/files/private-chef-ctl-commands/reindex.rb
@@ -49,13 +49,12 @@ def wait_for_empty_queue
 end
 
 def enqueue_data_for_org(org)
-  status = Dir.chdir(File.join(base_path, "embedded", "service", "opscode-erchef", "bin")) do
-    if running_config["private_chef"]["fips_enabled"]
-      run_command("./reindex-opc-organization complete #{org} http://127.0.0.1")
-    else
-      run_command("./reindex-opc-organization complete #{org}")
-    end
-  end
+  reindex_script = File.join(base_path, "embedded", "service", "opscode-erchef", "bin", "reindex-opc-organization")
+  status = if running_config["private_chef"]["fips_enabled"]
+             run_command("#{reindex_script} complete #{org} http://127.0.0.1")
+           else
+             run_command("#{reindex_script} complete #{org}")
+           end
   if !status.success?
     $stderr.puts "Failed to enqueue data for #{org}!"
   end


### PR DESCRIPTION
In 636b10dfa402ecbb55e598201b54ee80ae4f44aa the configuration for the
various erlang applications were changed to use `{include_erts,
false}` as a release build option. It appears that a side effect of
that change is that the start_clean.boot file in

/opt/opscode/embedded/service/opscode-erchef/bin

no longer points at the correct ERTS installation.  Since that boot
file is used automatically by erl when starting the command from that
directory, the reindex command was failing to launch.

This change avoid the problem by calling the reindex script with an
absolute path. Alternatives would include reverting the include_erts
change or determining how to configure rebar/relx such that the
produced start_clean.boot file is correct.

Signed-off-by: Steven Danna <steve@chef.io>