### PR TITLE
Disable Welcome Page

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -568,6 +568,8 @@ default['private_chef']['nginx']['strict_host_header'] = false
 # and any IPs associated with the machine.
 default['private_chef']['nginx']['use_implicit_hosts'] = false
 
+default['private_chef']['nginx']['show_welcome_page'] = true
+
 ###
 # PostgreSQL
 ###

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -44,19 +44,10 @@
     # Whitelist the docs necessary to serve up error pages and friendly
     # html to non-chef clients hitting this host.
     location ~ "^/[0-9]{3,3}\.(json|html)|favicon.ico|index.html$" {
-      <% unless node['private_chef']['nginx']['show_welcome_page'] %>
-        return 404;
-      <% end -%>
     }
     location "/css/" {
-      <% unless node['private_chef']['nginx']['show_welcome_page'] %>
-        return 404;
-      <% end -%>
     }
     location "/images/" {
-      <% unless node['private_chef']['nginx']['show_welcome_page'] %>
-        return 404;
-      <% end -%>
     }
 
     location /version {

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -44,10 +44,19 @@
     # Whitelist the docs necessary to serve up error pages and friendly
     # html to non-chef clients hitting this host.
     location ~ "^/[0-9]{3,3}\.(json|html)|favicon.ico|index.html$" {
+      <% unless node['private_chef']['nginx']['show_welcome_page'] %>
+        return 404;
+      <% end -%>
     }
     location "/css/" {
+      <% unless node['private_chef']['nginx']['show_welcome_page'] %>
+        return 404;
+      <% end -%>
     }
     location "/images/" {
+      <% unless node['private_chef']['nginx']['show_welcome_page'] %>
+        return 404;
+      <% end -%>
     }
 
     location /version {

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
@@ -44,9 +44,15 @@ if mode == "api" then
         ngx.exit(ngx.HTTP_OK)
       end
     else
-      -- the request did not originate with a chef client, we'll give something
-      -- more friendly to web browsers.
-      return ngx.exec("/index.html")
+      <% if node['private_chef']['nginx']['show_welcome_page'] %>
+        -- the request did not originate with a chef client, we'll give something
+        -- more friendly to web browsers.
+        return ngx.exec("/index.html")
+      <% else %>
+        -- return 404 because the welcome page has been disabled
+        ngx.status = ngx.HTTP_NOT_FOUND
+        ngx.exit(ngx.HTTP_OK)
+      <% end -%>
     end
   end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
@@ -44,11 +44,11 @@ if mode == "api" then
         ngx.exit(ngx.HTTP_OK)
       end
     else
-      <% if node['private_chef']['nginx']['show_welcome_page'] %>
+      <% if node['private_chef']['nginx']['show_welcome_page'] -%>
         -- the request did not originate with a chef client, we'll give something
         -- more friendly to web browsers.
         return ngx.exec("/index.html")
-      <% else %>
+      <% else -%>
         -- return 404 because the welcome page has been disabled
         ngx.status = ngx.HTTP_NOT_FOUND
         ngx.exit(ngx.HTTP_OK)


### PR DESCRIPTION
This allows a user to disable chef server's welcome page.
When the welcome page is disabled, a 404 will be returned when a request
is made that does not match any needed pattern.

To disable the welcome page add the below line to the chef-server.rb
file.

`nginx['show_welcome_page'] = false`

The change is only a cookbook change that modifies nginx's config file

This would close https://github.com/chef/chef-server/issues/972

I did not find a problem when installing chef manage with the welcome page disabled. Are there other addons or configurations that I would need to test? 

I am looking into adding a few tests.  

Signed-off-by: Lance Finfrock <lfinfrock@chef.io>