### PR TITLE
WIP Fix erlang dependency loading.

### DIFF
--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -77,6 +77,7 @@ vm:
        - rel/
        - _rel/
        - _build/
+       - _checkouts/
        - chef-mover/rel/mover/
        - ebin/
        - .eunit/

--- a/dev/dvm/lib/dvm/project/erlang_dep.rb
+++ b/dev/dvm/lib/dvm/project/erlang_dep.rb
@@ -1,7 +1,7 @@
 module DVM
   class ErlangDep < Dep
     # TODO the path names suck
-    attr_reader :ref, :url, :dep_path, :real_path, :parent, :libname, :libpath
+    attr_reader :ref, :url, :dep_path, :real_path, :parent, :libname, :libpath, :checkouts_path
     # Needed for now to make tools mixin behave:
     attr_reader :path
     def initialize(name, base_dir, data, parent_inst)
@@ -10,16 +10,17 @@ module DVM
       @url = data["url"]
       @ref  = data["ref"]
       @name = name
-      @real_path = File.join("/host", name)
+      @parent = parent_inst
+      @real_path = real_path
       @path = @real_path
       @dep_path = File.join(base_dir, name)
-      @parent = parent_inst
+      @checkouts_path =  File.join(parent.project_dir, "_checkouts", name)
       @available = nil
     end
 
     def loaded?
       load_info
-      @link_target == @real_path
+      File.exists?(@checkouts_path)
     end
 
     def available?
@@ -28,6 +29,12 @@ module DVM
     end
     def load_info
       return unless @available == nil
+      @available = true
+      @lib_path = lib_path
+      @libname = File.basename(@lib_path)
+    end
+
+    def lib_path
       # TODO handle multi matches, also what if we are truly a new version?
       # TODO smarter search, using project rel file and version? But not all have them...
       matches = Dir.glob(File.join(parent.libpath, "#{name}-*"))
@@ -40,45 +47,45 @@ module DVM
         @available = false
         return
       end
-      @available = true
-      @libpath = matches[0]
-      @libname = File.basename(matches[0])
-      @link_target = File.symlink?(libpath) ? File.readlink(libpath) : libpath
+      matches[0]
     end
 
+    def real_path
+      if !external_deps_dir_exists_on_host?(name)
+        say(HighLine.color("#{host_external_deps_dir(name)} not found, need to copy or link the dependency there in the host system.", :red))
+        nil
+      else
+        host_external_deps_dir(name)
+      end
+    end
 
+    #
+    # We used to checkout/clone the dir in place, now we link to external-deps, which is copied over from the host by sync.
+    #
     def load(opts)
       load_info
-      # Again, muich of this can be offloaded to a base class that hooks into child class via callbacks.
-      if !project_dir_exists_on_host?(name)
-        # Some things to consider:
-        # do we want to match the revision/branch from rebar?
-        # do we want to auto-create a new branch from it if we did the clone ourselves or detect master or
-        if opts[:skip_checkout]
-          raise DVMArgumentError "The project directory for #{name} can't be found, and you told me not to check it out."
-        end
-        # Ensure we're starting with the same code base that we had in the dependency to avoid
-        # hot-loading headaches.
-        clone(name, url)
+      if !loaded?
+        #
+        # Rebar3 provides the _checkouts dir, which overrides deps if present. To load we link to external deps
+        #
+        FileUtils.ln_s(@real_path, @checkouts_path)
+        say(HighLine.color("Added link to #{@real_path} in #{@checkouts_path}, rebar3 will use it instead of #{@lib_path}. Please wait a moment for rebuild to pick up the change.", :green))
+      else
+        say(HighLine.color("Already loaded #{name} with link to #{@real_path} in #{checkouts_path}.", :green))
       end
-      # TODO if project is not running, do a normal build of the project - or shoudl we anyway so that
-      #      our beam files persist?
-
-      checkout(name, ref) unless opts[:skip_checkout]
-      # INstead of linking it into the dep directory, replace the library path in the project installation
-      # That way we don't have to overlay or preserve the project dep in it's original state - we'll
-      # just restore the link on unload.
-      FileUtils.rm(libpath)
-      FileUtils.ln_s(real_path, libpath)
-      say(HighLine.color("The dependency has been loaded, please wait a moment for sync to pick up the change.", :green))
     end
+
     def unload
       load_info
-      # restore original-link
-      FileUtils.rm(libpath)
-      FileUtils.ln_s(dep_path, libpath)
-      say(HighLine.color("Restored library link for #{name} to #{libname}.  PLease wait a moment for sync to pick up the change", :green))
-      puts ""
+      if loaded?
+        # restore original-link
+        FileUtils.rm(checkouts_path)
+        say(HighLine.color("Removed link for #{name} in #{checkouts_path}, rebar3 will use the code in #{@lib_path}. Please wait a moment for rebuild to pick up the change", :green))
+        puts ""
+      else
+         say(HighLine.color("#{name} not loaded in #{checkouts_path}", :red))
+        puts ""
+      end
     end
   end
 end

--- a/dev/dvm/lib/dvm/tools.rb
+++ b/dev/dvm/lib/dvm/tools.rb
@@ -69,14 +69,25 @@ module DVM
       File.join(host_raw_dir, path)
     end
 
-    def clone(name, uri)
-      run_command("git clone '#{uri}' '#{name}'", "Cloning #{name} to host. For future reference, you may also symlink it into chef-server/external-deps from another location on the host.",
-                  cwd: host_external_deps_dir)
-    end
-
     def project_dir_exists_on_host?(name)
       puts "Checking #{host_project_dir(name)} "
       File.directory?(host_project_dir(name))
+    end
+
+    def host_external_deps_dir(name = nil)
+      path = [host_raw_dir, "external-deps"]
+      path << name if !name.nil?
+      File.join(path)
+    end
+
+    def external_deps_dir_exists_on_host?(name)
+      puts "Checking #{host_external_deps_dir(name)} "
+      File.directory?(host_external_deps_dir(name))
+    end
+    
+    def clone(name, uri)
+      run_command("git clone '#{uri}' '#{name}'", "Cloning #{name} to host. For future reference, you may also symlink it into chef-server/external-deps from another location on the host.",
+                  cwd: host_external_deps_dir)
     end
 
     def checkout(name, ref)


### PR DESCRIPTION
Work in progress rework of the dependency loading. This breaks the
contract around the library loading, and I'm still sorting that
out. Putting this out there for commentary on the general approach.

Rebar3 now provides a feature for overriding the loading of
dependencies. If a dep is provided in the _checkouts directory, rebar3
will build it in preference to the version loaded with get-deps.

This rewrite uses a soft link from _checkouts to /host/external-deps;
the dev at this time will have to have a link on the host side to
their checkout of the dep.

I'm not quite sure how the old code was supposed to work with loading
things into /host/*, as sync was pretty aggressive about stomping on
things there.

Signed-off-by: Mark Anderson <mark@chef.io>