### PR TITLE
Bump omnibus-software pin

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/license_scout
-  revision: ff3cb28159e72414d63008f9a0d42e85d4aec4ba
+  revision: e9c48c6773dec6fd718642194bfcb166d5685e03
   specs:
     license_scout (0.1.3)
       ffi-yajl (~> 2.2)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus
-  revision: ffbda9ad7d37ddb485342505ff4407c6ff23d95f
+  revision: 3475e6fb36c54bf5bc97c822a63d6f7e04e532fc
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -25,7 +25,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus-software
-  revision: 4e3a4599e66d85f64a91fe5586e3d2760988aea2
+  revision: 266a8ab07b0380607ce8a6ec5fd824ea002be2f1
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -41,14 +41,14 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    awesome_print (1.7.0)
-    aws-sdk (2.9.7)
-      aws-sdk-resources (= 2.9.7)
-    aws-sdk-core (2.9.7)
+    awesome_print (1.8.0)
+    aws-sdk (2.9.42)
+      aws-sdk-resources (= 2.9.42)
+    aws-sdk-core (2.9.42)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.7)
-      aws-sdk-core (= 2.9.7)
+    aws-sdk-resources (2.9.42)
+      aws-sdk-core (= 2.9.42)
     aws-sigv4 (1.0.0)
     berkshelf (5.6.4)
       addressable (~> 2.3, >= 2.3.4)
@@ -190,8 +190,8 @@ GEM
     nio4r (2.0.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (8.23.0)
-      chef-config (>= 12.5.0.alpha.1, < 13)
+    ohai (8.24.0)
+      chef-config (>= 12.5.0.alpha.1, < 14)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
@@ -208,7 +208,7 @@ GEM
       multipart-post (~> 2.0.0)
       progressbar
       zhexdump (>= 0.0.2)
-    plist (3.2.0)
+    plist (3.3.0)
     progressbar (1.8.2)
     proxifier (1.0.3)
     public_suffix (2.0.5)
@@ -303,4 +303,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.14.6
+   1.15.1


### PR DESCRIPTION
This drags in https://github.com/chef/omnibus-software/compare/4e3a4599e66d85f64a91fe5586e3d2760988aea2...266a8ab07b0380607ce8a6ec5fd824ea002be2f1

:warning: among them is postgres 9.2.11. (but this should be fine.)

Signed-off-by: Stephan Renatus <srenatus@chef.io>