### PR TITLE
[SUSTAIN-600] Make request logging configurable

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -285,6 +285,7 @@ default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = nil
 default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
 default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
+default['private_chef']['opscode-erchef']['enable_request_logging'] = true
 
 #
 # Reindex configurables
@@ -662,6 +663,7 @@ default['private_chef']['oc_bifrost']['sql_db_timeout'] = 5000
 # Enable extended performance logging data for bifrost.  Setting this to false
 # will cut bifrost request log size approximately in half.
 default['private_chef']['oc_bifrost']['extended_perf_log'] = true
+default['private_chef']['oc_bifrost']['enable_request_logging'] = true
 
 ####
 # Authz
@@ -708,6 +710,11 @@ default['private_chef']['bookshelf']['db_pooler_timeout'] = 2000
 default['private_chef']['bookshelf']['sql_db_timeout'] = 5000
 default['private_chef']['bookshelf']['sql_ro_user'] = 'bookshelf_ro'
 default['private_chef']['bookshelf']['sql_user'] = 'bookshelf'
+# Request logging (enable_request_logging)is disabled because
+# it is redendant (nginx also logs requests)
+# If debug logging is needed, enable_request_logging can be set to true
+# to start verbose logs
+default['private_chef']['bookshelf']['enable_request_logging'] = false
 
 ###
 # Chef Identity

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -122,15 +122,15 @@
 <% end -%>
  {webmachine, [
           {log_handlers, [
-%%% Log handling is disabled, because it is redundant (nginx also logs requests)
-%%% If debug logging is needed, this can be uncommented to start logging somewhat verbose logs
-%%%              {oc_wm_request_logger, [
-%%%                       {file, "<%= File.join(@log_directory, 'requests.log') %>"},
-%%%                       {file_size, 100},  %% Size in MB
-%%%                       {files, 5},
-%%%                       {annotations, [user, req_id]}
-%%%                       ]
-%%%               }
+          <% if node['private_chef']['bookshelf']['enable_request_logging'] %>
+              {oc_wm_request_logger, [
+                       {file, "<%= File.join(@log_directory, 'requests.log') %>"},
+                       {file_size, 100},  %% Size in MB
+                       {files, 5},
+                       {annotations, [user, req_id]}
+                       ]
+               }
+          <% end -%>
                          ]
           }]}
 ].

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -82,14 +82,17 @@
         ]},
  {webmachine, [
           {log_handlers, [
+            <% if node['private_chef']['oc_bifrost']['enable_request_logging'] %>
                {oc_wm_request_logger, [
                        {file, "<%= File.join(@log_directory, 'requests.log') %>"},
                        {file_size, <%= (@log_rotation['file_maxbytes'].to_f/1024/1024).round %>},  %% Size in MB
                        {files, <%= @log_rotation['num_to_keep'] %>},
                          {annotations, [requestor_id, created_authz_id, perf_stats, msg]}
                        ]
-                      }]}]
- },
+               }
+            <% end %>
+        ]}
+ ]},
  {sqerl, [
           {db_driver_mod, sqerl_pgsql_client},
           {config_cb, {chef_secrets_sqerl, config, [{<<"oc_bifrost">>, <<"sql_password">>}]}},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -327,12 +327,14 @@
 
     {webmachine, [
         {log_handlers, [
+           <% if node['private_chef']['opscode-erchef']['enable_request_logging'] %>
             {oc_wm_request_logger, [
                 {file, "<%= File.join(@log_directory, 'requests.log') %>"},
                 {file_size, <%= (@log_rotation['file_maxbytes'].to_f/1024/1024).round %>},  %% Size in MB
                 {files, <%= @log_rotation['num_to_keep'] %>},
                 {annotations, [req_id, org_name, msg, darklaunch, perf_stats, user, req_api_version]}
             ]}
+           <% end %>
         ]}
     ]},
 


### PR DESCRIPTION
This makes request logging configurable for oc_erchef, oc_bifrost and bookshelf with individual switches.

```root@api:/vagrant# cat /etc/opscode/chef-server.rb 
opscode_erchef['enable_request_logging'] = false
```

ensure that there are no request logs generated:
```
root@api:/vagrant# ls -l /var/log/opscode/opscode-erchef/
total 840
-rw-r--r-- 1 root    root        38 Dec  6 20:32 config
-rw-r--r-- 1 opscode opscode 411921 Dec  6 21:57 crash.log
-rw-r--r-- 1 opscode opscode 220151 Dec  6 21:57 current
-rw-r--r-- 1 opscode opscode 209261 Dec  6 21:57 erchef.log
-rw------- 1 opscode opscode      0 Dec  6 20:32 lock
drwxr-x--- 2 opscode opscode   4096 Dec  6 21:30 sasl
-rw-r--r-- 1 opscode opscode      0 Dec  6 21:30 sasl-error.log
```

All tests pass.

Green build: http://wilson.ci.chef.co/job/chef-server-trigger-ad_hoc/37/downstreambuildview/

TODO: 
[x] verify with knife
[x] upload cookbooks
[x] bootstrap a node

Signed-off-by: Prajakta Purohit <prajakta@opscode.com>