### PR TITLE
Add config for 12.18 release branch.

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -11,6 +11,13 @@ automate:
   project: chef-server
 
 github:
+  release_branch:
+    - master:
+        # we'll have to bump this later, as globs won't let us do > 18
+        version_constraint: "12.19.*"
+    - 12-18-stable:
+        # this branch should only be active 
+        version_constraint: "12.18.*"
   # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file
   # is bumped automatically via the `built_in:bump_version` merge_action.
   version_file: "VERSION"


### PR DESCRIPTION
### Description

Creating a 12.18 release branch to hopefully unstick the release
process. We've been blocked from releasing by CI issues with non-x86
platforms, and we have a bunch of moderate risk changes to merge into
master. Splitting this off will let us move forward on master without
resetting the release process.

Signed-off-by: Mark Anderson <mark@chef.io>



