### PR TITLE
Remove duplicate rubygems pin and roll back to 2.7.X

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,8 +4,8 @@
 #
 override :erlang, version: "18.3.4.9"
 override :lua, version: "5.1.5"
-override :rubygems, version: "3.0.2"
-override :bundler, version: '~> 1.17'
+override :rubygems, version: "2.7.8"
+override :bundler, version: "1.17.3"
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v14.11.21"
 override :ohai, version: "v14.8.11"


### PR DESCRIPTION
This version was being pinned twice. No need for that.

Signed-off-by: Tim Smith <tsmith@chef.io>