### PR TITLE
Fix 1284: 500 returned instead of 404 for unknown groups.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,8 @@ dev/*.deb
 src/oc_erchef/log
 compile_commands.json
 .kitchen
-
+# IntelliJ IDEA files
+.idea/
+*.iml
+# Vim Files
+*.swp

--- a/oc-chef-pedant/spec/api/account/account_group_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_group_spec.rb
@@ -464,6 +464,28 @@ describe "opscode-account groups", :groups do
         end
       end
 
+      context "user requesting not existing group(#1284)" do
+        let(:not_real) { "not-real" }
+        it "should return 404" do
+          get("#{request_url}/#{not_real}", platform.admin_user).should look_like({
+              :status => 404
+          })
+
+          get("#{request_url}/#{not_real}", platform.non_admin_user).should look_like({
+               :status => 404
+          })
+        end
+      end
+
+      context "user requesting not existing group acl(#1284)" do
+        let(:not_real) { "not-real" }
+        it "should return 404" do
+          get("#{request_url}/#{not_real}/_acl", platform.admin_user).should look_like({
+               :status => 404
+          })
+        end
+      end
+
       context "normal user without read ACE returns 403", :authorization do
         it "can't read group" do
           put(api_url("groups/#{test_group}/_acl/read"), platform.admin_user,

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -111,7 +111,7 @@ environment_not_found_message(EnvName) ->
 %% TODO: Why are these messages phrased differently?  This is what the Ruby endpoints were
 %% doing, FYI.  Is this something we're stuck with, or can we update the API and normalize
 %% these messages?
--spec not_found_message( node | role | data_bag | data_bag_item1 |
+-spec not_found_message( node | role | group | data_bag | data_bag_item1 |
                          data_bag_item2 | client | data_bag_missing_for_item_post |
                          environment | sandbox | sandboxes | cookbook |
                          cookbook_version | user | invitation | policy | policy_group,
@@ -120,6 +120,8 @@ not_found_message(node, Name) ->
     error_message_envelope(iolist_to_binary(["node '", Name, "' not found"]));
 not_found_message(role, Name) ->
     error_message_envelope(iolist_to_binary(["Cannot load role ", Name]));
+not_found_message(group, Name) ->
+    error_message_envelope(iolist_to_binary(["group '", Name, "' not found"]));
 not_found_message(data_bag, Name) ->
     error_message_envelope(iolist_to_binary(["Cannot load data bag ", Name]));
 not_found_message(data_bag_item1, {BagName, ItemName}) ->


### PR DESCRIPTION
This PR actually fixes #1284 when user makes a request to show a group not existing it actually returns a 500 instead of the proper 404 with error message.