### PR TITLE
[CLOUD-429] Update vendored cookbooks

### DIFF
--- a/omnibus/files/private-chef-cookbooks/Berksfile
+++ b/omnibus/files/private-chef-cookbooks/Berksfile
@@ -1,6 +1,6 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
-cookbook 'enterprise', :git => 'https://github.com/chef-cookbooks/enterprise-chef-common', :tag => '0.10.3'
-cookbook 'chef-ha-drbd', :path => './chef-ha-drbd'
-cookbook 'private-chef', :path => './private-chef'
+cookbook 'enterprise', git: 'https://github.com/chef-cookbooks/enterprise-chef-common', tag: '0.11.0'
+cookbook 'chef-ha-drbd', path: './chef-ha-drbd'
+cookbook 'private-chef', path: './private-chef'
 cookbook 'runit', '> 1.6.0'


### PR DESCRIPTION
* Update embedded enterprise cookbook to 0.11.0 to fix runsvdir with
  Upstart