### PR TITLE
[partybus] Store migration-level in postgresql database

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
@@ -49,32 +49,3 @@ execute "set initial migration level" do
   command "cd /opt/opscode/embedded/service/partybus && ./bin/partybus init"
   subscribes :run, "file[#{OmnibusHelper.bootstrap_sentinel_file}]", :delayed
 end
-
-ruby_block 'migration-level file sanity check' do
-  block do
-    begin
-      ::JSON.parse(::File.read('/var/opt/opscode/upgrades/migration-level'))
-    rescue Exception => e
-      message = <<-EOF
-ERROR:
-The /var/opt/opscode/upgrades/migration-level file is missing or corrupt!  Please read http://docs.chef.io/install_server_pre.html and correct this file before proceeding
-
-* If this is a new installation:
-  run: "cd /opt/opscode/embedded/service/partybus ; /opt/opscode/embedded/bin/bundle exec bin/partybus init"
-* If you have upgraded a previous installation:
-  copy the /var/opt/opscode/upgrades/migration-level file from a not-yet-upgraded FrontEnd node
-
-Error message #{e}
-EOF
-
-      raise message
-    end
-  end
-  not_if 'test -f /var/opt/opscode/upgrades/migration-level'
-  action :nothing
-  if OmnibusHelper.has_been_bootstrapped?
-    subscribes :run, 'private-chef_pg_upgrade[upgrade_if_necessary]', :delayed
-  else
-    subscribes :run, 'execute[set initial migration level]', :immediately
-  end
-end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/partybus_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/partybus_config.rb.erb
@@ -1,12 +1,25 @@
 Partybus.configure do |c|
+  c.partybus_migration_directory  = "/opt/opscode/embedded/upgrades"
+  c.postgresql_port               = <%= node['private_chef']['postgresql']['port'] %>
+  c.postgresql_host               = "<%= node['private_chef']['postgresql']['vip'] %>"
+  c.postgresql_user               = "<%= node['private_chef']['postgresql']['db_superuser'] %>"
+  c.is_data_master                = <%= @is_data_master %>
+  c.bootstrap_server              = <%= @bootstrap_server %>
+  c.legacy_migration_state_file   = "/var/opt/opscode/upgrades/migration-level"
+
+  # Legacy Configuration Options
+  #
+  # The options below are for much older migrations
+  # that are unlikely to run on any supported version of Chef Server.
+  #
+  # If you are having a problem that you think is related to one of
+  # these configuration options, there is most likely a different
+  # problem that has led partybus to run very old migrations.
+  #
   c.database_connection_string    = "<%= @connection_string %>"
   c.database_unix_user            = "<%= @as_user %>"
   c.database_migration_directory  = "/opt/opscode/embedded/service/chef-sql-schema/db/migrate"
-  c.partybus_migration_directory  = "/opt/opscode/embedded/upgrades"
-  c.migration_state_file          = "/var/opt/opscode/upgrades/migration-level"
   c.private_chef_role             = "<%= @node_role %>"
   c.database_service_name         = "<%= @db_service_name %>"
-  c.is_data_master                = <%= @is_data_master %>
-  c.bootstrap_server              = <%= @bootstrap_server %>
   c.couchdb_data_dir              = "<%= node['private_chef']['couchdb']['data_dir'] %>"
 end

--- a/omnibus/partybus/bin/partybus
+++ b/omnibus/partybus/bin/partybus
@@ -6,6 +6,7 @@ $:.unshift File.expand_path('../../lib', __FILE__)
 require 'partybus'
 require 'partybus/dsl_runner'
 require 'partybus/migrations'
+require 'partybus/migration_state'
 
 # load the config from a file
 require File.expand_path('../../config.rb', __FILE__)
@@ -34,27 +35,9 @@ end
 
 partybus_action = ARGV[0]
 
-def load_current_migration_state
-  Partybus::MigrationState.new(Partybus.config.migration_state_file)
-end
-
 def load_migrations
   migration_files = Dir.glob("#{Partybus.config.partybus_migration_directory}/**/*.rb")
   migration_files.map {|path| Partybus::MigrationFile.new(path)}.sort
