### PR TITLE
[cookbooks] Removed unused cookbook cache config option

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -465,7 +465,6 @@ default['private_chef']['lb']['enable'] = true
 default['private_chef']['lb']['vip'] = "127.0.0.1"
 default['private_chef']['lb']['api_fqdn'] = node['fqdn']
 default['private_chef']['lb']['web_ui_fqdn'] = node['fqdn']
-default['private_chef']['lb']['cache_cookbook_files'] = false
 default['private_chef']['lb']['debug'] = false
 default['private_chef']['lb']['upstream']['opscode-erchef'] = [ "127.0.0.1" ]
 default['private_chef']['lb']['upstream']['oc_bifrost'] = [ "127.0.0.1" ]

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -439,7 +439,6 @@ module PrivateChef
       PrivateChef["opscode_expander"]["enable"] ||= false
       PrivateChef["postgresql"]["enable"] ||= false
       PrivateChef["postgresql"]["vip"] ||= PrivateChef["backend_vips"]["ipaddress"]
-      PrivateChef["lb"]["cache_cookbook_files"] ||= true
       PrivateChef["lb"]["upstream"] ||= Mash.new
       if PrivateChef["use_ipv6"] && PrivateChef["backend_vips"]["ipaddress"].include?(":")
         PrivateChef["lb"]["upstream"]["bookshelf"] ||= [ "[#{PrivateChef["backend_vips"]["ipaddress"]}]" ]


### PR DESCRIPTION
I believe this was the configuration option for the older cookbook
caching feature. The older feature worked because URLs were not
signed. This feature broke a long time ago and was replaced by a new
caching mechanism that uses the following new settings:

    opscode_erchef'['nginx_bookshelf_caching'] = :off
    opscode_erchef'['s3_url_expiry_window_size'] = :off

Signed-off-by: Steven Danna <steve@chef.io>
Signed-off-by: Jaymala Sinha <jsinha@chef.io>