### PR TITLE
omnibus: fix knife-ec-backup

### DIFF
--- a/omnibus/config/software/knife-ec-backup-gem.rb
+++ b/omnibus/config/software/knife-ec-backup-gem.rb
@@ -31,8 +31,6 @@ dependency "sequel-gem"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --local --without development", env: env
-
   gem "build knife-ec-backup.gemspec", env: env
-  gem "install knife-ec-backup*.gem --no-rdoc --no-ri --without development", env: env
+  gem "install knife-ec-backup*.gem --no-rdoc --no-ri --ignore-dependencies", env: env
 end


### PR DESCRIPTION
We've instructed bundler to only use local dependencies -- so we might
as well not use bundler at all.

This change was made necessary by
https://github.com/chef/knife-ec-backup/pull/98, which does a better job
at explaining the state of affairs.
