### PR TITLE
Add an X-Orgname header to data_collector requests

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -81,6 +81,7 @@
       access_by_lua_block { validator.validate("POST") }
       proxy_set_header x-data-collector-token $data_collector_token;
       proxy_set_header x-data-collector-auth "version=1.0";
+      proxy_set_header x-orgname $request_org;
       rewrite ^ <%= URI.parse(node['private_chef']['data_collector']['root_url']).path %> break;
       proxy_pass <%= URI.parse(node['private_chef']['data_collector']['root_url']).scheme %>://data-collector;
     }

--- a/src/nginx/habitat/config/chef_http_lb_common
+++ b/src/nginx/habitat/config/chef_http_lb_common
@@ -79,6 +79,7 @@
       access_by_lua_block { validator.validate("POST") }
       proxy_set_header x-data-collector-token $data_collector_token;
       proxy_set_header x-data-collector-auth "version=1.0";
+      proxy_set_header x-orgname $request_org;
       rewrite ^ /data-collector/v0/ break;
       proxy_pass https://data-collector;
     }

--- a/src/oc_erchef/apps/data_collector/src/data_collector_http.erl
+++ b/src/oc_erchef/apps/data_collector/src/data_collector_http.erl
@@ -52,11 +52,12 @@ get(Path, Body, Headers) ->
 
 -spec post(list(), iolist() | binary()) -> ok | {error, term()}.
 post(Path, Body) ->
-    post(Path, Body, default_headers()).
+    post(Path, Body, []).
 
 -spec post(list(), iolist() | binary(), list()) -> ok | {error, term()}.
 post(Path, Body, Headers) ->
-    request_with_caught_errors(Path, post, Body, Headers).
+    request_with_caught_errors(Path, post, Body,
+                               lists:append(default_headers(), Headers)).
 
 -spec delete(list(), iolist() | binary()) -> ok | {error, term()}.
 delete(Path, Body) ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_data_collector.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_data_collector.erl
@@ -5,7 +5,7 @@
 -export([notify/2]).
 
 -spec notify(Req :: wm_req(), State :: #base_state{}) -> ok.
-notify(Req, #base_state{reqid = ReqId, resource_state = ResourceState, resource_mod = ResourceMod} = State) when
+notify(Req, #base_state{reqid = ReqId, resource_state = ResourceState, resource_mod = ResourceMod, organization_name = OrgName} = State) when
     is_record(ResourceState, acl_state);
     is_record(ResourceState, association_state);
     is_record(ResourceState, client_state);
@@ -34,7 +34,7 @@ notify(Req, #base_state{reqid = ReqId, resource_state = ResourceState, resource_
                 case stats_hero:ctime(ReqId, {data_collector, notify},
                                       fun() ->
                                               Msg = oc_chef_action:create_message(Req, State, true),
-                                              data_collector_http:post("/", Msg)
+                                              data_collector_http:post("/", Msg, [{"x-orgname", binary_to_list(OrgName)}])
                                       end) of
                     ok ->
                         ok;


### PR DESCRIPTION
This allows easy identification of the chef organization making the request, and allows sending data collector requests to different automate instances based on organization name, by means of an intermediate proxy. This is intended to be used with hosted chef.

My erlang skills are practically non-existent, so if there's a better way to do the erchef side of things, let me know.