### PR TITLE
Allow SSL configuration in bifrost sys.config

### DIFF
--- a/src/oc_bifrost/apps/bifrost/src/bifrost_sup.erl
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost_sup.erl
@@ -17,10 +17,10 @@ start_link() ->
 
 init([]) ->
 
-    {ok, Ip} = application:get_env(bifrost, ip),
-    {ok, Port} = application:get_env(bifrost, port),
-    Ssl = application:get_env(bifrost, ssl, false),
-    SslOpts = application:get_env(bifrost, ssl_opts, []),
+    Ip = envy:get(bifrost, ip, string),
+    Port = envy:get(bifrost, port, integer),
+    Ssl = envy:get(bifrost, ssl, false, boolean),
+    SslOpts = envy:get(bifrost, ssl_opts, [], list),
     {ok, Dispatch} = file:consult(filename:join([code:priv_dir(bifrost),
                                                  "dispatch.conf"])),
 

--- a/src/oc_bifrost/apps/bifrost/src/bifrost_sup.erl
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost_sup.erl
@@ -19,12 +19,16 @@ init([]) ->
 
     {ok, Ip} = application:get_env(bifrost, ip),
     {ok, Port} = application:get_env(bifrost, port),
+    Ssl = application:get_env(bifrost, ssl, false),
+    SslOpts = application:get_env(bifrost, ssl_opts, []),
     {ok, Dispatch} = file:consult(filename:join([code:priv_dir(bifrost),
                                                  "dispatch.conf"])),
 
     WebConfig = [
                  {ip, Ip},
                  {port, Port},
+                 {ssl, Ssl},
+                 {ssl_opts, SslOpts},
                  {log_dir, "priv/log"},
                  {dispatch, add_dynamic_config(Dispatch)},
                  {nodelay, true} % TCP 'no delay' for latency


### PR DESCRIPTION
### Description

This will allow bifrost to be configured for mTLS connections.

Basic SSL configuration for webmachine is documented here:
https://github.com/webmachine/webmachine/wiki/Configuration

Webmachine passes `ssl_opts` to mochiweb which passes them to the
built-in `ssl` module.

Full mTLS configuration is similar to the following:

```
             {ssl, true},
             {ssl_opts, [
                         {cacertfile, "/base/path/root_ca.crt"},
                         {certfile, "/base/path/service.crt"},
                         {keyfile, "/base/path/service.key"},
                         {verify, verify_peer},
                         {fail_if_no_peer_cert, true}
                        ]}
```

Note in particular the documentation of `fail_if_no_peer_cert`:

> `{fail_if_no_peer_cert, boolean()}`
>
> Used together with {verify, verify_peer} by an TLS/DTLS server. If set
> to true, the server fails if the client does not have a certificate to
> send, that is, sends an empty certificate. If set to false, it fails
> only if the client sends an invalid certificate (an empty certificate is
> considered valid). Defaults to false.

Signed-off-by: Daniel DeLeo <dan@chef.io>

### Issues Resolved

internal ticket DEPLOY-381

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
