### PR TITLE
Trigger nightly build with Expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -62,6 +62,13 @@ habitat_packages:
       export:
         - docker
 
+# At the given time, trigger the following scheduled workloads
+# https://expeditor.chef.io/docs/getting-started/subscriptions/#scheduling-workloads
+schedules:
+  - name: nightly_build
+    description: "Run a nightly build in the Jenkins pipeline"
+    cronline: "0 6 * * *"
+
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:bump_version:
@@ -137,6 +144,9 @@ subscriptions:
       - bash:.expeditor/purge_cdn.sh:
           post_commit: true
       - built_in:notify_chefio_slack_channels
+  - workload: schedule_triggered:chef/chef-server:master:nightly_build:*
+    actions:
+      - built_in:trigger_omnibus_expcache_build
 
 promote:
   actions:


### PR DESCRIPTION
Now that we removed the nightly trigger from the Jenkins pipeline (per
chef-cookbooks/opscode-ci#936) we need to update the Expeditor config to
begin triggering a nightly build of the project. This build also expires
the Omnibus cache so we can be sure Chef Server builds correctly even if
some transitive deps have been udpated.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
