### PR TITLE
removing forcing of the doc formatter

### DIFF
--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) 2012-2018, Chef Software Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,7 +103,7 @@ module Pedant
       format_args = if junit_file
                       %W[-r rspec_junit_formatter -f RspecJunitFormatter -o #{junit_file} -f documentation]
                     else
-                      %w[ --color -f documentation --tty]
+                      %w[ --color --tty]
                     end
       format_args + %w(--require rspec-rerun/formatter --format RSpec::Rerun::Formatter)
     end

--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012-2018, Chef Software Inc.
+# Copyright: Copyright (c) 2012-2019, Chef Software Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
the output is so long that it blows out travis's line limits and the way
it gets forced here is difficult to override.

it can go into .rspec files in projects to bring it back if people
really like it by default, but its very wrong to have it here.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>