### PR TITLE
Add DateStamp to the SOLR GC log

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -141,7 +141,7 @@ end
 
 # Enable GC Logging (very useful for debugging issues)
 if node['private_chef']['opscode-solr4']['log_gc']
-  command << " -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCTimeStamps -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintTenuringDistribution"
+  command << " -verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCApplicationConcurrentTime -XX:+PrintTenuringDistribution"
   # have java rotate the gclog.log (to avoid issues around copytruncate and sparse
   # files, see SPOOL-383)
   command << " -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=#{node['private_chef']['opscode-solr4']['log_rotation']['num_to_keep']} -XX:GCLogFileSize=#{node['private_chef']['opscode-solr4']['log_rotation']['file_maxbytes']}"


### PR DESCRIPTION
It can be a hassle to align events between the SOLR logs (which
currently logs time since start) and the rest of the system, which log
date/time stamps. This replaces time since start with a (IMHO) more
useful datestamp.

Signed-off-by: Mark Anderson <mark@chef.io>