### PR TITLE
[deployment cookbooks] Use single quotes in nginx config

### DIFF
--- a/cookbooks/chef-server-deploy/metadata.rb
+++ b/cookbooks/chef-server-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Chef Server in ACC'
 long_description 'Installs/Configures Chef Server in ACC'
-version '0.1.9'
+version '0.1.10'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 

--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -9,7 +9,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -146,7 +146,7 @@ file '/var/opt/opscode/nginx/etc/addon.d/99-supermarket-credentials_external.con
 location /supermarket-credentials {
   types { }
   default_type application/json;
-  return 200 "#{oc_id_applciation_config('supermarket')}";
+  return 200 '#{oc_id_applciation_config('supermarket')}';
 }
 EOF
   end)


### PR DESCRIPTION
The json contains double quotes.

Signed-off-by: Steven Danna <steve@chef.io>