### PR TITLE
Pin berkshelf-no-depselector to avoid pulling in 6.0

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -8,3 +8,5 @@ override :chef, version: "v12.19.36"
 override :ohai, version: "v8.23.0"
 override :ruby, version: "2.2.6"
 override :rubygems, version: "2.6.8"
+# This SHA is the last commit before the 6.0 release
+override :'berkshelf-no-depselector', version: '6016ca10b2f46508b1b107264228668776f505d9'


### PR DESCRIPTION
Signed-off-by: Steven Danna <steve@chef.io>