### PR TITLE
[oc-chef-pedant] Add logging for timeouts.

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -165,9 +165,9 @@ module Pedant
         else
           response
         end
-      rescue RestClient::Exceptions::OpenTimeout => e
-        puts "RestClient::Exceptions::OpenTimeout started #{request_time} took #{Time.now.utc - request_time} with method #{method} to #{url} #{e}"
-        throw e
+      rescue RestClient::Exceptions::OpenTimeout, RestClient::Exceptions::ReadTimeout => e
+        puts "#{e.class} error from request started #{request_time} took #{Time.now.utc - request_time} with method #{method} to #{url} \n#{e.message} #{e.original_exception}"
+        raise e
       end
     end
 

--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rest-client', '>= 1.6')
   s.add_dependency('rspec_junit_formatter', '~> 0.2')
   s.add_dependency('net-http-spy', '~> 0.2')
+  s.add_dependency('uuidtools', '~> 2.0')
   s.add_dependency('erubis', '~> 2.7')
   s.add_dependency('rspec-rerun', '~> 1.0')
 end


### PR DESCRIPTION
### Description

We have some intermittent timeouts in our CI pipeline which are
remarkably hard to pin down. This adds retries and logging to help pin down these failures.



- [ x ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
