### PR TITLE
Set the correct owner and permissions for SSL certificate and key

### DIFF
--- a/cookbooks/chef-server-deploy/metadata.rb
+++ b/cookbooks/chef-server-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Chef Server in ACC'
 long_description 'Installs/Configures Chef Server in ACC'
-version '0.1.7'
+version '0.1.8'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 

--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -26,26 +26,6 @@ node.default['chef-server-deploy']['enable_liveness_agent'] = (environment == 'd
 # Chef Server
 ################################################################################
 
-# Ensure `opscode` user exists so we can set SSL cert ownership correctly.
-# We create the user and group in the way, with the same settings as the
-# Chef recipes that execute during `chef-server-ctl reconfigure`. See the
-# following links for more:
-#
-#   https://git.io/v7Hg6
-#   https://git.io/v7Hgi
-#   https://git.io/v7HgX
-#
-
-user 'opscode' do
-  system true
-  shell '/bin/sh'
-  home '/opt/opscode/embedded'
-end
-
-group 'opscode' do
-  members ['opscode']
-end
-
 cert_filename = "/etc/opscode/#{node['chef-server-deploy']['chef_cert_filename']}"
 key_filename  = "/etc/opscode/#{node['chef-server-deploy']['chef_key_filename']}"
 automate_liveness_recipe_path = '/etc/opscode/automate-liveness-recipe.rb'
@@ -55,15 +35,11 @@ directory '/etc/opscode' do
 end
 
 file cert_filename do
-  user 'opscode'
-  group 'root'
   mode '0600'
   content citadel[node['chef-server-deploy']['chef_cert_filename']]
 end
 
 file key_filename do
-  user 'opscode'
-  group 'root'
   mode '0600'
   content citadel[node['chef-server-deploy']['chef_key_filename']]
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -71,13 +71,26 @@ if (node['private_chef']['nginx']['ssl_certificate'].nil? &&
      key_length node['private_chef']['nginx']['ssl_key_length']
      expire node['private_chef']['nginx']['ssl_duration']
      subject_alt_name [ "#{server_name_type}:#{server_name}" ]
-     owner 'root'
-     group 'root'
-     mode '0644'
+     owner OmnibusHelper.new(node).ownership['owner']
+     group OmnibusHelper.new(node).ownership['group']
+     mode '0600'
    end
 
   node.default['private_chef']['nginx']['ssl_certificate'] = ssl_crtfile
   node.default['private_chef']['nginx']['ssl_certificate_key'] = ssl_keyfile
+end
+
+# The cert and key must be readable by the opscode user since rabbitmq also reads it
+file node['private_chef']['nginx']['ssl_certificate'] do
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
+  mode '0600'
+end
+
+file node['private_chef']['nginx']['ssl_certificate_key'] do
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
+  mode '0600'
 end
 
 # Copy the required_recipe source into the nginx static root directory and

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -71,26 +71,26 @@ if (node['private_chef']['nginx']['ssl_certificate'].nil? &&
      key_length node['private_chef']['nginx']['ssl_key_length']
      expire node['private_chef']['nginx']['ssl_duration']
      subject_alt_name [ "#{server_name_type}:#{server_name}" ]
-     owner OmnibusHelper.new(node).ownership['owner']
+     owner 'root'
      group OmnibusHelper.new(node).ownership['group']
-     mode '0600'
+     mode '0640'
    end
 
   node.default['private_chef']['nginx']['ssl_certificate'] = ssl_crtfile
   node.default['private_chef']['nginx']['ssl_certificate_key'] = ssl_keyfile
 end
 
-# The cert and key must be readable by the opscode user since rabbitmq also reads it
+# The cert and key must be readable by the opscode group since rabbitmq also reads it
 file node['private_chef']['nginx']['ssl_certificate'] do
-  owner OmnibusHelper.new(node).ownership['owner']
+  owner 'root'
   group OmnibusHelper.new(node).ownership['group']
-  mode '0600'
+  mode '0640'
 end
 
 file node['private_chef']['nginx']['ssl_certificate_key'] do
-  owner OmnibusHelper.new(node).ownership['owner']
+  owner 'root'
   group OmnibusHelper.new(node).ownership['group']
-  mode '0600'
+  mode '0640'
 end
 
 # Copy the required_recipe source into the nginx static root directory and


### PR DESCRIPTION
This is a follow up to https://github.com/chef/chef-server/pull/1366 and
https://github.com/chef/chef-server/pull/1368.

This patch will set the owner of the ssl certificate and key to the
user that is running rabbitmq/nginx. In #1366, we discovered that
rabbitmq was expecting certs to be in the nginx directory, however
that wasn't necessarily the case when the ssl certificate was not
generated by private-chef-cookbooks. In these cases, the rabbitmq
management interface would be completely broken as the certs we
asked it to use were not there. After fixing that, #1368 was required
because the custom certificate that was being set for the accpetance
environment was owned by root and had the permissions 600, which meant
the opscode user could not read it. Rabbitmq does not start as root like
nginx, so rabitmq was unable to read the certificate. While #1368 got
our environment working, I suspect others may run into a similar issue
unless we explicitly set the owner and permissions on the files to what
we expect.