### PR TITLE
Upgrade Postgres 9.2 to 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty # precise doesn't have pg 9.6 yet
 sudo: false
 branches:
   only:
@@ -21,7 +22,7 @@ language: erlang
 otp_release:
   - 18.3
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
   apt:
     sources:
       - chef-stable-precise

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,28 @@ For prior releases, see [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
   the secret being changed. With the optional flag `--with-restart`,
   `chef-server-ctl set-secret` will attempt to automatically restart the
   dependent services.
+* [Upgrade to PostgreSQL 9.6](https://github.com/chef/chef-server/pull/1310),
+  Chef Server now uses the latest stable version of the 9.6 series (9.6.3). Upgrades of existing
+  installations are done automatically, but creating backups is advised.
+
+  The information below only applies if you have set a custom value for `checkpoint_segments`
+  in your `/etc/opscode/chef-server.rb`. If you have not set a custom value, there is nothing to
+  change:
+
+  The `checkpoint_segments` configuration setting is gone, so if you before have set
+
+      postgresql['checkpoint_segments'] = 10
+
+  you now have to specify (for example, please consult the documentation linked below)
+
+      postgresql['max_wal_size'] = '3G'
+
+  The default setting for `max_wal_size` is 1G. [The PostgreSQL release notes](https://www.postgresql.org/docs/9.6/static/release-9-5.html) mention a conversion
+  rule: `max_wal_size = (3 * checkpoint_segments) * 16MB`. They also say that the default value
+  for `max_wal_size` (1GB) should fit in most settings, so this conversion is not done automatically.
+
+  This update also adds two further new configurables in the ["Checkpoints" group](https://www.postgresql.org/docs/9.6/static/runtime-config-wal.html#RUNTIME-CONFIG-WAL-CHECKPOINTS), `min_wal_size` and
+  `checkpoint_flush_after`.
 
 ## 12.15.8 (2017-06-20)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,6 +37,9 @@ For prior releases, see [PRIOR\_RELEASE\_NOTES.md](PRIOR_RELEASE_NOTES.md).
   This update also adds two further new configurables in the ["Checkpoints" group](https://www.postgresql.org/docs/9.6/static/runtime-config-wal.html#RUNTIME-CONFIG-WAL-CHECKPOINTS), `min_wal_size` and
   `checkpoint_flush_after`.
 
+  As part of the upgrade procdure, running `chef-server-ctl cleanup` will remove Postgres 9.2's data
+  and logs.
+
 ## 12.15.8 (2017-06-20)
 
 * [Stricter validation of non-functional user record fields](https://github.com/chef/chef-server/pull/1294),

--- a/omnibus/config/software/oc_id.rb
+++ b/omnibus/config/software/oc_id.rb
@@ -27,7 +27,7 @@ license_file "LICENSE"
 # and makeds more sense than adding the thing that is stopping
 # it from building on s390 (libxml2).
 dependency "nokogiri"
-dependency "postgresql92" # for libpq
+dependency "postgresql96" # for libpq
 dependency "nodejs-binary"
 dependency "ruby"
 dependency "bundler"

--- a/omnibus/config/software/partybus.rb
+++ b/omnibus/config/software/partybus.rb
@@ -21,7 +21,7 @@ source path: "#{Omnibus::Config.project_root}/#{name}"
 license :project_license
 
 dependency "bundler"
-dependency "postgresql92"
+dependency "postgresql96"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/perl_pg_driver.rb
+++ b/omnibus/config/software/perl_pg_driver.rb
@@ -22,7 +22,7 @@ license_file "LICENSES/artistic.txt"
 
 dependency "perl"
 dependency "cpanminus"
-dependency "postgresql92"
+dependency "postgresql96"
 
 source url: "http://search.cpan.org/CPAN/authors/id/T/TU/TURNSTEP/DBD-Pg-#{version}.tar.gz",
        md5: "547de1382a47d66872912fe64282ff55"

--- a/omnibus/config/software/postgresql92-bin.rb
+++ b/omnibus/config/software/postgresql92-bin.rb
@@ -1,0 +1,57 @@
+#
+# Copyright 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "postgresql92-bin"
+
+default_version "9.2.21"
+
+license "PostgreSQL"
+license_file "COPYRIGHT"
+skip_transitive_dependency_licensing true
+
+dependency "zlib"
+dependency "openssl"
+dependency "libedit"
+dependency "ncurses"
+dependency "libossp-uuid"
+dependency "config_guess"
+
+source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+
+version("9.2.21") { source sha256: "0697e843523ee60c563f987f9c65bc4201294b18525d6e5e4b2c50c6d4058ef9" }
+
+relative_path "postgresql-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  short_version = version.gsub(/^([0-9]+).([0-9]+).[0-9]+$/, '\1.\2')
+
+  update_config_guess(target: "config")
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded/postgresql/#{short_version}" \
+          " --with-libedit-preferred" \
+          " --with-openssl" \
+          " --with-ossp-uuid" \
+          " --with-includes=#{install_dir}/embedded/include" \
+          " --with-libraries=#{install_dir}/embedded/lib", env: env
+
+  make "world -j #{workers}", env: env
+  make "-C src/interfaces/libpq install", env: env  # libpq.so
+  make "-C src/backend install-bin", env: env       # postgres binary
+  make "-C src/timezone/tznames  install", env: env # share/timezonesets
+  make "-C src/bin install", env: env               # pg_*, psql binaries
+end

--- a/omnibus/config/software/postgresql96.rb
+++ b/omnibus/config/software/postgresql96.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017 Chef Software, Inc.
+# Copyright 2017 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
 # limitations under the License.
 #
 
-name "postgresql92"
-default_version "9.2.21"
+name "postgresql96"
+
+default_version "9.6.3"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
 skip_transitive_dependency_licensing true
-
-source url: "https://ftp.postgresql.org/pub/source/v9.2.21/postgresql-9.2.21.tar.bz2",
-       sha256: "0697e843523ee60c563f987f9c65bc4201294b18525d6e5e4b2c50c6d4058ef9"
 
 dependency "zlib"
 dependency "openssl"
@@ -31,15 +29,19 @@ dependency "ncurses"
 dependency "libossp-uuid"
 dependency "config_guess"
 
-relative_path "postgresql-9.2.21"
+source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+version("9.6.3") { source sha256: "1645b3736901f6d854e695a937389e68ff2066ce0cde9d73919d6ab7c995b9c6" }
+
+relative_path "postgresql-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  short_version = version.gsub(/^([0-9]+).([0-9]+).[0-9]+$/, '\1.\2')
 
   update_config_guess(target: "config")
 
   command "./configure" \
-          " --prefix=#{install_dir}/embedded/postgresql/9.2" \
+          " --prefix=#{install_dir}/embedded/postgresql/#{short_version}" \
           " --with-libedit-preferred" \
           " --with-openssl" \
           " --with-ossp-uuid" \
@@ -49,13 +51,8 @@ build do
   make "world -j #{workers}", env: env
   make "install-world -j #{workers}", env: env
 
-
-  # Postgres 9.2 is our "real" Postgres installation (prior versions
-  # that are installed are solely to facilitate upgrades).  As a
-  # result, we need to have the binaries for this version available
-  # with the other binaries used by Private Chef.
   block do
-    Dir.glob("#{install_dir}/embedded/postgresql/9.2/bin/*").sort.each do |bin|
+    Dir.glob("#{install_dir}/embedded/postgresql/#{short_version}/bin/*").sort.each do |bin|
       link bin, "#{install_dir}/embedded/bin/#{File.basename(bin)}"
     end
   end

--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -53,7 +53,8 @@ build do
         run_list: [
           'recipe[private-chef::post_11_upgrade_cleanup]',
           'recipe[private-chef::post_12_upgrade_cleanup]',
-          'recipe[private-chef::solr4_gclog_cleanup]'
+          'recipe[private-chef::solr4_gclog_cleanup]',
+          'recipe[private-chef::postgres_upgrade_cleanup]'
         ]
       )
     end

--- a/omnibus/config/software/server-complete.rb
+++ b/omnibus/config/software/server-complete.rb
@@ -33,7 +33,8 @@ dependency "veil-gem" # chef-server-ctl rotate-credentials
 dependency "erlang-crypto2"
 
 # the backend
-dependency "postgresql92"
+dependency "postgresql92-bin" # for upgrading 9.2 -> 9.6
+dependency "postgresql96"
 dependency "rabbitmq"
 dependency "redis" # dynamic routing controls
 dependency "opscode-solr4"

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -593,7 +593,7 @@ default['private_chef']['postgresql']['md5_auth_cidr_addresses'] = [ '127.0.0.1/
 default['private_chef']['postgresql']['shmmax'] = 17179869184
 default['private_chef']['postgresql']['shmall'] = 4194304
 default['private_chef']['postgresql']['wal_level'] = "minimal"
-default['private_chef']['postgresql']['archive_mode'] = "off"
+default['private_chef']['postgresql']['archive_mode'] = "off" # "cannot be enabled when wal_level is set to minimal"
 default['private_chef']['postgresql']['archive_command'] = ""
 default['private_chef']['postgresql']['archive_timeout'] = 0 # 0 is disabled.
 
@@ -617,10 +617,19 @@ end
 default['private_chef']['postgresql']['shared_buffers'] = "#{(shared_bytes/1024).to_i}MB"
 
 default['private_chef']['postgresql']['work_mem'] = "8MB"
-default['private_chef']['postgresql']['effective_cache_size'] = "#{(node['memory']['total'].to_i / 2) / (1024)}MB"
-default['private_chef']['postgresql']['checkpoint_segments'] = 3
+default['private_chef']['postgresql']['effective_cache_size'] = "#{(node['memory']['total'].to_i / 2)/1024}MB"
+# Note: the checkpoint_segments setting was removed.
+# https://www.postgresql.org/docs/9.6/static/release-9-5.html says
+#   max_wal_size = (3 * checkpoint_segments) * 16MB
+# would be a usable conversion rule, but it also says the new setting's default
+# should be OK for most people. Since the conversion rule yields a value that
+# is so much smaller than the default, we don't do the conversion, but merely
+# allow for overriding the default setting.
+default['private_chef']['postgresql']['max_wal_size'] = "1GB"
+default['private_chef']['postgresql']['min_wal_size'] = "80MB"
 default['private_chef']['postgresql']['checkpoint_timeout'] = "5min"
 default['private_chef']['postgresql']['checkpoint_completion_target'] = 0.5
+default['private_chef']['postgresql']['checkpoint_flush_after'] = "256kB"
 default['private_chef']['postgresql']['checkpoint_warning'] = "30s"
 
 ###

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -562,7 +562,7 @@ default['private_chef']['nginx']['enable_ipv6'] = false
 # PostgreSQL
 ###
 # For now, we're hardcoding the version directory suffix here:
-default['private_chef']['postgresql']['version'] = "9.2"
+default['private_chef']['postgresql']['version'] = "9.6"
 # In the future, we're probably going to want to do something more elegant so we
 # don't accidentally overwrite this directory if we upgrade PG to 9.3: keeping these
 # directories straight is important because in the distant future (the year 2000)

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/post_11_upgrade_cleanup.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/post_11_upgrade_cleanup.rb
@@ -65,16 +65,3 @@ private_chef_package_cleaner "redis" do
 end
 
 private_chef_package_cleaner "varnish"
-
-# Remove old PostgreSQL data directory
-#
-# pg_upgrade will helpfully generate a cleanup script which removes
-# the previous database cluster.  This is nice, because we don't have
-# to worry about keeping track of the location of the old cluster.
-execute "remove_old_postgres_data_directory" do
-  cleanup_script = "#{node['private_chef']['postgresql']['data_dir']}/delete_old_cluster.sh"
-  command cleanup_script
-  only_if {File.exists? cleanup_script}
-  # The script itself is idempotent; it just runs an 'rm -Rf' on the
-  # old $PG_DATA directory
-end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgres_upgrade_cleanup.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgres_upgrade_cleanup.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Remove old PostgreSQL data directory
+#
+# pg_upgrade will helpfully generate a cleanup script which removes
+# the previous database cluster.  This is nice, because we don't have
+# to worry about keeping track of the location of the old cluster.
+execute "remove_old_postgres_data_directory" do
+  cleanup_script = "#{node['private_chef']['postgresql']['data_dir']}/delete_old_cluster.sh"
+  command cleanup_script
+  only_if {File.exists? cleanup_script}
+  # The script itself is idempotent; it just runs an 'rm -Rf' on the
+  # old $PG_DATA directory
+end
+
+directory '/var/log/opscode/postgresql/9.2' do
+  recursive true
+  action :delete
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -143,7 +143,7 @@ if is_data_master?
         Chef::Log.fatal <<-ERR
 
 Could not connect to the postgresql database.
-Please check /var/log/opscode/posgresql/current for more information.
+Please check 'chef-server-ctl tail postgresql' for more information.
 
 ERR
         exit!(1)

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
@@ -152,8 +152,9 @@ work_mem = <%= node['private_chef']['postgresql']['work_mem'] %>				# min 64kB
 
 # - Settings -
 
-wal_level = <%= node['private_chef']['postgresql']['wal_level'] %>			# minimal, archive, or hot_standby
+wal_level = <%= node['private_chef']['postgresql']['wal_level'] %>			# minimal, logical, or replica
 					# (change requires restart)
+					# old names "archive" and "hot_standby" are accepted, too, but mapped to "replica"
 #fsync = on				# turns forced synchronization on or off
 #synchronous_commit = on		# synchronization level; on, off, or local
 #wal_sync_method = fsync		# the default is the first option
@@ -173,10 +174,12 @@ wal_level = <%= node['private_chef']['postgresql']['wal_level'] %>			# minimal, 
 
 # - Checkpoints -
 
-checkpoint_segments =  <%= node['private_chef']['postgresql']['checkpoint_segments'] %>		# in logfile segments, min 1, 16MB each, default 3
 checkpoint_timeout = <%= node['private_chef']['postgresql']['checkpoint_timeout'] %>		# range 30s-1h, default 5min
 checkpoint_completion_target = <%= node['private_chef']['postgresql']['checkpoint_completion_target'] %>	# checkpoint target duration, 0.0 - 1.0, default 0.5
+checkpoint_flush_after = <%= node['private_chef']['postgresql']['checkpoint_flush_after'] %>
 checkpoint_warning = <%= node['private_chef']['postgresql']['checkpoint_warning'] %>		# 0 disables, default 30s
+max_wal_size = <%= node['private_chef']['postgresql']['max_wal_size'] %>		# integer, defaults to 1GB
+min_wal_size = <%= node['private_chef']['postgresql']['min_wal_size'] %>		# integer, defaults to 80MB
 
 # - Archiving -
 


### PR DESCRIPTION
I looks like the old machinery made for going from 9.1 to 9.2 still works just fine! 🎉 

Pending:
- [x] automatic upgrade tests (qa-chef-server-cluster)
- [x] check tunables one-by-one to see if any other ones are gone, clarify release notes
- [x] figure out an edge case or bug with the sentinel file creation
- [x] cleanup 9.2 stuff