### PR TITLE
Update custom resource in chef-server-deploy.

### DIFF
--- a/cookbooks/chef-server-deploy/resources/chef_server_secret.rb
+++ b/cookbooks/chef-server-deploy/resources/chef_server_secret.rb
@@ -5,9 +5,9 @@ property :secret_spec, String, name_property: true
 property :value, String
 
 action :set do
-  execute "Add secret #{secret_spec}" do
-    command ['chef-server-ctl', 'set-secret', secret_spec.split('.'),
-             value].flatten
-    not_if "/opt/opscode/embedded/bin/veil-env-helper -s #{secret_spec} true"
+  execute "Add secret #{new_resource.secret_spec}" do
+    command ['chef-server-ctl', 'set-secret', new_resource.secret_spec.split('.'),
+             new_resource.value].flatten
+    not_if "/opt/opscode/embedded/bin/veil-env-helper -s #{new_resource.secret_spec} true"
   end
 end


### PR DESCRIPTION
Promotions to current have been failing as the cookbook is referencing the properties without using the `new_resource` object to reference them.