### PR TITLE
Removed deprecated maintainer_group config from expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,5 @@
+# Documentation available at https://expeditor.chef.io/docs/getting-started/
 ---
-# Documentation available at http://expeditor-docs.es.chef.io/
 product_key: chef-server
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
@@ -17,8 +17,6 @@ github:
   # The file where our CHANGELOG is kept. This file is updated automatically with
   # details from the Pull Request via the `built_in:update_changelog` merge_action.
   changelog_file: "CHANGELOG.md"
-  # The Github Team primarily responsible for handling incoming Pull Requests.
-  maintainer_group: chef/chef-server-maintainers
 
 # Habitat + Docker exporting
 habitat_packages:


### PR DESCRIPTION
This isn't a thing anymore

Signed-off-by: Tim Smith <tsmith@chef.io>