### PR TITLE
CON-638 Experimental developer support for external ES5

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -33,8 +33,10 @@ First, add the following configuration to your `/etc/hosts` file:
     192.168.33.100 api.chef-server.dev manage.chef-server.dev
     192.168.33.150 database.chef-server.dev
     192.168.33.151 backend.chef-server.dev
-    192.168.33.153 ldap.chef-server.dev
+    192.168.33.152 ldap.chef-server.dev
+    192.168.33.153 custom.chef-server.dev
     192.168.33.155 reportingdb.chef-server.dev
+    192.168.33.156 elasticsearch.chef-server.dev
 
 Next, bring up the VMs!
 
@@ -303,3 +305,13 @@ vm:
     start: true
     use-external: true
 ```
+# Using elasticsearch 
+
+To create a separate elasticsearch vm create a `config.yml` file with the following contents:
+```
+  elasticsearch:
+    start: true
+    # The major version family to use - either "2" or "5".
+    version: "5"
+```
+

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -12,7 +12,8 @@ IPS = {
   be: "192.168.33.151",
   ldap: "192.168.33.152",
   custom: "192.168.33.153",
-  reportingdb: "192.168.33.155"
+  reportingdb: "192.168.33.155",
+  elasticsearch: "192.168.33.156"
 }
 
 
@@ -93,6 +94,16 @@ Vagrant.configure("2") do |config|
     attributes['vm']['chef-backend'] = nil
   end
 
+  if attributes['vm'].has_key? 'elasticsearch'
+    if attributes['vm']['elasticsearch']['start'] == true
+      config.vm.define('elasticsearch') do |c|
+        define_elasticsearch_server(c, attributes)
+      end
+    end
+  else
+    attributes['vm']['elasticsearch'] = nil
+  end
+
   if attributes['vm']['start-custom'] == true
     config.vm.define("custom") do |c|
       define_custom_server(c, attributes)
@@ -158,6 +169,15 @@ def define_chef_server(config, attributes)
                "ldap['login_attribute']" => '"uid"'
       }
       json = simple_deep_merge(json, { "provisioning" => { "chef-server-config" => ldap } })
+    end
+
+    if vmattr['elasticsearch'] && vmattr['elasticsearch']['start']
+      elasticsearch = { "opscode_solr4['external']" => "true",
+                        "opscode_solr4['external_url']" => '"http://elasticsearch:9200"',
+                        "opscode_erchef['search_provider']" => '"elasticsearch"',
+                        "opscode_erchef['search_queue_mode']" => '"batch"'
+      }
+      json = simple_deep_merge(json, { "provisioning" => { "chef-server-config" => elasticsearch } })
     end
 
     dotfiles_path = vmattr["dotfile_path"] || "dotfiles"
@@ -250,6 +270,17 @@ def define_custom_server(config, attributes)
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
 end
 
+def define_elasticsearch_server(config, attributes)
+  config.vm.hostname = "elasticsearch.chef-server.dev"
+  config.vm.network "private_network", ip: IPS[:elasticsearch]
+  customize_vm(config, name: "elasticsearch", memory: 2048, cpus: 2)
+  set_chef_zero_provisioning(config,
+                             recipes: ["provisioning::hosts"],
+                             json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
+  config.vm.provision "shell",
+                      path: "scripts/provision-elasticsearch.sh",
+                      env: { 'ELASTIC_VERSION' => attributes["vm"]["elasticsearch"]["version"] }
+end
 
 def define_backend_server(config, attribute)
   provisioning, installer, installer_path = prepare('BE_INSTALLER', 'chef-backend', 'Chef Backend 1.1+')

--- a/dev/config.yml.example
+++ b/dev/config.yml.example
@@ -32,6 +32,11 @@ vm:
   # this vm as an external postgresql server from the start.
   #  use-external: true
 
+  elasticsearch:
+  # enable a separate elasticsearch vm
+  # start: true
+  # version: "5" # options are "2" or "5"
+
   # These will map directly to entries in the generated chef-server.rb
   node-attributes:
     provisioning:

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -34,6 +34,12 @@ vm:
     # enable a separate ldap vm but do not use it unless
     # use-external is set.
     start: false
+  # Brings up elasticsearch 5 - not connected to chef-server right now.
+  # This is experimental.
+  #elasticsearch:
+    #start: true
+    # The major version family to use - either "2" or "5".
+    #version: "2"
   # Override this in config.yml if you want to install chef server plugins with
   # specific packages.
   plugins:
@@ -100,7 +106,7 @@ vm:
     base_output_path: /vagrant/testdata/cover # maps to dev/testdata/cover
   node-attributes:
     placeholder: true
-  # Overriding config.vm.stsrt-custom to true will create an empty VM of the same
+  # Overriding config.vm.start-custom to true will create an empty VM of the same
   # distro as the chef server, with 2GB/2core, using CUSTOM_VM_ADDRESS
   start-custom: false
 

--- a/dev/scripts/provision-elasticsearch.sh
+++ b/dev/scripts/provision-elasticsearch.sh
@@ -1,0 +1,17 @@
+add-apt-repository ppa:openjdk-r/ppa
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+
+if [ "${ELASTIC_VERSION}" = "2" ]; then
+  echo "deb https://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
+else
+  echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
+fi
+
+apt-get update
+
+apt-get install openjdk-8-jdk -y
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+apt-get install elasticsearch -y
+echo "http.host: 0.0.0.0" > /etc/elasticsearch/elasticsearch.yml
+service elasticsearch start

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -33,6 +33,8 @@ erchef_config = File.join(opscode_erchef_dir, "sys.config")
 
 rabbitmq = OmnibusHelper.new(node).rabbitmq_configuration
 
+elastic_search_version = OmnibusHelper.new(node).elastic_search_major_version
+
 actions_vip = rabbitmq['vip']
 actions_port = rabbitmq['node_port']
 actions_user = rabbitmq['actions_user']
@@ -52,6 +54,7 @@ template erchef_config do
                                                                  :actions_vhost => actions_vhost,
                                                                  :actions_exchange => actions_exchange,
                                                                  :ldap_encryption_type => ldap_encryption_type,
+                                                                 :solr_elasticsearch_major_version => elastic_search_version,
                                                                  :helper => OmnibusHelper.new(node)))
   notifies :run, 'execute[remove_erchef_siz_files]', :immediately
   notifies :restart, 'runit_service[opscode-erchef]' unless backend_secondary?

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
@@ -56,4 +56,106 @@ describe OmnibusHelper do
       expect(helper.nginx_ssl_url).to eq('https://nginx-url:8443')
     end
   end
+
+  describe '#elastic_search_major_version' do
+    let(:external) { true }
+    let(:hostname) { 'myserver' }
+    let(:port) { 2000 }
+    let(:external_url) { "http://#{hostname}:#{port}" if hostname }
+    let(:node) do
+      {
+        'private_chef' => {
+          'opscode-solr4' => {
+            'external' => external,
+            'external_url' => external_url
+          }
+        }
+      }
+    end
+
+    let(:elastic_version) { '2.4.5' }
+    let(:http_code) { '200' }
+    let(:json_response) do <<-EOS
+        {
+          "name": "Zero-G",
+          "cluster_name": "elasticsearch",
+          "cluster_uuid": "uLwCC2LpQcqM0clO1d97AA",
+          "version": {
+            "number": "#{elastic_version}",
+            "build_hash": "c849dd13904f53e63e88efc33b2ceeda0b6a1276",
+            "build_timestamp": "2017-04-24T16:18:17Z",
+            "build_snapshot": false,
+            "lucene_version": "5.5.4"
+          },
+          "tagline": "You Know, for Search"
+        }
+      EOS
+    end
+
+    let(:response) do
+      r = double(Net::HTTPResponse)
+      allow(r).to receive(:body).and_return(json_response)
+      allow(r).to receive(:code).and_return(http_code)
+      r
+    end
+
+    context 'when elastic search is disabled' do
+      let(:external) { false }
+      let(:hostname) { nil }
+      let(:port) { nil }
+      let(:elastic_version) { '50.0' }
+
+      it 'should return a default version 0' do
+        helper = described_class.new(node)
+        expect(helper.elastic_search_major_version).to eq(0)
+      end
+    end
+
+    context 'when elastic search is unavailable' do
+      it 'should return raise an exception after 5 retries.' do
+        helper = described_class.new(node)
+        expect(Net::HTTP).to receive(:start).with(hostname, port, use_ssl: false).exactly(5).times.and_raise('Bad connection')
+        allow(helper).to receive(:sleep).and_return(0)
+        expect { helper.elastic_search_major_version }.to raise_error(/Failed to connect/)
+      end
+    end
+
+    context 'when elastic search is version 2' do
+      it 'should return 2' do
+        helper = described_class.new(node)
+        expect(Net::HTTP).to receive(:start).with(hostname, port, use_ssl: false).and_return(response)
+        expect(helper.elastic_search_major_version).to eq(2)
+      end
+    end
+
+    context 'when elastic search is version 5' do
+      let(:elastic_version) { '5.0.1' }
+
+      it 'should return 5' do
+        helper = described_class.new(node)
+        expect(Net::HTTP).to receive(:start).with(hostname, port, use_ssl: false).and_return(response)
+        expect(helper.elastic_search_major_version).to eq(5)
+      end
+    end
+
+    context 'when elastic search is version unsupported' do
+      let(:elastic_version) { '200.50.35' }
+
+      it 'should raise an exception' do
+        helper = described_class.new(node)
+        expect(Net::HTTP).to receive(:start).with(hostname, port, use_ssl: false).and_return(response)
+        expect { helper.elastic_search_major_version }.to raise_error(/Unsupported elasticsearch version/)
+      end
+    end
+
+    context 'when elastic search returns a bad response' do
+      let(:http_code) { '404' }
+
+      it 'should raise an exception' do
+        helper = described_class.new(node)
+        expect(Net::HTTP).to receive(:start).with(hostname, port, use_ssl: false).and_return(response)
+        expect { helper.elastic_search_major_version }.to raise_error(/Unable to interrogate/)
+      end
+    end
+  end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -217,6 +217,7 @@
         {reindex_sleep_min_ms, <%= @reindex_sleep_min_ms -%>},
         {reindex_sleep_max_ms, <%= @reindex_sleep_max_ms -%>},
         {reindex_item_retries, <%= @reindex_item_retries -%>},
+        {solr_elasticsearch_major_version, <%= @solr_elasticsearch_major_version %>},
         {solr_service, [
             {root_url, "<%= @helper.solr_url() %>"},
             {timeout, <%= @solr_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -75,7 +75,7 @@ search_server "<%= @solr_url %>"
 
 <% if node['private_chef']['opscode-erchef']['search_provider'] == "elasticsearch" %>
 search_commit_url "/_refresh"
-search_url_fmt "/chef/_search?fq=X_CHEF_type_CHEF_X:%{type}&q=%{query}"
+search_url_fmt "/chef/_search?q=X_CHEF_type_CHEF_X:%{type}%%20%{query}"
 <% end %>
 
 # Some tests expect access erchef server directly, instead of routing through

--- a/src/chef-mover/apps/chef_index/README.md
+++ b/src/chef-mover/apps/chef_index/README.md
@@ -6,7 +6,7 @@ Chef is a system integration framework written in erlang and ruby and designed t
 
 The Chef Wiki is the definitive source of user documentation.
 
-    http://wiki.chef.io/display/chef/Home
+    https://docs.chef.io/
 
 This README focuses on developers who want to modify Chef source code.  For users who just want to run the latest and greatest Chef development version in their environment, see:
 
@@ -15,12 +15,9 @@ This README focuses on developers who want to modify Chef source code.  For user
 # DEVELOPMENT:
 
 Before working on the code, if you plan to contribute your changes, you need to read the Opscode Contributing document.
-
-    http://wiki.chef.io/display/chef/How+to+Contribute
-
 You will also need to set up the repository with the appropriate branches. We document the process on the Chef Wiki.
 
-    http://wiki.chef.io/display/chef/Working+with+git
+    https://github.com/chef/chef/blob/master/CONTRIBUTING.md
 
 Once your repository is set up, you can start working on the code.
 
@@ -36,7 +33,7 @@ Tickets/Issues:
 
 Documentation:
 
-    http://wiki.chef.io/display/chef/Home/
+    https://docs.chef.io/
 
 # LICENSE:
 

--- a/src/oc_erchef/apps/chef_index/README.md
+++ b/src/oc_erchef/apps/chef_index/README.md
@@ -2,48 +2,4 @@
 
 This is the search/indexing layer for chef.
 
-Chef is a system integration framework written in erlang and ruby and designed to bring the benefits of configuration management to your entire infrastructure.
-
-The Chef Wiki is the definitive source of user documentation.
-
-    http://wiki.chef.io/display/chef/Home
-
-This README focuses on developers who want to modify Chef source code.  For users who just want to run the latest and greatest Chef development version in their environment, see:
-
-   [TODO: add URL when available for erlang chef build process]
-
-# DEVELOPMENT:
-
-Before working on the code, if you plan to contribute your changes, you need to read the Opscode Contributing document.
-
-    http://wiki.chef.io/display/chef/How+to+Contribute
-
-You will also need to set up the repository with the appropriate branches. We document the process on the Chef Wiki.
-
-    http://wiki.chef.io/display/chef/Working+with+git
-
-Once your repository is set up, you can start working on the code. **If your changes will affect oc_reporting, make sure to sync your changes in the [chef_index](https://github.com/chef/chef_index) repository.**
-
-# LINKS:
-
-Source:
-
-    https://github.com/opscode/chef_index
-
-Tickets/Issues:
-
-    http://tickets.chef.io/
-
-Documentation:
-
-    http://wiki.chef.io/display/chef/Home/
-
-# LICENSE:
-
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.
+**If your changes will affect oc_reporting, make sure to sync your changes in the [chef_index](https://github.com/chef/chef_index) repository.**

--- a/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
@@ -12,10 +12,11 @@
         ]).
 
 -include("chef_solr.hrl").
+-define(JSON_HEADER, [{"Content-Type", "application/json"}]).
 
 -spec ping() -> pong | pang.
 ping() ->
-    case chef_index_http:get("/chef") of
+    case chef_index_http:get("/chef", [], ?JSON_HEADER) of
         ok -> pong;
         _Error -> pang
     end.
@@ -24,7 +25,7 @@ ping() ->
 update(Body) when is_list(Body) ->
     update(iolist_to_binary(Body));
 update(Body) ->
-    chef_index_http:post("/_bulk", Body).
+    chef_index_http:post("/_bulk", Body, ?JSON_HEADER).
 
 -spec search(#chef_solr_query{}) ->
                     {ok, non_neg_integer(), non_neg_integer(), [binary()]} |
@@ -32,7 +33,7 @@ update(Body) ->
                     {error, {solr_500, string()}}.
 search(#chef_solr_query{} = Query) ->
     Url = "/chef/_search",
-    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, query_body(Query)),
+    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, query_body(Query), ?JSON_HEADER),
     case Code of
         "200" ->
             handle_successful_search(Body);
@@ -55,40 +56,46 @@ transform_data(Data) ->
     Data.
 
 commit() ->
-    chef_index_http:post("/_refresh", []).
+    chef_index_http:post("/_refresh", [], ?JSON_HEADER).
 
 query_body(#chef_solr_query{
               query_string = Query,
               filter_query = undefined,
               start = Start,
               rows = Rows}) ->
-    jiffy:encode({[{<<"fields">>, <<"_id">>},
+    jiffy:encode({[{fields_tag(), <<"_id">>},
                    {<<"from">>, Start},
                    {<<"size">>, Rows},
-                   query_string_query_ejson(Query)]});
+                   {<<"query">>, {[query_string_query_ejson(Query)]}}
+                  ]});
 query_body(#chef_solr_query{
               query_string = Query,
               filter_query = FilterQuery,
               start = Start,
               rows = Rows}) ->
     chef_index_query:assert_org_id_filter(FilterQuery),
-    jiffy:encode({[{<<"fields">>, <<"_id">>},
-                   {<<"from">>, Start},
-                   {<<"size">>, Rows},
-                   {<<"sort">>, [{[{<<"X_CHEF_id_CHEF_X">>, {[{<<"order">>, <<"asc">>}]}}]}]},
-                   {<<"query">>, {[
-                                   {<<"filtered">>,{[
-                                                     query_string_query_ejson(Query),
-                                                     {<<"filter">>, {[query_string_query_ejson(FilterQuery)]}}
-                                                    ]}}]}}]}).
+    jiffy:encode({[{ fields_tag(), <<"_id">>},
+        {<<"from">>, Start},
+        {<<"size">>, Rows},
+        {<<"sort">>, [{[{<<"X_CHEF_id_CHEF_X">>, {[{<<"order">>, <<"asc">>}]}}]}]},
+        {<<"query">>, {[
+            {<<"bool">>,{[
+                {<<"must">>, {[query_string_query_ejson(Query)]}},
+                {<<"filter">>, {[query_string_query_ejson(FilterQuery)]}}
+            ]}}]}
+        }]}).
+
+fields_tag() ->
+    case envy:get(chef_index, solr_elasticsearch_major_version, 2, non_neg_integer) of
+        5 -> <<"stored_fields">>;
+        _ -> <<"fields">>
+    end.
 
 query_string_query_ejson(QueryString) ->
-    { <<"query">>, {
-          [{<<"query_string">>,{
-                [{<<"lowercase_expanded_terms">>, false},
-                 {<<"query">>, list_to_binary(QueryString)}]}}]
-         }
-    }.
+    {<<"query_string">>,{[
+        {<<"lowercase_expanded_terms">>, false},
+        {<<"query">>, list_to_binary(QueryString)}
+    ]}}.
 
 %%
 %% A note on deleting
@@ -138,7 +145,7 @@ delete_search_db(OrgId) ->
                     {error, {solr_500, string()}}.
 search_with_scroll(#chef_solr_query{} = Query) ->
     Url = "/chef/_search?scroll=1m",
-    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, query_body(Query)),
+    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, query_body(Query), ?JSON_HEADER),
     case Code of
         "200" ->
             EjsonBody = jiffy:decode(Body),
@@ -157,11 +164,11 @@ search_with_scroll(#chef_solr_query{} = Query) ->
     end.
 
 scroll(ScrollId, NumFound, NumFound, Ids) ->
-    ok = chef_index_http:delete("/_search/scroll", ScrollId),
+    ok = chef_index_http:delete("/_search/scroll", ScrollId, ?JSON_HEADER),
     {ok, undefined, NumFound, Ids};
 scroll(ScrollId, NumFound, _, Ids) ->
     Url = "/_search/scroll?scroll=1m",
-    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, ScrollId),
+    {ok, Code, _Head, Body} = chef_index_http:request(Url, get, ScrollId, ?JSON_HEADER),
     case Code of
         "200" ->
             DocList = ej:get({<<"hits">>, <<"hits">>}, jiffy:decode(Body)),
@@ -180,5 +187,5 @@ delete_ids([]) ->
     ok = commit(),
     ok;
 delete_ids([Id | Ids]) ->
-    ok = chef_index_http:delete("/chef/object/" ++ Id, []),
+    ok = chef_index_http:delete("/chef/object/" ++ Id, [], ?JSON_HEADER),
     delete_ids(Ids).

--- a/src/oc_erchef/apps/chef_index/test/chef_index_expand_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_expand_tests.erl
@@ -302,6 +302,7 @@ solr_api_test_() ->
 es_api_test_() ->
     MinItem = {[{<<"key1">>, <<"value1">>},
                 {<<"key2">>, <<"value-2">>}]},
+    JsonContentType = [{"Content-Type", "application/json"}],
     {foreach,
      fun() ->
              application:set_env(chef_index, search_provider, elasticsearch)
@@ -315,7 +316,8 @@ es_api_test_() ->
                         chef_index_test_utils:set_provider(elasticsearch),
                         Expect = es_send_item_json_expect(),
                         meck:expect(chef_index_http, post,
-                                    fun("/_bulk", Doc) ->
+                                    fun("/_bulk", Doc, Headers) ->
+                                            ?assertEqual(JsonContentType, Headers),
                                             ?assertEqual(Expect, Doc),
                                             ok
                                     end),
@@ -327,7 +329,8 @@ es_api_test_() ->
                         chef_index_test_utils:set_provider(elasticsearch),
                         Expect = es_send_delete_json_expect(),
                         meck:expect(chef_index_http, post,
-                                    fun("/_bulk", Doc) ->
+                                    fun("/_bulk", Doc, Headers) ->
+                                            ?assertEqual(JsonContentType, Headers),
                                             ?assertEqual(Expect, Doc),
                                             ok
                                     end),


### PR DESCRIPTION
This adds elastic search 5 support to chef_index but this support is
experimental.  It does not take care of upgrading a current chef-server
from ES 2 -> ES 5.  It also does not ensure that all other chef-server
functionality such as the reporting or the chef-backend plugin correctly
work when ES 5 is used.  Using ES5 as the search engine is completely
unsupported in a customer environment.

For the dev environment, a new optional VM has been added to
dev/Vagrantfile.  To enable it, check out defaults.yml for the commented
out 'elasticsearch' section.  It supports bring ES2 or ES5 currently.

@ssd, @sdelano, @marcparadise, @chef/chef-server-maintainers 