### PR TITLE
[SUSTAIN-784] Add security headers

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -29,6 +29,13 @@
     proxy_send_timeout      300;
     proxy_read_timeout      300;
 
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection 1;
+    <% if @server_proto == 'https' %>
+    add_header Strict-Transport-Security max-age=3156000;
+    <% end %>
+
     error_page 404 =404 /404.html;
     error_page 503 =503 /503.json;
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -29,11 +29,13 @@
     proxy_send_timeout      300;
     proxy_read_timeout      300;
 
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection 1;
-    <% if @server_proto == 'https' %>
-    add_header Strict-Transport-Security max-age=31536000;
+    <% if !node['packages']['chef-manage'] %>
+      add_header X-Frame-Options DENY;
+      add_header X-Content-Type-Options nosniff;
+      add_header X-XSS-Protection 1;
+      <% if @server_proto == 'https' %>
+      add_header Strict-Transport-Security max-age=31536000;
+      <% end %>
     <% end %>
 
     error_page 404 =404 /404.html;

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -33,7 +33,7 @@
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection 1;
     <% if @server_proto == 'https' %>
-    add_header Strict-Transport-Security max-age=3156000;
+    add_header Strict-Transport-Security max-age=31536000;
     <% end %>
 
     error_page 404 =404 /404.html;


### PR DESCRIPTION
Adds the following security related headers to HTTP responses:

* X-Frame-Options: DENY
* X-Content-Type-Options: nosniff
* X-XSS-Protection: 1
* Strict-Transport-Security: max-age=3156000 (Not set if server is
configured to operate without SSL)

These headers are already set if chef-manage is installed. This change
provides parity in responses from a Chef Server without Manage
installed.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>