### PR TITLE
Update tag for enterprise cookbook.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/Berksfile
+++ b/omnibus/files/private-chef-cookbooks/Berksfile
@@ -1,6 +1,6 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'enterprise', git: 'https://github.com/chef-cookbooks/enterprise-chef-common', tag: 'v0.14.0'
+cookbook 'enterprise', git: 'https://github.com/chef-cookbooks/enterprise-chef-common', tag: 'v0.14.1'
 cookbook 'chef-ha-drbd', path: './chef-ha-drbd'
 cookbook 'private-chef', path: './private-chef'
 cookbook 'runit', '> 1.6.0'


### PR DESCRIPTION
### Description
Update tag used for the [enterprise-chef-common](https://github.com/chef-cookbooks/enterprise-chef-common) cookbook. The new version of the enterprise cookbook pins the runit cookbook dependency to fix PATH issues which were [introduced by a bugfix in the runit cookbook on Ubuntu.](https://github.com/chef-cookbooks/runit/pull/217)

### Issues Resolved
- SUSTAIN-985

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
