### PR TITLE
Use NGINX cert path attributes to configure RabbitMQ

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -116,7 +116,6 @@ end
 
 # Configure Services
 [
-  "rabbitmq",
   "postgresql",
   "oc_bifrost",
   "oc_id",
@@ -128,6 +127,7 @@ end
   "opscode-chef-mover",
   "redis_lb",
   "nginx",
+  "rabbitmq",
   "keepalived"
 ].each do |service|
   if node["private_chef"][service]["external"]

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
@@ -79,12 +79,8 @@ template config_file do
   variables(rabbitmq.to_hash)
 end
 
-# reuse nginx certs for RabbitMQ Management Plugin
-nginx_dir = node['private_chef']['nginx']['dir']
-nginx_ca_dir = File.join(nginx_dir, 'ca')
-ssl_keyfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.key")
-ssl_crtfile = File.join(nginx_ca_dir, "#{node['private_chef']['nginx']['server_name']}.crt")
-
+ssl_crtfile = node['private_chef']['nginx']['ssl_certificate']
+ssl_keyfile = node['private_chef']['nginx']['ssl_certificate_key']
 ssl_versions = node['private_chef']['rabbitmq']['ssl_versions'].map{ |v| "'#{v}'"}.join(",")
 
 template "#{rabbitmq_etc_dir}/rabbitmq.config" do


### PR DESCRIPTION
These attributes work resolve correctly for a generated SSL cert OR a
full SSL cert path passed in via config.

Signed-off-by: Seth Chisamore <schisamo@chef.io>