### PR TITLE
Dan/bookshelf mtls

### DIFF
--- a/src/bookshelf/src/bksw_conf.erl
+++ b/src/bookshelf/src/bksw_conf.erl
@@ -78,7 +78,9 @@ get_wm_configuration() ->
     [{ip, ip()},
      {port, port()},
      {dispatch, dispatch()},
-     {log_dir, log_dir()}].
+     {log_dir, log_dir()},
+     {ssl, ssl()},
+     {ssl_opts, ssl_opts()}].
 
 -spec access_key_id(context()) -> binary().
 access_key_id(#context{access_key_id=AccessKeyId}) ->
@@ -143,6 +145,12 @@ ip() ->
 
 port() ->
     envy:get(bookshelf, port, 4321, positive_integer).
+
+ssl() ->
+    envy:get(bookshelf, ssl, false, boolean).
+
+ssl_opts() ->
+    envy:get(bookshelf, ssl_opts, [], list).
 
 keys() ->
     {ok, AWSAccessKey} = chef_secrets:get(<<"bookshelf">>, <<"access_key_id">>),

--- a/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
@@ -163,7 +163,8 @@ get_external_config(VHostUrl) ->
 aws_config(S3Url) ->
     {ok, S3AccessKeyId} = chef_secrets:get(<<"bookshelf">>, <<"access_key_id">>),
     {ok, S3SecretKeyId} = chef_secrets:get(<<"bookshelf">>, <<"secret_access_key">>),
-    mini_s3:new(erlang:binary_to_list(S3AccessKeyId), erlang:binary_to_list(S3SecretKeyId), S3Url, path).
+    SslOpts = envy:get(chef_objects, s3_ssl_opts, [], list),
+    mini_s3:new(erlang:binary_to_list(S3AccessKeyId), erlang:binary_to_list(S3SecretKeyId), S3Url, path, SslOpts).
 
 %% @doc returns a url for accessing s3 internally. This is used
 %% to contact bookshelf or S3.

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -90,7 +90,7 @@
   1},
  {<<"mini_s3">>,
   {git,"https://github.com/chef/mini_s3",
-       {ref,"83814499d870c552867f440304e536f7558f70e3"}},
+       {ref,"8ab626297b673115eb9ff2930978a641d92d6078"}},
   0},
  {<<"mixer">>,
   {git,"https://github.com/chef/mixer",


### PR DESCRIPTION
### Description

Allows SSL/TLS to be enabled for bookshelf, including mTLS. This has two parts:
* pass through ssl options from config to webmachine when starting bookshelf
* pass through ssl options from erchef config to mini_s3; this is required for erchef to successfully connect to bookshelf when bookshelf is configured for mTLS

Includes dep change to include https://github.com/chef/mini_s3/pull/25

### Issues Resolved

Internal tickets DEPLOY-382 and DEPLOY-347

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>