### PR TITLE
[chef-server] Remove do_end function from chef-server-ctl hab plan

### DIFF
--- a/src/chef-server-ctl/habitat/plan.sh
+++ b/src/chef-server-ctl/habitat/plan.sh
@@ -115,10 +115,3 @@ EOF
 do_check() {
   return 0
 }
-
-do_end() {
-  # Clean up the `env` link, if we set it up.
-  if [[ -n "$_clean_env" ]]; then
-    rm -fv /usr/bin/env
-  fi
-}


### PR DESCRIPTION
As far as I can see, this was probably copy-and-pasted from another
plan. In this plan we do not set _clean_env anywhere so we do not need
to clean it.

In reality, I need to rebuild this package in an attempt to get out of
a dependency mess downstream.

Signed-off-by: Steven Danna <steve@chef.io>