### PR TITLE
[SUSTAIN-807] Clean up oc_id PID on restart

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-oc_id-run.erb
@@ -7,5 +7,6 @@ export PATH=/opt/opscode/embedded/bin:$PATH
 export LD_LIBRARY_PATH=/opt/opscode/embedded/lib
 export HOME=$DIR
 
+rm -f $DIR/tmp/pids/server.pid
 cd $DIR
 exec veil-env-helper --use-file -s chef-server.webui_key -s oc_id.sql_password -s oc_id.secret_key_base -- chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> /opt/opscode/embedded/bin/bundle exec bin/rails server -p <%= node['private_chef']['oc_id']['port'] %> -b <%= node['private_chef']['oc_id']['vip'] %>


### PR DESCRIPTION
When a Chef Server host is taken down hard, the PID file for the oc_id Rails
app does not cleaned up. Upon restart of the system, the PID stored in that file is
often assigned to another service. When this happens, oc_id fails to
restart, because Rails/Rack sees there's a process with the PID stored
in the oc_id PID file that it does not own. This sends oc_id into a
restart loop with this log message:

```
A server is already running. Check
/opt/opscode/embedded/service/oc_id/tmp/pids/server.pid.
```

Cleaning up the pidfile in the runit script before launching the rails
app prevents this.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>