### PR TITLE
More pedant mTLS support

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
@@ -313,6 +313,9 @@ module Pedant
           http.use_ssl = true
           http.ssl_version = Pedant::Config.ssl_version
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          http.cert        = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
+          http.key         = Pedant::Config.ssl_client_key  if Pedant::Config.ssl_client_key
+          http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
         end
 
         response = http.get(uri.request_uri, {})

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
@@ -212,6 +212,9 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
             http.use_ssl = true
             http.ssl_version = Pedant::Config.ssl_version
             http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            http.cert        = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
+            http.key         = Pedant::Config.ssl_client_key  if Pedant::Config.ssl_client_key
+            http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
           end
 
           response = http.get(uri.request_uri, {})

--- a/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
@@ -320,6 +320,9 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_read do
               http.use_ssl = true
               http.ssl_version = Pedant::Config.ssl_version
               http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+              http.cert        = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
+              http.key         = Pedant::Config.ssl_client_key  if Pedant::Config.ssl_client_key
+              http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
             end
 
             response = http.get(uri.request_uri, {})


### PR DESCRIPTION
### Description

Pedant has 2 other HTTP code paths that need to be configured for mTLS when Chef Server's load balancer is configured to require mTLS.

### Issues Resolved

internal ticket DEPLOY 393 and 347

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>