### PR TITLE
Tell expeditor to trigger a release build.

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -73,7 +73,7 @@ merge_actions:
         - "Changelog: Skip Update"
         - "Expeditor: Skip All"
         - "Expeditor: ACC Only"
-  - built_in:trigger_omnibus_build:
+  - built_in:trigger_omnibus_release_build:
       ignore_labels:
         - "Omnibus: Skip Build"
         - "Expeditor: Skip All"


### PR DESCRIPTION
### Description

The builds off master to not automatically trigger release builds since we run nightly builds. However, since expeditor tracks both branches as separate projects we can configure the 12-18-stable branch to always generate release builds without causing issues.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
