### PR TITLE
WIP [chef-server-ctl] Make chef-server-ctl configurable

### DIFF
--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -5,4 +5,5 @@ gemspec
 gem "chef", '~>14.3.0'
 gem "chef_backup", git: "https://github.com/chef/chef_backup.git"
 gem "omnibus-ctl", git: "https://github.com/chef/omnibus-ctl.git"
+gem "veil", git: "https://github.com/chef/chef_secrets.git"
 gem "toml" # for habitat-land

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -7,6 +7,14 @@ GIT
       mixlib-shellout (~> 2.0)
 
 GIT
+  remote: https://github.com/chef/chef_secrets.git
+  revision: 9098dd3c3ea22c11cadd7ae0a86e69ee5a105bda
+  specs:
+    veil (0.3.0)
+      bcrypt (~> 3.1)
+      pbkdf2
+
+GIT
   remote: https://github.com/chef/omnibus-ctl.git
   revision: e160156deaa0afc037748b10d1c9ef0a5be97dc1
   specs:
@@ -22,6 +30,7 @@ PATH
       ffi-yajl (>= 1.2.0)
       highline (~> 1.6, >= 1.6.9)
       knife-opc
+      mixlib-log
       omnibus-ctl
       pg (~> 0.17, >= 0.17.1)
       pry
@@ -192,7 +201,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    sequel (5.10.0)
+    sequel (5.11.0)
     serverspec (2.41.3)
       multi_json
       rspec (~> 3.0)
@@ -214,9 +223,6 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
     uuidtools (2.1.5)
-    veil (0.3.0)
-      bcrypt (~> 3.1)
-      pbkdf2
     wmi-lite (1.0.0)
 
 PLATFORMS
@@ -232,6 +238,7 @@ DEPENDENCIES
   rake
   rspec
   toml
+  veil!
 
 BUNDLED WITH
    1.16.1

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -4,6 +4,8 @@ require 'rubygems'
 gem 'omnibus-ctl'
 require 'omnibus-ctl'
 require 'veil'
+require 'chef_server_ctl/log'
+require 'chef_server_ctl/config'
 
 module Omnibus
   # This implements callbacks for handling commands related to the
@@ -246,9 +248,24 @@ end
 require 'pathname'
 file_path = Pathname.new(__FILE__)
 cmd_name = 'opscode' # what does this do? was ARGV[0]
-plugin_path = file_path.dirname.parent.join('plugins') 
+plugin_path = file_path.dirname.parent.join('plugins')
 arguments = ARGV[0..-1] # Get the rest of the command line arguments
 
+
+# Intialize logging
+log_level = if ENV['CSC_LOG_LEVEL']
+              ENV['CSC_LOG_LEVEL'].to_sym
+            else
+              :info
+            end
+
+ChefServerCtl::Log.level = log_level
+
 ctl = Omnibus::ChefServerCtl.new(cmd_name, true, "Chef Server")
+
+#Initialize global configuration
+ChefServerCtl::Config.init(ctl)
+
+
 ctl.load_files(plugin_path)
 ctl.run(arguments)

--- a/src/chef-server-ctl/chef-server-ctl.gemspec
+++ b/src/chef-server-ctl/chef-server-ctl.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   # https://gist.github.com/tylercloke/a8d4bc1b915b958ac160#version-2
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "knife-opc"
+  spec.add_runtime_dependency "mixlib-log"
 
   spec.add_runtime_dependency "uuidtools", "~> 2.1", ">= 2.1.3"
   spec.add_runtime_dependency "veil" # todo get latest from https://github.com/chef/chef_secrets.git

--- a/src/chef-server-ctl/habitat/bin/chef-server-ctl.sh
+++ b/src/chef-server-ctl/habitat/bin/chef-server-ctl.sh
@@ -20,7 +20,14 @@ export SVWAIT=30
 # Could do relative to $0, but that can be messy sometimes
 pkg_prefix=$(cat /hab/svc/chef-server-ctl/config/pkg_path)
 cd "$pkg_prefix/omnibus-ctl"
