### PR TITLE
[pedant] Add sleep to re-indexing tests

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/search_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/search_util.rb
@@ -903,6 +903,10 @@ module Pedant
         return if i == 0
         if queues_empty?
           puts "RabbitMQ queue is empty (or failed to call rabbitmqctl list_queues)"
+          # Why? It may be that expander has pulled the item from the queue
+          # but hasn't posted it to Solr.
+          puts "Waiting an additional 5 seconds"
+          sleep 5
         else
           puts "Waiting for RabbitMQ queue to be empty (#{i} tries remaining)"
           sleep 1


### PR DESCRIPTION
My best guess for what is happening in Wilson is that we are hitting a
race between the queue being empty and expander posting the data to
solr.

I'm pretty skeptical of this given that the search that is failing is
often the /last/ search in a series of searches so there is already a
large amount of time between seeing an empty queue and doing the
failing search.

The other issue I'm investigating is whether our queues_empty?
function may be erroneously reporting empty queues, but perhaps this
will help in the meantime.

Signed-off-by: Steven Danna <steve@chef.io>