### PR TITLE
MSYS-848 : Prevent Chef Server headers from exposing openresty name and version

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -141,6 +141,7 @@ http {
           server {
             <%= @helper.listen_port('http') %>
             server_name <%= @helper.server_name %>;
+            more_clear_headers Server;
             access_log /var/log/opscode/nginx/rewrite-port-80.log;
             return 301 https://$host$request_uri;
           }
@@ -156,6 +157,7 @@ http {
   server {
     <%= @helper.listen_port(node['private_chef']['lb_internal']['chef_port']) %>
     server_name <%= @helper.server_name %>;
+    more_clear_headers Server;
 
     client_max_body_size <%= @client_max_body_size %>;
     proxy_set_header        Host            $host;
@@ -188,6 +190,7 @@ http {
   server {
     <%= @helper.listen_port(node['private_chef']['lb_internal']['oc_bifrost_port']) %>
     server_name <%= @helper.server_name %>;
+    more_clear_headers Server;
 
     client_max_body_size <%= @client_max_body_size %>;
     proxy_set_header        Host            $host;

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -1,6 +1,7 @@
   server {
     <%= @helper.listen_port(@server_proto) %>
     server_name <%= @helper.server_name %>;
+    more_clear_headers Server;
 
     set_by_lua $data_collector_token 'return os.getenv("DATA_COLLECTOR_TOKEN")';
 


### PR DESCRIPTION
When connecting to the Chef Server, it currently exposes in a `Server` header that the openresty package is used and it's current version. For security reasons we would prefer to not expose that information.

Reproduction steps:
```
openssl s_client -connect my_chef_server:443
[snip ssl related output]
HEAD / HTTP/1.0
```

depending on the Chef server version you'll see output containing a line like:
```
Server: openresty/1.11.2.1
```

This can also be seen over HTTP:
```
root@chef-server:/var/opt/opscode/nginx/etc# nc localhost 80
HEAD / HTTP/1.0

HTTP/1.1 301 Moved Permanently
Server: openresty/1.11.2.1
Date: Mon, 25 Jun 2018 20:59:57 GMT
Content-Type: text/html
Content-Length: 191
Connection: close
Location: https://chef-server.ninjr.org/
```

When installed on a server the nginx configs are in /var/opt/opscode/nginx/etc. It appears that adding this configuration will prevent the line from being displayed:
```
more_clear_headers Server;
```

Acceptance Criteria:
Chef Server does not print information about openresty via http or https.

Signed-off-by: piyushawasthi <piyush.awasthi@msystechnologies.com>