### PR TITLE
Update doorkeeper gem to 4.4.0

### DIFF
--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     diffy (3.2.1)
-    doorkeeper (4.3.2)
+    doorkeeper (4.4.0)
       railties (>= 4.2)
     erubi (1.7.1)
     erubis (2.7.0)


### PR DESCRIPTION
This mitigates [CVE-2018-1000211](https://nvd.nist.gov/vuln/detail/CVE-2018-1000211).