### PR TITLE
Update postgresql

### DIFF
--- a/omnibus/config/software/postgresql92-bin.rb
+++ b/omnibus/config/software/postgresql92-bin.rb
@@ -16,7 +16,7 @@
 
 name "postgresql92-bin"
 
-default_version "9.2.22"
+default_version "9.2.24"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -31,7 +31,7 @@ dependency "config_guess"
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
 
-version("9.2.22") { source sha256: "a70e94fa58776b559a8f7b5301371ac4922c9e3ed313ccbef20862514de7c192" }
+version("9.2.24") { source sha256: "a754c02f7051c2f21e52f8669a421b50485afcde9a581674d6106326b189d126" }
 
 relative_path "postgresql-#{version}"
 

--- a/omnibus/config/software/postgresql96.rb
+++ b/omnibus/config/software/postgresql96.rb
@@ -16,7 +16,7 @@
 
 name "postgresql96"
 
-default_version "9.6.4"
+default_version "9.6.10"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -30,7 +30,7 @@ dependency "libossp-uuid"
 dependency "config_guess"
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
-version("9.6.4") { source sha256: "2b3ab16d82e21cead54c08b95ce3ac480696944a68603b6c11b3205b7376ce13" }
+version("9.6.10") { source sha256: "8615acc56646401f0ede97a767dfd27ce07a8ae9c952afdb57163b7234fe8426" }
 
 relative_path "postgresql-#{version}"
 


### PR DESCRIPTION
### Description

Update 9.6 to 9.6.10
Update 9.2 to 9.2.24 (note we only ship 9.2 for upgrades from Chef 11)

Signed-off-by: Mark Anderson <mark@chef.io>

### Issues Resolved

This pulls in fixes for postgres CVE-2018-10915 in 9.6
9.2 is eol, (and only used for migrations from Chef 11, so isn't a big risk)
but we should at least use the latest version of that.

