### PR TITLE
Render supermarket oc-id file contents into NGINX config

### DIFF
--- a/cookbooks/chef-server-deploy/libraries/helpers.rb
+++ b/cookbooks/chef-server-deploy/libraries/helpers.rb
@@ -5,6 +5,12 @@ module ChefOpsDCC
       release = JSON.parse(github_api.get('/repos/chef/automate-liveness-agent/releases/latest'))
       release['assets'].find { |a| a['name'] == 'automate-liveness-recipe.rb' }['browser_download_url']
     end
+
+    def oc_id_applciation_config(app_name)
+      File.read("/etc/opscode/oc-id-applications/#{app_name}.json")
+    rescue Errno::ENOENT
+      ''
+    end
   end
 end
 

--- a/cookbooks/chef-server-deploy/metadata.rb
+++ b/cookbooks/chef-server-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Chef Server in ACC'
 long_description 'Installs/Configures Chef Server in ACC'
-version '0.1.8'
+version '0.1.9'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 


### PR DESCRIPTION
We previously just touched the file as the `opscode` user so NGINX could
serve the file up. That is not a long term solution as `chef-server-ctl
reconfigure` explicitly sets the owner to `root`:
https://git.io/v7F4z

We'll just read the contents of the file during our deployment CCR (when
privileges are elevated).

Signed-off-by: Seth Chisamore <schisamo@chef.io>