### PR TITLE
Lazily evaluate ES version detection code

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -4,6 +4,7 @@
 #
 # All Rights Reserved
 
+helper = OmnibusHelper.new(node)
 opscode_erchef_dir = node['private_chef']['opscode-erchef']['dir']
 opscode_erchef_log_dir = node['private_chef']['opscode-erchef']['log_directory']
 opscode_erchef_sasl_log_dir = File.join(opscode_erchef_log_dir, "sasl")
@@ -13,8 +14,8 @@ opscode_erchef_sasl_log_dir = File.join(opscode_erchef_log_dir, "sasl")
   opscode_erchef_sasl_log_dir
 ].each do |dir_name|
   directory dir_name do
-    owner OmnibusHelper.new(node).ownership['owner']
-    group OmnibusHelper.new(node).ownership['group']
+    owner helper.ownership['owner']
+    group helper.ownership['group']
     mode node['private_chef']['service_dir_perms']
     recursive true
   end
@@ -24,16 +25,14 @@ link "/opt/opscode/embedded/service/opscode-erchef/log" do
   to opscode_erchef_log_dir
 end
 
-ldap_authentication_enabled = OmnibusHelper.new(node).ldap_authentication_enabled?
+ldap_authentication_enabled = helper.ldap_authentication_enabled?
  # These values are validated and managed in libraries/private_chef.rb#gen_ldap
 enable_ssl = ldap_authentication_enabled ? node['private_chef']['ldap']['enable_ssl'] : nil
 ldap_encryption_type = ldap_authentication_enabled ? node['private_chef']['ldap']['encryption_type'] : nil
 
 erchef_config = File.join(opscode_erchef_dir, "sys.config")
 
-rabbitmq = OmnibusHelper.new(node).rabbitmq_configuration
-
-elastic_search_version = OmnibusHelper.new(node).elastic_search_major_version
+rabbitmq = helper.rabbitmq_configuration
 
 actions_vip = rabbitmq['vip']
 actions_port = rabbitmq['node_port']
@@ -43,23 +42,21 @@ actions_exchange = rabbitmq['actions_exchange']
 
 template erchef_config do
   source "oc_erchef.config.erb"
-  owner OmnibusHelper.new(node).ownership['owner']
-  group OmnibusHelper.new(node).ownership['group']
+  owner helper.ownership['owner']
+  group helper.ownership['group']
   mode "644"
   variables lazy {
-      {
-        node['private_chef']['opscode-erchef'].to_hash.merge(:ldap_enabled => ldap_authentication_enabled,
-                                                                 :enable_ssl =>  enable_ssl,
-                                                                 :actions_vip => actions_vip,
-                                                                 :actions_port => actions_port,
-                                                                 :actions_user => actions_user,
-                                                                 :actions_vhost => actions_vhost,
-                                                                 :actions_exchange => actions_exchange,
-                                                                 :ldap_encryption_type => ldap_encryption_type,
-                                                                 :solr_elasticsearch_major_version => elastic_search_version,
-                                                                 :helper => OmnibusHelper.new(node))
-     }
-   }
+    node['private_chef']['opscode-erchef'].to_hash.merge(:ldap_enabled => ldap_authentication_enabled,
+                                                         :enable_ssl => enable_ssl,
+                                                         :actions_vip => actions_vip,
+                                                         :actions_port => actions_port,
+                                                         :actions_user => actions_user,
+                                                         :actions_vhost => actions_vhost,
+                                                         :actions_exchange => actions_exchange,
+                                                         :ldap_encryption_type => ldap_encryption_type,
+                                                         :solr_elasticsearch_major_version => helper.elastic_search_major_version,
+                                                         :helper => helper)
+  }
   notifies :run, 'execute[remove_erchef_siz_files]', :immediately
   notifies :restart, 'runit_service[opscode-erchef]' unless backend_secondary?
 end
@@ -89,8 +86,8 @@ vmargs_config = File.join(opscode_erchef_dir, "vm.args")
 
 template vmargs_config do
   source "oc_erchef.vm.args.erb"
-  owner OmnibusHelper.new(node).ownership['owner']
-  group OmnibusHelper.new(node).ownership['group']
+  owner helper.ownership['owner']
+  group helper.ownership['group']
   mode "644"
   notifies :restart, 'runit_service[opscode-erchef]' unless backend_secondary?
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -46,7 +46,9 @@ template erchef_config do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
-  variables(node['private_chef']['opscode-erchef'].to_hash.merge(:ldap_enabled => ldap_authentication_enabled,
+  variables lazy {
+      {
+        node['private_chef']['opscode-erchef'].to_hash.merge(:ldap_enabled => ldap_authentication_enabled,
                                                                  :enable_ssl =>  enable_ssl,
                                                                  :actions_vip => actions_vip,
                                                                  :actions_port => actions_port,
@@ -55,7 +57,9 @@ template erchef_config do
                                                                  :actions_exchange => actions_exchange,
                                                                  :ldap_encryption_type => ldap_encryption_type,
                                                                  :solr_elasticsearch_major_version => elastic_search_version,
-                                                                 :helper => OmnibusHelper.new(node)))
+                                                                 :helper => OmnibusHelper.new(node))
+     }
+   }
   notifies :run, 'execute[remove_erchef_siz_files]', :immediately
   notifies :restart, 'runit_service[opscode-erchef]' unless backend_secondary?
 end


### PR DESCRIPTION
When running against chef-backend, the external elasticsearch node is proxies by HAProxy, which is started by Chef Server.  Thus, we need to make sure the ES version detection code runs at compile-time to avoid it getting ECONNREFUSED.