-export PATH=$PATH:$(hab pkg path "core/bundler")/bin:$(hab pkg path "core/ruby")/bin
+
+BUNDLE_BIN_DIR=$(hab pkg path "core/bundler")/bin
+RUBY_BIN_DIR=$(hab pkg path "core/ruby")/bin
+
+export PATH=$PATH:$BUNDLE_BIN_DIR:$RUBY_BIN_DIR
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(hab pkg path "core/libffi")/lib
 export CHEF_SECRETS_DATA=$(cat /hab/svc/chef-server-ctl/config/hab-secrets-config.json)
+export CSC_KNIFE_CONFIG=/hab/svc/chef-server-ctl/config/pivotal.rb
+export CSC_KNIFE_BIN="${BUNDLE_BIN_DIR}/bundle exec ${pkg_prefix}/chef/bin/knife"
+
 bundle exec binstubs/chef-server-ctl "$@"

--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -1,0 +1,162 @@
+require 'chef_server_ctl/log'
+
+# ChefServerCtl::Config is a global configuration class for
+# ChefServerCtl subcommands.
+#
+# We use a global at the moment to avoid too much upheaval in the
+# various subcommands.
+#
+# Configuration is based on environment variables to make it easy to
+# implement wrappers in our Habitat packaged versions of chef-server.
+#
+# If the environment variables become too unwieldy, we can change them
+# as long as we remember to go fix the Habitat wrappers.
+#
+# TODO(ssd) 2018-08-08: Maybe use a configuration file instead?  I've
+# opted against it for now to avoid having to write yet-another-file
+# out during reconfiugration.
+module ChefServerCtl
+  module Config
+    DEFAULT_KNIFE_CONFIG_FILE = "/etc/opscode/pivotal.rb".freeze
+    DEFAULT_KNIFE_BIN = "/opt/opscode/embedded/bin/knife".freeze
+    DEFAULT_LB_URL = "https://127.0.0.1".freeze
+    DEFAULT_FIPS_LB_URL = "http://127.0.0.1".freeze
+    DEFAULT_RABBITMQCTL_BIN = "/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl".freeze
+    DEFAULT_ERCHEF_REINDEX_SCRIPT = "/opt/opscode/embedded/service/opscode-erchef/bin/reindex-opc-organization".freeze
+
+    def self.init(ctl)
+      @@ctl = ctl
+      Log.debug("Using KNIFE_CONFIG_FILE=#{self.knife_config_file}")
+      Log.debug("Using KNIFE_BIN=#{self.knife_bin}")
+      Log.debug("Using BIFROST_URL=#{self.bifrost_url}")
+      Log.debug("Using LB_URL=#{self.lb_url}")
+      Log.debug("Using HABITAT_MODE=#{self.habitat_mode}")
+    end
+
+    # knife_config should be the path to a configuration file that
+    # allows the `knife` executable to run with pivotal permissions.
+    def self.knife_config_file
+      if ENV['CSC_KNIFE_CONFIG_FILE']
+        ENV['CSC_KNIFE_CONFIG_FILE']
+      else
+        DEFAULT_KNIFE_CONFIG_FILE
+      end
+    end
+
+    # knife_bin is the command used to execute knife.
+    def self.knife_bin
+      if ENV['CSC_KNIFE_BIN']
+        ENV['CSC_KNIFE_BIN']
+      else
+        DEFAULT_KNIFE_BIN
+      end
+    end
+
+    # rabbitmqctl_bin is the command used to execute rabbitmqctl. This
+    # is used for the --wait flag of the reindex command.
+    def self.rabbitmqctl_bin
+      if ENV['CSC_RABBITMQCTL_BIN']
+        ENV['CSC_RABBITMQCTL_BIN']
+      else
+        DEFAULT_RABBITMQCTL_BIN
+      end
+    end
+
+    # fips_enabled indicates whether the chef-server is running in
+    # fips mode.
+    def self.fips_enabled
+      if ENV['CSC_FIPS_ENABLED']
+        ENV['CSC_FIPS_ENABLED'] == "true"
+      else
+        @ctl.running_config["private_chef"]["fips_enabled"]
+      end
+    end
+
+    # The lb_url should be an HTTP address that supports the Chef
+    # Server API.
+    def self.lb_url
+      if ENV['CSC_LB_URL']
+        ENV['CSC_LB_URL']
+      elsif self.fips_enabled
+        DEFAULT_FIPS_LB_URL
+      else
+        DEFAULT_LB_URL
+      end
+    end
+
+    # The bifrost_superuser_id is a shared secret of the bifrost
+    # service that allows us to make requests without access controls.
+    def self.bifrost_superuser_id
+      @@bifrost_superuser_id ||= if ENV['CSC_BIFROST_SUPERUSER_ID']
+                                   ENV['CSC_BIFROST_SUPERUSER_ID']
+                                 else
+                                   @@ctl.credentials.get('oc_bifrost', 'superuser_id')
+                                 end
+    end
+
+    # bifrost_url is an HTTP url for the Bifrost authentication
+    # service.
+    def self.bifrost_url
+      @@bifrost_url ||= if ENV['CSC_BIFROST_URL']
+                          ENV['CSC_BIFROST_URL']
+                        else
+                          bifrost_config = @@ctl.running_service_config('oc_bifrost')
+                          vip = bifrost_config['vip']
+                          port = bifrost_config['port']
+                          "http://#{vip}:#{port}"
+                        end
+    end
+
+    # bifrost_sql_connuri returns a string in the libpq connection URI
+    # format. This string is suitable for passing directly to
+    # ::PGConn.open.
+    def self.bifrost_sql_connuri
+      @@bifrost_connuri ||= if ENV['CSC_BIFROST_DB_URI']
+                              ENV['CSC_BIFROST_DB_URI']
+                            else
+                              bifrost_config = running_service_config('oc_bifrost')
+                              user = bifrost_config['sql_user']
+                              password = @@ctl.credentials.get('oc_bifrost', 'sql_password')
+                              make_connection_string('bifrost', user, password)
+                            end
+    end
+
+    # erchef_sql_connuri returns a string in the libpq connection URI
+    # format. This string is suitable for passing directly to
+    # ::PGConn.open.
+    def self.erchef_sql_connuri
+      @@erchef_connuri ||= if ENV['CSC_ERCHEF_DB_URI']
+                             ENV['CSC_ERCHEF_DB_URI']
+                           else
+                             erchef_config = running_service_config('opscode-erchef')
+                             user = echef_config['sql_user']
+                             password = @@ctl.credentials.get('opscode_erchef', 'sql_password')
+                             make_connection_string('opscode_chef', user, password)
+                           end
+    end
+
+    # erchef_reindex_script is a command to execute to run the erchef
+    # reindex RPC calls. This is an RPC script that is part of the
+    # erchef application.
+    def self.erchef_reindex_script
+      if ENV['CSC_ERCHEF_REINDEX_SCRIPT']
+        ENV['CSC_ERCHEF_REINDEX_SCRIPT']
+      else
+        DEFAULT_ERCHEF_REINDEX_SCRIPT
+      end
+    end
+
+    # habitat_mode is a boolean that is true if running in habitat
+    # mode.
+    def self.habitat_mode
+      ENV['CSC_HABITAT_MODE'] == "true"
+    end
+
+    def self.make_connection_string(dbname, db_user, db_password)
+      pg_config = @@ctl.running_service_config('postgresql')
+      host = pg_config['vip']
+      port = pg_config['port']
+      "postgresql://#{db_user}:#{db_password}@#{host}:#{port}/#{db_name}"
+    end
+  end
+end

