### PR TITLE
Add tests for chef-server-running.json

### DIFF
--- a/oc-chef-pedant/bin/oc-chef-pedant
+++ b/oc-chef-pedant/bin/oc-chef-pedant
@@ -6,7 +6,7 @@ require 'rspec/core'
 require 'pedant'
 require 'pedant/organization'
 
-Pedant.config.suite = "api"
+Pedant.config.suite = ["api", "running_configs"]
 Pedant.setup(ARGV)
 puts Pedant::UI.new.info_banner
 

--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -58,8 +58,10 @@ module Pedant
     # tests.  Includes only the tests specified by the value of
     # +Pedant.config.suite+.
     def self.test_directories
-      suite = Pedant.config.suite || raise("Test suite unspecified!  Set 'Pedant.config.suite' in the test runner!")
-      Pedant::Gem.test_directories(suite)
+      suites = Pedant.config.suite || raise("Test suite unspecified!  Set 'Pedant.config.suite' in the test runner!")
+      Array(suites).map do |suite|
+        Pedant::Gem.test_directories(suite)
+      end
     end
 
 

--- a/oc-chef-pedant/spec/running_configs/analytics_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/analytics_spec.rb
@@ -7,8 +7,8 @@ describe 'running configs required by Analytics Server', :config do
   # written out in some configurations.
   #
   running_config = JSON.parse(IO.read('/etc/opscode/chef-server-running.json'))
-  if running_config['insecure_addon_compat'] && running_config['darklaunch']['actions']
-    skip 'Analytics config is only written when insecure_addon_compat = true && darklaunch["actions"] = true'
+  if !(running_config['private_chef']['insecure_addon_compat'] && running_config['private_chef']['dark_launch']['actions'])
+    skip 'Analytics config is only written when insecure_addon_compat = true && dark_launch["actions"] = true'
   else
     let(:actions_source) { JSON.parse(IO.read('/etc/opscode-analytics/actions-source.json')) }
     let(:config) { actions_source['private_chef'] }

--- a/oc-chef-pedant/spec/running_configs/analytics_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/analytics_spec.rb
@@ -1,0 +1,48 @@
+require 'json'
+require 'pedant/rspec/common'
+
+describe 'running configs required by Analytics Server', :config do
+  #
+  # The analyics add-on reads from actions-source.json which is only
+  # written out in some configurations.
+  #
+  running_config = JSON.parse(IO.read('/etc/opscode/chef-server-running.json'))
+  if running_config['insecure_addon_compat'] && running_config['darklaunch']['actions']
+    skip 'Analytics config is only written when insecure_addon_compat = true && darklaunch["actions"] = true'
+  else
+    let(:actions_source) { JSON.parse(IO.read('/etc/opscode-analytics/actions-source.json')) }
+    let(:config) { actions_source['private_chef'] }
+
+    it 'api_fqdn' do
+      expect(config['api_fqdn'].to_s).to_not eq('')
+    end
+
+    it 'oc_id_application' do
+      expect(config['oc_id_application'].class).to eq(Hash)
+    end
+
+    it 'rabbitmq_host' do
+      expect(config['rabbitmq_host'].to_s).to_not eq('')
+    end
+
+    it 'rabbitmq_port' do
+      expect(config['rabbitmq_port'].to_i).to_not eq(0)
+    end
+
+    it 'rabbitmq_vhost' do
+      expect(config['rabbitmq_vhost'].to_s).to_not eq('')
+    end
+
+    it 'rabbitmq_exchange' do
+      expect(config['rabbitmq_exchange'].to_s).to_not eq('')
+    end
+
+    it 'rabbitmq_user' do
+      expect(config['rabbitmq_user'].to_s).to_not eq('')
+    end
+
+    it 'rabbitmq_password' do
+      expect(config['rabbitmq_password'].to_s).to_not eq('')
+    end
+  end
+end

