### PR TITLE
InSpec smoke test improvements

### DIFF
--- a/inspec/chef-server-smoke/controls/base.rb
+++ b/inspec/chef-server-smoke/controls/base.rb
@@ -27,14 +27,9 @@ title 'Chef Server Smoke Tests'
   end
 end
 
-# Only perform SSL verification on hosts where we know the SSL certs are
-# properly configured
-verify = false # TODO: switch this back after JEX-633 is complete
-# verify = fetch_target_host.include?('cd.chef.co') ? false : true
-
 chef_server_version = fetch_chef_server_version
 
-describe http("https://#{fetch_target_host}/_status", ssl_verify: verify) do
+describe http("https://#{fetch_target_host}/_status") do
   its('status') { should eq 200 }
 end
 

--- a/inspec/chef-server-smoke/libraries/helper.rb
+++ b/inspec/chef-server-smoke/libraries/helper.rb
@@ -1,7 +1,7 @@
 def fetch_chef_server_version
-  attribute('application_version', default: ENV['CHEF_SERVER_VERSION'])
+  attribute('application_version', default: ENV['APPLICATION_VERSION'])
 end
 
 def fetch_target_host
-  attribute('target_host', default: command('grep -Po "api_fqdn\s[\"\']+\K.*(?=[\"\']+?)" /etc/opscode/chef-server.rb').stdout.strip)
+  inspec.backend.hostname
 end


### PR DESCRIPTION
* Use SSL verifications by default now (our wildcard cert now covers
  *.cd.chef.co)
* Extract the target host from the InSpec backend

Signed-off-by: Seth Chisamore <schisamo@chef.io>