### PR TITLE
[CLOUD-371] Allow oc-chef-pedant chef_server URL to be configurable

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -419,6 +419,10 @@ default['private_chef']['oc-chef-pedant']['log_http_requests'] = true
 default['private_chef']['oc-chef-pedant']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['oc-chef-pedant']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['oc-chef-pedant']['debug_org_creation'] = false
+# Set this if you want to override pedant's chef server URL from the nginx ssl
+# URL. This is useful for special cases where you want to run pedant through
+# a proxy that sits in front of the chef server.
+default['private_chef']['oc-chef-pedant']['chef_server'] = nil
 
 ###
 # redis_lb

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
@@ -45,7 +45,7 @@ template pedant_config do
   mode  "0755"
   variables({
     :actions_enabled => node['private_chef']['dark_launch']['actions'],
-    :api_url  => OmnibusHelper.new(node).nginx_ssl_url,
+    :api_url  => node['private_chef']['oc-chef-pedant']['chef_server'] || OmnibusHelper.new(node).nginx_ssl_url,
     :base_resource_url => node['private_chef']['opscode-erchef']['base_resource_url'],
     :solr_url => OmnibusHelper.new(node).solr_url,
     :opscode_account_internal_url => node['private_chef']['lb_internal']['vip'],


### PR DESCRIPTION
This change allows an operator to override the oc-chef-pedant's
`chef_server` setting in the `chef-server.rb` configuration file.

This is useful if the Chef Server sits behind a proxy and we want to
ensure all endpoints work when accessed through the proxy.

Signed-off-by: Ryan Cragun <me@ryan.ec>