-end
-
-def set_initial_migration_state(migrations)
-  write_migration_state(migrations.last)
-end
-
-def write_migration_state(migration)
-  File.open(Partybus.config.migration_state_file, 'w') do |f|
-    f.puts({:major => migration.major, :minor => migration.minor}.to_json)
-  end
-end
-
-def migration_state_has_content?
-  !File.zero?(Partybus.config.migration_state_file)
 end
 
 #
@@ -78,12 +61,7 @@ end
 #
 INFER_LOWER_BOUND_MAJOR=1
 INFER_LOWER_BOUND_MINOR=20
-def infer_migration_state(migrations, force)
-  if migration_state_has_content? && !force
-    log("Migration state file non-empty, inference not required.")
-    exit(0)
-  end
-
+def infer_migration_state(migration_state, migrations)
   log("Infering migration-level from system state")
   applied_version = nil
   migrations.sort.reverse.each do |m|
@@ -108,7 +86,7 @@ def infer_migration_state(migrations, force)
 
   if applied_version
     log "Infered migration level: #{applied_version}"
-    write_migration_state(applied_version)
+    migration_state.init(applied_version)
     exit(0)
   else
     # We still have a chance. If migration 16 is applied but
@@ -118,7 +96,7 @@ def infer_migration_state(migrations, force)
     if migration_16.run_check
       log "Inferring migration level of Chef Server 12.0.0 (1.19) from presence of migration 16 and absence of migration 20"
       migration_19 = migrations.find {|m| m.major == 1 && m.minor == 19}
-      write_migration_state(migration_19)
+      migration_state.init(migration_19)
       exit(0)
     end
 
@@ -128,7 +106,7 @@ def infer_migration_state(migrations, force)
     migration_13 = migrations.find {|m| m.major == 1 && m.minor == 13}
     if migration_13.run_check
       log "Inferred migration level of 1.13"
-      write_migration_state(migration_13)
+      migration_state.init(migration_13)
       exit(0)
     else
       log "Data appears to be from a version of Chef Server before Enterprise Chef 11.1 (migration 1.13)"
@@ -148,41 +126,38 @@ def do_upgrade(migration_state, migrations)
     log("Current Migration Version: #{migration_state}")
     start_time = Time.now
     log("Starting Migration #{migration}")
-    migration.run_migration
+    migration.run_migration(migration_state)
     end_time = Time.now
     elapsed_time = end_time - start_time
     log("Finished Migration #{migration} in #{elapsed_time.round(2)} seconds")
   end
 end
 
-# obtain the file lock on the migration state file
-File.open(Partybus.config.migration_state_file, File::RDWR | File::CREAT) do |f|
-  if f.flock(File::LOCK_EX | File::LOCK_NB)
-    case partybus_action
-    when "init"
-      migrations = load_migrations
-      set_initial_migration_state(migrations)
-    when "infer"
-      force = ARGV[1] == "force"
-      migrations = load_migrations
-      infer_migration_state(migrations, force)
-    when "upgrade"
-
-      if !migration_state_has_content?
-        log "ERROR: migration-level not initialized."
-        log "ERROR: If this is an existing Chef Server install try running `chef-server-ctl rebuild-migration-state` and then retry the upgrade"
-        exit(1)
-      end
-
-      migration_state = load_current_migration_state
-      migrations = load_migrations
-      do_upgrade(migration_state, migrations)
-    when "help"
-      print_usage_and_exit(0)
-    else
-      print_usage_and_exit
-    end
+# Obtain the file lock on the migration state file
+migration_state = Partybus::MigrationState.new
+case partybus_action
+when "init"
+  migrations = load_migrations
+  migration_state.init(migrations.last)
+when "infer"
+  force = ARGV[1] == "force"
+  if migration_state.load_or_upgrade && !force
+    log "Migrations state already initialized."
+    exit(0)
   else
-    log("ERROR: Unable to obtain file lock on #{Partybus.config.migration_state_file}")
+    migrations = load_migrations
+    infer_migration_state(migration_state, migrations)
   end
