### PR TITLE
Remove analytics plain text secrets when insecure_addon_compat false

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -162,6 +162,8 @@ include_recipe "private-chef::cleanup"
 
 if darklaunch_values["actions"] && node['private_chef']['insecure_addon_compat']
   include_recipe "private-chef::actions"
+else
+  include_recipe "private-chef::remove_actions"
 end
 
 include_recipe "private-chef::private-chef-sh"

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/remove_actions.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/remove_actions.rb
@@ -1,0 +1,5 @@
+%w{webui_priv.pem actions-source.json}.each do |secrets_file|
+  file ::File.join("/etc/opscode-analytics/", secrets_file) do
+    action :delete
+  end
+end


### PR DESCRIPTION
So far, secrets would be laid on disk, and kept being there when
insecure_addon_compat was turned _off_. Now, those files will be deleted
if it is turned off.

Signed-off-by: Stephan Renatus <srenatus@chef.io>