### PR TITLE
[partybus] Add `infer` command to fix missing migration-level file

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/rebuild_migration_state.rb
+++ b/omnibus/files/private-chef-ctl-commands/rebuild_migration_state.rb
@@ -1,0 +1,22 @@
+add_command_under_category "rebuild-migration-state", "general", "Attempt to rebuild the migration-state file before upgrade.", 2 do
+  require 'optparse'
+  rebuild_args = ARGV[3..-1]
+  options = {}
+
+  OptionParser.new do |opts|
+    opts.banner = "chef-server-ctl rebuild-migration-state [options]"
+    opts.on("--force", "Overwrite existing migration state.") do |b|
+      options[:force] = true
+    end
+  end.parse!(rebuild_args)
+
+  Dir.chdir(File.join(base_path, "embedded", "service", "partybus"))
+  bundle = File.join(base_path, "embedded", "bin", "bundle")
+  force_arg = options[:force] ? " force" : ""
+  status = run_command("#{bundle} exec ./bin/partybus infer#{force_arg}")
+  if status.success?
+    exit 0
+  else
+    exit 1
+  end
+end

--- a/omnibus/files/private-chef-upgrades/001/013_bcrypt_users.rb
+++ b/omnibus/files/private-chef-upgrades/001/013_bcrypt_users.rb
@@ -17,3 +17,7 @@ define_upgrade do
                 :cwd => "/opt/opscode/embedded/service/opscode-erchef/schema")
   end
 end