+when "upgrade"
+  if !migration_state.load_or_upgrade
+    log "ERROR: migration-level not initialized."
+    log "ERROR: If this is an existing Chef Server install try running `chef-server-ctl rebuild-migration-state` and then retry the upgrade"
+    exit(1)
+  end
+  migrations = load_migrations
+  do_upgrade(migration_state, migrations)
+when "help"
+  print_usage_and_exit(0)
+else
+  print_usage_and_exit
 end

--- a/omnibus/partybus/config.rb.example
+++ b/omnibus/partybus/config.rb.example
@@ -2,5 +2,5 @@ Partybus.configure do |c|
   c.database_connection_string   = "mysql2://root@127.0.0.1/partybus_test"
   c.database_migration_directory = "/Users/stephen/opscode/dev/chef-sql-schema/db/migrate"
   c.partybus_migration_directory = "/Users/stephen/opscode/dev/opscode-omnibus/files/upgrades"
-  c.migration_state_file         = "/tmp/partybus-state"
+  c.legacy_migration_state_file  = "/tmp/partybus-state"
 end

--- a/omnibus/partybus/lib/partybus.rb
+++ b/omnibus/partybus/lib/partybus.rb
@@ -13,25 +13,66 @@ module Partybus
     SECRETS_FILE = "/etc/opscode/private-chef-secrets.json"
     RUNNING_CONFIG_FILE = "/etc/opscode/chef-server-running.json"
 
+    # Actively used configuration
+    attr_accessor :bootstrap_server
+    attr_accessor :is_data_master
+    attr_accessor :partybus_migration_directory
+    attr_writer :legacy_migration_state_file
+    attr_writer :postgresql_user
+    attr_writer :postgresql_port
+    attr_writer :postgresql_host
+
+    # Referenced but defunct configuration
+    #
+    # These are referenced from the code or the migrations but are not
+    # likely to be used since they are only used by very old
+    # migrations that we don't technically support. These can likely
+    # be removed once we do
+    #
+    # https://github.com/chef/chef-server/pull/721
+    #
+    # or something similar.
+    #
     attr_accessor :database_connection_string
     attr_accessor :database_unix_user
     attr_accessor :database_migration_directory
     attr_accessor :database_service_name
-    attr_accessor :partybus_migration_directory
-    attr_accessor :migration_state_file
     attr_accessor :private_chef_role
-    attr_accessor :is_data_master
-    attr_accessor :bootstrap_server
     attr_accessor :couchdb_data_dir
 
-    attr_accessor :running_server
-    attr_accessor :postgres
-    attr_accessor :secrets
+    # Unused config. We keep these attr_writer's to support reading
+    # older configuration files.
+    attr_writer :migration_state_file
 
-    def initialize
+    # Just in case we *really* need to run against older configuration
+    # files and can't run a reconfigure for some reason, we provide
+    # some accessors here that check two possible locations for
+    # recently moved configuration values.
+    #
+    # TODO(ssd) 2017-11-29: Do we really need to do this?  It would be nice
+    # to remove most references to "running_server" from this tool.
+    #
+    def postgresql_port
+      @postgresql_port || running_server['private_chef']['postgresql']['port']
+    end
+
+    def postgresql_host
+      @postgresql_host || running_server['private_chef']['postgresql']['vip']
+    end
+
+    def postgresql_user
+      @postgresql_user || running_server['private_chef']['postgresql']['db_superuser']
+    end
+
+    def legacy_migration_state_file
+      @legacy_migration_state_file || @migration_state_file
+    end
+
+    def running_server
+      return @running_server if @running_server
+
       if File.exists?(RUNNING_CONFIG_FILE)
         @running_server = JSON.parse(IO.read(RUNNING_CONFIG_FILE))
-        @postgres = @running_server['private_chef']['postgresql']
       else
         STDERR.puts <<EOF
 ***
@@ -42,6 +83,11 @@ Try running `chef-server-ctl reconfigure` first.
 EOF
         exit(1)
       end
+    end
+
+    def secrets
+      return @secrets if @secrets
+
       if File.readable?(SECRETS_FILE)
         require 'veil'
         @secrets = Veil::CredentialCollection::ChefSecretsFile.from_file(SECRETS_FILE)
