### PR TITLE
[expeditor] Modernize to use subscriptions

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -16,7 +16,7 @@ github:
         # we'll have to bump this later, as globs won't let us do > 18
         version_constraint: "12.19.*"
     - 12-18-stable:
-        # this branch should only be active 
+        # this branch should only be active
         version_constraint: "12.18.*"
   # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file
   # is bumped automatically via the `built_in:bump_version` merge_action.
@@ -99,14 +99,16 @@ subscriptions:
       - built_in:trigger_omnibus_expcache_build:
           only_if_modified:
             - config/software/*
+
 # These actions are taken, in the order specified, when an Omnibus artifact is promoted
 # within Chef's internal artifact storage system.
 #
 # TODO: add promoted_to_unstable action to update changelog with modified omnibus components
-artifact_actions:
-  promoted_to_unstable:
-    - built_in:update_acc
-  promoted_to_current:
-  promoted_to_stable:
-    - built_in:rollover_changelog
-    - built_in:notify_chefio_slack_channels
+subscriptions:
+  - workload: artifact_published:unstable:chef-server:*
+    actions:
+      - built_in:update_acc
+  - workload: artifact_published:stable:chef-server:*
+    actions:
+      - built_in:rollover_changelog
+      - built_in:notify_chefio_slack_channels


### PR DESCRIPTION
### Description
The artifact_actions keyword has been deprecated, port to the
subscriptions api instead.  This work leans heavily on this page
https://expeditor.chef.io/docs/getting-started/subscriptions/#artifact_actions,
but I'm not 100% sure I did everything right. In particular, I'm not
sure about how this will interact with there being two branches being
promoted, master and 12-18-stable.

### Issues Resolved

This should fix the warning from expeditor in the PR checks.

### Check List
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
