### PR TITLE
[omnibus] bump postgres versions

### DIFF
--- a/omnibus/config/software/postgresql92-bin.rb
+++ b/omnibus/config/software/postgresql92-bin.rb
@@ -16,7 +16,7 @@
 
 name "postgresql92-bin"
 
-default_version "9.2.21"
+default_version "9.2.22"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -31,7 +31,7 @@ dependency "config_guess"
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
 
-version("9.2.21") { source sha256: "0697e843523ee60c563f987f9c65bc4201294b18525d6e5e4b2c50c6d4058ef9" }
+version("9.2.22") { source sha256: "a70e94fa58776b559a8f7b5301371ac4922c9e3ed313ccbef20862514de7c192" }
 
 relative_path "postgresql-#{version}"
 

--- a/omnibus/config/software/postgresql96.rb
+++ b/omnibus/config/software/postgresql96.rb
@@ -16,7 +16,7 @@
 
 name "postgresql96"
 
-default_version "9.6.3"
+default_version "9.6.4"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -30,7 +30,7 @@ dependency "libossp-uuid"
 dependency "config_guess"
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
-version("9.6.3") { source sha256: "1645b3736901f6d854e695a937389e68ff2066ce0cde9d73919d6ab7c995b9c6" }
+version("9.6.4") { source sha256: "2b3ab16d82e21cead54c08b95ce3ac480696944a68603b6c11b3205b7376ce13" }
 
 relative_path "postgresql-#{version}"
 


### PR DESCRIPTION
[2017-08-10 Security Update Release](https://www.postgresql.org/about/news/1772/)

An ad-hoc build has made it past those two definitions. Probably fine.