### PR TITLE
Unlock and bump chef-mover jiffy.

### DIFF
--- a/src/chef-mover/rebar.config
+++ b/src/chef-mover/rebar.config
@@ -14,7 +14,7 @@
         {moser, ".*",
          {git, "https://github.com/opscode/moser", {branch, "master"}}},
         {jiffy, ".*",
-         {git, "https://github.com/davisp/jiffy", {tag, "0.14.1"}}},
+         {git, "https://github.com/davisp/jiffy", {branch, "master"}}},
         {chef_reindex, ".*",
          {git, "https://github.com/opscode/chef_reindex", {branch, "master"}}},
         {ibrowse, ".*",

--- a/src/chef-mover/rebar.lock
+++ b/src/chef-mover/rebar.lock
@@ -97,7 +97,7 @@
   0},
  {<<"jiffy">>,
   {git,"https://github.com/davisp/jiffy",
-       {ref,"f661ee9fd80e5b6b03e9dfbb17d1c72fb6cfdba9"}},
+       {ref,"7ecd610286a6cfbf3008d33deff081a6b28648c4"}},
   0},
  {<<"lager">>,
   {git,"https://github.com/basho/lager",


### PR DESCRIPTION
This fixes a build failure on 16.04 and other more modern linux
distributions.

Newer versions of the C++ compiler alert with warning about the older
version of jiffy we are using; updating fixes this. However it's
unclear why we locked in the first place, so as a fallback strategy we
may want to try ignoring warnings

The error in question is:
 c++ -c -m64  -Ic_src/ -g -Wall -Werror -O3 -g -Wall -fPIC -MMD  -I"/home/mark/.erln8.d/otps/18.3.4.4/dist/lib/erlang/lib/erl_interface-3.8.2/include" -I"/home/mark/.erln8.d/otps/18.3.4.4/dist/lib/erlang/erts-7.3.1.2/include"   /home/mark/oc/chef-server/src/chef-mover/_build/default/lib/jiffy/c_src/double-conversion/bignum.cc -o /home/mark/oc/chef-server/src/chef-mover/_build/default/lib/jiffy/c_src/double-conversion/bignum.o
 /home/mark/oc/chef-server/src/chef-mover/_build/default/lib/jiffy/c_src/double-conversion/bignum.cc: In member function ‘void double_conversion::Bignum::AssignDecimalString(double_conversion::Vector<const char>)’:
 /home/mark/oc/chef-server/src/chef-mover/_build/default/lib/jiffy/c_src/double-conversion/bignum.cc:102:6: error: assuming signed overflow does not occur when assuming that (X + c) < X is always false [-Werror=strict-overflow]
  void Bignum::AssignDecimalString(Vector<const char> value) {

This is made more opaque because rebar 3 is having a secondary failure
with this, failing with a bad match here:

[{rebar_state,get,2,
              [{file,"/home/tristan/Devel/rebar3/_build/prod/lib/rebar/src/rebar_state.erl"},
	                     {line,150}]},

Signed-off-by: Mark Anderson <mark@chef.io>