### PR TITLE
12.15.7 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Chef Server Changelog
 
+## [12.15.7](https://github.com/chef/chef-server/tree/12.15.7) (2017-05-17)
+[Full Changelog](https://github.com/chef/chef-server/compare/12.15.6...12.15.7)
+
+**Closed issues:**
+
+- Upgrade from Chef 11 to 12 fails in fix\_permissions stage with error 400 for every node [\#1274](https://github.com/chef/chef-server/issues/1274)
+- not install chefserver in my ubuntu, when i tried to install like following below [\#1269](https://github.com/chef/chef-server/issues/1269)
+
+**Merged pull requests:**
+
+- \[erchef\] Fix ACL updates when actor names includes '.' [\#1275](https://github.com/chef/chef-server/pull/1275) ([stevendanna](https://github.com/stevendanna))
+- \[ctl-commands\] Call reindex escript with absolute path [\#1272](https://github.com/chef/chef-server/pull/1272) ([stevendanna](https://github.com/stevendanna))
+- \[pedant\] Downcase chef\_server\_uid [\#1271](https://github.com/chef/chef-server/pull/1271) ([stevendanna](https://github.com/stevendanna))
+- Mp/oc id missing all.svg [\#1267](https://github.com/chef/chef-server/pull/1267) ([marcparadise](https://github.com/marcparadise))
+- Grab umask for gather-logs [\#1266](https://github.com/chef/chef-server/pull/1266) ([marcparadise](https://github.com/marcparadise))
+- Fix issues in postgresql preflight validator [\#1264](https://github.com/chef/chef-server/pull/1264) ([stevendanna](https://github.com/stevendanna))
+- \[pedant\] Enable compliance-proxy-tests, wait for listener [\#1262](https://github.com/chef/chef-server/pull/1262) ([stevendanna](https://github.com/stevendanna))
+
+### Components
+Updated Components
+* berkshelf-no-depselector (e3dd3d6f -> 6016ca10)
+
+### Contributors
+* Marc Paradise
+* Steven Danna
+* Sean Horn
+* Bryan McLellan
+
+## [12.15.6](https://github.com/chef/chef-server/tree/12.15.6) (2017-05-05)
+[Full Changelog](https://github.com/chef/chef-server/compare/12.15.5...12.15.6)
+
+**Merged pull requests:**
+
+- 12.15.6 release prep [\#1259](https://github.com/chef/chef-server/pull/1259) ([marcparadise](https://github.com/marcparadise))
+- Use a different user for oc\_id tests to prevent side effects [\#1258](https://github.com/chef/chef-server/pull/1258) ([marcparadise](https://github.com/marcparadise))
+- \[oc-id\] Use the v0 API for all chef interactions [\#1257](https://github.com/chef/chef-server/pull/1257) ([stevendanna](https://github.com/stevendanna))
+
+
 ## [12.15.6](https://github.com/chef/chef-server/tree/12.15.6) (2017-05-05)
 
 [Full Changelog](https://github.com/chef/chef-server/compare/12.15.5...12.15.6)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,11 +7,23 @@ in the release. For a detailed list of changed components, refer to
 This document contains release notes for the current major release and all patches.
 For prior releases, see [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
 
-## 12.15.5 (2017-05-05)
+## 12.15.7 (2017-05-16)
+
+* Fixed [regression](https://github.com/chef/chef-server/issues/1274) that prevented
+  some Open Source Chef 11 upgrades due to too-strict validations on object names in ACLs. This
+  issue would also prevent editing of ACLs directly on node objects if the
+  node name contained a ".".  This issue was introduced in 12.15.0
+* Fixed [regression](https://github.com/chef/chef-server/pull/1272) that prevented the `reindex`
+  command from working. This issue was a side effect of consolidating the multiple Erlang runtimes
+  that we distributed with Chef Server into one for 12.15.0.
+
+## 12.15.6 (2017-05-05)
+
 * Fixed [regression](https://github.com/chef/chef-server/pull/1257) in oc-id.
   The identity service was using the wrong Chef Server API version level.
   .
 ## 12.15.5 (2017-05-04)
+
 * Fixed [regression](https://github.com/chef/chef-server/pull/1253) in the nginx proxy
   that prevented Automate-based Compliance profiles from being reachable
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -39,7 +39,7 @@ In order to release, you will need the following accounts/permissions:
 ### Informing everyone of a pending release.
 
 - [ ] Announce your intention to drive the release to #cft-announce on slack.
-- [ ] Cross-post this intention on #chef-server and #spool.  Determine whether
+- [ ] Cross-post this intention on #chef-server and #pool.  Determine whether
   this upgrade requires a major/minor/patch bump and what the major changes
   are.
 - [ ] Ensure that the chef-server pipeline on wilson is currently green - you
@@ -99,8 +99,8 @@ The git SHA of the build you are testing can be found in
 
 ### Preparing for the release
 
-- [ ] Check that omnibus/config/projects/chef-server.rb has the
-  correct version given the type of changes in this release.
+- [ ] Check that omnibus_overrides.rb has the correct version given
+  the type of changes in this release.
 
 - [ ] Download the previous release of Chef Server (.deb).
 
@@ -118,7 +118,7 @@ The git SHA of the build you are testing can be found in
   appropriate.  If a there is a major version change, transfer all
   contents to PRIOR_RELEASE_NOTES.md before adding release notes.
 - [ ] Open a PR with these changes and post the link to #chef-server-rfr
-  and #spool.
+  and #pool.
 
 ### Building and Releasing the Release
 
@@ -163,6 +163,5 @@ Chef Server is now released.
 
 ## Post Release
 
-- [ ] Bump the Chef Server version number in
-  `omnibus/config/projects/chef-server.rb` for development to the next
-  logical version number.
+- [ ] Bump the Chef Server version number in `omnibus_overrides.rb`
+  for development to the next logical version number.

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -24,16 +24,18 @@ package_name    "chef-server-core"
 replace         "private-chef"
 conflict        "private-chef"
 install_dir     "/opt/opscode"
-build_version   "12.15.6"
-build_iteration 1
-#
-# Load dynamically updated overrides
+
+# In order to prevent unecessary cache expiration,
+# package and package version overrides, build_version
+# and build_iteration are kept in <project-root>/omnibus_overrides.rb
 overrides_path = File.expand_path("../../../../omnibus_overrides.rb", __FILE__)
 instance_eval(IO.read(overrides_path), overrides_path)
 
 # creates required build directories
 dependency "preparation"
 
+# Meta-dependency containing all of
+# the Chef Server dependencies.
 dependency "server-complete"
 
 dependency "cleanup" # MUST BE LAST DO NOT MOVE

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,4 +1,4 @@
-build_version   "12.15.6"
+build_version   "12.15.7"
 build_iteration 1
 
 override :erlang, version: "18.3"

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,3 +1,6 @@
+build_version   "12.15.6"
+build_iteration 1
+
 override :erlang, version: "18.3"
 override :lua, version: "5.1.5"
 override :'omnibus-ctl', version: "master"


### PR DESCRIPTION
In addition to 12.15.7 release notes/version update, this PR also moves the product version out of `omnibus/projects/chef-server.rb` and into `omnibus-overrides.rb` to prevent a rebuild with every version bump. 

CHANGELOG will be updated before we close this out. 