--- a/src/chef-server-ctl/lib/chef_server_ctl/helpers/key_ctl_helper.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/helpers/key_ctl_helper.rb
@@ -5,7 +5,7 @@ module ChefServerCtl
   module Helpers
     class KeyCtlHelper
       def initialize
-        Chef::Config.from_file(pivotal_config)
+        Chef::Config.from_file(ChefServerCtl::Config.knife_config_file)
       end
 
       # Optparse doesn't properly handle the case where you specify an argument with mandatory input
@@ -31,10 +31,6 @@ module ChefServerCtl
       def exit_failure(msg)
         STDERR.puts msg
         raise SystemExit.new(1, msg)
-      end
-
-      def pivotal_config
-        "/etc/opscode/pivotal.rb"
       end
 
       def populate_client_key(clientname, name, public_key, expiration_date)

--- a/src/chef-server-ctl/lib/chef_server_ctl/log.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/log.rb
@@ -1,0 +1,7 @@
+require 'mixlib/log'
+
+module ChefServerCtl
+  class Log
+    extend Mixlib::Log
+  end
+end

--- a/src/chef-server-ctl/plugins/cleanup_bifrost.rb
+++ b/src/chef-server-ctl/plugins/cleanup_bifrost.rb
@@ -210,26 +210,10 @@ def timed(description)
   res
 end
 
