### PR TITLE
[nginx] Add request id to nginx log

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -18,7 +18,7 @@ http {
   log_format opscode '$remote_addr - $remote_user [$time_iso8601]  '
 <% end -%>
                     '"$request" $status "$request_time" $body_bytes_sent '
-                    '"$http_referer" "$http_user_agent" "$upstream_addr" "$upstream_status" "$upstream_response_time" "$http_x_chef_version" "$http_x_ops_sign" "$http_x_ops_userid" "$http_x_ops_timestamp" "$http_x_ops_content_hash" $request_length';
+                    '"$http_referer" "$http_user_agent" "$upstream_addr" "$upstream_status" "$upstream_response_time" "$http_x_chef_version" "$http_x_ops_sign" "$http_x_ops_userid" "$http_x_ops_timestamp" "$http_x_ops_content_hash" $request_length "$http_x_remote_request_id"';
 
   server_names_hash_bucket_size <%= @server_names_hash_bucket_size %>;
 


### PR DESCRIPTION
### Description
Chef Client sends a request id (X-REMOTE-REQUEST-ID) with every request. This adds logging to nginx so that we can track that.

Signed-off-by: Mark Anderson <mark@chef.io>


