### PR TITLE
Fix partybus db schema upgrades when using External Postgres

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
@@ -32,7 +32,7 @@ template partybus_config do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode   "0644"
-  variables(:connection_string => "postgres:/opscode_chef",
+  variables(:connection_string => OmnibusHelper.new(node).db_connection_uri,
             :as_user => node['private_chef']['postgresql']['username'],
             :node_role => node_role,
             :db_service_name => db_service_name,


### PR DESCRIPTION
- Simple change to se the helper method `db_connection_uri` instead of hard-coding the connection string, this fixes upgrades with external Postgres

For discussion:   The helper method [db_connection_uri](https://github.com/chef/chef-server/blob/master/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb#L122) doesn't appear to be used anywhere else in the code.   Given the secrets changes, we can safely remove the credentials from the connection string, right?