### PR TITLE
Mitigate Host Header cache-poisoning attacks

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -563,7 +563,7 @@ default['private_chef']['nginx']['server_names_hash_bucket_size'] = 128
 default['private_chef']['nginx']['enable_ipv6'] = false
 # Only respond to requests with a Host: header that matches
 # a configured fqdn.
-default['private_chef']['nginx']['strict_host_header'] = true
+default['private_chef']['nginx']['strict_host_header'] = false
 # Implicitly add server_name entries for localhost, 127.0.0.1, ::1,
 # and any IPs associated with the machine.
 default['private_chef']['nginx']['use_implicit_hosts'] = true

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -561,6 +561,12 @@ default['private_chef']['nginx']['client_max_body_size'] = '250m'
 default['private_chef']['nginx']['cache_max_size'] = '5000m'
 default['private_chef']['nginx']['server_names_hash_bucket_size'] = 128
 default['private_chef']['nginx']['enable_ipv6'] = false
+# Only respond to requests with a Host: header that matches
+# a configured fqdn.
+default['private_chef']['nginx']['strict_host_header'] = true
+# Implicitly add server_name entries for localhost, 127.0.0.1, ::1,
+# and any IPs associated with the machine.
+default['private_chef']['nginx']['use_implicit_hosts'] = true
 
 ###
 # PostgreSQL

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -105,6 +105,33 @@ http {
     proxy_cache_path  <%= File.join(@dir, "cache", "cookbooks") %> levels=1:2 keys_zone=cookbooks:50m max_size=<%= @cache_max_size %> inactive=600m;
     proxy_temp_path <%= File.join(@dir, "cache-tmp") %>;
 
+    <%- if @strict_host_header %>
+    # Reject requests with unknown Host header
+      <%- if @non_ssl_port %>
+    server {
+      listen <%= @non_ssl_port %> default_server;
+      server_tokens off;
+      server_name _;
+      return 404;
+    }
+      <%- end %>
+
+    server {
+      listen <%= @ssl_port %> ssl;
+      server_tokens off;
+
+      ssl_certificate <%= @ssl_certificate %>;
+      ssl_certificate_key <%= @ssl_certificate_key %>;
+      ssl_session_timeout 5m;
+      ssl_protocols <%= @ssl_protocols %>;
+      ssl_ciphers <%= @ssl_ciphers %>;
+      ssl_prefer_server_ciphers on;
+
+      server_name _;
+      return 404;
+  }
+  <% end -%>
+
     # We support three options: serve nothing on non_ssl_port (80),
     # redirect to https, or actually serve the API.
     <%- if @non_ssl_port -%>
@@ -113,6 +140,7 @@ http {
       <%- else -%>
           server {
             <%= @helper.listen_port('http') %>
+            server_name <%= @helper.server_name %>;
             access_log /var/log/opscode/nginx/rewrite-port-80.log;
             return 301 https://$host$request_uri;
           }
@@ -127,8 +155,7 @@ http {
   <%- if node['private_chef']['lb_internal']['enable'] -%>
   server {
     <%= @helper.listen_port(node['private_chef']['lb_internal']['chef_port']) %>
-    # The name doesn't matter; this is the only listener on this port
-    server_name <%= @server_name %>;
+    server_name <%= @helper.server_name %>;
 
     client_max_body_size <%= @client_max_body_size %>;
     proxy_set_header        Host            $host;
@@ -160,7 +187,7 @@ http {
   # internal service access for oc_bifrost
   server {
     <%= @helper.listen_port(node['private_chef']['lb_internal']['oc_bifrost_port']) %>
-    server_name <%= @server_name %>;
+    server_name <%= @helper.server_name %>;
 
     client_max_body_size <%= @client_max_body_size %>;
     proxy_set_header        Host            $host;

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -1,6 +1,6 @@
   server {
     <%= @helper.listen_port(@server_proto) %>
-    server_name <%= @server_name %>;
+    server_name <%= @helper.server_name %>;
 
     set_by_lua $data_collector_token 'return os.getenv("DATA_COLLECTOR_TOKEN")';
 


### PR DESCRIPTION
Previously, a request such as:

    curl -H Host:evil.com http://chef-server.dev

would create a response where the Location was set to the user
provided Host header.

    Location: https://evil.com/

If this 301 was erroneously cached, it may then be served to another
user, whose traffic might be redirected to an attacker-controlled
server.

This PR changes the nginx configuration so that we only respond to
requests with Host headers that match the configured FQDNs for the
machine. Any requests for an unknown host will get a 404.

To ease the transition burden, we also add any IPs on the machine and
localhost to the list of known server names.

The main dis-advantage is that it we can't account for IPs that route
to the machine but aren't accessible via Ohai.

This adds two new configuration options

    delivery['nginx']['strict_host_header'] = true
    delivery['nginx']['use_implicit_hosts'] = true

The old behavior can be restored with

    delivery['nginx']['strict_host_header'] = false
    delivery['nginx']['use_implicit_hosts'] = false

This is similar to the approach taken in chef/automate#1118 (apologies
private). A much more simple solution would be to replace $host with
$server_name in the rewrite/return rule. The concern with this
approach in Automate was that users hitting the site with an IP
address would get redirected to a hostname, causing consternation.
This might not be as much of a concern here because we only use $host
for the HTTP->HTTPS rewrite, so the user could avoid such
consternation by using HTTPS from the outset.

Signed-off-by: Steven Danna <steve@chef.io>