### PR TITLE
Remove use of skip_omnibus_build?

### DIFF
--- a/.delivery/build_cookbook/metadata.rb
+++ b/.delivery/build_cookbook/metadata.rb
@@ -2,7 +2,7 @@ name 'build_cookbook'
 maintainer 'Chef Software Inc Engineering'
 maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
-version '0.1.0'
+version '0.1.1'
 
 chef_version '>= 12.19'
 

--- a/.delivery/build_cookbook/recipes/smoke.rb
+++ b/.delivery/build_cookbook/recipes/smoke.rb
@@ -23,7 +23,6 @@ expeditor_jenkins_job "#{workflow_change_project}-test" do # ~FC005
   git_ref workflow_change_merge_sha
   initiated_by workflow_project_slug
   action :trigger_async
-  not_if { skip_omnibus_build? }
   only_if { workflow_stage?('acceptance') }
 end
 
@@ -66,6 +65,5 @@ expeditor_jenkins_job "#{workflow_change_project}-test" do
   git_ref workflow_change_merge_sha
   initiated_by workflow_project_slug
   action :wait_until_complete
-  not_if { skip_omnibus_build? }
   only_if { workflow_stage?('acceptance') }
 end


### PR DESCRIPTION
We can't use this helper right now as there is now PR (to read labels
off of) directly associated with the Automate Workflow change which is
driving the build out and testing of acceptance. We'll add this
functionality back in the near future when we've found a way to link
things together.

Signed-off-by: Seth Chisamore <schisamo@chef.io>