### PR TITLE
Set compression_level for RPM

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -44,7 +44,7 @@ dependency "cleanup" # MUST BE LAST DO NOT MOVE
 
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']
-  compression_level xz_level
+  compression_level 6
   compression_type :xz
 end
 


### PR DESCRIPTION
I missed this in the last commit related to compression level.

Signed-off-by: Steven Danna <steve@chef.io>