### PR TITLE
Improve how Manage is configured in internal pipeline

### DIFF
--- a/cookbooks/chef-server-deploy/metadata.rb
+++ b/cookbooks/chef-server-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Chef Server in ACC'
 long_description 'Installs/Configures Chef Server in ACC'
-version '0.1.10'
+version '0.1.11'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 

--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -98,15 +98,13 @@ end
 ################################################################################
 # Chef Manage
 ################################################################################
+node.default['chef-server-deploy']['manage-config']['saml.enabled'] = node['chef-server-deploy']['enable_saml']
+node.default['chef-server-deploy']['manage-config']['saml.issuer_url'] = "'https://#{node['chef-server-deploy']['automate_server_fqdn']}/api/v0'"
+
 chef_ingredient 'manage' do
   channel :stable
   accept_license true
-  if node['chef-server-deploy']['enable_saml']
-    config <<-EOF.gsub(/^\s+/, '')
-    saml.enabled true
-    saml.issuer_url 'https://#{node['chef-server-deploy']['automate_server_fqdn']}/api/v0'
-    EOF
-  end
+  config node['chef-server-deploy']['manage-config'].map { |k, v| "#{k} #{v}" }.join("\n")
   action :upgrade
   # We need to reconfigure after an install/upgrade
   notifies :reconfigure, 'chef_ingredient[manage]'


### PR DESCRIPTION
By moving the entirety of the manage config into the node object, we can
inject some secret variables into the node object via the environment in
order to further customize our internal environment with variables that
are not open-source friendly.

Signed-off-by: Tom Duffield <tom@chef.io>