### PR TITLE
[cookbooks] Don't manage SHMMAX and SHMALL

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -133,6 +133,18 @@ module PrivateChef
       end
     end
 
+    def deprecated_postgresql_settings
+      [ 'shmmax', 'shmall'].each do |setting|
+        if PrivateChef['postgresql'][setting]
+          ChefServer::Warnings.warn <<EOF
+The configuration parameter postgresql['#{setting}'] is no longer used
+by Chef Server. To limit the amount of shared memory used by
+postgresql use postgresql['shared_buffers'] instead.
+EOF
+        end
+      end
+    end
+
     # Mutate PrivateChef to account for common cases of user-provided
     # types not being what we want
     def transform_to_consistent_types
@@ -813,6 +825,7 @@ EOF
 
       # Transition Solr memory and JVM settings from OSC11 to Chef 12.
       import_legacy_service_config("opscode_solr", "opscode_solr4", ["heap_size", "new_size", "java_opts"])
+      deprecated_postgresql_settings
       transform_to_consistent_types
 
       PrivateChef["nginx"]["enable_ipv6"] ||= PrivateChef["use_ipv6"]

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/90-postgresql.conf.sysctl.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/90-postgresql.conf.sysctl.erb
@@ -1,5 +1,0 @@
-#
-# opscode private chef postgresql kernel shm tweaks
-#
-kernel.shmmax = <%= node['private_chef']['postgresql']['shmmax'] %>
-kernel.shmall = <%= node['private_chef']['postgresql']['shmall'] %>


### PR DESCRIPTION
According to the postgresql documentation [1] a resonable value for
SHMMAX is now 1KB and that

> PostgreSQL requires a few bytes of System V shared memory (typically
> 48 bytes, on 64-bit platforms) for each copy of the server. On most
> modern operating systems, this amount can easily be
> allocated. However, if you are running many copies of the server, or
> if other applications are also using System V shared memory, it may
> be necessary to increase SHMMAX, the maximum size in bytes of a
> shared memory segment, or SHMALL, the total amount of System V
> shared memory system-wide. Note that SHMALL is measured in pages
> rather than bytes on many systems.

The previous values were required for Postgresql 9.2 which used
substantially more shared memory.

Removing the management of these system paramaters removes one of the
barriers to running the chef-server package directly in a container.

I've avoided doing any cleanup since this changed a core system
configuration which might also be needed by other software on the
system.

[1] https://www.postgresql.org/docs/9.6/static/kernel-resources.html

Signed-off-by: Steven Danna <steve@chef.io>