### PR TITLE
[chef-server-ctl] Install only appbundled version

### DIFF
--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -37,7 +37,7 @@ build do
   gem "build chef-server-ctl.gemspec", env: env
 
   # Hack: install binaries in /tmp because we don't actually want them at all
-  gem "install chef-server-ctl-*.gem --no-ri --no-document --verbose --bindir=/tmp", env: env
+  gem "install chef-server-ctl-*.gem --no-document --verbose --bindir=/tmp", env: env
 
   appbundle "chef-server-ctl", env: env
 

--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -35,9 +35,15 @@ build do
   bundle "install", env: env
 
   gem "build chef-server-ctl.gemspec", env: env
-  gem "install chef-server-ctl-*.gem --no-document --verbose", env: env
+
+  # Hack: install binaries in /tmp because we don't actually want them at all
+  gem "install chef-server-ctl-*.gem --no-ri --no-document --verbose --bindir=/tmp", env: env
 
   appbundle "chef-server-ctl", env: env
 
   link "#{install_dir}/bin/chef-server-ctl", "#{install_dir}/bin/private-chef-ctl"
+
+  # These are necessary until we remove all hardcoded references to embedded/bin/*-ctl
+  link "#{install_dir}/bin/chef-server-ctl", "#{install_dir}/embedded/bin/chef-server-ctl"
+  link "#{install_dir}/bin/chef-server-ctl", "#{install_dir}/embedded/bin/private-chef-ctl"
 end


### PR DESCRIPTION
### Description

We don't want to gem-install any versions of chef-server ctl in the user path, only the appbundled version.

### Issues Resolved

This addresses some potential breakage where we pick up the non-appbundled version in /opt/opscode/embedded/bin. 

Signed-off-by: Mark Anderson <mark@chef.io>
