### PR TITLE
set use_implicit_hosts to false

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -566,7 +566,7 @@ default['private_chef']['nginx']['enable_ipv6'] = false
 default['private_chef']['nginx']['strict_host_header'] = false
 # Implicitly add server_name entries for localhost, 127.0.0.1, ::1,
 # and any IPs associated with the machine.
-default['private_chef']['nginx']['use_implicit_hosts'] = true
+default['private_chef']['nginx']['use_implicit_hosts'] = false
 
 ###
 # PostgreSQL


### PR DESCRIPTION
Interim fix for : Users on clouds where the ohai (v8.23.0) plugin for their cloud doesn't report a list of strings for `public_ipv4` and `private_ipv4` will have a broken nginx config on upgrade.