### PR TITLE
Allow find in gather-logs to follow symlinks.

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -93,7 +93,7 @@ for i in /opt/{chef,$path}*/version-manifest.txt \
     fi
 done
 
-for i in `find /var/log/${path}* -type f -mmin -"$modified_within_last_x_minutes"`; do
+for i in `find -L /var/log/${path}* -type f -mmin -"$modified_within_last_x_minutes"`; do
     if [[ -e "$i" ]]; then
         mkdir -p "$tmpdir/`dirname ${i:1}`"
         tail -"$tail_lines" "$i" > "$tmpdir/${i:1}"


### PR DESCRIPTION
This is needed to fix an issue when users symlink another directory
to `/var/log/opscode` and allows find to follow the symlink when
searching for the log files to include.

Signed-off-by: Will Fisher <wfisher@chef.io>