### PR TITLE
omnibus: pin openresty 1.11.2.1

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -7,3 +7,11 @@ override :ruby, version: "2.4.3"
 override :rubygems, version: "2.6.13"
 # This SHA is the last commit before the 6.0 release
 override :'berkshelf-no-depselector', version: '6016ca10b2f46508b1b107264228668776f505d9'
+
+# Note 2018/02/01 (sr): This is related to issue #1417:
+# This is the last version that supports --with-lua51=PATH, which allows us to
+# build it with lua on ppc64[le] and s390x. Those platforms are not supported
+# in mainline luajit. There's forks for ppc64, and s390x, but going forward with
+# those was so far blocked by ppc64 not being supported even with the PPC64
+# fork.
+override :openresty, version: "1.11.2.1"


### PR DESCRIPTION
[As foretold here](https://github.com/chef/omnibus-software/pull/916#pullrequestreview-93069493) 😉 

Related to #1417. Should unbreak the build for now.