### PR TITLE
Include the fixie utility in chef-server

### DIFF
--- a/omnibus/config/software/fixie-gem.rb
+++ b/omnibus/config/software/fixie-gem.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2017-2018 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef_fixie"
+default_version "0.4.0"
+
+license "Apache"
+license_file "https://github.com/chef/fixie/blob/master/LICENSE"
+
+source git: "https://github.com/chef/fixie.git"
+
+dependency "ruby"
+dependency "rubygems"
+dependency "bundler"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --without development test", env: env
+
+  gem "build chef_fixie.gemspec", env: env
+  gem "install chef_fixie-*.gem", env: env
+end

--- a/omnibus/config/software/server-complete.rb
+++ b/omnibus/config/software/server-complete.rb
@@ -70,6 +70,9 @@ dependency "chef" # for embedded chef-client -z runs (built from master - build 
 # used in osc to ec upgrade path
 dependency "knife-ec-backup-gem"
 
+# Fixie tool for fixing server
+dependency "fixie-gem"
+
 # most frequently changed dependencies
 # by placing these deps at the end of the build, we can take
 # advantage of the git caching and increase build times


### PR DESCRIPTION
We might as well ship fixie with chef server, as it saves time in emergencies.

The branch spec and version pin will be removed before merging; they're there until https://github.com/chef/fixie/pull/40 merges.

Signed-off-by: Mark Anderson <mark@chef.io>