### PR TITLE
[erchef] Remove input validation for user info

### DIFF
--- a/src/oc_erchef/apps/chef_objects/src/chef_user.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_user.erl
@@ -301,8 +301,6 @@ parse_binary_json(_ApiVersion, Bin, Operation, User) ->
 %% If user is invalid, an error is thrown
 common_user_validation(EJ, User, Operation) ->
     validate_user_name(EJ),
-    lists:map(fun(Field) -> validate_field(EJ, Field) end,
-              [first_name, middle_name, last_name, display_name]),
     chef_object_base:validate_ejson(EJ, user_spec(common)),
     chef_object_base:validate_ejson(EJ, user_spec(Operation)),
 
@@ -342,22 +340,6 @@ delete_null_public_key(Ejson) ->
             ej:delete({<<"public_key">>}, Ejson);
         _ ->
             Ejson
-    end.
-
-validate_field(User, Field) ->
-    Key = erlang:atom_to_binary(Field, latin1),
-    validate_field(User, Field, Key, ej:get([Key], User)).
-
-validate_field(_User, _Field, _Key, undefined) ->
-    ok;
-validate_field(User, Field, Key, _) ->
-    RE = chef_regex:regex_for(Field),
-    KeySpec = {[ {Key, {string_match, RE}} ]},
-    case ej:valid(KeySpec, User) of
-        ok ->
-            ok;
-        BadSpec ->
-            throw(BadSpec#ej_invalid{key = Key})
     end.
 
 %% Our user spec does not include 'username' because one of

--- a/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
@@ -331,19 +331,6 @@ parse_binary_json_tests(Version) ->
     ]
     ++
     [
-     {?VD(lists:flatten(io_lib:format("Errors when invalid ~s", [Field]))),
-      fun() ->
-              HtmlyValue = <<"I <3 Chef">>,
-              UserEJson = {make_min_valid_create_user_ejson()},
-              UserEJson1 = ej:set({Field}, UserEJson, HtmlyValue),
-              ?assertThrow(#ej_invalid{key = Field},
-                           chef_user:parse_binary_json(Version, chef_json:encode(UserEJson1), create, undefined))
-      end
-     }
-     || Field <- NonfunctionalFields
-    ]
-    ++
-    [
      {?VD(lists:flatten(io_lib:format("Works with non-ASCII ~s", [Field]))),
       fun() ->
               %% "Maryam", #1 female name in the arab world as of 2015


### PR DESCRIPTION
Existing user records have characters not covered by the existing
regular expressions, including ',' and likely '@'.

This commit removes the checks for now.

Signed-off-by: Steven Danna <steve@chef.io>