### PR TITLE
Add SSL configuration parameters to pedant

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -26,7 +26,7 @@ module Pedant
 
     # TODO: alternative suggestions?
     # These accessors will at least hide the fact we're using a global...
-    def server_api_version= (v)
+    def server_api_version=(v)
       $server_api_version = v || Pedant::Config.server_api_version
     end
     def server_api_version
@@ -222,8 +222,19 @@ module Pedant
     def reset_server_api_version
       $server_api_version  = Pedant::Config.server_api_version
     end
+
     def use_max_server_api_version
       $server_api_version  = 2 # TODO Pedant::Config.max_server_api_version
+    end
+
+    def ssl_options
+      # be careful to not pass options at all if they are not set. We don't
+      # want to accidentally pass a meaningful nil value in
+      {}.tap do |opts|
+        opts[:ssl_client_cert] = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
+        opts[:ssl_client_key]  = Pedant::Config.ssl_client_key if Pedant::Config.ssl_client_key
+        opts[:ssl_ca_file]     = Pedant::Config.ssl_ca_file if Pedant::Config.ssl_ca_file
+      end
     end
 
   end

--- a/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
@@ -313,6 +313,9 @@ module Pedant
           http.use_ssl = true
           http.ssl_version = Pedant::Config.ssl_version
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          http.cert        = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
+          http.key         = Pedant::Config.ssl_client_key  if Pedant::Config.ssl_client_key
+          http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
         end
 
         response = http.get(uri.request_uri, {})

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
@@ -212,6 +212,9 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
             http.use_ssl = true
             http.ssl_version = Pedant::Config.ssl_version
             http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+            http.cert        = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
+            http.key         = Pedant::Config.ssl_client_key  if Pedant::Config.ssl_client_key
+            http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
           end
 
           response = http.get(uri.request_uri, {})

--- a/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
@@ -320,6 +320,9 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_read do
               http.use_ssl = true
               http.ssl_version = Pedant::Config.ssl_version
               http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+              http.cert        = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
+              http.key         = Pedant::Config.ssl_client_key  if Pedant::Config.ssl_client_key
+              http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
             end
 
             response = http.get(uri.request_uri, {})


### PR DESCRIPTION
This adds SSL-related configurables to pedant.  

This fix has been running regularly as part of a Habitatized Chef server
built from a branch containing a collection of patches.  Moving this patch over
will help us get rid of that branch.