### PR TITLE
Lock bundler to 1.17 to defer bundler 2.0 upgrade

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,5 +1,7 @@
 override :erlang, version: "18.3.4.9"
 override :lua, version: "5.1.5"
+override :rubygems, version: "3.0.2"
+override :bundler, version: "1.17.3"
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v14.5.33"
 override :ohai, version: "v14.5.4"


### PR DESCRIPTION
Signed-off-by: Mark Anderson <mark@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
