### PR TITLE
[erchef] Fix ACL updates when actor names includes '.'

### DIFF
--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -1299,16 +1299,23 @@ describe "ACL API", :acl do
                   end
 
                   context "when client with '.' in name is used in actors hash" do
-                    let(:update_body) do
-                      { permission => {
-                          "actors" => [@client_with_dot.name, platform.admin_user.name, "pivotal"],
-                          "groups" => ["admins"]
-                        }
+                    let(:groups_and_actors) do
+                      {
+                        "actors" => [@client_with_dot.name, platform.admin_user.name, "pivotal"],
+                        "groups" => ["admins"]
                       }
+                    end
+
+                    let(:update_body) do
+                      { permission => groups_and_actors }
                     end
 
                     it "returns 200", :acl do
                       put("#{request_url}/#{permission}", platform.admin_user, :payload => update_body).should look_like({:status => 200})
+
+                      check_body = acl_body
+                      check_body[permission] = groups_and_actors
+                      get(request_url, platform.admin_user).should look_like({:status => 200, :body => check_body})
                     end
                   end
                 end

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -1222,9 +1222,14 @@ describe "ACL API", :acl do
             end # context GET /<type>/<name>/_acl/<permission>
 
             context "PUT /#{type}/<name>/_acl/#{permission}" do
-              before do
-                @client_with_dot = platform.create_client("test-client.#{rand_id}").name
+              before(:all) do
+                @client_with_dot = platform.create_client("test-client.#{rand_id}")
               end
+
+              after(:all) do
+                platform.delete_client(@client_with_dot)
+              end
+
 
               let(:clients) { [platform.non_admin_client.name] }
               let(:users) {
@@ -1296,7 +1301,7 @@ describe "ACL API", :acl do
                   context "when client with '.' in name is used in actors hash" do
                     let(:update_body) do
                       { permission => {
-                          "actors" => [@client_with_dot, platform.admin_user.name, "pivotal"],
+                          "actors" => [@client_with_dot.name, platform.admin_user.name, "pivotal"],
                           "groups" => ["admins"]
                         }
                       }

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -1222,6 +1222,10 @@ describe "ACL API", :acl do
             end # context GET /<type>/<name>/_acl/<permission>
 
             context "PUT /#{type}/<name>/_acl/#{permission}" do
+              before do
+                @client_with_dot = platform.create_client("test-client.#{rand_id}").name
+              end
+
               let(:clients) { [platform.non_admin_client.name] }
               let(:users) {
                 [platform.non_admin_user.name, platform.admin_user.name, "pivotal"].uniq
@@ -1287,6 +1291,20 @@ describe "ACL API", :acl do
                         :status => 200,
                         :body => check_body
                       })
+                  end
+
+                  context "when client with '.' in name is used in actors hash" do
+                    let(:update_body) do
+                      { permission => {
+                          "actors" => [@client_with_dot, platform.admin_user.name, "pivotal"],
+                          "groups" => ["admins"]
+                        }
+                      }
+                    end
+
+                    it "returns 200", :acl do
+                      put("#{request_url}/#{permission}", platform.admin_user, :payload => update_body).should look_like({:status => 200})
+                    end
                   end
                 end
 

--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -1301,7 +1301,7 @@ describe "ACL API", :acl do
                   context "when client with '.' in name is used in actors hash" do
                     let(:groups_and_actors) do
                       {
-                        "actors" => [@client_with_dot.name, platform.admin_user.name, "pivotal"],
+                        "actors" => [@client_with_dot.name, platform.admin_user.name, "pivotal"].uniq,
                         "groups" => ["admins"]
                       }
                     end

--- a/src/oc_erchef/apps/chef_objects/src/chef_regex.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_regex.erl
@@ -59,7 +59,7 @@
 %% from the cookbook names and recipes in the opscode/cookbooks
 %% repository, this regular expression applies to them as well.
 -define(NAME_CHAR_CLASS, "[.[:alnum:]_-]").
--define(NAME_REGEX, ?NAME_CHAR_CLASS ++ "+").
+-define(NAME_REGEX, ?NAME_CHAR_CLASS "+").
 
 %% This is very similar to NAME_REGEX (differs only with the addition of ':').  This is used
 %% for data bags, data bag items, roles, nodes, and keys.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -41,16 +41,6 @@
 -compile([export_all]).
 -endif.
 
-%%
-%% Process names with scoping descriptor.
-%%
-
-%% This is derived from oc_chef_wm/src/oc_chef_wm_groups.erl; investigate what it will take to refactor this.
--define(NAME, "[a-z0-9\-_]").
-
--define(SCOPE_SEPARATOR, <<"::">>).
--define(SCOPED_NAME_REGEX, "^(?:(" ?NAME "+)|(?:(" ?NAME "*)\\:\\:(" ?NAME "+)))$").
-
 -type db_callback() :: fun((any()) -> any()).
 
 -record(context, {org_id :: binary(),
@@ -355,8 +345,9 @@ is_scoped_type(_) ->
 %% This simplifies testing
 -spec make_regex() -> re:mp().
 make_regex() ->
-    {ok, Pattern} = re:compile(?SCOPED_NAME_REGEX),
+    {Pattern, _Message} = chef_regex:regex_for(scoped_name),
     Pattern.
+
 %% A scoped name is of the form scope::name. If scope is elided, then we are in the global
 %% scope. If there is no scope separator, then it is in the current context.
 %%


### PR DESCRIPTION
Unlike users and groups, client names can contain the `.` character.
In fact, this character this likely since the client name is often
based on the node name which is based on the FQDN of the node.

In chef/chef-server#1159, we added the ability to add name-spaced
actors and groups to ACLs.  However, that changed validated the actor
names against the more restrictive user/group regular expression.

This change uses the standard NAME_REGEX for validation which includes
`.`.  It does mean that some invalid user and group names will pass
validation; however, presumably such users and groups will fail to be
found in the database since they can't be created.

Fixes #1274

Signed-off-by: Steven Danna <steve@chef.io>