### PR TITLE
[POOL-608] allow for case insensitive users search by email

### DIFF
--- a/omnibus/files/private-chef-upgrades/001/033_users_email_lower_idx.rb
+++ b/omnibus/files/private-chef-upgrades/001/033_users_email_lower_idx.rb
@@ -1,0 +1,10 @@
+define_upgrade do
+
+  if Partybus.config.bootstrap_server
+    must_be_data_master
+
+    # schema update for adding a functional index for index-supported queries
+    # using `WHERE lower(email) = lower("USER@FOO.com")`.
+    run_sqitch('@users_email_functional_index', 'oc_erchef')
+  end
+end

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -554,7 +554,8 @@
 
 {list_users, <<"SELECT username FROM users">>}.
 
-{list_users_by_email, <<"SELECT username FROM users WHERE email = $1">>}.
+%% This is supported by a functional index on lower(email): TODO
+{list_users_by_email, <<"SELECT username FROM users WHERE lower(email) = lower($1)">>}.
 
 {list_users_by_ext_auth_uid, <<"SELECT username FROM users WHERE external_authentication_uid = $1">>}.
 

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -554,7 +554,7 @@
 
 {list_users, <<"SELECT username FROM users">>}.
 
-%% This is supported by a functional index on lower(email): TODO
+%% This is supported by a functional index on lower(email)
 {list_users_by_email, <<"SELECT username FROM users WHERE lower(email) = lower($1)">>}.
 
 {list_users_by_ext_auth_uid, <<"SELECT username FROM users WHERE external_authentication_uid = $1">>}.

--- a/src/oc_erchef/schema/baseline/Makefile
+++ b/src/oc_erchef/schema/baseline/Makefile
@@ -6,7 +6,7 @@ TEST_FUNCTIONS = $(wildcard t/test_*.sql)
 
 setup_schema:
 	@echo "Dropping and recreating database '$(TEST_DB)'"
-	@psql --dbname template1 --single-transaction --command 'DROP DATABASE IF EXISTS $(TEST_DB)'
+	@psql --dbname template1 --command 'DROP DATABASE IF EXISTS $(TEST_DB)'
 	@createdb $(TEST_DB)
 	@sqitch --engine pg --db-name $(TEST_DB) deploy
 

--- a/src/oc_erchef/schema/deploy/users_email_functional_index.sql
+++ b/src/oc_erchef/schema/deploy/users_email_functional_index.sql
@@ -1,0 +1,10 @@
+-- Deploy enterprise_chef:users_email_functional_index to pg
+-- requires: users
+
+BEGIN;
+
+  -- TODO 2017/05/30 sr: check with ops if this should include CONCURRENTLY
+  -- https://www.postgresql.org/docs/9.2/static/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY
+  CREATE INDEX users_lower_email_idx ON users (lower(email));
+
+COMMIT;

--- a/src/oc_erchef/schema/deploy/users_email_functional_index.sql
+++ b/src/oc_erchef/schema/deploy/users_email_functional_index.sql
@@ -1,10 +1,4 @@
 -- Deploy enterprise_chef:users_email_functional_index to pg
 -- requires: users
 
-BEGIN;
-
-  -- TODO 2017/05/30 sr: check with ops if this should include CONCURRENTLY
-  -- https://www.postgresql.org/docs/9.2/static/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY
-  CREATE INDEX users_lower_email_idx ON users (lower(email));
-
-COMMIT;
+CREATE INDEX CONCURRENTLY users_lower_email_idx ON users (lower(email));

--- a/src/oc_erchef/schema/revert/users_email_functional_index.sql
+++ b/src/oc_erchef/schema/revert/users_email_functional_index.sql
@@ -1,0 +1,7 @@
+-- Revert enterprise_chef:users_email_functional_index from pg
+
+BEGIN;
+
+  DROP INDEX users_lower_email_idx;
+
+COMMIT;

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -79,3 +79,4 @@ node_policy_name_policy_group 2015-09-04T01:15:03Z Daniel DeLeo <ddeleo@lorentz.
 @node-policyfile-fields 2015-09-05T01:47:34Z Daniel DeLeo <ddeleo@lorentz.local># Add policyfile fields to node
 
 users_email_functional_index [users] 2017-05-30T12:10:32Z Stephan Renatus <srenatus@chef.io> # Add functional index for index-based lower(email) lookups
