### PR TITLE
oc-chef-pedant: fix override logic

### DIFF
--- a/oc-chef-pedant/lib/pedant/platform.rb
+++ b/oc-chef-pedant/lib/pedant/platform.rb
@@ -380,12 +380,12 @@ module Pedant
 
     def create_min_user(username, options = {})
       payload = {
-        "username" => username,
-        "email" => "#{username}@chef.io",
-        "first_name" => username,
-        "last_name" => username,
-        "display_name" => username,
-        "password" => "foobar"
+        username: username,
+        email: "#{username}@chef.io",
+        first_name: username,
+        last_name: username,
+        display_name: username,
+        password: "foobar"
       }
       if options.has_key?(:overrides)
         payload = payload.merge(options[:overrides])


### PR DESCRIPTION
Before, we'd end up with a payload that contained both
`"email" => "username@chef.io"` and `:email => "what-was-overridden"`.

Signed-off-by: Stephan Renatus <srenatus@chef.io>