### PR TITLE
Remove a few more couchdb configurables

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -375,7 +375,6 @@ default['private_chef']['opscode-erchef']['depsolver_pooler_timeout'] = '0'
 default['private_chef']['opscode-erchef']['depsolver_pool_queue_max'] = '50'
 default['private_chef']['opscode-erchef']['depsolver_worker_count'] = 5
 default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
-default['private_chef']['opscode-erchef']['couchdb_max_conn'] = '100'
 default['private_chef']['opscode-erchef']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 # general search settings used to set up chef_index

--- a/src/oc_erchef/config/vars.config
+++ b/src/oc_erchef/config/vars.config
@@ -1,7 +1,6 @@
 %% -*- mode: erlang -*-
 {couchdb_server, "localhost"}.
 {couchdb_port, 5984}.
-{couchdb_max_conn, 50}.
 {chef_rest_ip, "127.0.0.1"}.
 {chef_rest_port, 4001}.
 {estatsd_server, "127.0.0.1"}.


### PR DESCRIPTION
I imagine sometime in the 2020s we'll be able to grep the code base
and not see `couch` in it. I found these when reviewing available
erchef configuration. I have not tested this at all. If something is
using this I really want to find out.

Signed-off-by: Steven Danna <steve@chef.io>