### PR TITLE
Mitigate Host Header cache-poisoning attacks

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -114,7 +114,7 @@ http {
           server {
             <%= @helper.listen_port('http') %>
             access_log /var/log/opscode/nginx/rewrite-port-80.log;
-            return 301 https://$host$request_uri;
+            return 301 https://$server_name$request_uri;
           }
       <%- end -%>
     <%-  end %>


### PR DESCRIPTION
Previously, a request such as:

    curl -H Host:evil.com http://chef-server.dev

would create a response where the Location was set to the user
provided Host header.

    Location: https://evil.com/

If this 301 was erroneously cached, it may then be served to another
user, whose traffic might be redirected to an attacker-controlled
server.

This PR changes the nginx configuration so that we use the server_name
rather than the user-provided Host header when generating redirects.

Signed-off-by: Steven Danna <steve@chef.io>