### PR TITLE
[oc-id] Update Gemfile to pick up new rubyzip

### DIFF
--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -58,6 +58,6 @@ end
 group :test do
   gem 'capybara', '~> 2.4.4'
   gem 'factory_girl_rails', '~> 4.4.0'
-  gem 'selenium-webdriver', '2.35.1'
+  gem 'selenium-webdriver', '~> 2.53.0'
   gem 'timecop'
 end

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     diffy (3.2.1)
-    doorkeeper (4.4.0)
+    doorkeeper (4.4.1)
       railties (>= 4.2)
     erubi (1.7.1)
     erubis (2.7.0)
@@ -241,10 +241,10 @@ GEM
       mixlib-log
     mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.12)
+    mixlib-config (2.2.13)
       tomlrb
     mixlib-log (1.7.1)
-    mixlib-shellout (2.3.2)
+    mixlib-shellout (2.4.0)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -257,8 +257,8 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    net-telnet (0.1.1)
-    newrelic_rpm (5.2.0.345)
+    net-telnet (0.2.0)
+    newrelic_rpm (5.3.0.346)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
     ohai (8.26.1)
@@ -373,7 +373,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubyzip (0.9.9)
+    rubyzip (1.2.1)
     sass (3.4.25)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -383,11 +383,10 @@ GEM
       tilt (>= 1.1, < 3)
     sdoc (1.0.0)
       rdoc (>= 5.0)
-    selenium-webdriver (2.35.1)
-      childprocess (>= 0.2.5)
-      multi_json (~> 1.0)
-      rubyzip (< 1.0.0)
-      websocket (~> 1.0.4)
+    selenium-webdriver (2.53.4)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     serverspec (2.41.3)
@@ -404,9 +403,9 @@ GEM
       eventmachine (~> 1.0.0)
       thin (>= 1.5, < 1.7)
     slop (3.6.0)
-    specinfra (2.74.0)
+    specinfra (2.75.0)
       net-scp
-      net-ssh (>= 2.7, < 5.0)
+      net-ssh (>= 2.7)
       net-telnet
       sfl
     spring (2.0.2)
@@ -442,18 +441,18 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unicode_utils (1.4.0)
-    unicorn (5.4.0)
+    unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     unicorn-rails (1.1.0)
       rack
       unicorn
     uuidtools (2.1.5)
-    websocket (1.0.7)
+    websocket (1.2.8)
     wmi-lite (1.0.0)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yard (0.9.14)
+    yard (0.9.15)
 
 PLATFORMS
   ruby
@@ -487,7 +486,7 @@ DEPENDENCIES
   rspec-rails (~> 3.2)
   sass-rails (>= 4.0.3)
   sdoc
-  selenium-webdriver (= 2.35.1)
+  selenium-webdriver (~> 2.53.0)
   sentry-raven
   spring
   spring-commands-rspec
@@ -499,4 +498,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3


### PR DESCRIPTION
### Description

Rubyzip < 1.2.1 has a security vulnerability, bump versions to remove.

This isn't too big of a deal as it a development dependency only, but
still worth doing.

Signed-off-by: Mark Anderson <mark@chef.io>


