### PR TITLE
[reconfigure] Rescue all IPAddr errors

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -41,7 +41,7 @@ class OmnibusHelper
   def self.is_ip?(addr)
     IPAddr.new addr
     true
-  rescue IPAddr::InvalidAddressError
+  rescue IPAddr::Error
     false
   end
 


### PR DESCRIPTION
This bug was discovered in Chef Automate when a similar feature was
added there.  It isn't clear what values of `server_name` lead to
this (possibly `nil` or an Integer).

Signed-off-by: Steven Danna <steve@chef.io>