-def connection_params
-  running_config = JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
-  pg_config = running_config['private_chef']['postgresql']
-
-  password = if respond_to?(:credentials) # veil helper method doesn't exist on older chef-servers
-               credentials.get('postgresql', 'db_superuser_password')
-             else
-               pg_config['db_superuser_password']
-             end
-
-  { 'host' => pg_config['vip'],
-    'port' => pg_config['port'],
-    'user' => pg_config['db_superuser'],
-    'password' => password }
-end
-
 def erchef_db
-  @erchef_db ||= ::PGconn.open(connection_params.merge('dbname' => 'opscode_chef'))
+  @erchef_db ||= ::PG::Connection.open(::ChefServerCtl::Config.erchef_sql_connuri)
 end
 
 def bifrost_db
-  @bifrost_db ||= ::PGconn.open(connection_params.merge('dbname' => 'bifrost'))
+  @bifrost_db ||= ::PG::Connection.open(::ChefServerCtl::Config.bifrost_sql_connuri)
 end

--- a/src/chef-server-ctl/plugins/filtered-dump.rb
+++ b/src/chef-server-ctl/plugins/filtered-dump.rb
@@ -5,7 +5,7 @@ add_command_under_category "filtered-dump", "Debug Tools", "Generate a filtered 
   require 'zlib'
   require 'stringio'
 
-  conn = erchef_db_connection
+  conn = ::PG::Connection.open(::ChefServerCtl::Config.erchef_sql_connuri)
   File.write("orgs.json",organizations(conn).to_json)
   File.write("nodes.json", nodes(conn).to_json)
   File.write("data_bag_items.json", data_bag_items(conn).to_json)
@@ -13,7 +13,6 @@ add_command_under_category "filtered-dump", "Debug Tools", "Generate a filtered 
   File.write("roles.json", roles(conn).to_json)
   File.write("clients.json", clients(conn).to_json)
   conn.close
-
 end
 
 def organizations(conn)
@@ -107,14 +106,4 @@ def inflate(conn, data)
     # not in gz format
     data
   end
-end
-
-def erchef_db_connection
-  erchef_config = running_service_config('opscode-erchef')
-  pg_config = running_service_config('postgresql')
-  ::PGconn.open('user' => erchef_config['sql_user'],
-                'host' => pg_config['vip'],
-                'password' => credentials.get('opscode_erchef', 'sql_password'),
-                'port' => pg_config['port'],
-                'dbname' => 'opscode_chef')
 end

--- a/src/chef-server-ctl/plugins/password.rb
+++ b/src/chef-server-ctl/plugins/password.rb
@@ -7,8 +7,8 @@
 require 'highline/import'
 require 'shellwords'
 
-knife_config = "/etc/opscode/pivotal.rb"
-knife_cmd    = "/opt/opscode/embedded/bin/knife opc user password"
+knife_config = ::ChefServerCtl::Config.knife_config_file
+knife_cmd    = "#{::ChefServerCtl::Config.knife_bin} opc user password"
 
 add_command_under_category "password", "organization-and-user-management", "Set a user's password or System Recovery Password.", 2 do
   # changed arg to turn on ldap to --enable-external-auth since that makes more sense to new users, but left in
