### PR TITLE
increase authn:keygen_timeout for oc_erchef hab pkg

### DIFF
--- a/src/oc_erchef/habitat/default.toml
+++ b/src/oc_erchef/habitat/default.toml
@@ -23,7 +23,7 @@ strict_search_result_acls=false
 keygen_cache_workers=10
 keygen_cache_size=10
 keygen_start_size=0
-keygen_timeout=1000
+keygen_timeout=5000
 
 [oc_chef_authz]
 


### PR DESCRIPTION
### Description
This is a very simple change to the `oc_erchef` Hab package default configuration.
We noticed that the `keygen_timeout` value was too small out of the box and would continually spam these warnings:

```
oc-erchef.default(O): [warning] {chef_keygen_cache,keygen_timeout}
```

Increasing to this proposed value yielded no adverse affects in our testing over the months and so I decided  to just make it the new default 😄 

Signed-off-by: Jeremy J. Miller <jm@chef.io>