### PR TITLE
Use our standard ruby-cleanup definition

### DIFF
--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -40,7 +40,9 @@ dependency "preparation"
 # the Chef Server dependencies.
 dependency "server-complete"
 
-dependency "cleanup" # MUST BE LAST DO NOT MOVE
+# THESE MUST BE LAST DO NOT MOVE
+dependency "ruby-cleanup"
+dependency "cleanup"
 
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']

--- a/omnibus/config/software/cleanup.rb
+++ b/omnibus/config/software/cleanup.rb
@@ -4,9 +4,6 @@ skip_transitive_dependency_licensing true
 license :project_license
 
 build do
-  # Delete cached .gem files and git checkouts
-  delete "#{install_dir}/embedded/lib/ruby/gems/2.*/cache/*.gem"
-  delete "#{install_dir}/embedded/service/gem/ruby/2.*/cache/*.gem"
   # strip shared object files related to gecode installs
   command "strip #{install_dir}/embedded/lib/libgecode*.so.32.0"
 


### PR DESCRIPTION
This looks like it will shrink our install by ~5% on disk by cleaning up
more files. We'll need a real build before standing by that number
though.

Signed-off-by: Tim Smith <tsmith@chef.io>