### PR TITLE
Make erchef webmachine ssl opts configurable

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
@@ -33,11 +33,16 @@ init([]) ->
 
     Ip = envy:get(oc_chef_wm, ip, string),
     Port = envy:get(oc_chef_wm, port, pos_integer),
+    Ssl = envy:get(oc_chef_wm, ssl, false, boolean),
+    SslOpts = envy:get(oc_chef_wm, ssl_opts, [], list),
+
     WebConfig = [
                  {ip, Ip},
                  {port, Port},
                  {log_dir, "priv/log"},
-                 {dispatch, dispatch_table()}],
+                 {dispatch, dispatch_table()},
+                 {ssl, Ssl},
+                 {ssl_opts, SslOpts}],
 
     Web = {webmachine_mochiweb,
            {webmachine_mochiweb, start, [WebConfig]},


### PR DESCRIPTION
### Description

This enables erchef to be configured to listen with ssl/tls and
be configured for mTLS

### Issues Resolved

Internal tickets DEPLOY 383 and 347

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
