### PR TITLE
Use the version of LicenseScout that comes with the Omnibus gem.

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -13,7 +13,6 @@ end
 group :omnibus do
   gem 'omnibus', git: 'https://github.com/chef/omnibus'
   gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software'
-  gem 'license_scout', git: 'https://github.com/chef/license_scout'
 end
 
 group :test do


### PR DESCRIPTION
LicenseScout is being refactored. We have released a 1.x version that
is pinned within the Omnibus gem.

Signed-off-by: Tom Duffield <tom@chef.io>