### PR TITLE
adding the compliance upstream to chef-server-nginx hab pkg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       --bind bookshelf:bookshelf.default
       --bind oc_bifrost:oc_bifrost.default
       --bind database:postgresql.default
-      --bind elasticsearch:elasticsearch.default
+      --bind elasticsearch:elasticsearch5.default
       --bind chef-server-ctl:chef-server-ctl.default
     environment:
       HAB_OC_ERCHEF: |

--- a/src/nginx/habitat/config/chef_http_lb_common
+++ b/src/nginx/habitat/config/chef_http_lb_common
@@ -16,7 +16,7 @@
     set_by_lua $data_collector_token 'return os.getenv("DATA_COLLECTOR_TOKEN")';
     {{~/if}}
 
-    access_log stdout opscode;
+    access_log /dev/stdout opscode;
 {{~#if is_ssl}}
     ssl on;
     ssl_certificate {{../pkg.svc_data_path}}/ca/{{../cfg.server_name}}.cert;
@@ -82,6 +82,20 @@
       rewrite ^ /data-collector/v0/ break;
       proxy_pass https://data-collector;
     }
+
+    # Compliance endpoint to forward profiles calls to the Automate API:
+    #   /organizations/ORG/owners/OWNER/compliance[/PROFILE]
+    # Supports the legacy(chef-gate) URLs as well:
+    #   /compliance/organizations/ORG/owners/OWNER/compliance[/PROFILE]
+    location ~ (?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*) {
+      set $request_org $1;
+      access_by_lua_block { validator.validate("GET") }
+      proxy_set_header x-data-collector-token $data_collector_token;
+      proxy_set_header x-data-collector-auth "version=1.0";
+      rewrite ^(?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*) /compliance/profiles/$2$3 break;
+      proxy_pass https://compliance-profiles;
+    }
+
       {{/if ~}}
     {{/if ~}}
   {{/eachAlive ~}}
@@ -97,7 +111,6 @@
       # a 200 instead of 404.
       return 404;
     }
-
 
     # bookshelf
     location ~ "^/bookshelf/organization-.+" {

--- a/src/nginx/habitat/config/nginx.conf
+++ b/src/nginx/habitat/config/nginx.conf
@@ -106,6 +106,12 @@ http {
   upstream data-collector {
          server {{member.cfg.data_collector_server}}:{{member.cfg.data_collector_port}};
   }
+
+  upstream compliance-profiles {
+         server {{member.cfg.data_collector_server}}:{{member.cfg.data_collector_port}};
+  }
+
+
       {{/if ~}}
     {{/if ~}}
   {{/eachAlive ~}}


### PR DESCRIPTION
![tenor](https://user-images.githubusercontent.com/1991696/39589277-5bf6e1d4-4ec3-11e8-87f8-d15819d3d709.gif)

### :nut_and_bolt: Description

We forgot to add the Compliance upstream to the chef-server-nginx Habitat package!!!

This PR does the following:

* fixes an incorrect habitat bind for elasticsearch in`docker-compose.yml`
* changes nginx access_log from a file named `stdout` to the standard linux kernel device `/dev/stdout`
* adds the Chef Automate Compliance upstream when the data_collector is enabled

### :athletic_shoe: Demo Script

Some logs from the nginx service now additionally showing the GET requests from the health check:

```bash
chef-server-nginx.default hook[health_check]:(HK): {"status":"pong","upstreams":{"chef_elasticsearch":"pong","chef_sql":"pong","oc_chef_authz":"pong"},"keygen":{"keys":10,"max":10,"max_workers":10,"cur_max_workers":10,"inflight":0,"avail_workers":10,"start_size":0},"indexing":{"mode":"batch"}}
chef-server-nginx.default(O): 172.31.43.231 - - [03/May/2018:16:10:33 +0000]  "GET /_status HTTP/1.1" 200 "0.004" 174 "-" "ELB-HealthChecker/2.0" "172.31.27.8:8000" "200" "0.004" "-" "-" "-" "-" "-" 138
chef-server-nginx.default(O): 172.31.28.92 - - [03/May/2018:16:10:40 +0000]  "GET / HTTP/1.1" 200 "0.000" 2474 "-" "-" "-" "-" "-" "-" "-" "-" "-" "-" 181
chef-server-nginx.default(O): 172.31.28.92 - - [03/May/2018:16:10:50 +0000]  "GET /_status HTTP/1.1" 200 "0.005" 174 "-" "ELB-HealthChecker/2.0" "172.31.27.8:8000" "200" "0.005" "-" "-" "-" "-" "-" 138
```

### :white_check_mark: Checklist

- [x] Code actually executed?

Signed-off-by: Jeremy J. Miller <jm@chef.io>