### PR TITLE
[oc-chef-pedant] don't insist on pg's data_dir when using external pg

### DIFF
--- a/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
@@ -115,7 +115,12 @@ describe "running configs required by chef-server-ctl", :config do
 
     it "postgresql/data_dir" do
       expect(config["postgresql"]["data_dir"].to_s).to_not eq("")
-      expect(File.exist?(config["postgresql"]["data_dir"])).to eq(true)
+
+      if config["postgresql"]["external"]
+        skip "not used for external postgresql"
+      else
+        expect(File.exist?(config["postgresql"]["data_dir"])).to eq(true)
+      end
     end
   end
 end

--- a/oc-chef-pedant/spec/running_configs/pushy_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/pushy_spec.rb
@@ -34,7 +34,11 @@ describe "running configs required by Pushy Server", :config do
   end
 
   it "postgresql/data_dir" do
-    expect(File.exists?(config['postgresql']['data_dir'])).to be true
+    if config['postgresql']['external']
+      skip "not used for external postgresql"
+    else
+      expect(File.exists?(config['postgresql']['data_dir'])).to be true
+    end
   end
 
   it "postgresql/username" do

--- a/oc-chef-pedant/spec/running_configs/reporting_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/reporting_spec.rb
@@ -83,7 +83,11 @@ describe "running configs required by Reporting", :config do
   context "providers/pg_upgrade" do
 
     it "postgresql/data_dir" do
-      expect(File.exists?(config['postgresql']['data_dir'])).to be true
+      if config['postgresql']['external']
+        skip "not used for external postgresql"
+      else
+        expect(File.exists?(config['postgresql']['data_dir'])).to be true
+      end
     end
 
     it "postgresql/username" do


### PR DESCRIPTION
(This test fails for chef-backend-ha's pipeline.)