### PR TITLE
Check for sufficient disk space before upgrade

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/du.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/du.rb
@@ -1,0 +1,25 @@
+require 'mixlib/shellout'
+module Du
+  # Calculate the disk space used by the given path. Requires that
+  # `du` is in our PATH.
+  #
+  # @param path [String] Path to a directory on disk
+  # @return [Integer] KB used by directory on disk
+  #
+  def self.du(path)
+    # TODO(ssd) 2017-08-18: Do we need to worry about sparse files
+    # here? If so, can we expect the --apparent-size flag to exist on
+    # all of our platforms.
+    command = Mixlib::ShellOut.new("du -sk #{path}")
+    command.run_command
+    if command.status.success?
+      command.stdout.split("\t").first.to_i
+    else
+      Chef::Log.error("du -sk #{path} failed with exit status: #{command.exitstatus}")
+      Chef::Log.error("du stderr: #{command.stderr}")
+      raise "du failed"
+    end
+  rescue Errno::ENOENT
+    raise "The du utility is not available. Unable to check disk usage"
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/statfs.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/statfs.rb
@@ -1,0 +1,78 @@
+require 'ffi'
+
+class Statfs
+  #
+  # Statfs provides a simple interface to the statvfs system call.
+  # Since the statvfs struct varies a bit across platforms, this
+  # likely only works on Linux and OSX at the moment.
+  #
+  extend FFI::Library
+  ffi_lib FFI::Library::LIBC
+
+  attach_function(:statvfs, [:string, :pointer], :int)
+  attach_function(:strerror, [:int], :string)
+
+  FSBLKCNT_T = if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i
+                 :uint
+               else
+                 :ulong
+               end
+
+  # See http://man7.org/linux/man-pages/man2/statvfs.2.html
+  class Statvfs < FFI::Struct
+    spec = [
+            :f_bsize,   :ulong,      # Filesystem block size
+            :f_frsize,  :ulong,      # Fragement size
+            :f_blocks,  FSBLKCNT_T,  # Size of fs in f_frsize units
+            :f_bfree,   FSBLKCNT_T,  # Number of free blocks
+            :f_bavail,  FSBLKCNT_T,  # Number of free blocks for unpriviledged users
+            :f_files,   FSBLKCNT_T,  # Number of inodes
+            :f_ffree,   FSBLKCNT_T,  # Number of free inodes
+            :f_favail,  FSBLKCNT_T,  # Number of free inodes for unprivilged users
+            :f_fsid,    :ulong,      # Filesystem ID
+            :f_flag,    :ulong,      # Mount Flags
+            :f_namemax, :ulong       # Max filename length
+           ]
+
+    # Linux has this at the end of the struct and if we don't include
+    # it we end up getting a memory corruption error when th object
+    # gets GCd.
+    if RbConfig::CONFIG['host_os'] =~ /linux/i
+      spec << :f_spare
+      spec << [:int, 6]
+    end
+
+    layout(*spec)
+  end
+
+  def initialize(path)
+    @statvfs = stat(path)
+  end
+
+  #
+  # @returns [Integer] Free inodes on the given filesystem
+  #
+  def free_inodes
+    @statvfs[:f_favail]
+  end
+
+  #
+  # @returns [Integer] Free space in KB on the given filesystem
+  #
+  def free_space
+    # Since we are running as root we could report f_bfree but will
+    # stick with f_bavail since it will typically be more
+    # conservative.
+    (@statvfs[:f_frsize] * @statvfs[:f_bavail])/1024
+  end
+
+  private
+
+  def stat(path)
+    statvfs = Statvfs.new
+    if statvfs(path, statvfs.to_ptr) != 0
+      raise 'statvfs: ' + strerror(FFI.errno)
+    end
+    statvfs
+  end
+end


### PR DESCRIPTION
The `pg_upgrade` tool copies all of the database files as part of the
upgrade.  While this could be avoided with the `--link` flag, the
`--link` flag would also prevent falling back to the old pg cluster in
case of a problem.

To avoid upgrade failures, we check that the disk for the new data
directory has enough free space for another copy of the database plus
some headroom to ensure we have some room to operate after the
upgrade.

Available disk space is currently queried via an FFI call into libc's
statvfs function. The downside of the FFI approach is making sure our
representation of the statvfs struct is correct on all of our
supported platforms. A more straightforward approach might be to parse
`df` output; however, the first and the last columns of the `df`
output are paths which could theoretically contain spaces making it a
bit of a pain to parse. However, if all of our platforms support the
`--output` flag, this problem can be easily avoided.

Signed-off-by: Steven Danna <steve@chef.io>