@@ -54,7 +100,6 @@ Try running `chef-server-ctl reconfigure` first.
 
 EOF
         exit(1)
-
       end
     end
 

--- a/omnibus/partybus/lib/partybus/migration_api/v1.rb
+++ b/omnibus/partybus/lib/partybus/migration_api/v1.rb
@@ -107,8 +107,8 @@ EOF
         command = <<-EOM.gsub(/\s+/," ").strip!
           sqitch --engine pg
             --db-name #{options[:database]}
-            --db-host #{Partybus.config.postgres['vip']}
-            --db-port #{Partybus.config.postgres['port']}
+            --db-host #{Partybus.config.postgresql_host}
+            --db-port #{Partybus.config.postgresql_port}
             --db-user #{options[:username]}
             --top-dir /opt/opscode/embedded/service/#{options[:path]}
             deploy #{target} --verify
@@ -132,12 +132,12 @@ EOF
         ::PGconn.open({'user' => options[:username],
                       'password' => options[:password],
                       'dbname' => options[:database],
-                      'host' => Partybus.config.postgres['vip'],
-                      'port' => Partybus.config.postgres['port']})
+                      'host' => Partybus.config.postgresql_host,
+                      'port' => Partybus.config.postgresql_port})
       end
 
       def default_opts_for_service(service)
-        username = Partybus.config.postgres['db_superuser']
+        username = Partybus.config.postgresql_user
         password = Partybus.config.secrets['postgresql']['db_superuser_password'].value
         path = "#{service}/schema"
         case service

--- a/omnibus/partybus/lib/partybus/migration_state.rb
+++ b/omnibus/partybus/lib/partybus/migration_state.rb
@@ -1,0 +1,137 @@
+require 'pg'
+
+module Partybus
+  class MigrationState
+    # NOTE(ssd) 2017-11-28: Why not use sqitch?
+    #
+    # We are inside the tool responsible for deciding whether or not
+    # we need to run sqitch.
+    #
+    # I'm open to other ways of managing this though, as it does feel
+    # a little ugly.
+    MIGRATION_STATE_SCHEMA =<<SQL
+CREATE TABLE IF NOT EXISTS partybus_migration_state(
+    name        TEXT PRIMARY KEY,
+    value       TEXT,
+    updated_at  TIMESTAMP WITHOUT TIME ZONE NOT NULL
+)
+SQL
+
+    # NOTE(ssd) 2017-11-28: Why not a table level lock?
+    #
+    # The table might not exist yet and we also want to lock against
+    # concurrent initialization of this data.  Or at least, that is
+    # what I'm telling myself at the moment. Maybe a table-level lock
+    # would be better.
+    MIGRATION_STATE_LOCK_ID = 21193.freeze
+    LOCK_ACQUIRE_SQL = "SELECT pg_try_advisory_lock(#{MIGRATION_STATE_LOCK_ID})".freeze
+    LOCK_RELEASE_SQL = "SELECT pg_advisory_unlock(#{MIGRATION_STATE_LOCK_ID})".freeze
+
+    INIT_QUERY = "SELECT true as initialized FROM partybus_migration_state WHERE name = 'migration-level'".freeze
+    INSERT_SQL = "INSERT INTO partybus_migration_state VALUES ('migration-level', $1, NOW())".freeze
+    UPDATE_SQL = "UPDATE partybus_migration_state SET value = $1 WHERE name = 'migration-level'".freeze
+
+    def initialize
+      @connection = init_db_connection
+      lock # Released on session close
+    end
+
+    def init(migration)
+      init_schema
+      insert_from_migration(migration)
+    end
+
+    def load_or_upgrade(legacy_migration_state_file_path = Partybus.config.legacy_migration_state_file)
+      if initialized?
+        load_from_db
+        true
+      elsif legacy_state_valid?(legacy_migration_state_file_path)
+        log "Valid legacy migration-state found. Creating db entry from legacy state."
+        init_schema
+        insert_from_file(legacy_migration_state_file_path)
+        load_from_db
+        true
+      else
+        false
+      end
+    end
+
+    def apply(migration)
+      update_from_migration(migration)
+    end
+
+    private
+
+    def init_schema
+      @connection.exec(MIGRATION_STATE_SCHEMA)
+    end
+
+    def initialized?
+      r = @connection.exec(INIT_QUERY)
+      r.first['initialized'] == 't'
+    rescue
+      false
+    end
+
+    def insert_from_file(path)
+      data = IO.read(path)
+      @connection.exec(INSERT_SQL, [data])
+    end
+
+    def insert_from_migration(migration)
+      data = {:major => migration.major, :minor => migration.minor}.to_json
+      @connection.exec(INSERT_SQL, [data])
+    end
+
+    def update_from_migration(migration)
+      data = {:major => migration.major, :minor => migration.minor}.to_json
+      @connection.exec(UPDATE_SQL, [data])
+    end
+
+    def load_from_db
+      res = @connection.exec("SELECT * FROM partybus_migration_state WHERE name = 'migration-level'")
+      @major, @minor = parse_migration_level_data(res.first['value'])
+    end
+
+    def lock
+      res = @connection.exec(LOCK_ACQUIRE_SQL)
+      if res.first['pg_try_advisory_lock'] == "t"
+        true
+      else
+        raise "Cannot lock migration state.  Another upgrade in progress?"
+      end
+    end
+
+    # The lock gets released when our session gets closed so no one
+    # calls this.
+    def unlock
+      @connection.exec(LOCK_RELEASE_SQL)
+    end
+
+    def parse_migration_level_data(data)
+      d = JSON.parse(data)
+      [d["major"].to_i, d["minor"].to_i]
+    end
+
+    def legacy_state_valid?(path)
+      major, minor = parse_migration_level_data(IO.read(path))
+      major && minor
+    rescue
+      false
+    end
+
+    def init_db_connection
+      dbname = 'opscode_chef'
+      host = Partybus.config.postgresql_host
+      port = Partybus.config.postgresql_port
+      username = Partybus.config.postgresql_user
+      password = Partybus.config.secrets['postgresql']['db_superuser_password'].value
+
+      ::PGconn.open({'user' => username,
+                     'password' => password,
+                     'dbname' => dbname,
+                     'host' => host,
+                     'port' => port})
+    end
+  end
+end