--- a/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
@@ -5,51 +5,94 @@ describe "running configs required by chef-server-ctl", :config do
   let (:complete_config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json")) }
   let (:config) { complete_config['private_chef'] }
 
-  it "fips_enabled" do
-    expect(config['fips_enabled']).to be(true).or be(false)
-  end
-
-  it "opscode-erchef/search_queue_mode" do
-    expect(config["opscode-erchef"]["search_queue_mode"]).to eq("rabbitmq")
-                                                               .or eq("batch")
-                                                                     .or eq("inline")
-  end
-
-  it "ldap/enabled" do
-    expect(config["ldap"]["enabled"]).to be(true).or be(false).or be(nil)
-  end
-
-  it "runit/sv_dir" do
-    expect(complete_config["runit"]["sv_dir"].to_s).to_not eq("")
-    expect(File.exist?(complete_config["runit"]["sv_dir"])).to be(true)
-  end
-
-  context "redis_lb" do
-    it "vip" do
-      expect(config["redis_lb"]["vip"].to_s).to_not eq("")
+  context "partybus upgrade framework" do
+    it "postgresql/vip" do
+      expect(config["postgresql"]["vip"].to_s).to_not eq('')
     end
 
-    it "port" do
-      expect(config["redis_lb"]["vip"].to_i).to_not eq(0)
+    it "postgresql/port" do
+      expect(config["postgresql"]["port"].to_i).to_not eq(0)
+    end
+
+    it "postgresql/db_superuser" do
+      expect(config["postgresql"]["db_superuser"].to_s).to_not eq('')
     end
   end
 
-  context "keepalived" do
-    it "enable" do
+  context "migration 20" do
+    it "opscode-erchef/sql_user" do
+      expect(config["opscode-erchef"]["sql_user"].to_s).to_not eq('')
+    end
+
+    it "postgresql/vip" do
+      expect(config["postgresql"]["vip"].to_s).to_not eq('')
+    end
+
+    it "postgresql/port" do
+      expect(config["postgresql"]["port"].to_i).to_not eq(0)
+    end
+  end
+
+  context "migration 31" do
+    it "rabbitmq/user" do
+      expect(config["rabbitmq"]["user"].to_s).to_not eq('')
+    end
+
+    it "rabbitmq/actions_user" do
+      expect(config["rabbitmq"]["actions_user"].to_s).to_not eq('')
+    end
+
+    it "rabbitmq/management_user" do
+      expect(config["rabbitmq"]["management_user"].to_s).to_not eq('')
+    end
+  end
+
+  context "password" do
+    it "ldap/enabled" do
+      expect(config["ldap"]["enabled"]).to be(true).or be(false).or be(nil)
+    end
+  end
+
+  context "ha" do
+    it "runit/sv_dir" do
+      expect(complete_config["runit"]["sv_dir"].to_s).to_not eq("")
+      expect(File.exist?(complete_config["runit"]["sv_dir"])).to be(true)
+    end
+
+    it "keepalived/enable" do
       expect(config['keepalived']['enable']).to be(true).or be(false)
     end
 
-    it "vrrp_instance_ipaddress" do
+    it "keepalived/vrrp_instance_ipaddress" do
       expect(config['keepalived']['vrrp_instance_ipaddress'])
     end
 
-    it "vrrp_instance_ipaddress_dev" do
+    it "keepalived/vrrp_instance_ipaddress_dev" do
       expect(config['keepalived']['vrrp_instance_ipaddress_dev'])
     end
 
-    it "vrrp_instance_interface" do
+    it "keepalived/vrrp_instance_interface" do
       expect(config['keepalived']['vrrp_instance_interface'])
     end
   end
 
+  context "reindex" do
+    it "fips_enabled" do
+      expect(config['fips_enabled']).to be(true).or be(false)
+    end
+
+    it "opscode-erchef/search_queue_mode" do
+      expect(config["opscode-erchef"]["search_queue_mode"]).to eq("rabbitmq")
+                                                                 .or eq("batch")
+                                                                       .or eq("inline")
+    end
+
+    it "redis_lb/vip" do
+      expect(config["redis_lb"]["vip"].to_s).to_not eq("")
+    end
+
+    it "redis_lb/port" do
+      expect(config["redis_lb"]["vip"].to_i).to_not eq(0)
+    end
+  end
 end

--- a/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
@@ -1,0 +1,55 @@
+require 'json'
+require 'pedant/rspec/common'
+
+describe "running configs required by chef-server-ctl", :config do
+  let (:complete_config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json")) }
+  let (:config) { complete_config['private_chef'] }
+
+  it "fips_enabled" do
+    expect(config['fips_enabled']).to be(true).or be(false)
+  end
+
+  it "opscode-erchef/search_queue_mode" do
+    expect(config["opscode-erchef"]["search_queue_mode"]).to eq("rabbitmq")
+                                                               .or eq("batch")
+                                                                     .or eq("inline")
+  end
+
+  it "ldap/enabled" do
+    expect(config["ldap"]["enabled"]).to be(true).or be(false).or be(nil)
+  end
+
+  it "runit/sv_dir" do
+    expect(complete_config["runit"]["sv_dir"].to_s).to_not eq("")
+    expect(File.exist?(complete_config["runit"]["sv_dir"])).to be(true)
+  end
+
+  context "redis_lb" do
+    it "vip" do
+      expect(config["redis_lb"]["vip"].to_s).to_not eq("")
+    end
+
+    it "port" do
+      expect(config["redis_lb"]["vip"].to_i).to_not eq(0)
+    end
+  end
+
+  context "keepalived" do
+    it "enable" do
+      expect(config['keepalived']['enable']).to be(true).or be(false)
+    end
+
+    it "vrrp_instance_ipaddress" do
+      expect(config['keepalived']['vrrp_instance_ipaddress'])
+    end
+
+    it "vrrp_instance_ipaddress_dev" do
+      expect(config['keepalived']['vrrp_instance_ipaddress_dev'])
+    end
+
+    it "vrrp_instance_interface" do
+      expect(config['keepalived']['vrrp_instance_interface'])
+    end
+  end
+
+end

--- a/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
@@ -95,4 +95,27 @@ describe "running configs required by chef-server-ctl", :config do
       expect(config["redis_lb"]["vip"].to_i).to_not eq(0)
     end
   end
+
+  context "reconfigure" do
+    #
+    # The cookbooks themselves require chef-server-running.json to
+    # populate previous_run.
+    #
+    it "bookshelf/storage_type" do
+      expect(config["bookshelf"]["storage_type"]).to eq("filesystem").or eq("sql")
+    end
+
+    it "opscode-solr4/external" do
+      expect(config["opscode-solr4"]["external"]).to eq(true).or eq(false)
+    end
+
+    it "postgresql/external" do
+      expect(config["postgresql"]["external"]).to eq(true).or eq(false)
+    end
+
+    it "postgresql/data_dir" do
+      expect(config["postgresql"]["data_dir"].to_s).to_not eq("")
+      expect(File.exist?(config["postgresql"]["data_dir"])).to eq(true)
+    end
+  end
 end

--- a/oc-chef-pedant/spec/running_configs/manage_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/manage_spec.rb
@@ -1,0 +1,42 @@
+require 'json'
+require 'pedant/rspec/common'
+
+describe "running configs required by Manages", :config do
+  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
+
+  it "lb/api_fqdn" do
+    expect(config['lb']['api_fqdn'].to_s).to_not eq ''
+  end
+
+  it "nginx/ssl_port" do
+    expect(config['nginx']['ssl_port'].to_i).to_not eq 0
+  end
+
+  it "nginx/ssl_protocols" do
+    expect(config['nginx']['ssl_protocols'].to_s).to_not eq ''
+  end
+
+  it "nginx/ssl_ciphers" do
+    expect(config['nginx']['ssl_ciphers'].to_s).to_not eq ''
+  end
+
+  it "nginx/ssl_certificate" do
+    expect(File.exists?(config['nginx']['ssl_certificate'])).to be true
+  end
+
+  it "nginx/ssl_certificate_key" do
+    expect(File.exists?(config['nginx']['ssl_certificate_key'])).to be true
+  end
+
+  it "nginx/dir" do
+    expect(File.exists?(File.join(config['nginx']['dir'], "etc/addon.d"))).to be true
+  end
+
+  it "opscode-erchef/strict_search_result_acls" do
+    expect(config['opscode-erchef']['strict_search_result_acls']).to be(true).or be(false)
+  end
+
+  it "ldap is a hash" do
+    expect(config['ldap'].class).to eq(Hash)
+  end
+end

--- a/oc-chef-pedant/spec/running_configs/pushy_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/pushy_spec.rb
@@ -1,0 +1,67 @@
+require 'json'
+require 'pedant/rspec/common'
+
+describe "running configs required by Pushy Server", :config do
+  let (:complete_config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json")) }
+  let (:config) { complete_config['private_chef'] }
+
+  it "role" do
+    expect(config['role'].to_s).to eq("standalone").or eq("backend").or eq("frontend")
+  end
+
+  it "topology" do
+    expect(config['topology'].to_s).to eq("tier").or eq("ha").or eq("standalone")
+  end
+
+  it "postgresql/vip" do
+    expect(config['postgresql']['vip'].to_s).to_not eq ''
+  end
+
+  it "postgresql/port" do
+    expect(config['postgresql']['port'].to_i).to_not eq 0
+  end
+
+  it "postgresql/db_superuser" do
+    expect(config['postgresql']['db_superuser'].to_s).to_not eq ''
+  end
+
+  it "postgresql/vip or backend_vips/ipaddress" do
+    if ["ha", "tier"].include? config['topology']
+      expect(config['backend_vips']['ipaddress'].to_s).not_to eq ''
+    else
+      skip "not used for standalone"
+    end
+  end
+
+  it "postgresql/data_dir" do
+    expect(File.exists?(config['postgresql']['data_dir'])).to be true
+  end
+
+  it "postgresql/username" do
+    expect(config['postgresql']['username'].to_s).to_not eq ''
+  end
+
+  it "user/username" do
+    expect(config['user']['username'].to_s).to_not eq ''
+  end
+
+  it "nginx/dir" do
+    expect(File.exists?(File.join(config['nginx']['dir'], "etc/addon.d"))).to be true
+  end
+
+  it "nginx/ssl_protocols" do
+    expect(config['nginx']['ssl_protocols'].to_s).to_not eq ''
+  end
+
+  it "opscode-erchef/strict_search_result_acls" do
+    expect(config['opscode-erchef']['strict_search_result_acls']).to be(true).or be(false)
+  end
+
+  it "oc-chef-pedant/debug_org_creation" do
+    expect(config['oc-chef-pedant']['debug_org_creation']).to be(true).or be(false)
+  end
+
+  it "runit" do
+    expect(complete_config['runit'].class).to eq Hash
+  end
+end

--- a/oc-chef-pedant/spec/running_configs/reporting_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/reporting_spec.rb
@@ -1,0 +1,198 @@
+require 'json'
+require 'pedant/rspec/common'
+
+describe "running configs required by Reporting", :config do
+  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
+
+  it "role" do
+    expect(config['role'].to_s).to eq("standalone").or eq("backend").or eq("frontend")
+  end
+
+  it "topology" do
+    expect(config['topology'].to_s).to eq("tier").or eq("ha").or eq("standalone")
+  end
+
+  context "opscode-solr" do
+
+    it "opscode-solr4/external" do
+      expect(config['opscode-solr4']['external']).to be(true).or be(false)
+    end
+
+    it "opscode-solr4/external_url" do
+      if config['opscode-solr4']['external']
+        expect(config['opscode-solr4']['external_url'].to_s).not_to eq ''
+      else
+        skip "not using external solr"
+      end
+    end
+
+    it "opscode-solr4/vip" do
+      expect(config['opscode-solr4']['vip'].to_s).not_to eq ''
+    end
+
+    it "opscode-solr4/port" do
+      expect(config['opscode-solr4']['port'].to_i).not_to eq 0
+    end
+  end
+
+  context "postgresql" do
+
+    it "postgresql/vip" do
+      expect(config['postgresql']['vip'].to_s).not_to eq ''
+    end
+
+    it "postgresql/port" do
+      expect(config['postgresql']['port'].to_i).not_to eq 0
+    end
+
+    it "postgresql/username" do
+      expect(config['postgresql']['username'].to_s).not_to eq ''
+    end
+
+    it "postgresql/db_superuser" do
+      expect(config['postgresql']['db_superuser'].to_s).not_to eq ''
+    end
+
+    it "postgresql/vip or backend_vips/ipaddress" do
+      if config['role'] == 'standalone'
+        expect(config['postgresql']['vip'].to_s).not_to eq ''
+      else
+        expect(config['backend_vips']['ipaddress'].to_s).not_to eq ''
+      end
+    end
+  end
+
+  context "oc-reporting-pedant" do
+
+    it "api_version" do
+      expect(config['api_version'].to_s).not_to eq ''
+    end
+
+    it "nginx/ssl_protocols" do
+      expect(config['nginx']['ssl_protocols'].to_s).to_not eq ''
+    end
+  end
+
+  context "nginx" do
+
+    it "nginx/dir" do
+      expect(File.exists?(File.join(config['nginx']['dir'], "etc/addon.d"))).to be true
+    end
+  end
+
+  context "providers/pg_upgrade" do
+
+    it "postgresql/data_dir" do
+      expect(File.exists?(config['postgresql']['data_dir'])).to be true
+    end
+
+    it "postgresql/username" do
+      expect(config['postgresql']['username'].to_s).to_not eq ''
+    end
+  end
+
+  context "rabbitmq" do
+
+    it "user/username" do
+      expect(config['user']['username'].to_s).to_not eq ''
+    end
+
+    it "rabbitmq/actions_vhost" do
+      expect(config['rabbitmq']['actions_vhost'].to_s).to_not eq ''
+    end
+  end
+
+  context "pedant-config" do
+
+    it "lb/api_fqdn" do
+      expect(config['lb']['api_fqdn'].to_s).to_not eq ''
+    end
+
+    it "opscode-erchef/search_provider" do
+      expect(config['opscode-erchef']['search_provider'].to_s).to eq('solr').or eq('elasticsearch')
+    end
+
+    it "opscode-erchef/listen" do
+      expect(config['opscode-erchef']['listen'].to_s).not_to eq ''
+    end
+
+    it "opscode-erchef/port" do
+      expect(config['opscode-erchef']['port'].to_i).not_to eq 0
+    end
+  end
+
+  context "oc-reporting-config" do
+
+    it "oc_bifrost/vip" do
+      expect(config['oc_bifrost']['vip'].to_s).not_to eq ''
+    end
+
+    it "oc_bifrost/port" do
+      expect(config['oc_bifrost']['port'].to_i).not_to eq 0
+    end
+
+    it "couchdb/vip" do
+      expect(config['couchdb']['vip'].to_s).not_to eq ''
+    end
+
+    it "couchdb/port" do
+      expect(config['couchdb']['port'].to_i).not_to eq 0
+    end
+
+    it "nginx/enable_ipv6" do
+      expect(config['nginx']['enable_ipv6']).to be(true).or be(false)
+    end
+
+    it "opscode-erchef/search_provider" do
+      expect(config['opscode-erchef']['search_provider'].to_s).to eq('solr').or eq('elasticsearch')
+    end
+
+    it "opscode-erchef/solr_timeout" do
+      expect(config['opscode-erchef']['solr_timeout'].to_i).not_to eq 0
+    end
+
+    it "opscode-erchef/solr_http_init_count" do
+      expect(config['opscode-erchef']['solr_http_init_count'].to_i).not_to eq 0
+    end
+
+    it "opscode-erchef/solr_http_max_count" do
+      expect(config['opscode-erchef']['solr_http_max_count'].to_i).not_to eq 0
+    end
+
+    it "opscode-erchef/solr_http_cull_interval" do
+      expect(config['opscode-erchef']['solr_http_cull_interval'].to_s).not_to eq ''
+    end
+
+    it "opscode-erchef/solr_http_max_age" do
+      expect(config['opscode-erchef']['solr_http_max_age'].to_s).not_to eq ''
+    end
+
+    it "opscode-erchef/solr_http_max_connection_duration" do
+      expect(config['opscode-erchef']['solr_http_max_connection_duration'].to_s).not_to eq ''
+    end
+
+    it "opscode-erchef/solr_ibrowse_options" do
+      expect(config['opscode-erchef']['solr_ibrowse_options'].to_s).not_to eq ''
+    end
+
+    it "lb/api_fqdn" do
+      expect(config['lb']['api_fqdn'].to_s).not_to eq ''
+    end
+
+    it "lb/vip" do
+      expect(config['lb']['vip'].to_s).not_to eq ''
+    end
+
+    it "lb_internal/chef_port" do
+      expect(config['lb_internal']['chef_port'].to_i).not_to eq 0
+    end
+
+    it "estatsd/vip" do
+      expect(config['estatsd']['vip'].to_s).not_to eq ''
+    end
+
+    it "estatsd/port" do
+      expect(config['estatsd']['port'].to_i).not_to eq 0
+    end
+  end
+end


### PR DESCRIPTION
Previous Chef Server releases have broken compatibility with add-ons because we've changed the structure of `/etc/opscode/chef-server-running.json`.  This PR adds tests for the parts of that file required by the various add-ons, upgrades, and chef-server-ctl commands.

These tests are organized according to the integration point that requires the key.  As a result, some keys are tested a number of times.