@@ -67,5 +67,11 @@ def run_knife_opc_cmd(cmd, message)
 end
 
 def ldap_authentication_enabled?
-  running_config['private_chef']['ldap'] && running_config['private_chef']['ldap']['enabled']
+  # NOTE(ssd) 2018-08-09: Current neither of the Habitat-ized Chef
+  # Server's support ldap authentication.
+  if ::ChefServerCtl::Config.habitat_mode
+    false
+  else
+    running_config['private_chef']['ldap'] && running_config['private_chef']['ldap']['enabled']
+  end
 end

--- a/src/chef-server-ctl/plugins/reindex.rb
+++ b/src/chef-server-ctl/plugins/reindex.rb
@@ -20,12 +20,12 @@ require 'chef/org'
 require 'redis'
 
 def all_orgs
-  Chef::Config.from_file("/etc/opscode/pivotal.rb")
+  Chef::Config.from_file(::ChefServerCtl::Config.knife_config_file)
   Chef::Org.list.keys
 end
 
 def expander_queue_size
-  output = `/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl list_queues -p /chef | awk '{sum += $2} END {print sum}'`
+  output = `#{::ChefServerCtl::Config.rabbitmqctl_bin} list_queues -p /chef | awk '{sum += $2} END {print sum}'`
   status = $?
   if !status.success?
     $stderr.puts "Failed to get queue size!"
@@ -48,12 +48,9 @@ def wait_for_empty_queue
 end
 
 def enqueue_data_for_org(org)
-  reindex_script = File.join(base_path, "embedded", "service", "opscode-erchef", "bin", "reindex-opc-organization")
-  status = if running_config["private_chef"]["fips_enabled"]
-             run_command("#{reindex_script} complete #{org} http://127.0.0.1")
-           else
-             run_command("#{reindex_script} complete #{org}")
-           end
+  reindex_script = ::ChefServerCtl::Config.erchef_reindex_script
+  lb_url = ::ChefServerCtl::Config.lb_url
+  status = run_command("#{reindex_script} complete #{org} #{lb_url}")
   if !status.success?
     $stderr.puts "Failed to enqueue data for #{org}!"
   end
@@ -99,23 +96,29 @@ add_command_under_category "reindex", "general", "Reindex all server data for a 
   options = {}
 
   OptionParser.new do |opts|
-    opts.on("-w", "--wait", "Wait for reindex queue to clear before exiting") do |w|
-      # Don't attempt to wait if the search_queue_mode is "batch"
-      search_queue_mode = running_config["private_chef"]["opscode-erchef"]["search_queue_mode"]
-      if search_queue_mode == "batch"
-        $stderr.puts <<-EOF
+
+    # NOTE(ssd) 2018-08-09: --wait and --disable-api aren't currently
+    # supported in either of the Habitat packages we offer.
+    if !::ChefServerCtl::Config.habitat_mode
+      opts.on("-w", "--wait", "Wait for reindex queue to clear before exiting") do |w|
+        # Don't attempt to wait if the search_queue_mode is "batch"
+        search_queue_mode = running_config["private_chef"]["opscode-erchef"]["search_queue_mode"]
+        if search_queue_mode == "batch"
+          $stderr.puts <<-EOF
 The search queue mode is currently configured to be "#{search_queue_mode}."
 Ignoring "wait" option.
 EOF
-        options[:wait] = false
-      else
-        options[:wait] = w
+          options[:wait] = false
+        else
+          options[:wait] = w
+        end
+      end
+
+      opts.on("-d", "--disable-api", "Disable writes during reindexing") do |n|
+        options[:disable_api] = n
       end
     end
 
-    opts.on("-d", "--disable-api", "Disable writes during reindexing") do |n|
-      options[:disable_api] = n
-    end
 
     opts.on("-a", "--all-orgs", "Reindex all organizations. Overrides any organizations provided as arguments.") do |a|
       options[:all_orgs] = a

--- a/src/chef-server-ctl/plugins/version.rb
+++ b/src/chef-server-ctl/plugins/version.rb
@@ -18,6 +18,12 @@ add_command_under_category "version", "general", "Display current version of Che
 
   begin
     # detect if running as a habitat service
