### PR TITLE
[ctl-commands] Restart haproxy on upgrade in chef-backend mode

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/upgrade.rb
+++ b/omnibus/files/private-chef-ctl-commands/upgrade.rb
@@ -112,7 +112,13 @@ add_command_under_category "upgrade", "general", "Upgrade your private chef inst
     # with postgres being the exception to those rules. We are leaving
     # postgres up atm to avoid having to constantly restart it.
     run_command("private-chef-ctl stop")
-    run_command("private-chef-ctl start postgresql")
+
+    if running_config["private_chef"]["use_chef_backend"]
+      run_command("private-chef-ctl start haproxy")
+    else
+      run_command("private-chef-ctl start postgresql")
+    end
+
     sleep 15
     Dir.chdir(File.join(base_path, "embedded", "service", "partybus"))
     bundle = File.join(base_path, "embedded", "bin", "bundle")


### PR DESCRIPTION
When configured to use Chef Backend, all postgresql requests are
routed through HAProxy. Thus, in order to ensure that we can access
postgresql during upgrades, we need to start haproxy rather than
postgresql.

NB: This assumes that the existing 15 second sleep is enough time to
allow haproxy to stabilize (i.e. mark non-leader nodes as DOWN). In
the reconfigure cookbook we do an active check that looks for the
steady-state rather than a sleep.

Signed-off-by: Steven Danna <steve@chef.io>