### PR TITLE
Experiment around reindexing fixes (WIP)

### DIFF
--- a/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
@@ -54,7 +54,8 @@ start_link() ->
 -spec add_item(iolist()) -> term().
 add_item(Doc) ->
     Size = byte_size(iolist_to_binary(Doc)),
-    gen_server:call(?MODULE, {add_item, Doc, Size}).
+    Timeout = envy:get(chef_index, add_item_timeout, 30000),
+    gen_server:call(?MODULE, {add_item, Doc, Size}, Timeout).
 
 flush() ->
     gen_server:cast(?MODULE, flush).

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -35,6 +35,7 @@
 -export([
          make_context/0,
          reindex/2,
+         reindex/3,
          reindex_by_id/4,
          reindex_by_name/4
         ]).
@@ -255,8 +256,14 @@ log_failures(OrgName, [Failure|Rest]) ->
 humanize_failures([], Acc) ->
     Acc;
 humanize_failures([H|T], Acc) ->
-    {Id, Reason} = H,
-    humanize_failures(T, [{Id, pretty_reason(Reason)} | Acc]).
+    case H of
+        {Id, Reason} ->
+            humanize_failures(T, [{Id, pretty_reason(Reason)} | Acc]);
+        X ->
+            lager:error("humanize failures couldn't make sense of failure ~s~p", [X]),
+            humanize_failures(T, [{Id, pretty_reason(Reason)} | Acc]);
+    end.
+
 
 pretty_reason({error,{error,no_members}}) ->
     "no_members: Ran out of HTTP workers talking to search backend";

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -261,7 +261,7 @@ humanize_failures([H|T], Acc) ->
             humanize_failures(T, [{Id, pretty_reason(Reason)} | Acc]);
         Unknown ->
             lager:error("humanize failures couldn't make sense of failure ~s~p", [Unknown]),
-            humanize_failures(T, [{<<"unparsed reason">>, io:format("~s", [Unknown])}, Acc])
+            humanize_failures(T, [{<<"unparsed reason">>, io:format("~s", [Unknown])} |  Acc])
         end.
 
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -259,10 +259,10 @@ humanize_failures([H|T], Acc) ->
     case H of
         {Id, Reason} ->
             humanize_failures(T, [{Id, pretty_reason(Reason)} | Acc]);
-        X ->
-            lager:error("humanize failures couldn't make sense of failure ~s~p", [X]),
-            humanize_failures(T, [{Id, pretty_reason(Reason)} | Acc]);
-    end.
+        Unknown ->
+            lager:error("humanize failures couldn't make sense of failure ~s~p", [Unknown]),
+            humanize_failures(T, [{<<"unparsed reason">>, io:format("~s", [Unknown])}, Acc])
+        end.
 
 
 pretty_reason({error,{error,no_members}}) ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -261,7 +261,7 @@ humanize_failures([H|T], Acc) ->
             humanize_failures(T, [{Id, pretty_reason(Reason)} | Acc]);
         Unknown ->
             lager:error("humanize failures couldn't make sense of failure ~s~p", [Unknown]),
-            humanize_failures(T, [{<<"unparsed reason">>, io:format("~s", [Unknown])} |  Acc])
+            humanize_failures(T, [Acc])
         end.
 
 


### PR DESCRIPTION
This is an attempt to address an issue (#1586) we've seen when the indexer gets backlogged. We put a work item on the queue via a gen_server , and it is waiting to be indexed. But because it's backlogged, we don't get to it, and fail to reply to the caller before the 5 sec timeout fires. And so the server returns 500, and the client retries. However the indexer will eventually get to the item, and index it successfully. Indexing is basically the last thing we do in the request, and so we've successfully done all of the work, but the client still retries because we've told it has failed. This ends up causing load amplification on an already backlogged server. 

This increases the timeout and attempts to do better error logging.

This PR as is is incomplete, as it doesn't check the call chain to see if there's something else that will timeout once this gen server timeout is increased.

Signed-off-by: Mark Anderson <mark@chef.io>
