### PR TITLE
Pin chef-zero to 14.0.5 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
       script: bundle exec rake chef_zero_spec
       env:
         - "PEDANT_OPTS=\"--skip-oc_id\""
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'master' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v14.0.5' \""
       # Remove things only used by erlang
       install:
       after_failure:
@@ -102,7 +102,7 @@ matrix:
       script: bundle exec rake chef_zero_spec
       env:
         - "PEDANT_OPTS=\"--skip-oc_id\""
-        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', branch: 'master' \""
+        - "GEMFILE_MOD=\"gem 'rake'; gem 'chef-zero', github: 'chef/chef-zero', tag: 'v14.0.5' \""
         - CHEF_FS=1
       # Remove things only used by erlang
       install:


### PR DESCRIPTION
This locks us to a Chef 13 compatible version while we sort out upgrading to Chef 14.

There's also a dependency in oc-id, but that requires more work to
fix and will be in a separate PR.

Signed-off-by: Mark Anderson <mark@chef.io>