### PR TITLE
[expeditor] Build chef-server-ctl when pedant changes

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -48,7 +48,9 @@ habitat_packages:
         - docker
   - chef-server-ctl:
       source: src/chef-server-ctl
-      bldr_paths: src/chef-server-ctl/*
+      bldr_paths:
+        - src/chef-server-ctl/*
+        - oc-chef-pedant/*
       export:
         - docker
   - oc_bifrost:

--- a/src/chef-server-ctl/README.md
+++ b/src/chef-server-ctl/README.md
@@ -1,10 +1,13 @@
 ## chef-server-ctl commands
 
-This folder contains the additional commands that are added to chef-server-ctl for managing the server. These are commands for performing various admin related tasks on the chef-server box itself.
+This folder contains the additional commands that are added to
+chef-server-ctl for managing the server. These are commands for
+performing various admin related tasks on the chef-server box itself.
 
 #### Testing
 
-To run the unit tests for these commands, simply `cd` back to the base `chef-server` directory, then:
+To run the unit tests for these commands, simply `cd` back to the base
+`chef-server` directory, then:
 
 ```
 bundle install --binstubs


### PR DESCRIPTION
The chef-server-ctl package contains oc-chef-pedant but the expeditor
configuration did not list it as a builder path.  This change should
ensure that the chef-server-ctl package gets rebuilt on pedant
changes.

Additionally, it wraps the README to force a rebuild.

Signed-off-by: Steven Danna <steve@chef.io>