### PR TITLE
Update oc-bifrost-pedant to use rest-client 1.8.X

### DIFF
--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       activesupport (~> 3.2.8)
       mixlib-config (~> 1.1.2)
       net-http-spy (~> 0.2.1)
-      rest-client (~> 1.6.7)
+      rest-client (~> 1.8.0)
       rspec (~> 2.11.0)
       rspec-rerun (= 0.1.1)
       rspec_junit_formatter (~> 0.1.1)
@@ -28,15 +28,22 @@ GEM
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     diff-lcs (1.1.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    mime-types (1.25.1)
+    mime-types (2.99.3)
     mixlib-config (1.1.2)
     multi_json (1.13.1)
     net-http-spy (0.2.1)
+    netrc (0.11.0)
     pbkdf2 (0.1.0)
-    rest-client (1.6.9)
-      mime-types (~> 1.16)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -51,6 +58,9 @@ GEM
       builder
       rspec (~> 2.0)
       rspec-core (!= 2.12.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby
@@ -60,4 +70,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/src/oc_bifrost/oc-bifrost-pedant/oc-bifrost-pedant.gemspec
+++ b/src/oc_bifrost/oc-bifrost-pedant/oc-bifrost-pedant.gemspec
@@ -1,13 +1,12 @@
 Gem::Specification.new do |s|
   s.name          = 'oc-bifrost-pedant'
   s.version       = '0.0.1'
-  s.date          = '2013-01-24'
-  s.summary       = "Opscode Chef API Testing Framework"
-  s.authors       = ["Opscode Software Engineering"]
+  s.summary       = "Chef Server API Testing Framework"
+  s.authors       = ["Chef Software Engineering"]
   s.email         = 'dev@chef.io'
   s.require_paths = ['lib', 'spec']
   s.files         = Dir['lib/**/*'] + Dir['spec/**/*'] + Dir['bin/*'] + Dir['fixtures/**/*']
-  s.homepage      = 'http://chef.io'
+  s.homepage      = 'https://chef.io'
 
   s.bindir        = 'bin'
   s.executables   = ['oc-bifrost-pedant']
@@ -15,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rspec', '~> 2.11.0')
   s.add_dependency('activesupport', '~> 3.2.8') # For active_support/concern
   s.add_dependency('mixlib-config', '~> 1.1.2')
-  s.add_dependency('rest-client', '~> 1.6.7')
+  s.add_dependency('rest-client', '~> 1.8.0')
   s.add_dependency('rspec_junit_formatter', '~> 0.1.1')
   s.add_dependency('net-http-spy', '~> 0.2.1')
   s.add_dependency('rspec-rerun', '= 0.1.1')


### PR DESCRIPTION
Resolves a Github security warning that we don't really need to worry about in the test framework, but might as well fix. Sad news: This drops ruby 1.8 support. Whatever will we do ;)

Signed-off-by: Tim Smith <tsmith@chef.io>