### PR TITLE
Fix `omnibus cache missing` etc

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -6,8 +6,6 @@ driver:
     memory: 4096
   synced_folders:
     - ['..', '/home/vagrant/chef-server']
-    - ['../../omnibus', '/home/vagrant/omnibus']
-    - ['../../omnibus-software', '/home/vagrant/omnibus-software']
 
 provisioner:
   name: chef_zero

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -33,4 +33,6 @@ suites:
         build_user_group: vagrant
         build_user_password: vagrant
         install_dir: /opt/opscode
-    run_list: omnibus::default
+    run_list:
+      - omnibus::default
+      - zip

--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -6,6 +6,7 @@ cookbook 'apt', '~> 2.0'
 
 cookbook 'omnibus'
 cookbook 'yum-epel', '~> 0.6'
+cookbook 'zip', '~> 1.1.0'
 
 # Uncomment to use the latest version of the Omnibus cookbook from GitHub
 # cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'

--- a/omnibus/Berksfile.lock
+++ b/omnibus/Berksfile.lock
@@ -2,6 +2,7 @@ DEPENDENCIES
   apt (~> 2.0)
   omnibus
   yum-epel (~> 0.6)
+  zip (~> 1.1.0)
 
 GRAPH
   apt (2.9.2)
@@ -41,3 +42,4 @@ GRAPH
   yum (5.0.0)
   yum-epel (0.7.1)
     yum (>= 3.6.3)
+  zip (1.1.0)

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -176,18 +176,20 @@ section:
 
 ```shell
 $ kitchen login ubuntu-1204
-[vagrant@ubuntu...] $ cd opscode-omnibus
+[vagrant@ubuntu...] $ . load-omnibus-toolchain.sh
+[vagrant@ubuntu...] $ cd chef-server/omnibus
 [vagrant@ubuntu...] $ bundle install --binstubs
-[vagrant@ubuntu...] $ ...
+...
 [vagrant@ubuntu...] $ bin/omnibus build chef-server -l internal
 ```
 or if you prefer not to use binstubs and to use bundle exec instead:
 
 ```shell
 $ kitchen login ubuntu-1204
-[vagrant@ubuntu...] $ cd opscode-omnibus
+[vagrant@ubuntu...] $ . load-omnibus-toolchain.sh
+[vagrant@ubuntu...] $ cd chef-server/omnibus
 [vagrant@ubuntu...] $ bundle install
-[vagrant@ubuntu...] $ ...
+...
 [vagrant@ubuntu...] $ bundle exec omnibus build chef-server -l internal
 ```
 

--- a/omnibus/config/projects/chef-server-fips.rb
+++ b/omnibus/config/projects/chef-server-fips.rb
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-chef_server_contents = IO.read(File.expand_path('../chef-server.rb', __FILE__))
-self.instance_eval(chef_server_contents)
+chef_server_path = File.expand_path('../chef-server.rb', __FILE__)
+instance_eval(IO.read(chef_server_path), chef_server_path)
 
 name "chef-server-fips"
 package_name "chef-server-fips-core"


### PR DESCRIPTION
Seems like the _second parameter_ to `instance_eval` is not *only*

> used when reporting compilation errors

but also fixes the __FILE__ references. Without this change,

    omnibus cache missing

would end up trying to read omnibus_overrides.rb from a path relative to
the CWD, and therefore fail.

Signed-off-by: Stephan Renatus <srenatus@chef.io>