### PR TITLE
Only run smoke tests on s390x

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -evx
 
+echo "Sleeping even longer (120 seconds) to let the system settle"
+sleep 120
+
 sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --all --compliance-proxy-tests
 
 if [ "$OMNIBUS_FIPS_MODE" == "true" ]

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -4,7 +4,14 @@ set -evx
 echo "Sleeping even longer (120 seconds) to let the system settle"
 sleep 120
 
-sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --all --compliance-proxy-tests
+if [ "s390x" = "$(uname -m)" ]; then
+    # FIX ME FIX ME FIX ME
+    # This is to see if we can get the build passing at all on the s390x platform
+    # FIX ME FIX ME FIX ME
+    sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --smoke --compliance-proxy-tests
+else
+    sudo chef-server-ctl test -J $WORKSPACE/pedant.xml --all --compliance-proxy-tests
+fi
 
 if [ "$OMNIBUS_FIPS_MODE" == "true" ]
 then


### PR DESCRIPTION
The s390x tests have become unstable.  This appears to be caused by a performance regression; however, we have not yet identified whether the problem is with the s390x testers themselves or an actual performance regression in the product.  To ensure that the pipeline can be used for other changes until this is solved, this PR modifies our CI test phase to only run the smoke tests on s390x.