### PR TITLE
resolve lingering issues from PR#1472

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,40 @@ make dev dev-build
 
 Once the build is complete, the package should be in omnibus/pkg. By default the dev-build target will create an Ubuntu 10.04 build.
 
+## Habitized Chef Server
+
+The following components now exist as Habitat packages and are available [here](https://bldr.habitat.sh/#/origins/chef-server/packages):
+- nginx
+- bookshelf
+- oc_id
+- oc_erchef
+- oc_bifrost
+- chef-server-ctl
+
+To build the packages locally:
+
+```shell
+./habitat_pkgs_build.sh
+```
+
+A top-level `docker-compose.yml` file exists for running Chef Server from Habitized Docker images:
+
+```shell
+docker-compose down && docker system prune --volumes -f && docker-compose up
+```
+
+Running pedant tests:
+
+```shell
+docker-compose exec chef-server-ctl chef-server-test
+```
+
+Running chef-server-ctl:
+
+```shell
+docker-compose exec chef-server-ctl chef-server-ctl command (subcommands)
+```
+
 ## Dependencies contained in other repositories
 
 - [knife-ec-backup](https://www.github.com/chef/knife-ec-backup), used to ease migrations from Open Source Chef Server 11 (and below)
@@ -77,7 +111,7 @@ For information on contributing to this project see <https://github.com/chef/che
 
 ## License & Authors
 
-**Copyright:** 2008-2017, Chef Software, Inc.
+**Copyright:** 2008-2018, Chef Software, Inc.
 
 ```text
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # Configurable environment variables:
-# HAB_ORIGIN - denotes the docker origin (dockerhub ID)
+# HOST_IP - the docker host IP address
+# DOCKER_ORIGIN - denotes the docker origin (dockerhub ID)
 # VERSION -  the version identifier tag on the packages
 # AUTOMATE_ENABLED - enable the Automate data collector (true or false)
 # AUTOMATE_SERVER - the IP address or hostname of the Automate server
@@ -20,8 +21,8 @@ services:
       - postgresql-data:/hab/svc/postgresql/data
 
   chef-server-ctl:
-    image: ${HAB_ORIGIN:-chefserverofficial}/chef-server-ctl:${VERSION:-latest}
-    user: ${USER_ID:-42}:${GROUP_ID:-42}
+    image: ${DOCKER_ORIGIN:-chefservertesting}/chef-server-ctl:${VERSION:-localdev}
+    user: ${USER_ID:-42}:${GROUP_ID:-0}
     cap_drop:
     - NET_BIND_SERVICE
     - SETUID
@@ -45,8 +46,8 @@ services:
       - elasticsearch-data:/hab/svc/elasticsearch/data
 
   oc_id:
-    image: ${HAB_ORIGIN:-chefserverofficial}/oc_id:${VERSION:-latest}
-    user: ${USER_ID:-42}:${GROUP_ID:-42}
+    image: ${DOCKER_ORIGIN:-chefservertesting}/oc_id:${VERSION:-localdev}
+    user: ${USER_ID:-42}:${GROUP_ID:-0}
     cap_drop:
     - NET_BIND_SERVICE
     - SETUID
@@ -56,8 +57,8 @@ services:
       --bind chef-server-ctl:chef-server-ctl.default
 
   bookshelf:
-    image: ${HAB_ORIGIN:-chefserverofficial}/bookshelf:${VERSION:-latest}
-    user: ${USER_ID:-42}:${GROUP_ID:-42}
+    image: ${DOCKER_ORIGIN:-chefservertesting}/bookshelf:${VERSION:-localdev}
+    user: ${USER_ID:-42}:${GROUP_ID:-0}
     cap_drop:
     - NET_BIND_SERVICE
     - SETUID
@@ -67,8 +68,8 @@ services:
       --bind chef-server-ctl:chef-server-ctl.default
 
   oc_bifrost:
-    image: ${HAB_ORIGIN:-chefserverofficial}/oc_bifrost:${VERSION:-latest}
-    user: ${USER_ID:-42}:${GROUP_ID:-42}
+    image: ${DOCKER_ORIGIN:-chefservertesting}/oc_bifrost:${VERSION:-localdev}
+    user: ${USER_ID:-42}:${GROUP_ID:-0}
     cap_drop:
     - NET_BIND_SERVICE
     - SETUID
@@ -78,8 +79,8 @@ services:
       --bind chef-server-ctl:chef-server-ctl.default
 
   oc_erchef:
-    image: ${HAB_ORIGIN:-chefserverofficial}/oc_erchef:${VERSION:-latest}
-    user: ${USER_ID:-42}:${GROUP_ID:-42}
+    image: ${DOCKER_ORIGIN:-chefservertesting}/oc_erchef:${VERSION:-localdev}
+    user: ${USER_ID:-42}:${GROUP_ID:-0}
     cap_drop:
     - NET_BIND_SERVICE
     - SETUID
@@ -103,8 +104,8 @@ services:
         port = 443
 
   chef-server-nginx:
-    image: ${HAB_ORIGIN:-chefserverofficial}/chef-server-nginx:${VERSION:-latest}
-    user: ${USER_ID:-42}:${GROUP_ID:-42}
+    image: ${DOCKER_ORIGIN:-chefservertesting}/chef-server-nginx:${VERSION:-localdev}
+    user: ${USER_ID:-42}:${GROUP_ID:-0}
     cap_drop:
     - NET_BIND_SERVICE
     - SETUID
@@ -116,8 +117,6 @@ services:
       --bind bookshelf:bookshelf.default
       --bind elasticsearch:elasticsearch.default
       --bind chef-server-ctl:chef-server-ctl.default
-    volumes:
-      - nginx-data:/hab/svc/chef-server-nginx/data
     ports:
       - 80:8080
       - 443:8443
@@ -125,4 +124,3 @@ services:
 volumes:
   postgresql-data:
   elasticsearch-data:
-  nginx-data:

--- a/habitat_pkgs_build.sh
+++ b/habitat_pkgs_build.sh
@@ -4,12 +4,19 @@
 # additionaly, it exports them as a local docker image
 
 CHEF_SERVER_SRC='/src/src'
+ORIGIN=chefservertesting
 
 for dir in dbdpg oc-id openresty-noroot nginx bookshelf chef-server-ctl oc_bifrost oc_erchef; do
   cd $CHEF_SERVER_SRC/$dir
   echo "[STATUS] building $dir"
   build > /var/log/build-${dir}-$(date +%s).log
-  if [[ $dir =~ dbdpg ]]; then continue; fi
+  if [[ $dir =~ dbdpg|openresty-noroot ]]; then continue; fi
   echo "[STATUS] exporting $dir pkg to docker daemon"
-  hab pkg export docker -i "chefserverofficial/{{pkg_name}}" $(ls -1t results/*.hart | head -1)
+  hab pkg export docker -i "$ORIGIN/{{pkg_name}}" \
+    --no-push-image \
+    --no-tag-latest \
+    --no-tag-version \
+    --no-tag-version-release \
+    --tag-custom "localdev" \
+    $(ls -1t results/*.hart | head -1)
 done

--- a/src/chef-server-ctl/habitat/plan.sh
+++ b/src/chef-server-ctl/habitat/plan.sh
@@ -98,6 +98,7 @@ do_install() {
 
   # in pedant dir bundle install
   pushd ${pedant_dir}
+  bundle update
   bundle install --path ${RUBY_VENDOR}
   bundle config path ${RUBY_VENDOR}
   popd
@@ -143,7 +144,6 @@ EOF
   find ${RUBY_VENDOR} -name .git | xargs rm -rf
   rm -rf "${HOME}/.bundle/cache"
   rm -rf ${RUBY_VENDOR}/ruby/*/cache
-
 }
 
 do_check() {

--- a/src/oc_erchef/habitat/plan.sh
+++ b/src/oc_erchef/habitat/plan.sh
@@ -102,7 +102,7 @@ do_install() {
   export HOME="${pkg_prefix}"
   cp Gemfile_habitat ${pkg_prefix}/Gemfile
   cp Gemfile_habitat.lock ${pkg_prefix}/Gemfile.lock
-  bundle install --path "${pkg_prefix}/vendor/bundle" && bundle config path ${pkg_prefix}/vendor/bundle
+  bundle install --gemfile ${pkg_prefix}/Gemfile --path "${pkg_prefix}/vendor/bundle" && bundle config path ${pkg_prefix}/vendor/bundle
   cp -r "_build/default/rel/oc_erchef/"* "${pkg_prefix}"
   cp -R "$HAB_CACHE_SRC_PATH/$pkg_dirname/schema" "$pkg_prefix"
 }


### PR DESCRIPTION
This does not touch any other non-habitat parts of the code base.

- [x] update README
- [x] specify root group in `docker-compose.yml` to take advantage of Hab non-root user
- [x] modify `habitat_pkgs_build.sh` for easier local dev
- [x] progressive updates of oc-chef-pedant gems for the chef-server-ctl pkg - this fixes broken pedant tests
- [x] fix habitat build for `oc_erchef` by adding bundle path to the Gemfile

Signed-off-by: Jeremy J. Miller <jm@chef.io>