### PR TITLE
Add note about out of date dep to trigger a rebuild

### DIFF
--- a/src/openresty-noroot/habitat/plan.sh
+++ b/src/openresty-noroot/habitat/plan.sh
@@ -35,6 +35,7 @@ pkg_exports=(
 )
 pkg_exposes=(port)
 
+# TODO: current version is 1.0.1, we should try updating
 lpeg_version="0.12"
 lpeg_source="http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-${lpeg_version}.tar.gz"
 


### PR DESCRIPTION
openresty is built against core/openssl/1.0.2n/20180608102213, latest is 1.0.2q