+@users_email_functional_index 2017-05-30T13:27:15Z Stephan Renatus <srenatus@chef.io> # Add functional index for index-based lower(email) lookups

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -77,3 +77,5 @@ cbv_type 2015-04-23T08:33:00Z Steven Danna <steve@chef.io> # Add cbv type for ne
 
 node_policy_name_policy_group 2015-09-04T01:15:03Z Daniel DeLeo <ddeleo@lorentz.local># Add policy_name and policy_group fields to node
 @node-policyfile-fields 2015-09-05T01:47:34Z Daniel DeLeo <ddeleo@lorentz.local># Add policyfile fields to node
+
+users_email_functional_index [users] 2017-05-30T12:10:32Z Stephan Renatus <srenatus@chef.io> # Add functional index for index-based lower(email) lookups

--- a/src/oc_erchef/schema/t/test_users_table.sql
+++ b/src/oc_erchef/schema/t/test_users_table.sql
@@ -73,6 +73,7 @@ BEGIN
   RETURN QUERY SELECT chef_pgtap.has_index('users', 'users_authz_id_key', 'authz_id');
   RETURN QUERY SELECT chef_pgtap.has_index('users', 'users_username_key', 'username');
   RETURN QUERY SELECT chef_pgtap.has_index('users', 'users_email_key', 'email');
+  RETURN QUERY SELECT chef_pgtap.has_index('users', 'users_lower_email_idx', 'lower(email)');
 
   -- Keys
 

--- a/src/oc_erchef/schema/verify/users_email_functional_index.sql
+++ b/src/oc_erchef/schema/verify/users_email_functional_index.sql
@@ -1,0 +1,18 @@
+-- Verify enterprise_chef:users_email_functional_index on pg
+
+BEGIN;
+
+  -- with input from https://www.postgresql.org/message-id/16343.1222138948%40sss.pgh.pa.us
+  SELECT
+    (1/COUNT(*)) AS result
+  FROM pg_class t, pg_class i, pg_index d, pg_attribute a
+  WHERE i.relkind = 'i'
+    AND d.indexrelid = i.oid
+    AND d.indisprimary = 'f'
+    AND t.oid = d.indrelid
+    AND a.attrelid = i.oid
+    AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN ('public'))
+    AND t.relname = 'users'
+    AND pg_get_indexdef(i.oid, a.attnum, false)='lower(email)';
+
+ROLLBACK;

--- a/src/oc_erchef/schema/verify/users_email_functional_index.sql
+++ b/src/oc_erchef/schema/verify/users_email_functional_index.sql
@@ -2,17 +2,27 @@
 
 BEGIN;
 
+  -- NOTE 2017/06/01 sr: This snippet is how it would be tested.
+  -- However, for the sake of hosted (with many users), we've added CONCURRENTLY
+  -- to the CREATE INDEX call.
+  -- Thus for very large tables, the index creating might not have finished when
+  -- this verify script is executed.
+  -- Since the query this index meant to support will be fast for deployments
+  -- with few users with or without the index, and thus work irregardless of the
+  -- success of the index creation, we don't verify if it was successful.
+  -- This seems like the smoothest tradeoff for all concerned parties.
+
   -- with input from https://www.postgresql.org/message-id/16343.1222138948%40sss.pgh.pa.us
-  SELECT
-    (1/COUNT(*)) AS result
-  FROM pg_class t, pg_class i, pg_index d, pg_attribute a
-  WHERE i.relkind = 'i'
-    AND d.indexrelid = i.oid
-    AND d.indisprimary = 'f'
-    AND t.oid = d.indrelid
-    AND a.attrelid = i.oid
-    AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN ('public'))
-    AND t.relname = 'users'
-    AND pg_get_indexdef(i.oid, a.attnum, false)='lower(email)';
+  -- SELECT
+  --   (1/COUNT(*)) AS result
+  -- FROM pg_class t, pg_class i, pg_index d, pg_attribute a
+  -- WHERE i.relkind = 'i'
+  --   AND d.indexrelid = i.oid
+  --   AND d.indisprimary = 'f'
+  --   AND t.oid = d.indrelid
+  --   AND a.attrelid = i.oid
+  --   AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname IN ('public'))
+  --   AND t.relname = 'users'
+  --   AND pg_get_indexdef(i.oid, a.attnum, false)='lower(email)';
 
 ROLLBACK;


### PR DESCRIPTION
So far, this is for `GET /users?email=foo%40bar.com`, and adding an index to make this not super slow (not verified if it's strictly necessary, so if tests in hosted reveal that we don't need this, we could drop b358900).

It doesn't yet forbid creating a second user with the same email (case sensitively).