### PR TITLE
[SUSTAIN-728] Add /_acl for cookbook_artifacts

### DIFF
--- a/oc-chef-pedant/spec/api/account/account_acl_spec.rb
+++ b/oc-chef-pedant/spec/api/account/account_acl_spec.rb
@@ -1,8 +1,10 @@
 require 'pedant/rspec/common'
 require 'pedant/acl'
+require 'pedant/rspec/cookbook_util'
 
 describe "ACL API", :acl do
   include Pedant::ACL
+  include Pedant::RSpec::CookbookUtil
 
   # Generate random string identifier prefixed with current pid
   def rand_id
@@ -836,7 +838,7 @@ describe "ACL API", :acl do
     # TODO: Sanity check: users don't seem to have any ACLs, or at least, nothing is
     # accessible from external API as far as I can tell:
     # - [jkeiser] Users have ACLs, but they are at /users/NAME/_acl
-    %w(clients groups containers data nodes roles environments cookbooks policies policy_groups).each do |type|
+    %w(cookbook_artifacts clients groups containers data nodes roles environments cookbooks policies policy_groups).each do |type|
       context "for #{type} type" do
 
         let(:new_object) { "new-object" }
@@ -989,10 +991,18 @@ describe "ACL API", :acl do
           }}
           let(:groups) { ["users", "admins"] }
           let(:read_groups) { ["users", "clients", "admins"] }
+        when "cookbook_artifacts"
+          let(:creation_url) { api_url("#{type}/#{new_object}/1111111111111111111111111111111111111111") }
+          let(:creation_body) { new_cookbook_artifact("new-object", "1111111111111111111111111111111111111111", version: "1") }
+          let(:deletion_url) { api_url("#{type}/#{new_object}/1111111111111111111111111111111111111111")}
+          let(:groups) { ["admins", "users"] }
+          let(:read_groups) { ["admins", "clients", "users"] }
+          let(:update_groups) { ["admins", "users"] }
+          let(:delete_groups) { ["admins", "users"] }
         end
 
         before :each do
-          if (type == "cookbooks" || type == "policy_groups")
+          if (type == "cookbooks" || type == "policy_groups" || type == "cookbook_artifacts")
             # Inconsistent API needs a PUT here.  We love consistency!
             put(creation_url, setup_user,
               :payload => creation_body).should look_like({

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
@@ -160,6 +160,13 @@ fetch_id(policy, DbContext, Name, OrgId) ->
         #oc_chef_policy{authz_id = AuthzId} ->
             AuthzId
     end;
+fetch_id(cookbook_artifact, DbContext, Name, OrgId) ->
+    case chef_db:fetch(#oc_chef_cookbook_artifact{org_id = OrgId, name = Name}, DbContext) of
+        not_found ->
+            not_found;
+        #oc_chef_cookbook_artifact{authz_id = AuthzId} ->
+            AuthzId
+    end;
 fetch_id(policy_group, DbContext, Name, OrgId) ->
     case chef_db:fetch(#oc_chef_policy_group{org_id = OrgId, name = Name}, DbContext) of
         not_found ->
@@ -349,6 +356,8 @@ acl_path(user, AuthzId) ->
 acl_path(organization, AuthzId) ->
     acl_path(object, AuthzId);
 acl_path(policy, AuthzId) ->
+    acl_path(object, AuthzId);
+acl_path(cookbook_artifact, AuthzId) ->
     acl_path(object, AuthzId);
 acl_path(policy_group, AuthzId) ->
     acl_path(object, AuthzId);

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -29,6 +29,8 @@
  oc_chef_wm_acl, [{acl_object_type, policy}]}.
 {["organizations", organization_id, "policy_groups", policy_group_name, "_acl"],
  oc_chef_wm_acl, [{acl_object_type, policy_group}]}.
+{["organizations", organization_id, "cookbook_artifacts", cookbook_artifact_name, "_acl"],
+ oc_chef_wm_acl, [{acl_object_type, cookbook_artifact}]}.
 
 {["users", user_name, "_acl", acl_permission],
  oc_chef_wm_acl_permission, [{acl_object_type, user}]}.
@@ -55,6 +57,8 @@
 {["organizations", organization_id, "policy_groups", policy_group_name, "_acl", acl_permission],
  oc_chef_wm_acl_permission, [{acl_object_type, policy_group}]}.
 
+{["organizations", organization_id, "cookbook_artifacts", cookbook_artifact_name, "_acl", acl_permission],
+ oc_chef_wm_acl_permission, [{acl_object_type, cookbook_artifact}]}.
 {["organizations", organization_id, "cookbooks"], chef_wm_cookbooks, []}.
 %% 'qualifier' will be things like "_latest", "_recipes"
 {["organizations", organization_id, "cookbooks", qualifier], chef_wm_cookbooks, []}.

--- a/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
+++ b/src/oc_erchef/apps/oc_chef_wm/priv/dispatch.conf
@@ -56,9 +56,9 @@
  oc_chef_wm_acl_permission, [{acl_object_type, policy}]}.
 {["organizations", organization_id, "policy_groups", policy_group_name, "_acl", acl_permission],
  oc_chef_wm_acl_permission, [{acl_object_type, policy_group}]}.
-
 {["organizations", organization_id, "cookbook_artifacts", cookbook_artifact_name, "_acl", acl_permission],
  oc_chef_wm_acl_permission, [{acl_object_type, cookbook_artifact}]}.
+
 {["organizations", organization_id, "cookbooks"], chef_wm_cookbooks, []}.
 %% 'qualifier' will be things like "_latest", "_recipes"
 {["organizations", organization_id, "cookbooks", qualifier], chef_wm_cookbooks, []}.

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_util.erl
@@ -260,6 +260,8 @@ object_name(policy, Req) ->
     extract_from_path(policy_name, Req);
 object_name(policy_group, Req) ->
     extract_from_path(policy_group_name, Req);
+object_name(cookbook_artifact, Req) ->
+    extract_from_path(cookbook_artifact_name, Req);
 %% For requests to `/policy_groups/:policy_group/policies/:policy_name`,
 %% the lookup key is `policy_group` without the `_name`
 object_name(policy_group_asoc_name, Req) ->


### PR DESCRIPTION
Currently, knife-ec-backup (via ChefFS) returns a 404 when attempting
to retrieve ACLs on `cookbook_artifacts`.  This change adds the `/_acl`
endpoint to `cookbook_artifacts` so that they can be retrieved and
written.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>