### PR TITLE
[SUSTAIN-782] Fix permissions on gemfiles created with strict umask on reconfigure

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@chef.io"
 license           "Apache 2.0"
 description       "Installs and configures Chef Server from Omnibus"
-long_description       "Installs and configures Chef Server from Omnibus"
+long_description  "Installs and configures Chef Server from Omnibus"
 version           "0.1.1"
 recipe            "chef-server", "Configures the Chef Server from Omnibus"
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -114,6 +114,8 @@ if node['private_chef']['use_chef_backend']
   include_recipe "private-chef::haproxy"
 end
 
+include_recipe "private-chef::fix_permissions"
+
 # Configure Services
 [
   "postgresql",

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/fix_permissions.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/fix_permissions.rb
@@ -1,0 +1,11 @@
+LIB_PATH="/opt/opscode/embedded/lib"
+# The GEM_PATH should work since we allow only one version of ruby to be installed.
+GEM_PATH="#{LIB_PATH}/ruby/gems/*/gems"
+
+execute "find #{GEM_PATH} -perm /u=x,g=x,o=x -exec chmod 755 {} \\;" do
+  user "root"
+end
+
+execute "find #{GEM_PATH} -perm /u=r,g=r,o=r ! -perm /u=x -exec chmod 644 {} \\;" do
+  user "root"
+end


### PR DESCRIPTION
Currently if a user installs gems with a umask stricter than 022, the opscode user does not have sufficient privileges to read them.

This with certain gems causes the reconfigure to fail.

This PR tries to make sure that the `/opt/opscode/embedded/lib/ruby/gems` permissions are lenient enough for the opscode user to be able to read.

rake and knife-tidy gems installed with 077 umask.
```
d---------  6 root root 4096 Nov 30 15:32 rake-12.3.0
d---------  5 root root 4096 Nov 30 15:32 knife-tidy-0.7.0
d---------  4 root root 4096 Nov 30 15:46 knife-ec-backup-2.2.3
root@api:/opt/opscode/embedded/lib/ruby/gems/2.2.0/gems# pwd
/opt/opscode/embedded/lib/ruby/gems/2.2.0/gems
root@api:/opt/opscode/embedded/lib/ruby/gems/2.2.0/gems# ls -l rake-12.3.0/
total 116
-rw-r--r-- 1 root root  1097 Nov 30 15:32 CONTRIBUTING.rdoc
-rw-r--r-- 1 root root    39 Nov 30 15:32 Gemfile
-rw-r--r-- 1 root root 69957 Nov 30 15:32 History.rdoc
-rw-r--r-- 1 root root  1051 Nov 30 15:32 MIT-LICENSE
-rw-r--r-- 1 root root  5348 Nov 30 15:32 README.rdoc
-rw-r--r-- 1 root root   934 Nov 30 15:32 Rakefile
d--------- 2 root root  4096 Nov 30 15:32 bin
d--------- 3 root root  4096 Nov 30 15:32 doc
d--------- 2 root root  4096 Nov 30 15:32 exe
d--------- 3 root root  4096 Nov 30 15:32 lib
-rw-r--r-- 1 root root  1934 Nov 30 15:32 rake.gemspec
root@api:/opt/opscode/embedded/lib/ruby/gems/2.2.0/gems# ls -l rake-12.3.0/exe/
total 4
-rwxr-xr-x 1 root root 1182 Nov 30 15:32 rake
root@api:/opt/opscode/embedded/lib/ruby/gems/2.2.0/gems# umask
0777
```
reconfigure
```
Recipe: private-chef::fix_permissions
  * execute[find /opt/opscode/embedded/lib/ruby/gems/*/gems -executable -exec chmod 755 {} \;] action run
    - execute find /opt/opscode/embedded/lib/ruby/gems/*/gems -executable -exec chmod 755 {} \;
  * execute[find /opt/opscode/embedded/lib/ruby/gems/*/gems ! -executable -exec chmod 644 {} \;] action run
    - execute find /opt/opscode/embedded/lib/ruby/gems/*/gems ! -executable -exec chmod 644 {} \;
```
fixed permissions:
```
drwxr-xr-x  5 root root 4096 Dec  1 17:14 knife-tidy-0.7.0
drwxr-xr-x  4 root root 4096 Dec  1 17:14 knife-ec-backup-2.2.3
drwxr-xr-x  6 root root 4096 Dec  1 17:14 rake-12.3.0
root@api:/vagrant# ls -ltr /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/
Display all 163 possibilities? (y or n)
root@api:/vagrant# ls -ltr /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/rake-12.3.0/
total 116
-rw-r--r-- 1 root root   934 Dec  1 17:14 Rakefile
-rw-r--r-- 1 root root  5348 Dec  1 17:14 README.rdoc
-rw-r--r-- 1 root root  1051 Dec  1 17:14 MIT-LICENSE
-rw-r--r-- 1 root root 69957 Dec  1 17:14 History.rdoc
-rw-r--r-- 1 root root    39 Dec  1 17:14 Gemfile
-rw-r--r-- 1 root root  1097 Dec  1 17:14 CONTRIBUTING.rdoc
drwxr-xr-x 3 root root  4096 Dec  1 17:14 lib
drwxr-xr-x 2 root root  4096 Dec  1 17:14 exe
drwxr-xr-x 3 root root  4096 Dec  1 17:14 doc
drwxr-xr-x 2 root root  4096 Dec  1 17:14 bin
-rw-r--r-- 1 root root  1934 Dec  1 17:14 rake.gemspec
root@api:/vagrant# ls -ltr /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/rake-12.3.0/exe/
total 4
-rwxr-xr-x 1 root root 1182 Dec  1 17:14 rake
root@api:/vagrant# ls -ltr /opt/opscode/embedded/lib/ruby/gems/2.2.0/gems/rake-12.3.0/lib/
total 8
-rw-r--r-- 1 root root 2162 Dec  1 17:14 rake.rb
drwxr-xr-x 4 root root 4096 Dec  1 17:14 rake
root@api:/vagrant# cat /opt/opscode/embedded/cookbooks/private-chef/recipes/fix_permissions.rb
LIB_PATH="/opt/opscode/embedded/lib"
# The GEM_PATH should work since we allow only one version of ruby to be installed.
GEM_PATH="#{LIB_PATH}/ruby/gems/*/gems"

execute "find #{GEM_PATH} -perm /u=x,g=x,o=x -exec chmod 755 {} \\;" do
  user "root"
end

execute "find #{GEM_PATH} -perm /u=r,g=r,o=r ! -perm /u=x -exec chmod 644 {} \\;" do
  user "root"
end
```

http://wilson.ci.chef.co/job/chef-server-trigger-ad_hoc/34/downstreambuildview/

Signed-off-by: Prajakta Purohit <prajakta@opscode.com>