### PR TITLE
Disable data-collector in accceptance

### DIFF
--- a/cookbooks/chef-server-deploy/metadata.rb
+++ b/cookbooks/chef-server-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures Chef Server in ACC'
 long_description 'Installs/Configures Chef Server in ACC'
-version '0.1.11'
+version '0.1.12'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 

--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -74,7 +74,8 @@ template '/etc/opscode/chef-server.rb' do
     chef_server_deploy: node['chef-server-deploy'],
     chef_cert_filename: cert_filename,
     chef_key_filename: key_filename,
-    required_recipe_path: automate_liveness_recipe_path
+    required_recipe_path: automate_liveness_recipe_path,
+    enable_data_collector: (environment == 'delivered' ? true : false)
   )
   notifies :reconfigure, 'chef_ingredient[chef-server]', :immediately
 end

--- a/cookbooks/chef-server-deploy/templates/default/chef-server.rb.erb
+++ b/cookbooks/chef-server-deploy/templates/default/chef-server.rb.erb
@@ -14,9 +14,11 @@ estatsd['vip'] = 'localhost'
 estatsd['port'] = 8125
 estatsd['protocol'] = 'statsd'
 
+<% if @enable_data_collector -%>
 # Automatically send node run data to Automate
 data_collector['root_url'] = 'https://<%= @chef_server_deploy['automate_server_fqdn'] %>/data-collector/v0/'
 data_collector['token'] = '<%= @chef_server_deploy['data_collection_token'] %>'
+<% end -%>
 
 # Enable fetching Compliance profiles from Automate
 profiles['root_url'] = 'https://<%= @chef_server_deploy['automate_server_fqdn'] %>'


### PR DESCRIPTION
We are currently having issues in the upstream A1 acceptance instance.
Until this is fixed we'll stop sending traffic to the A1 instance as it
causes the Chef Server instance to fail status checks.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
