### PR TITLE
Add queue insertion information to statistics.

### DIFF
--- a/src/oc_erchef/apps/chef_index/src/chef_index_queue.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_queue.erl
@@ -23,7 +23,8 @@
          set/5,
          set/6,
          create_management_pool/3,
-         ping/1
+         ping/1,
+         message_queue_len/1
         ]).
 
 -ifdef(TEST).
@@ -122,6 +123,16 @@ ping(VHost) ->
         _ -> pang
     end.
 
+-spec message_queue_len(binary()) -> integer() | undefined.
+message_queue_len(VHost) ->
+    Name = chef_index_sup:server_for_vhost(VHost),
+    case whereis(Name) of
+        undefined -> undefined;
+        Pid ->
+            {message_queue_len, Len} = erlang:process_info(Pid, message_queue_len),
+            Len
+    end.
+
 %%%%
 %% Internal
 %%%%
@@ -182,4 +193,3 @@ object_id_to_i(UUID) ->
 unix_time() ->
   {MS, S, _US} = os:timestamp(),
   (1000000 * MS) + S.
-

--- a/src/oc_erchef/apps/chef_index/test/chef_index_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_tests.erl
@@ -60,7 +60,7 @@ chef_index_test_() ->
        fun() ->
                application:set_env(chef_index, search_queue_mode, batch),
                meck:expect(chef_index_batch, add_item, fun(?EXPECTED_DOC) -> ok end),
-               chef_index:add(role, <<"a1">>, <<"db1">>, Item, none),
+               chef_index:add(role, <<"a1">>, <<"db1">>, Item, <<"undefined">>),
                ?assert(meck:validate(chef_index_batch))
        end
       },
@@ -68,7 +68,7 @@ chef_index_test_() ->
        fun() ->
                application:set_env(chef_index, search_queue_mode, inline),
                meck:expect(chef_index_expand, send_item, fun(?EXPECTED_DOC) -> ok end),
-               chef_index:add(role, <<"a1">>, <<"db1">>, Item, none),
+               chef_index:add(role, <<"a1">>, <<"db1">>, Item, <<"undefined">>),
                ?assert(meck:validate(chef_index_expand))
        end
       },
@@ -86,7 +86,7 @@ chef_index_test_() ->
        fun() ->
                application:set_env(chef_index, search_queue_mode, rabbitmq),
                meck:expect(chef_index_queue, delete, fun(<<"testvhost">>, role, <<"a1">>, <<"db1">>) -> ok end),
-               chef_index:delete(role, <<"a1">>, <<"db1">>, none),
+               chef_index:delete(role, <<"a1">>, <<"db1">>, <<"undefined">>),
                ?assert(meck:validate(chef_index_queue))
        end
       },

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
@@ -70,11 +70,12 @@ check_health() ->
 
     log_failure(Status, Pings, QueueMonStatus),
     KeyGen = chef_keygen_cache:status_for_json(),
-
+    Indexing = chef_index:status(),
 
     StatList = [{<<"status">>, ?A2B(Status)},
                 {<<"upstreams">>, {Pings}},
-                {<<"keygen">>, {KeyGen} }
+                {<<"keygen">>, {KeyGen}},
+                {<<"indexing">>, {Indexing}}
                 ] ++ QueueMonStatus,
 
     {Status, chef_json:encode({StatList})}.

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -654,7 +654,7 @@ is_user_in_org(Type, DbContext, Name, OrgName) ->
 
 %% These are modules that we instrument with stats_hero and aggregate into common prefix via
 %% stats_hero_label.
--type metric_module() :: oc_chef_authz | chef_s3 | chef_sql | chef_solr | data_collector.
+-type metric_module() :: oc_chef_authz | chef_s3 | chef_sql | chef_solr | data_collector | index_queue.
 
 %% @doc Given a `{Mod, Fun}' tuple, generate a stats hero metric with a prefix appropriate
 %% for stats_hero aggregation. An error is thrown if `Mod' is unknown. This is where we
@@ -672,6 +672,8 @@ stats_hero_label({chef_depsolver, Fun}) ->
     chef_metrics:label(depsolver, {chef_depsolver, Fun});
 stats_hero_label({data_collector, Fun}) ->
     chef_metrics:label(data_collector, {data_collector, Fun});
+stats_hero_label({index_queue, Fun}) ->
+    chef_metrics:label(index_queue, {index_queue, Fun});
 stats_hero_label({BadPrefix, Fun}) ->
     erlang:error({bad_prefix, {BadPrefix, Fun}}).
 
@@ -679,7 +681,7 @@ stats_hero_label({BadPrefix, Fun}) ->
 %% @doc The prefixes that stats_hero should use for aggregating timing data over each
 %% request.
 stats_hero_upstreams() ->
-    [<<"authz">>, <<"depsolver">>, <<"data_collector">>, <<"rdbms">>, <<"s3">>, <<"solr">>].
+    [<<"authz">>, <<"depsolver">>, <<"data_collector">>, <<"index_queue">>, <<"rdbms">>, <<"s3">>, <<"solr">>].
 
 
 

--- a/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
@@ -44,6 +44,7 @@ setup_env() ->
     application:set_env(oc_chef_wm, health_ping_timeout, ?PING_TIMEOUT),
     application:set_env(oc_chef_wm, health_ping_modules, ?CHECK_MODS),
     application:set_env(oc_chef_wm, rabbitmq, default_config()),
+    application:set_env(chef_index, rabbitmq_vhost, <<"/chef">>),
     oc_chef_action_queue_config:set_rabbit_queue_monitor_setting(queue_length_monitor_enabled, false),
     ok.
 

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
@@ -39,7 +39,8 @@ stats_hero_label_test_() ->
                                      {{chef_sql, fetch_client}, <<"rdbms.chef_sql.fetch_client">>},
                                      {{chef_solr, some_fun}, <<"solr.chef_solr.some_fun">>},
                                      {{oc_chef_authz, some_other_fun}, <<"authz.oc_chef_authz.some_other_fun">>},
-                                     {{chef_s3, delete_checksums}, <<"s3.s3_amazonaws_com.test_bucket.chef_s3.delete_checksums">>}
+                                     {{chef_s3, delete_checksums}, <<"s3.s3_amazonaws_com.test_bucket.chef_s3.delete_checksums">>},
+                                     {{index_queue, update}, <<"index_queue.index_queue.update">>}
                                     ]],
 
     BadTests = [


### PR DESCRIPTION
We have seen on occasion in the wild instances where the gen_bunny erlang message queue for the indexing queue gets backed up, and requests fail due to timeouts. This can be a bit of a pain to for users to debug.

This adds statistics gathering to 
1) log the insertion time 
2) Add the queue depth to the _status command

