### PR TITLE
[JEX-633] Remove `-2` suffix from Chef Server instance naming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,7 @@
 *                                @chef/chef-server-maintainers
 .delivery/**                     @chef/acc-maintainers
 .expeditor/**                    @chef/engineering-services
+.travis.yml                      @chef/chef-server-maintainers @chef/engineering-services
 cookbooks/chef-server-deploy/**  @chef/acc-maintainers
+inspec/**                        @chef/acc-maintainers
 terraform/**                     @chef/acc-maintainers

--- a/cookbooks/chef-server-deploy/metadata.rb
+++ b/cookbooks/chef-server-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Chef Server in ACC'
 long_description 'Installs/Configures Chef Server in ACC'
-version '0.1.6'
+version '0.1.7'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 

--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -43,7 +43,7 @@ user 'opscode' do
 end
 
 group 'opscode' do
-  members [ 'opscode' ]
+  members ['opscode']
 end
 
 cert_filename = "/etc/opscode/#{node['chef-server-deploy']['chef_cert_filename']}"
@@ -205,7 +205,7 @@ end
   'expeditor' => {
     password: citadel['expeditor_password'].chomp,
     serveradmin: false,
-  }
+  },
 }.each do |user_name, user_options|
 
   chef_user user_name do

--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 node.default['chef-server-deploy']['automate_server_fqdn'] = server_fqdn_for('automate')
-node.default['chef-server-deploy']['chef_server_fqdn'] = server_fqdn_for('chef-server-2')
+node.default['chef-server-deploy']['chef_server_fqdn'] = server_fqdn_for('chef-server')
 node.default['chef-server-deploy']['supermarket_fqdn'] = server_fqdn_for('supermarket')
 node.default['chef-server-deploy']['enable_liveness_agent'] = (environment == 'delivered' ? true : false)
 

--- a/terraform/acceptance/omnibus-standalone-inplace-upgrade.tf
+++ b/terraform/acceptance/omnibus-standalone-inplace-upgrade.tf
@@ -8,9 +8,7 @@ module "chef_server_omnibus_standalone_inplace_upgrade_server" {
   aws_private_key      = "${var.aws_private_key}"
   aws_key_name         = "${var.aws_key_name}"
   aws_root_volume_size = 200
-
-  # This value will be switched to chef-server after a migration
-  aws_subdomain = "chef-server-2"
+  aws_subdomain        = "chef-server"
 
   # AWS Tags
   aws_tag_chef_product      = "chef-server"

--- a/terraform/u-r-d/omnibus-standalone-inplace-upgrade.tf
+++ b/terraform/u-r-d/omnibus-standalone-inplace-upgrade.tf
@@ -9,9 +9,7 @@ module "chef_server_omnibus_standalone_inplace_upgrade_server" {
   aws_private_key      = "${var.aws_private_key}"
   aws_key_name         = "${var.aws_key_name}"
   aws_root_volume_size = 200
-
-  # This value will be switched to chef-server after a migration
-  aws_subdomain = "chef-server-2"
+  aws_subdomain        = "chef-server"
 
   # AWS Tags
   aws_tag_chef_product      = "chef-server"


### PR DESCRIPTION
Now that we've fully moved management of the Chef Server instances to this pipeline (see chef/automate#965) we need to reprovision instances using the final naming.

Signed-off-by: Seth Chisamore <schisamo@chef.io>