### PR TITLE
Ensure our SSL certs are owned by the `opscode` user

### DIFF
--- a/cookbooks/chef-server-deploy/attributes/default.rb
+++ b/cookbooks/chef-server-deploy/attributes/default.rb
@@ -27,7 +27,6 @@ default['chef-server-deploy']['delivery_chef_org'] = 'delivery'
 # Key locations
 default['chef-server-deploy']['chef_cert_filename'] = 'wildcard.chef.co.crt'
 default['chef-server-deploy']['chef_key_filename'] = 'wildcard.chef.co.key'
-default['chef-server-deploy']['license_base64_encoded'] = false
 
 # Automatic node run data collection (token randomly generated with `SecureRandom.hex(32)`)
 default['chef-server-deploy']['data_collection_token'] = 'e120f9ed31db404889bf0f40d83673fddf0d07d1b906643717675733ae56ea55'

--- a/cookbooks/chef-server-deploy/metadata.rb
+++ b/cookbooks/chef-server-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Chef Server in ACC'
 long_description 'Installs/Configures Chef Server in ACC'
-version '0.1.5'
+version '0.1.6'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 

--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -25,6 +25,27 @@ node.default['chef-server-deploy']['enable_liveness_agent'] = (environment == 'd
 ################################################################################
 # Chef Server
 ################################################################################
+
+# Ensure `opscode` user exists so we can set SSL cert ownership correctly.
+# We create the user and group in the way, with the same settings as the
+# Chef recipes that execute during `chef-server-ctl reconfigure`. See the
+# following links for more:
+#
+#   https://git.io/v7Hg6
+#   https://git.io/v7Hgi
+#   https://git.io/v7HgX
+#
+
+user 'opscode' do
+  system true
+  shell '/bin/sh'
+  home '/opt/opscode/embedded'
+end
+
+group 'opscode' do
+  members [ 'opscode' ]
+end
+
 cert_filename = "/etc/opscode/#{node['chef-server-deploy']['chef_cert_filename']}"
 key_filename  = "/etc/opscode/#{node['chef-server-deploy']['chef_key_filename']}"
 automate_liveness_recipe_path = '/etc/opscode/automate-liveness-recipe.rb'
@@ -34,11 +55,15 @@ directory '/etc/opscode' do
 end
 
 file cert_filename do
+  user 'opscode'
+  group 'root'
   mode '0600'
   content citadel[node['chef-server-deploy']['chef_cert_filename']]
 end
 
 file key_filename do
+  user 'opscode'
+  group 'root'
   mode '0600'
   content citadel[node['chef-server-deploy']['chef_key_filename']]
 end


### PR DESCRIPTION
Without this ownership being set correctly RabbitMQ cannnot read the SSL certs on startup and the RabbitMQ management plugin will not load correctly. This in turn will cause the newly expanded `/_status` endpoint to fail which in turn will block acceptance! SO MEAN!

Signed-off-by: Seth Chisamore <schisamo@chef.io>