### PR TITLE
[SUSTAIN-937] Adding resource_name to es index resource

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_resource.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_resource.rb
@@ -4,6 +4,7 @@ class Chef
   class Resource
     class ElasticSearchIndex < Chef::Resource::LWRPBase
       provides :elasticsearch_index
+      resource_name :elasticsearch_index
 
       actions [:create, :destroy]
       default_action :create


### PR DESCRIPTION
We're seeing the external ES index creation fail because it can't find
the `elastic_search_index` resource.

Setting the resource name to resolve this.

```
Recipe: private-chef::opscode-solr4-external
==> fe1:   * elastic_search_index[chef] action create
==> fe1:
==> fe1:     ================================================================================
==> fe1:     Error executing action `create` on resource 'elastic_search_index[chef]'
==> fe1:     ================================================================================
==> fe1:
==> fe1:     Chef::Exceptions::ProviderNotFound
==> fe1:     ----------------------------------
==> fe1:     Cannot find a provider for elastic_search_index[chef] on ubuntu version 14.04
```

Signed-off-by: Nolan Davidson <ndavidson@chef.io>