+
+define_check do
+  check_sqitch('@2.2.3', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/014_upgrade_migration_schema.rb
+++ b/omnibus/files/private-chef-upgrades/001/014_upgrade_migration_schema.rb
@@ -16,3 +16,7 @@ define_upgrade do
     run_sqitch('@2.2.4', 'oc_erchef')
   end
 end
+
+define_check do
+  check_sqitch('@2.2.4', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/016_add_org_tables_osc_hash_types.rb
+++ b/omnibus/files/private-chef-upgrades/001/016_add_org_tables_osc_hash_types.rb
@@ -8,3 +8,7 @@ define_upgrade do
     run_sqitch('@2.4.0', 'oc_erchef')
   end
 end
+
+define_check do
+  check_sqitch('@2.4.0', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
+++ b/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
@@ -24,3 +24,7 @@ define_upgrade do
     end
   end
 end
+
+define_check do
+  check_sqitch('@2.5.3', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/021_key_schema_migration_2.rb
+++ b/omnibus/files/private-chef-upgrades/001/021_key_schema_migration_2.rb
@@ -6,3 +6,7 @@ define_upgrade do
     run_sqitch('@2.9.0', 'oc_erchef')
   end
 end
+
+define_check do
+  check_sqitch('@2.9.0', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/022_cbv_type_addition.rb
+++ b/omnibus/files/private-chef-upgrades/001/022_cbv_type_addition.rb
@@ -5,3 +5,7 @@ define_upgrade do
     run_sqitch('@cbv-type', 'oc_erchef')
   end
 end
+
+define_check do
+  check_sqitch('@cbv-type', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/027_node_policyfile_fields.rb
+++ b/omnibus/files/private-chef-upgrades/001/027_node_policyfile_fields.rb
@@ -6,3 +6,6 @@ define_upgrade do
   end
 end
 
+define_check do
+  check_sqitch('@node-policyfile-fields', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/030_actor_keys_access_group.rb
+++ b/omnibus/files/private-chef-upgrades/001/030_actor_keys_access_group.rb
@@ -17,3 +17,38 @@ define_upgrade do
     stop_services(["opscode-chef-mover"])
   end
 end
+
+define_check do
+  # If there is at least one group with public_key_read_access group,
+  # assume the migration has run. This might not be true, but if there are
+  # no existing read_access_groups, we believe the migration should be
+  # safe to rerun.
+  #
+  # We can erroneously mark this migration as "run" in the following cases:
+  #
+  # (1) The user has created a group called public_read_access
+  #     unrelated to this migration.
+  #
+  # (2) If the user upgraded, failed to apply this upgrade, but then
+  #     somehow was able to create *new* organization using the
+  #     newer version of erchef.
+  #
+  # We can erroneously mark this migration as "not run" in the following cases:
+  #
+  # (1) The migration ran but this installation has no organizations.
+  #     Re-running the migration will have no ill effect as it
+  #     operates on a per-organization basis.
+  #
+  # (2) The migration ran but then the user deleted all of the
+  #     public_read_access groups. Re-running the migration should not
+  #     cause an error but the user might be surprised to find those
+  #     groups re-appear.  We think this case is rare.
+  #
+  begin
+    c = pg_conn_for('oc_erchef')
+    r = c.exec("SELECT COUNT(*) FROM groups WHERE name = 'public_key_read_access'")
+    r.first['count'].to_i > 0
+  ensure
+    c.close if c
+  end
+end

--- a/omnibus/files/private-chef-upgrades/001/033_users_email_lower_idx.rb
+++ b/omnibus/files/private-chef-upgrades/001/033_users_email_lower_idx.rb
@@ -8,3 +8,7 @@ define_upgrade do
     run_sqitch('@users_email_functional_index', 'oc_erchef')
   end
 end
+
+define_check do
+  check_sqitch('@users_email_functional_index', 'oc_erchef')
+end

--- a/omnibus/files/private-chef-upgrades/001/034_create_and_update_user.rb
+++ b/omnibus/files/private-chef-upgrades/001/034_create_and_update_user.rb
@@ -8,3 +8,7 @@ define_upgrade do
     run_sqitch('@sentinel_public_key_for_users', 'oc_erchef')
   end
 end
+
+define_check do
+  check_sqitch('@sentinel_public_key_for_users', 'oc_erchef')
+end

--- a/omnibus/partybus/bin/partybus
+++ b/omnibus/partybus/bin/partybus
@@ -24,6 +24,7 @@ Usage: partybus ACTION
 
 Actions:
   init        Set the initial migration level
+  infer       Infer the current migration level
   upgrade     Run through the pending upgrades
   help        Print this help message
 EOU
@@ -43,9 +44,97 @@ def load_migrations
 end
 
 def set_initial_migration_state(migrations)
-  latest_migration = migrations.last
+  write_migration_state(migrations.last)
+end
+
+def write_migration_state(migration)
   File.open(Partybus.config.migration_state_file, 'w') do |f|
-      f.puts({:major => latest_migration.major, :minor => latest_migration.minor}.to_json)
+    f.puts({:major => migration.major, :minor => migration.minor}.to_json)
+  end
+end
+
+def migration_state_has_content?
+  !File.zero?(Partybus.config.migration_state_file)
+end
+
+#
+# We infer the migration state to try to repair installations that
+# have lost their migration state file. Since the data may have come
+# from a backup, we can not rely on the currently installed version to
+# be up-to-date and we don't necessarily know the previously installed
+# version.
+#
+# We know we can not support upgrades from further back than
+# Enterprise Chef 11.1, which shipped migration 1.13:
+#
+#   https://github.com/chef/chef-server/tree/11.1.0/files/private-chef-upgrades/001
+#
+# We also know that migration 1.14 through 1.19 landed together in
+# Chef Server 12.0.
+#
+# Luckily for us, migration 1.20 shipped a sqitch tag.  Further luck:
+# migrations above 1.20 generally appear to be safe-to-reapply so we
+# don't have to detect perfectly.
+#
+INFER_LOWER_BOUND_MAJOR=1
+INFER_LOWER_BOUND_MINOR=20
+def infer_migration_state(migrations, force)
+  if migration_state_has_content? && !force
+    log("Migration state file non-empty, inference not required.")
+    exit(0)
+  end
+
+  log("Infering migration-level from system state")
+  applied_version = nil
+  migrations.sort.reverse.each do |m|
+    if m.run_check
+      log "#{m}: ALREADY APPLIED"
+      applied_version = m
+      break
+    else
+      log "#{m}: NOT APPLIED"
+    end
+
+    # A number of migrations before 1.20 (the Chef Server 12.0) are
+    # mover migrations that are harder to check for.  If we make it
+    # all the way to here, we stop checking and hope one of the two
+    # special cases below apply.
+    if m.major == INFER_LOWER_BOUND_MAJOR &&
+       m.minor == INFER_LOWER_BOUND_MINOR
+      log "No migration greater than #{INFER_LOWER_BOUND_MAJOR}.#{INFER_LOWER_BOUND_MINOR} applied."
+      break
+    end
+  end
+
+  if applied_version
+    log "Infered migration level: #{applied_version}"
+    write_migration_state(applied_version)
+    exit(0)
+  else
+    # We still have a chance. If migration 16 is applied but
+    # migration 20 is not, it means our backup is likely from a 12.0.0
+    # machine
+    migration_16 = migrations.find {|m| m.major == 1 && m.minor == 16}
+    if migration_16.run_check
+      log "Inferring migration level of Chef Server 12.0.0 (1.19) from presence of migration 16 and absence of migration 20"
+      migration_19 = migrations.find {|m| m.major == 1 && m.minor == 19}
+      write_migration_state(migration_19)
+      exit(0)
+    end
+
+    # Since migrations 14-19 shipped as a set in Chef Server 12.0.0
+    # and since we don't support upgrades from versions before
+    # migration 1.13, we either have 1.13 or we fail:
+    migration_13 = migrations.find {|m| m.major == 1 && m.minor == 13}
+    if migration_13.run_check
+      log "Inferred migration level of 1.13"
+      write_migration_state(migration_13)
+      exit(0)
+    else
+      log "Data appears to be from a version of Chef Server before Enterprise Chef 11.1 (migration 1.13)"
+      log "Please contact Chef Support (support@chef.io) for help upgrading your Enterprise Chef installation."
+      exit(1)
+    end
   end
 end
 
@@ -73,7 +162,18 @@ File.open(Partybus.config.migration_state_file, File::RDWR | File::CREAT) do |f|
     when "init"
       migrations = load_migrations
       set_initial_migration_state(migrations)
+    when "infer"
+      force = ARGV[1] == "force"
+      migrations = load_migrations
+      infer_migration_state(migrations, force)
     when "upgrade"
+
+      if !migration_state_has_content?
+        log "ERROR: migration-level not initialized."
+        log "ERROR: If this is an existing Chef Server install try running `chef-server-ctl rebuild-migration-state` and then retry the upgrade"
+        exit(1)
+      end
+
       migration_state = load_current_migration_state
       migrations = load_migrations
       do_upgrade(migration_state, migrations)

--- a/omnibus/partybus/lib/partybus.rb
+++ b/omnibus/partybus/lib/partybus.rb
@@ -33,11 +33,11 @@ module Partybus
         @running_server = JSON.parse(IO.read(RUNNING_CONFIG_FILE))
         @postgres = @running_server['private_chef']['postgresql']
       else
-        log <<EOF
+        STDERR.puts <<EOF
 ***
 ERROR: Cannot find #{RUNNING_CONFIG_FILE}
 ***
-Try running `chef-server-ctl reconfigure` before upgrading.
+Try running `chef-server-ctl reconfigure` first.
 
 EOF
         exit(1)
@@ -46,11 +46,11 @@ EOF
         require 'veil'
         @secrets = Veil::CredentialCollection::ChefSecretsFile.from_file(SECRETS_FILE)
       else
-        log <<EOF
+        STDERR.puts <<EOF
 ***
 ERROR: Cannot find or access #{SECRETS_FILE}
 ***
-Try running `chef-server-ctl reconfigure` before upgrading.
+Try running `chef-server-ctl reconfigure` first.
 
 EOF
         exit(1)

--- a/omnibus/partybus/lib/partybus/dsl_runner.rb
+++ b/omnibus/partybus/lib/partybus/dsl_runner.rb
@@ -10,19 +10,53 @@ class Partybus::DSLRunner
     @file_path     = migration_file.path
   end
 
-  def run
+  def load_migration
     instance_eval(IO.read(@file_path))
+  end
+
+  def run
+    load_migration
+    run_migration
+    write_migration_file
+  end
+
+  def check
+    load_migration
+    run_check
+  end
+
+  def write_migration_file
     File.open(Partybus.config.migration_state_file, 'w') do |f|
       f.puts({:major => @major_version, :minor => @minor_version}.to_json)
     end
   end
 
-  def define_upgrade(options={}, &block)
-    @api_version = options[:api_version] || :v1
-
+  def run_migration
     # TODO: use the API version to load the correct UpgradeAPI class
     # we need an UpgradeAPIFactory :D
-    Partybus::UpgradeAPI::V1.new(&block)
+    Partybus::UpgradeAPI::V1.new(&@block)
   end
 
+  def run_check
+    if @check_block
+      Partybus::UpgradeAPI::V1.new(&@check_block).eval_result
+    else
+      # NOTE(ssd) 2017-11-28: The assumption here is that a migration
+      # is safe to re-run unless otherwise specififed.
+      # Counter-intuitively, we define checks for the safest
+      # migrations to re-run (sqitch) because they are easy to check
+      # for.
+      false
+    end
+  end
+
+  def define_check(options={}, &block)
+    @check_api_version = options[:api_version] || :v1
+    @check_block = block
+  end
+
+  def define_upgrade(options={}, &block)
+    @api_version = options[:api_version] || :v1
+    @block = block
+  end
 end

--- a/omnibus/partybus/lib/partybus/migrations.rb
+++ b/omnibus/partybus/lib/partybus/migrations.rb
@@ -41,6 +41,11 @@ module Partybus
       runner.run
     end
 
+    def run_check
+      runner = DSLRunner.new(self)
+      runner.check
+    end
+
     private
 
     def parse_path(p)


### PR DESCRIPTION
Some users may be restoring a backup of external data sources and no
longer have a migration-level file. In this case, a `chef-server-ctl
upgrade` will fail because it will attempt to run all migrations,
starting from the beginning.

The `partybus infer` command attempts to reconstruct the
migration-level based on what it sees in the database.

For migrations that deploy a sqitch tag, we infer the migration has
run from the presence of the sqitch tag in the sqitch table.

Non-sqitch migrations are less reliable to detect and in most cases we
do not attempt to detect them since most should be idempotent.

Further, we assume the following:

- Migrations from versions prior to Enterprise Chef 11.1 are not
  supported and thus the lowest possible migration level we should
  ever infer is 1.13

- The Chef Server 12.0.0 upgrade deployed migrations 1.14 through
  1.19.  We will assume that our system has either completely applied
  this set of upgrades (and is thus on 1.19 or greater) or hasn't (and
  is thus on 1.13)

For the migrations we will currently infer, the following identifies
how we infer them or why we think it is safe to rerun.

# Migration-level Detection Methods

- `1.34`: Detect sqitch tag

- `1.33`: Detect sqitch tag

- `1.32`: Safe to rerun: simple service restart

- `1.31`: Safe to rerun: rabbitmqctl change_password to the /existing/ password

- `1.30`: Custom check function since migration appears unsafe to rerun.

- `1.29`: Likely safe to rerun: ACL addition should be idempotent in
       bifrost. We could be overwriting a user's intention to /remove/
       the server-admins from having READ on their user

- `1.28`: Likely safe to rerun: server-admins group isn't recreated if it
       exists:

     https://github.com/chef/chef-server/blob/master/src/chef-mover/src/mover_server_admins_global_group_callback.erl#L74-L76

     ACL modifications should be idempotent:
     https://github.com/chef/chef-server/blob/master/src/chef-mover/src/mover_server_admins_global_group_callback.erl#L79-L96

- `1.27`: Detect sqitch tag

- `1.26`: Safe to rerun: Only un-renamed groups are selected for
       migration:

     https://github.com/chef/chef-server/blob/master/src/chef-mover/src/mover_global_admins_rename_callback.erl#L48-L56

- `1.25`: Safe to rerun: Group member addition should be
       idempotent. Since global groups aren't user-modifiable, we
       can't be modifying user-altered data

- `1.24`: Safe to rerun: rm -rf on a cache directory

- `1.23`: Safe to rerun: Only orgs without policy containers are
       selected:

     https://github.com/chef/chef-server/blob/master/src/chef-mover/src/mover_policies_containers_creation_callback.erl#L76-L81

- `1.22`: Detect sqitch tag

- `1.21`: Detect sqitch tag

- `1.20`: Detect sqitch tag

- `1.19`: Detect sqitch tag of migration 1.16, assume all of 1.14-1.19
       have completed.  See note on this above.

- `1.13`: Detect sqitch tag

Signed-off-by: Steven Danna <steve@chef.io>