### PR TITLE
[WIP] [CON-692] Add support for updating ES index definition.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_backend.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_backend.rb
@@ -4,6 +4,35 @@ require 'chef/http'
 
 module ChefBackend
   ETCD_MEMBERS_URL = "/v2/members"
+  def self.enabled?(node)
+    node['private_chef']['use_chef_backend']
+  end
+
+  def self.members(node)
+    return [] unless ChefBackend.enabled?
+
+    if @members.nil?
+      node['private_chef']['chef_backend_members'].each do |member|
+        begin
+          @members = ChefBackend.etcd_members(member, node['private_chef']['haproxy']['etcd_port'])
+          break if @members && !@members.empty?
+        rescue StandardError => e
+          Chef::Log.warn("Error attempting to get cluster members from #{member}:")
+          Chef::Log.warn("  #{e}")
+          Chef::Log.info("Trying next configured chef_backend member.")
+        end
+      end
+    end
+  rescue StandardError => e
+    Chef::Log.warn("member discovery failed: #{e}")
+  ensure
+    if @members.nil? || @members.empty?
+      Chef::Log.warn("Using statically configured member list")
+      @members = ChefBackend.configured_members(node)
+    end
+    return @members
+  end
+
   def self.configured_members(node)
     ret = {}
     node['private_chef']['chef_backend_members'].each_with_index do |member, i|

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_provider.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_provider.rb
@@ -5,32 +5,69 @@ class Chef
     class ElasticSearchIndex < Chef::Provider::LWRPBase
       use_inline_resources if defined?(:use_inlined_resources)
 
-      action :create do
-        if ! index_exists?
-          converge_by "Creating elasticsearch index #{new_resource.index_name}" do
-            solr_server.put(new_resource.index_name, Chef::JSONCompat.to_json(new_resource.index_definition))
+      action :create_or_update do
+        if index_exists?
+          if index_changed?
+            converge_block_for_update
           end
+        else
+          converge_block_for_create
         end
       end
 
       action :destroy do
-        if index_exists?
-          converge_by "Deleting elasticsearch index #{new_resource.index_name}" do
-            solr_server.delete(new_resource.index_name)
+        converge_block_for_destroy if index_exists?
+      end
+
+      def existing_index_mappings
+        unless @orig_mappings
+          index = JSON.parse(solr_server.get("#{new_resource.index_name}"))
+          @orig_mappings = index[new_resource.index_name]['mappings']
+            solr_server.put("#{url}?update_all_types",
+                            Chef::JSONCompat.to_json(mapping))
           end
+        end
+
+      end
+
+      def converge_block_for_create
+        converge_by "Creating elasticsearch index #{new_resource.index_name}" do
+          solr_server.put(new_resource.index_name, Chef::JSONCompat.to_json(new_resource.index_definition))
         end
       end
 
-      def index_exists?
-        solr_server.get("/#{new_resource.index_name}")
-        true
-      rescue Net::HTTPServerException => e
-        if e.response && e.response.code == "404"
-          false
-        else
-          raise
+      def converge_block_for_destroy
+        converge_by "Deleting elasticsearch index #{new_resource.index_name}" do
+          solr_server.delete(new_resource.index_name)
         end
       end
+
+      def index_changed?
+        new_index_mappings = new_resource.index_definition['mappings']
+        eq = field_maps_are_equal?(existing_index_mappings,
+                                   new_index_mappings)
+      end
+
+      def index_exists?
+        !existing_index_mappings.nil?
+      end
+
+      def field_maps_are_equal?(map1, map2)
+        return false if map1.length != map2.length
+        map1.each do |k, v|
+          v2 = map2[k]
+          # This handles the nil case too:
+          return false unless v.class == v2.class
+          if v.class == Hash
+            return false unless field_maps_are_equal?(v, v2)
+          else
+            # Other values back are limited to directly comparaible key-values
+            return false unless v == v2
+          end
+        end
+        return true
+      end
+
 
       def solr_server
         @solr_server ||= Chef::HTTP.new(new_resource.server_url)

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_resource.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_resource.rb
@@ -4,9 +4,8 @@ class Chef
   class Resource
     class ElasticSearchIndex < Chef::Resource::LWRPBase
       self.resource_name = 'elasticsearch_index'
-
-      actions [:create, :destroy]
-      default_action :create
+      actions [:create_or_update, :destroy]
+      default_action :create_or_update
       attribute :index_name, :name_attribute => true
       attribute :server_url, :kind_of => String
       attribute :index_definition, :kind_of => Hash

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/es_helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/es_helper.rb
@@ -1,0 +1,19 @@
+require 'chef/http'
+
+class EsHelper
+  # Returns a Gem::Version object with the elasticsearch server version. Obtains
+  # version via ES REST API
+  # If the search provider is not elasticsearch, it returns an instance for
+  # v0.0.0
+  def self.es_version(node)
+    if node['private_chef']['opscode-erchef']['search_provider'] == 'solr'
+      return Gem::Version.new('0.0.0')
+    end
+    server_url = node['private_chef']['opscode-solr4']['external_url']
+    server = Chef::HTTP.new(server_url)
+    raw = server.get('')
+    server_info = JSON.parse(raw)
+    version = server_info['version']['number']
+    Gem::Version.new(version)
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/es_helper.rb!
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/es_helper.rb!
@@ -16,20 +16,18 @@ class EsHelper
       # If we have not been bootstrapped and are using chef-backend,
       # we won't be able to use the standard ha-proxy URL. In this case, we'll
       # hit the cluster members directly.
