### PR TITLE
[cookbooks] Make pg_upgrade timeout configurable

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -618,6 +618,9 @@ default['private_chef']['postgresql']['checkpoint_timeout'] = "5min"
 default['private_chef']['postgresql']['checkpoint_completion_target'] = 0.5
 default['private_chef']['postgresql']['checkpoint_flush_after'] = "256kB"
 default['private_chef']['postgresql']['checkpoint_warning'] = "30s"
+# These settings affect the pg_upgrade process.  For example, when
+# migrating from postgresql 9.2 to 9.6
+default['private_chef']['postgresql']['pg_upgrade_timeout'] = 7200
 
 ###
 # Bifrost

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_upgrade.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_upgrade.rb
@@ -244,5 +244,6 @@ def update_to_latest_version
     user node['private_chef']['postgresql']['username']
     cwd new_data_dir # TODO: Should this be some other directory, instead?
     creates sentinel_file
+    timeout node['private_chef']['postgresql']['pg_upgrade_timeout']
   end
 end


### PR DESCRIPTION
The default timeout for an execute resource is 3600 seconds. For large
Chef databases (such as those with a lot of reporting data), this may
not be enough time for pg_upgrade to succeed.

This makes the timeout configurable and sets the default to 7200 which
will hopefully be high enough for most production Chef Servers.

Signed-off-by: Steven Danna <steve@chef.io>