### PR TITLE
habitat mode for chef-server-ctl command

### DIFF
--- a/omnibus/files/private-chef-ctl-commands/Gemfile
+++ b/omnibus/files/private-chef-ctl-commands/Gemfile
@@ -9,5 +9,9 @@ gem "rb-readline"
 gem "rspec"
 gem "veil", git: "https://github.com/chef/chef_secrets.git"
 
-# Dependencies of ctl commands
+# Dependencies for ctl commands
 gem "redis"
+gem "sequel"
+gem "rest-client"
+gem 'pg'
+gem 'knife-opc'

--- a/omnibus/files/private-chef-ctl-commands/chef-server-ctl
+++ b/omnibus/files/private-chef-ctl-commands/chef-server-ctl
@@ -1,4 +1,5 @@
 #!/opt/opscode/embedded/bin/ruby
+
 require 'rubygems'
 gem 'omnibus-ctl'
 require 'omnibus-ctl'
@@ -19,9 +20,15 @@ module Omnibus
       d
     end
 
+    CREDENTIAL_ENV = 'CHEF_SECRETS_DATA'.freeze
+
     def credentials
-      secrets_file = ENV['SECRETS_FILE'] || "/etc/opscode/private-chef-secrets.json"
-      @credentials ||= Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file)
+      if ENV.has_key?(CREDENTIAL_ENV)
+        @credentials = Veil::CredentialCollection::ChefSecretsEnv.new(var_name: CREDENTIAL_ENV)
+      else
+        secrets_file = ENV['SECRETS_FILE'] || "/etc/opscode/private-chef-secrets.json"
+        @credentials ||= Veil::CredentialCollection::ChefSecretsFile.from_file(secrets_file)
+      end
     end
 
     # Note that as we expand our external service support,

--- a/omnibus/files/private-chef-ctl-commands/chef12_upgrade_data_transform.rb
+++ b/omnibus/files/private-chef-ctl-commands/chef12_upgrade_data_transform.rb
@@ -4,7 +4,11 @@
 # All Rights Reserved
 #
 
-require "/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade"
+begin
+  require_relative "open_source_chef12_upgrade"
+rescue LoadError
+  require "/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade"
+end
 require 'optparse'
 require 'ostruct'
 

--- a/omnibus/files/private-chef-ctl-commands/chef12_upgrade_download.rb
+++ b/omnibus/files/private-chef-ctl-commands/chef12_upgrade_download.rb
@@ -4,7 +4,11 @@
 # All Rights Reserved
 #
 
-require "/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade"
+begin
+  require_relative "open_source_chef12_upgrade"
+rescue LoadError
+  require "/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade"
+end
 require 'optparse'
 require 'ostruct'
 

--- a/omnibus/files/private-chef-ctl-commands/chef12_upgrade_upload.rb
+++ b/omnibus/files/private-chef-ctl-commands/chef12_upgrade_upload.rb
@@ -4,7 +4,11 @@
 # All Rights Reserved
 #
 
-require "/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade"
+begin
+  require_relative 'open_source_chef12_upgrade'
+rescue LoadError
+  require '/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade'
+end
 require 'optparse'
 require 'ostruct'
 

--- a/omnibus/files/private-chef-ctl-commands/key_control.rb
+++ b/omnibus/files/private-chef-ctl-commands/key_control.rb
@@ -19,11 +19,11 @@ require "optparse"
 require "ostruct"
 require "chef/key"
 
-# due to how things are being exec'ed, the CWD will be all wrong,
+# Due to how things are being exec'ed, the CWD will be all wrong,
 # so we want to use the full path when loaded from omnibus-ctl,
 # but we need the local relative path for it to work with rspec
 begin
-  require "helpers/key_ctl_helper"
+  require_relative "helpers/key_ctl_helper"
 rescue LoadError
   require '/opt/opscode/embedded/service/omnibus-ctl/helpers/key_ctl_helper'
 end

--- a/omnibus/files/private-chef-ctl-commands/upgrade.rb
+++ b/omnibus/files/private-chef-ctl-commands/upgrade.rb
@@ -3,7 +3,11 @@
 # All Rights Reserved
 #
 
-require "/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade"
+begin
+  require_relative 'open_source_chef12_upgrade'
+rescue LoadError
+  require '/opt/opscode/embedded/service/omnibus-ctl/open_source_chef12_upgrade'
+end
 require 'optparse'
 require 'ostruct'
 

--- a/omnibus/files/private-chef-ctl-commands/wrap-knife-opc.rb
+++ b/omnibus/files/private-chef-ctl-commands/wrap-knife-opc.rb
@@ -15,8 +15,17 @@
 
 require 'shellwords'
 
-knife_config = "/etc/opscode/pivotal.rb"
-knife_cmd    = "/opt/opscode/embedded/bin/knife"
+# detect if running as a habitat service
+if File.exist?('/hab/svc/chef-server-ctl/PID')
+  knife_config = "/hab/svc/chef-server-ctl/config/pivotal.rb"
+  knife_path = `cat /hab/svc/chef-server-ctl/config/pkg_path`.chomp + "/chef/bin/knife"
+  bundler_path = `hab pkg path "core/bundler"`.chomp + "/bin/bundle"
+  knife_cmd =  "#{bundler_path} exec #{knife_path}"
+else
+  knife_config = "/etc/opscode/pivotal.rb"
+  knife_cmd    = "/opt/opscode/embedded/bin/knife"
+end
+
 cmd_args     = ARGV[3..-1]
 
 cmds = {


### PR DESCRIPTION
This PR depends on #1472 

Here we're adapting the chef-server-ctl commands and files to allow for a new Habitat mode.

It should just work in either mode - like magic!

![magic](https://user-images.githubusercontent.com/1991696/36494143-dfee7f56-16f6-11e8-854b-a859afa9909b.gif)
