### PR TITLE
Modernize Expeditor config; Promote harts/containers

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -11,6 +11,13 @@ automate:
   project: chef-server
 
 github:
+  delete_branch_on_merge: true
+  # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file
+  # is bumped automatically via the `built_in:bump_version` merge_action.
+  version_file: "VERSION"
+  # The file where our CHANGELOG is kept. This file is updated automatically with
+  # details from the Pull Request via the `built_in:update_changelog` merge_action.
+  changelog_file: "CHANGELOG.md"
   release_branch:
     - master:
         # we'll have to bump this later, as globs won't let us do > 18
@@ -18,19 +25,13 @@ github:
     - 12-18-stable:
         # this branch should only be active
         version_constraint: "12.18.*"
-  # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file
-  # is bumped automatically via the `built_in:bump_version` merge_action.
-  version_file: "VERSION"
-  # The file where our CHANGELOG is kept. This file is updated automatically with
-  # details from the Pull Request via the `built_in:update_changelog` merge_action.
-  changelog_file: "CHANGELOG.md"
 
 # Habitat + Docker exporting
 habitat_packages:
   - openresty-noroot:
       source: src/openresty-noroot
       bldr_paths: src/openresty-noroot/*
-  - oc-id:
+  - oc_id:
       source: src/oc-id
       bldr_paths: src/oc-id/*
       export:
@@ -64,28 +65,42 @@ habitat_packages:
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:bump_version:
+      post_commit: false
       ignore_labels:
         - "Version: Skip Bump"
         - "Expeditor: Skip All"
         - "Expeditor: ACC Only"
   - built_in:update_changelog:
+      post_commit: false
       ignore_labels:
         - "Changelog: Skip Update"
         - "Expeditor: Skip All"
         - "Expeditor: ACC Only"
   - built_in:trigger_omnibus_build:
+      post_commit: true
       ignore_labels:
         - "Omnibus: Skip Build"
         - "Expeditor: Skip All"
         - "Expeditor: ACC Only"
       only_if: built_in:bump_version
   - built_in:trigger_habitat_package_build:
+      post_commit: true
       ignore_labels:
         - "Omnibus: Skip Build"
         - "Expeditor: Skip All"
         - "Expeditor: ACC Only"
       only_if: built_in:bump_version
+  - bash:.expeditor/upload_files.sh:
+      post_commit: true
+      only_if: built_in:trigger_habitat_package_build
+      ignore_labels:
+        - "Expeditor: Skip All"
+  - bash:.expeditor/purge_cdn.sh:
+      post_commit: true
+      ignore_labels:
+        - "Expeditor: Skip All"
   - built_in:update_acc:
+      post_commit: true
       only_if_labels:
         - "Expeditor: ACC Only"
 
@@ -103,12 +118,30 @@ subscriptions:
 # These actions are taken, in the order specified, when an Omnibus artifact is promoted
 # within Chef's internal artifact storage system.
 #
-# TODO: add promoted_to_unstable action to update changelog with modified omnibus components
+# TODO: add action to update changelog with modified omnibus components
 subscriptions:
   - workload: artifact_published:unstable:chef-server:*
     actions:
       - built_in:update_acc
+  - workload: artifact_published:current:chef-server:*
+    actions:
+      - bash:.expeditor/promote_harts_and_containers.sh:
+          post_commit: true
+      - bash:.expeditor/purge_cdn.sh:
+          post_commit: true
   - workload: artifact_published:stable:chef-server:*
     actions:
       - built_in:rollover_changelog
+      - bash:.expeditor/promote_harts_and_containers.sh:
+          post_commit: true
+      - bash:.expeditor/purge_cdn.sh:
+          post_commit: true
       - built_in:notify_chefio_slack_channels
+
+promote:
+  actions:
+    - built_in:promote_artifactory_artifact
+  channels:
+    - unstable
+    - current
+    - stable

--- a/.expeditor/create_manifest.rb
+++ b/.expeditor/create_manifest.rb
@@ -1,0 +1,88 @@
+#!/usr/bin/env ruby
+
+# By default, this script creates a manifest.json file that contains all the packages in the unstable channel.
+
+require 'date'
+require 'net/http'
+require 'json'
+require 'openssl'
+
+BLDR_API_HOST="bldr.habitat.sh"
+BLDR_API_USER_AGENT="Chef Expeditor"
+
+def get_latest(channel, origin, name)
+  http = Net::HTTP.new(BLDR_API_HOST, 443)
+  http.use_ssl = true
+  http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+  req = Net::HTTP::Get.new("/v1/depot/channels/#{origin}/#{channel}/pkgs/#{name}/latest", {'User-Agent' => BLDR_API_USER_AGENT})
+  response = http.request(req)
+  latest_release = JSON.parse(response.body)
+  latest_release["ident"]
+rescue
+  puts "ERROR: Could not find latest release for #{origin}/#{name} in #{channel}"
+  exit 1
+end
+
+def get_hab_deps_latest()
+  ret = {}
+  ["hab", "hab-sup", "hab-launcher"].each do |name|
+    d = get_latest("stable", "core", name)
+    ret[name] = "#{d["origin"]}/#{d["name"]}/#{d["version"]}/#{d["release"]}"
+  end
+  ret
+end
+
+version = ENV["VERSION"] || File.read("VERSION").chomp
+filename = ENV["VERSION"] || "manifest"
+
+manifest = {}
+
+# The version of the manifest schema - might need to be bumped in the future
+manifest["schema_version"] = "1"
+
+# The version of the manifest - the "engineering" version
+manifest["build"] = version
+
+# Grab the version of various Habitat components from the deployment-service
+
+hab_deps = get_hab_deps_latest
+manifest["hab"] = []
+manifest["hab"] << hab_deps["hab"]
+manifest["hab"] << hab_deps["hab-sup"]
+manifest["hab"] << hab_deps["hab-launcher"]
+
+# Grab the version of hab in the build environment. Comes out in the
+# form of 'hab 0.54.0/20180221020527'
+hab_version = /(\d+\.\d+\.\d+\/\d{14})/.match(`hab --version`.strip)[0]
+manifest["hab_build"] = "core/hab/#{hab_version}"
+
+# Grab the git SHA
+manifest["git_sha"] = `git show-ref HEAD --hash`.strip
+
+manifest["packages"] = []
+
+pkg_origin = "chef"
+
+%w{
+  openresty-noroot
+  oc_id
+  chef-server-nginx
+  bookshelf
+  chef-server-ctl
+  oc_bifrost
+  oc_erchef
+}.each do |pkg_name|
+  latest_release = get_latest("unstable", pkg_origin, pkg_name)
+
+  pkg_version = latest_release["version"]
+  pkg_release = latest_release["release"]
+
+  puts "  Adding package #{pkg_origin}/#{pkg_name}/#{pkg_version}/#{pkg_release}"
+  manifest["packages"] << "#{pkg_origin}/#{pkg_name}/#{pkg_version}/#{pkg_release}"
+end
+
+manifest["packages"].uniq!
+# Sort the packages for easier diff-ing
+manifest["packages"].sort!
+
+File.open("#{filename}.json", "w") { |file| file.write(JSON.pretty_generate(manifest)) }

--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eou pipefail
+
+if [[ "${EXPEDITOR:-false}" == "true" ]]; then
+  apt-get update
+  apt-get install -y libpq-dev libsqlite3-dev
+fi
+
+bundle_install_dirs=(
+  chef-server-ctl
+  oc-id
+  opscode-expander
+)
+
+for dir in "${bundle_install_dirs[@]}"; do
+  echo "--- Installing gem dependencies for $dir"
+  pushd "src/$dir"
+    if [[ "${EXPEDITOR:-false}" == "true" ]]; then
+      "$(hab pkg path core/ruby25)"/bin/bundle install
+    else
+      bundle install
+    fi
+  popd
+done
+
+echo "+++ Running License Scout"
+license_scout --only-show-failures

--- a/.expeditor/promote_harts_and_containers.sh
+++ b/.expeditor/promote_harts_and_containers.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -eou pipefail
+
+if [ "${CHANNEL}" = "unstable" ];
+then
+  echo "This file does not need to be run for the unstable channel"
+  exit 1
+fi
+
+# VERSION and CHANNEL are passed in via Expeditor when an omnibus package of
+# version VERSION is promoted to CHANNEL
+
+# Download the manifest
+aws s3 cp "s3://chef-automate-artifacts/manifests/chef-server/${VERSION}.json" manifest.json --profile chef-cd
+
+# Download or create the versions file
+aws s3 cp "s3://chef-automate-artifacts/${CHANNEL}/latest/chef-server/versions.json" existing-versions.json --profile chef-cd || echo "[]" > existing-versions.json
+
+# Promote the artifacts in Habitat Depot
+jq -r -c ".packages[]" manifest.json | while read service_ident; do
+  # service_ident will look like: chef/oc_erchef/12.18.2/20180806132701
+  pkg_origin=$(echo $service_ident | cut -d / -f 1) # chef
+  pkg_name=$(echo $service_ident | cut -d / -f 2) # oc_erchef
+  pkg_version=$(echo $service_ident | cut -d / -f 3) # 12.18.2
+  pkg_release=$(echo $service_ident | cut -d / -f 4) # 20180806132701
+
+  if [ "$pkg_origin" = "core" ];
+  then
+    echo "Skipping promotion of core origin package ${service_ident}"
+  else
+    echo "Promoting ${service_ident} hart to the ${CHANNEL} channel"
+    hab pkg promote "${service_ident}" "${CHANNEL}"
+
+    echo "Promoting ${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release} container to ${CHANNEL} tag"
+    docker pull "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}"
+    docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:${CHANNEL}"
+    docker push "${pkg_origin}/${pkg_name}:${CHANNEL}"
+
+    if [ "$CHANNEL" = "stable" ];
+    then
+      docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:latest"
+      docker push "${pkg_origin}/${pkg_name}:latest"
+      docker rmi "${pkg_origin}/${pkg_name}:latest"
+    fi
+
+    docker rmi "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:${CHANNEL}"
+  fi
+done
+
+# Append the new version to the target channel versions file
+jq ". |= .+ [\"$(jq -r -c ".build" manifest.json)\"]" existing-versions.json > updated-versions.json
+
+# Promote the License Scout Dependency Manifest
+aws s3 cp "s3://chef-automate-artifacts/licenses/chef-server/${VERSION}.json" "s3://chef-automate-artifacts/${CHANNEL}/latest/chef-server/licenses.json" --acl public-read  --profile chef-cd
+# Promote the manifest
+aws s3 cp manifest.json "s3://chef-automate-artifacts/${CHANNEL}/latest/chef-server/manifest.json" --acl public-read  --profile chef-cd
+# Upload the updated versions file
+aws s3 cp updated-versions.json "s3://chef-automate-artifacts/${CHANNEL}/latest/chef-server/versions.json" --acl public-read  --profile chef-cd
+
+# Cleanup
+rm manifest.json
+rm existing-versions.json
+rm updated-versions.json

--- a/.expeditor/purge_cdn.sh
+++ b/.expeditor/purge_cdn.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eou pipefail
+
+TARGET_CHANNEL="${CHANNEL:-unstable}"
+
+echo "Purging '${TARGET_CHANNEL}/chef-server/latest' Surrogate Key group from Fastly"
+curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${TARGET_CHANNEL}/chef-server/latest

--- a/.expeditor/upload_files.sh
+++ b/.expeditor/upload_files.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -eou pipefail
+
+VERSION=$(cat VERSION)
+export VERSION
+
+# Generate the License Scout Dependency Manifest
+.expeditor/license_scout.sh
+
+# Upload the License Scout Dependency Manifest to the S3 bucket
+aws s3 cp chef-server-dependency-licenses.json "s3://chef-automate-artifacts/licenses/chef-server/$VERSION.json" --acl public-read --profile chef-cd
+aws s3 cp chef-server-dependency-licenses.json "s3://chef-automate-artifacts/unstable/latest/chef-server/licenses.json" --acl public-read --profile chef-cd
+
+#
+# Generate the manifest.json
+#
+
+# Download or create the versions file
+aws s3 cp "s3://chef-automate-artifacts/unstable/latest/chef-server/versions.json" existing-versions.json --profile chef-cd || echo "[]" > existing-versions.json
+
+# Use create_manifest.rb to generate the manifest.json file
+ruby .expeditor/create_manifest.rb
+
+# Append the new version to the unstable channel versions file
+jq ". |= .+ [\"$VERSION\"]" existing-versions.json > updated-versions.json
+
+# Upload the manifest to the S3 bucket
+aws s3 cp "$VERSION.json" "s3://chef-automate-artifacts/manifests/chef-server/$VERSION.json" --acl public-read --profile chef-cd
+aws s3 cp "$VERSION.json" "s3://chef-automate-artifacts/unstable/latest/chef-server/manifest.json" --acl public-read --profile chef-cd
+aws s3 cp updated-versions.json "s3://chef-automate-artifacts/unstable/latest/chef-server/versions.json" --acl public-read --profile chef-cd
+
+#
+# Cleanup
+#
+
+rm "$VERSION.json"
+rm existing-versions.json
+rm updated-versions.json

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ compile_commands.json
 # Habitat
 results
 
+# CI
+manifest.json
+chef-server-dependency-licenses.json

--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -1,0 +1,132 @@
+---
+name: chef-server
+directories:
+  - ./
+  - ./src/bookshelf
+  - ./src/chef-mover
+  - ./src/chef-server-ctl
+  - ./src/nginx
+  - ./src/oc_bifrost
+  - ./src/oc_erchef
+  - ./src/oc-id
+  - ./src/openresty-noroot
+  - ./src/opscode-expander
+
+habitat:
+  channel_for_origin:
+    - origin: chef
+      channel: unstable
+
+allowed_licenses:
+  - Apache-1.0
+  - Apache-1.1
+  - Apache-2.0
+  - Artistic-2.0
+  - BSD-1-Clause
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - BSD-3-Clause-Attribution
+  - BSD-Source-Code
+  - BSL-2.0
+  - bzip2-1.0.6
+  - CC0-1.0
+  - CC-BY-2.0
+  - CC-BY-3.0
+  - CC-BY-4.0
+  - curl
+  - gnuplot
+  - ICU
+  - ISC
+  - MIT
+  - MPL-2.0
+  - OpenSSL
+  - PHP-3.0
+  - PHP-3.01
+  - PostgreSQL
+  - Python-2.0
+  - Ruby
+  - SAX-PD
+  - Unlicense
+  - WTFPL
+  - Zlib
+
+fallbacks:
+  ruby:
+    - name: amqp
+      license_id: Ruby
+      license_content: https://raw.githubusercontent.com/ruby-amqp/amqp/master/README.md
+    - name: compass
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/Compass/compass/stable/LICENSE.markdown
+    - name: coolline
+      license_id: Zlib
+      license_content: https://raw.githubusercontent.com/Mon-Ouie/coolline/master/LICENSE
+    - name: em-http-request
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/igrigorik/em-http-request/master/README.md
+    - name: net-telnet
+      license_id: Ruby
+      license_content: https://raw.githubusercontent.com/ruby/net-telnet/master/LICENSE.txt
+    - name: pbkdf2
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/emerose/pbkdf2-ruby/master/LICENSE.TXT
+    - name: pry-remote
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/emerose/pbkdf2-ruby/master/LICENSE.TXT
+    - name: syslog-logger
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/ngmoco/syslog_logger/master/README.rdoc
+    - name: unicorn-rails
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/samuelkadolph/unicorn-rails/master/LICENSE
+  habitat:
+    - name: core/bundler
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/bundler/bundler/master/LICENSE.md
+
+exceptions:
+  ruby:
+    - name: kgio
+      reason: Exception made by Chef Legal (unmodified library, used as-is)
+    - name: newrelic_rpm
+      reason: Exception made by Chef Legal (unmodified library, used as-is)
+    - name: raindrops
+      reason: Exception made by Chef Legal (unmodified library, used as-is)
+  habitat:
+    - name: core/attr
+      reason: Exception made by Chef Legal
+    - name: core/bash
+      reason: Exception made by Chef Legal
+    - name: core/busybox-static
+      reason: Exception made by Chef Legal
+    - name: core/coreutils
+      reason: Exception made by Chef Legal
+    - name: core/gcc-libs
+      reason: Exception made by Chef Legal
+    - name: core/gdbm
+      reason: Exception made by Chef Legal
+    - name: core/glibc
+      reason: Exception made by Chef Legal
+    - name: core/gmp
+      reason: Exception made by Chef Legal
+    - name: core/grep
+      reason: Exception made by Chef Legal
+    - name: core/less
+      reason: Exception made by Chef Legal
+    - name: core/libcap
+      reason: Exception made by Chef Legal
+    - name: core/libtool
+      reason: Exception made by Chef Legal
+    - name: core/linux-headers
+      reason: Exception made by Chef Legal
+    - name: core/readline
+      reason: Exception made by Chef Legal
+    - name: core/rsync
+      reason: Exception made by Chef Legal
+    - name: core/ruby
+      reason: Exception made by Chef Legal
+    - name: core/sed
+      reason: Exception made by Chef Legal
+    - name: core/sqitch_pg
+      reason: Exception made by Chef Legal
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,3 +150,9 @@ matrix:
         - eval "$(/opt/chefdk/bin/chef shell-init bash)"
       before_script: cd cookbooks/chef-server-deploy
       script: chef exec foodcritic . -t ~supermarket
+    # license-scout
+    - env:
+        - NAME=license-scout
+      language: minimal
+      install: true
+      script: docker run --rm --volume $(pwd):/workdir --workdir /workdir --env OCTOKIT_ACCESS_TOKEN --env EXPEDITOR=true chefes/lita-worker .expeditor/license_scout.sh

--- a/src/nginx/habitat/plan.sh
+++ b/src/nginx/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/curl
   core/libossp-uuid
-  $HAB_ORIGIN/openresty-noroot
+  ${HAB_ORIGIN:-chef}/openresty-noroot
 )
 pkg_build_deps=()
 pkg_exposes=(port ssl-port)


### PR DESCRIPTION
This PR makes a number of pipeline related improvements:

- Move away from `artifact_actions` and begin using `subscriptions` to
  control all promotion actions
- Declare `post_commit` config in `merge_actions`
- Automatically delete feature branches following a successful merge
- Create a `manifest.json` file at `*.hart` build time. This becomes the
  release artifact that maps a set of Habitat pkg idents to a particular
  Chef Server version
- Execute Habitat channel and Docker container tag promotions at the
  appropriate time

Signed-off-by: Seth Chisamore <schisamo@chef.io>
