### PR TITLE
Begin using new `built_in:trigger_omnibus_build` Expeditor action

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -20,7 +20,7 @@ merge_actions:
     ignore_labels: "Version: Skip Bump"
   built_in:update_changelog:
     ignore_labels: "Changelog: Skip Update"
-  built_in:trigger_omnibus_release_build:
+  built_in:trigger_omnibus_build:
     ignore_labels: "Omnibus: Skip Build"
     only_if: built_in:bump_version
 


### PR DESCRIPTION
This built-in action will only trigger the `chef-server-build` job on Jenkins (which is what we want). Execution of the `chef-server-test` job and promotion to `current` will be handled in the Workflow pipeline:
https://github.com/chef/chef-server/blob/master/.delivery/build_cookbook/recipes/smoke.rb#L21-L28
https://github.com/chef/chef-server/blob/master/.delivery/build_cookbook/recipes/provision.rb#L31-L38

Signed-off-by: Seth Chisamore <schisamo@chef.io>