--- a/omnibus/partybus/lib/partybus/migration_state.rb
+++ b/omnibus/partybus/lib/partybus/migration_state.rb
@@ -1,7 +1,11 @@
 require 'pg'
+require 'partybus/migrations'
 
 module Partybus
   class MigrationState
+
+    include MigrationComparable
+
     # NOTE(ssd) 2017-11-28: Why not use sqitch?
     #
     # We are inside the tool responsible for deciding whether or not

--- a/omnibus/partybus/lib/partybus/migrations.rb
+++ b/omnibus/partybus/lib/partybus/migrations.rb
@@ -36,9 +36,9 @@ module Partybus
       @major, @minor = parse_path(path)
     end
 
-    def run_migration
+    def run_migration(migration_state)
       runner = DSLRunner.new(self)
-      runner.run
+      runner.run(migration_state)
     end
 
     def run_check

--- a/omnibus/partybus/lib/partybus/migrations.rb
+++ b/omnibus/partybus/lib/partybus/migrations.rb
@@ -54,19 +54,4 @@ module Partybus
       [major, minor]
     end
   end
-
-  class MigrationState
-
-    include MigrationComparable
-
-    def initialize(path)
-      @major, @minor = begin
-                         json_data = JSON.parse(IO.read(path))
-                         [json_data["major"], json_data["minor"]]
-                       rescue JSON::ParserError => e
-                         [0, 0]
-                       end
-    end
-
-  end
 end


### PR DESCRIPTION
The migration-level was previously stored in a flat-file on disk.
This file then had to be specifically accounted at multiple points in
a Chef Server installations life cycle.

By placing the migration-state in the database, we hope to decrease
problems related to incorrectly synced migration-level files.

Both the /infer/ and /upgrade/ commands will import existing
migration-level files into the database if the database is not already
initialized.

TODO:

- [ ] For now I've treated PostgreSQL as a key-value store and didn't
  change what metadata we store. We should decide now if we think we
  want to do something fancier.

Signed-off-by: Steven Danna <steve@chef.io>