+    #
+    # TODO(ssd) 2018-08-09: I'm not sure what to do about this
+    # one. The version isn't really configuration but this output
+    # isn't appropriate in all cases.  One option would be to ask the
+    # LB for our version, but then the version command won't work when
+    # we are offline.
     if File.exist?('/hab/svc/chef-server-ctl/PID')
       ident_file = File.read('../IDENT')
       version = "chef-server #{ident_file.split('/')[2]}"

--- a/src/chef-server-ctl/plugins/wrap-knife-opc.rb
+++ b/src/chef-server-ctl/plugins/wrap-knife-opc.rb
@@ -15,17 +15,8 @@
 
 require 'shellwords'
 
-# detect if running as a habitat service
-if File.exist?('/hab/svc/chef-server-ctl/PID')
-  knife_config = "/hab/svc/chef-server-ctl/config/pivotal.rb"
-  knife_path = `cat /hab/svc/chef-server-ctl/config/pkg_path`.chomp + "/chef/bin/knife"
-  bundler_path = `hab pkg path "core/bundler"`.chomp + "/bin/bundle"
-  knife_cmd =  "#{bundler_path} exec #{knife_path}"
-else
-  knife_config = "/etc/opscode/pivotal.rb"
-  knife_cmd    = "/opt/opscode/embedded/bin/knife"
-end
-
+knife_config = ::ChefServerCtl::Config.knife_config_file
+knife_cmd    = ::ChefServerCtl::Config.knife_bin
 cmd_args     = ARGV[1..-1]
 
 cmds = {


### PR DESCRIPTION
This PR adds the ability to inject Chef Server configuration items
required by chef-server-ctl subcommands. A Config class has been added
that provides access to this configuration globally.

The short-term goal is to make it straightforward to get more of the
chef-server-ctl commands working from Habitat packages.  We now have 2
sets of Habitat packages:

- the docker-focused Habitat packages in this repository
- the A2-focused Habitat packages in the A2 repository

The A2 packages consume the packages in this repository.

Previously, the server-admins, key-rotation, reindex, bifrost-cleanup,
filtered-dump, and password commands were unlikely to work with either
set of packages. Now, these commands can work in our Habitat packages
if the wrappers set the appropriate configuration.

The long-term goal of this is two-fold. First, we want to make
chef-server-ctl are more standalone application. The first step of
this was the work that moved the command into its own gem. In addition
to supporting Habitat, making these dependencies configurable means we
can do things like:

- Inject stub versions of commands to test failure conditions Point

- chef-sever-ctl and chef-zero or similar API stubs for testing

- Decouple sub-command logic from the particulars of omnibus
  packaging, paving the way for future packaging changes.

The second long-term goal is to make the Habitat packages in Chef
Server more generically consumable for downstream consumers such as
A2.

## Ugh, why environment variables?

In the long-run I think we might want a custom configuration file
based on mixlib-config or similar. However, environment variables
have the following benefits:

- Easy to set from Habitat wrappers
- Easy to set at the command line for testing
- Doesn't require immediately fixing all of chef-server-ctl's command
  line argument processing bugs
- Avoids pre-baking a config-file format until we know what we need.

I think we should consider these environment variables UNSUPPORTED at
the moment and thus developers are free to change them

## Should we get rid of CHEF_SECRETS_DATA in favor of this?

No, at least not yet. Getting rid of CHEF_SECRETS_DATA in chef-server
itself will require being very careful to not add any credentials to
any new on-disk files.

## Why didn't you fix all of the commands?

I've limited this initial change to the commands supported in the A2
Habitat packages. This also has the benefit of not touching some of
the more complex commands just yet. The un-modified commands include:

  - reconfigure
  - oc-id commands
  - secrets rotation commands
  - All runit-based commands
  - HA commands
  - upgrade/chef-11-upgrade
  - gather-logs

Fixing all of chef-server-ctl will be a lengthy process since we have
a number of environments to test it in.

Signed-off-by: Steven Danna <steve@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
