### PR TITLE
audit cookbook is now applied via an optional recipe

### DIFF
--- a/.delivery/build_cookbook/metadata.rb
+++ b/.delivery/build_cookbook/metadata.rb
@@ -2,7 +2,7 @@ name 'build_cookbook'
 maintainer 'Chef Software Inc Engineering'
 maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
-version '0.1.1'
+version '0.1.2'
 
 chef_version '>= 12.19'
 

--- a/.delivery/build_cookbook/recipes/deploy.rb
+++ b/.delivery/build_cookbook/recipes/deploy.rb
@@ -28,6 +28,7 @@ infra_nodes.each do |infra_node|
     run_list %W(
       recipe[cd-infrastructure-base::default]
       recipe[chef-server-deploy::#{recipe_for(infra_node)}]
+      recipe[cd-infrastructure-base::audit]
     )
   end
 end


### PR DESCRIPTION
See the following change for details: chef/cd-infrastructure#97

Signed-off-by: Seth Chisamore <schisamo@chef.io>