### PR TITLE
[upgrades] Don't early return in upgrade 1.31

### DIFF
--- a/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
+++ b/omnibus/files/private-chef-upgrades/001/031_migrate_rabbitmq_password.rb
@@ -1,20 +1,22 @@
 define_upgrade do
   if Partybus.config.bootstrap_server # TODO: do we want this?
     rmq = Partybus.config.running_server["private_chef"]["rabbitmq"]
-    return unless rmq["enable"]
+    # You may be tempted to change this to an early return.
+    # Don't. You can't without changing how partybus works.
+    if rmq["enable"]
+      start_services(["rabbitmq"])
 
-    start_services(["rabbitmq"])
+      [
+        [rmq["user"], "password"],
+        [rmq["actions_user"], "actions_password"],
+        [rmq["management_user"], "management_password"]
+      ].each do |name, passname|
+        pass = Partybus.config.secrets.get('rabbitmq', passname)
+        run_command("/opt/opscode/embedded/bin/rabbitmqctl change_password #{name} #{pass}",
+                    log_msg: "rabbitmq password upgrade for user #{name}")
+      end
 
-    [
-      [rmq["user"], "password"],
-      [rmq["actions_user"], "actions_password"],
-      [rmq["management_user"], "management_password"]
-    ].each do |name, passname|
-      pass = Partybus.config.secrets.get('rabbitmq', passname)
-      run_command("/opt/opscode/embedded/bin/rabbitmqctl change_password #{name} #{pass}",
-                  log_msg: "rabbitmq password upgrade for user #{name}")
+      stop_services(["rabbitmq"])
     end
-
-    stop_services(["rabbitmq"])
   end
 end


### PR DESCRIPTION
Calling return from a migration callback results in:

   LocalJumpError: unexpected return

Signed-off-by: Steven Danna <steve@chef.io>