### PR TITLE
[cookbooks] Remove apt and yum dependencies

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
@@ -12,6 +12,4 @@ recipe            "chef-server", "Configures the Chef Server from Omnibus"
 end
 
 depends          'enterprise' # grabbed via Berkshelf + Git
-depends          'apt'
-depends          'yum', '~> 3.0'
 depends          'openssl', '>= 4.4'


### PR DESCRIPTION
These cookbooks appear unused in the private-chef cookbooks. These
were previously used to install the add-on repository; however, that
functionality was changed in 9d10dac3d3933503211217968449c38657e0f7a6
to use mixlib-install.

Signed-off-by: Steven Danna <steve@chef.io>