### PR TITLE
Pass ssl values to RestClient::Request.execute

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -169,7 +169,11 @@ module Pedant
                                                ssl_version: Pedant::Config.ssl_version,
                                                verify_ssl: false,
                                                open_timeout: 300,
+                                               ssl_client_cert: Pedant::Config.ssl_client_cert,
+                                               ssl_client_key: Pedant::Config.ssl_client_key,
+                                               ssl_ca_file: Pedant::Config.ssl_ca_file,
                                                &response_handler)
+
         if block_given?
           yield(response)
         else
@@ -226,16 +230,5 @@ module Pedant
     def use_max_server_api_version
       $server_api_version  = 2 # TODO Pedant::Config.max_server_api_version
     end
-
-    def ssl_options
-      # be careful to not pass options at all if they are not set. We don't
-      # want to accidentally pass a meaningful nil value in
-      {}.tap do |opts|
-        opts[:ssl_client_cert] = Pedant::Config.ssl_client_cert if Pedant::Config.ssl_client_cert
-        opts[:ssl_client_key]  = Pedant::Config.ssl_client_key if Pedant::Config.ssl_client_key
-        opts[:ssl_ca_file]     = Pedant::Config.ssl_ca_file if Pedant::Config.ssl_ca_file
-      end
-    end
-
   end
 end


### PR DESCRIPTION
The #ssl_options method added in c87e1afcf95b0489ed01c2e7bcf6f0ca49869ea0 was not passing the settings to RestClient::Request.execute.

As far as I cant tell it doesn't matter if you pass nil values for these keys, e.g.:

```
irb(main):003:0> RestClient::Request.execute(method: :get, url: "https://www.google.com")
=> <RestClient::Response 200 "<!doctype h...">
irb(main):004:0> RestClient::Request.execute(method: :get, url: "https://www.google.com", ssl_client_cert: nil)
=> <RestClient::Response 200 "<!doctype h...">
irb(main):005:0> RestClient::Request.execute(method: :get, url: "https://www.google.com", ssl_client_cert: nil, ssl_client_key: nil, ssl_ca_file: nil)
=> <RestClient::Response 200 "<!doctype h...">
```