### PR TITLE
Increase Net::HTTP / rest-client open_timeout

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -157,6 +157,7 @@ module Pedant
                                              headers: final_headers,
                                              ssl_version: Pedant::Config.ssl_version,
                                              verify_ssl: false,
+                                             open_timeout: 300,
                                              &response_handler)
 
       if block_given?


### PR DESCRIPTION
Starting with Ruby v2.3.0 the default value for `open_timeout` changed from `nil` (disabled) to `60` seconds. This 60 second value remains in current released versions of Ruby which is why we continue to see this behavior in newer versions as well.

  - Ruby cset in which the `open_timeout` default value was introduced: https://github.com/ruby/ruby/commit/52e1c3b0ab41041f7f51a7afc3fce3aab97bc010

This caused periodic test failures which were observed and documented when we originally moved from Ruby v2.2.6 to v2.3.3.
 
  - See commit message in: https://github.com/chef/chef-server/commit/e7a2ac802f50b832c402f54e78881208d80ce6ad

More recently these timeouts have caused increase of erratic test failures on both TravisCI and internal Jenkins build for slower platforms. Rather than setting an `open_timeout` value of `nil` and disabling the
`open_timeout` entirely I have chosen to set a 300 second timeout as a starting point for increasing the timeout value to allow for legitimate timeouts to occur rather than having test jobs get stuck indefinitely.

Signed-off-by: Ryan Hass <rhass@users.noreply.github.com>