### PR TITLE
fix builds in privilege restricted environments like builder

### DIFF
--- a/src/oc-id/habitat/plan.sh
+++ b/src/oc-id/habitat/plan.sh
@@ -22,6 +22,8 @@ pkg_build_deps=(
   core/tar
   core/pkg-config
   core/coreutils
+  core/libxml2
+  core/libxslt
 )
 pkg_binds_optional=(
   [database]="port"
@@ -70,8 +72,6 @@ _tar_pipe_app_cp_to() {
   tar="$(pkg_path_for tar)/bin/tar"
 
   "$tar" -cp \
-      --owner=root:0 \
-      --group=root:0 \
       --no-xattrs \
       --exclude-backups \
       --exclude-vcs \
@@ -81,6 +81,7 @@ _tar_pipe_app_cp_to() {
       --files-from=- \
       -f - \
   | "$tar" -x \
+      --no-same-owner \
       -C "$dst_path" \
       -f -
 }
@@ -93,6 +94,10 @@ do_install() {
       | _tar_pipe_app_cp_to "$HOME"
   bundle config path ${HOME}/vendor/bundle
   bundle config build.sqlite3 --with-sqlite3-lib=$(pkg_path_for core/sqlite)/lib
+  bundle config build.nokogiri --with-xml2-include=$(pkg_path_for core/libxml2)/include/libxml2 \
+    --with-xml2-lib=$(pkg_path_for core/libxml2)/lib \
+    --with-xslt-include=$(pkg_path_for core/libxslt)/include/libxslt \
+    --with-xslt-lib=$(pkg_path_for core/libxslt)/lib
   bundle install --path "${HOME}/vendor/bundle" --binstubs="${HOME}/bin" --shebang ruby --deployment
   # fix tzdata location
   echo "Adding core/tzdata zoneinfo search path to tzinfo gem"

--- a/src/openresty-noroot/habitat/plan.sh
+++ b/src/openresty-noroot/habitat/plan.sh
@@ -78,7 +78,7 @@ do_install() {
 
   cd $HAB_CACHE_SRC_PATH
   wget $lpeg_source
-  tar -xzf lpeg-${lpeg_version}.tar.gz --owner=$(id -u) --group=$(id -g)
+  tar --no-same-owner -xzf lpeg-${lpeg_version}.tar.gz
   cd lpeg-${lpeg_version}
   make "LUADIR=$pkg_prefix/luajit/include/luajit-2.1" || attach
   install -p -m 0755 lpeg.so $pkg_prefix/luajit/lib/lua/5.1/ || attach


### PR DESCRIPTION
Attempts to fix Builder builds currently failing because they occur in a privilege restricted environment and cannot change owner or group based on the archive metadata during a tar extract.

This should introduce a new behavior to the tar command where owner/group archive metadata is ignored.

Additionally, it adds `core/libxml2` and `core/libxslt` to the build deps of `oc_id` so that we can then pass custom paths during the `nokogiri` gem build. 

Otherwise, when we bundle install, `nokogiri` fails to build because of a `tar` extraction failure of libxml like [this](https://bldr.habitat.sh/#/pkgs/chef-server/oc_id/builds/959414338453241856)

Further Discussion on the `tar` extraction issue: https://github.com/habitat-sh/builder/issues/365

Signed-off-by: Jeremy J. Miller <jm@chef.io>