-      if !OmnibusHelper.has_been_bootstrapped?  && ChefBackend.enabled?(node)
+      if !OmnibusHelper.has_been_bootstrapped?  && ChefBackend.enabled?
         port = node['private_chef']['haproxy']['remote_elasticsearch_port']
-        puts "*** #{ChefBackend.members(node)}"
-        ChefBackend.members(node).each do |_, host|
+        ChefBackend.members.each do |host|
           @es_version = try_version_from_server("http://#{host}:#{port}")
           break if @es_version
         end
       else
-        # If we're using a vanilla external ES, it's expected to be up and running for us
+        # If we're using a vanilla ES url, it's expected to be up and running for us
         # and reachable at the configured url.
         @es_version = try_version_from_server(node['private_chef']['opscode-solr4']['external_url'])
       end
     end
-    @es_version
   end
 
   def self.try_version_from_server(url)
@@ -38,10 +36,9 @@ class EsHelper
     server_info = JSON.parse(raw)
     version = server_info['version']['number']
     Gem::Version.new(version)
-  rescue => e
-    Chef::Log.warn("Could not get version from #{url}")
-    puts "**** Could not get version from #{url}: #{e}"
+  rescue
+    Chef::Logger.warn("Could not get version from #{url}")
     false
   end
-end
 
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
@@ -20,6 +20,20 @@ case node['private_chef']['opscode-erchef']['search_provider']
 when 'solr'
   Chef::Log.warn("External Solr Support does not include configuring the Solr schema.")
 when 'elasticsearch'
+  # The string field type has beein split into 'text' and 'keyword' for ES5
+  # Generally, we will want text for partial matching content
+  # (data field)
+  # (data are separated out from 'string' in ES5+:
+  if EsHelper.es_version(node) >= Gem::Version.new("5.0.0")
+    text_field_type = "text"
+    keyword_field_type = "keyword"
+    puts "*** 5.+ detected"
+  else
+    keyword_field_type = "string"
+    text_field_type = "string"
+    puts "*** earlier version #{EsHelper.es_version(node)}"
+  end
+
   elasticsearch_index "chef" do
     server_url node['private_chef']['opscode-solr4']['external_url']
     index_definition({"settings" => {
@@ -38,31 +52,31 @@ when 'elasticsearch'
                           "_source" => { "enabled" => false },
                           "_all" => { "enabled" => false },
                           "properties" => {
-                            "X_CHEF_database_CHEF_X" => { "type" => "string",
+                            "X_CHEF_database_CHEF_X" => { "type" => keyword_field_type,
                                                           "index" => "not_analyzed",
                                                           "norms" => {
                                                             "enabled" => false
                                                           }
                                                         },
-                            "X_CHEF_type_CHEF_X" => { "type" => "string",
+                            "X_CHEF_type_CHEF_X" => { "type" => keyword_field_type,
                                                       "index" => "not_analyzed",
                                                       "norms" => {
                                                         "enabled" => false
                                                       }
                                                     },
-                            "X_CHEF_id_CHEF_X" => { "type" => "string",
+                            "X_CHEF_id_CHEF_X" => { "type" => keyword_field_type,
                                                     "index" => "not_analyzed",
                                                     "norms" => {
                                                       "enabled" => false
                                                     }
                                                   },
-                            "data_bag" => { "type" => "string",
+                            "data_bag" => { "type" => keyword_field_type,
                                             "index" => "not_analyzed",
                                             "norms" => {
                                               "enabled" => false
                                             }
                                           },
-                            "content" => { "type" => "string", "index" => "analyzed"}
+                            "content" => { "type" => text_field_type, "index" => "analyzed"}
                           }
                         }
                       }

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
@@ -22,16 +22,13 @@ when 'solr'
 when 'elasticsearch'
   # The string field type has beein split into 'text' and 'keyword' for ES5
   # Generally, we will want text for partial matching content
-  # (data field)
-  # (data are separated out from 'string' in ES5+:
+  # ('data' field) and 'keyword' for all non-analyzed fields.
   if EsHelper.es_version(node) >= Gem::Version.new("5.0.0")
     text_field_type = "text"
     keyword_field_type = "keyword"
-    puts "*** 5.+ detected"
   else
     keyword_field_type = "string"
     text_field_type = "string"
-    puts "*** earlier version #{EsHelper.es_version(node)}"
   end
 
   elasticsearch_index "chef" do


### PR DESCRIPTION
* add update supprot so that indices that have changed can be updated
* add ES version checking
* use ES version to determine field type mappings.

TODO: 
* [x] validate change detection and versoin behavior under ES 2.3
* [ ] validate update logic against ES5 - has been done by hand/manual PUTs so far: 
  * bring up chef-backend with ES 2.x
  * upgrade to 5.x package 
  * reconfigure chef server 
  * verify that the index changes are applied by querying the ES API and inspecting the new definition (all string types have been replaced with keyword or text. ) 
