### PR TITLE
Update Chef Client and Ruby version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - luarocks install --local lpeg
   - luarocks install --local lua-cjson
   - eval $(luarocks path)
-  - travis_retry rvm use 2.4.2 --install --binary --fuzzy
+  - travis_retry rvm use 2.4.3 --install --binary --fuzzy
   - cpanm --notest --quiet --local-lib=$HOME/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
   - cpanm --notest --quiet App::Sqitch
   - cd $COMPONENT && travis_retry make install
@@ -68,7 +68,7 @@ after_failure:
 matrix:
   include:
     - language: ruby
-      rvm: 2.4.2
+      rvm: 2.4.3
       gemfile: oc-chef-pedant/Gemfile
       # We remove Gemfile.lock because Travis does
       # "bundle install --path bundle/vendor" which breaks our ability
@@ -87,7 +87,7 @@ matrix:
       before_cache:
       cache:
     - language: ruby
-      rvm: 2.4.2
+      rvm: 2.4.3
       gemfile: oc-chef-pedant/Gemfile
       # We remove Gemfile.lock because Travis does
       # bundle install --path bundle/vendor" which breaks our ability

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,9 +1,9 @@
 override :erlang, version: "18.3"
 override :lua, version: "5.1.5"
 override :'omnibus-ctl', version: "master"
-override :chef, version: "v12.19.36"
+override :chef, version: "v12.21.31"
 override :ohai, version: "v8.23.0"
-override :ruby, version: "2.4.2"
+override :ruby, version: "2.4.3"
 override :rubygems, version: "2.6.13"
 # This SHA is the last commit before the 6.0 release
 override :'berkshelf-no-depselector', version: '6016ca10b2f46508b1b107264228668776f505d9'


### PR DESCRIPTION
This updates the Chef Client version to the latest Chef 12 release and bumps the Ruby version to v2.4.3 to mitigate a few CVEs in Ruby 2.4.2.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>