### PR TITLE
Update openresty to 1.13.6.2

### DIFF
--- a/omnibus/config/software/openresty-lpeg.rb
+++ b/omnibus/config/software/openresty-lpeg.rb
@@ -15,16 +15,25 @@
 #
 
 name "openresty-lpeg"
-default_version "0.12"
-
 license "MIT"
 license_file "lpeg.html"
 skip_transitive_dependency_licensing true
-
-source url: "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-#{version}.tar.gz",
-       md5: "4abb3c28cd8b6565c6a65e88f06c9162"
+default_version "1.0.1"
 
 dependency "openresty"
+
+version("0.12") do
+  source md5: "4abb3c28cd8b6565c6a65e88f06c9162"
+end
+
+version("1.0.1") do
+  source sha256: "62d9f7a9ea3c1f215c77e0cadd8534c6ad9af0fb711c3f89188a8891c72f026b"
+end
+
+#
+# This has an unofficial git mirror: https://github.com/luvit/lpeg
+# Project homepage: http://www.inf.puc-rio.br/~roberto/lpeg/
+source url: "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-#{version}.tar.gz"
 
 relative_path "lpeg-#{version}"
 

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -10,9 +10,9 @@ override :ruby, version: "2.5.3"
 override :'berkshelf-no-depselector', version: '6016ca10b2f46508b1b107264228668776f505d9'
 
 # Note 2018/02/01 (sr): This is related to issue #1417:
-# This is the last version that supports --with-lua51=PATH, which allows us to
+# 1.11.2.1 was the last version that supports --with-lua51=PATH, which allows us to
 # build it with lua on ppc64[le] and s390x. Those platforms are not supported
 # in mainline luajit. There's forks for ppc64, and s390x, but going forward with
 # those was so far blocked by ppc64 not being supported even with the PPC64
 # fork.
-override :openresty, version: "1.11.2.1"
+override :openresty, version: "1.13.6.2"

--- a/src/openresty-noroot/habitat/plan.sh
+++ b/src/openresty-noroot/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=openresty-noroot
 pkg_origin=chef
-pkg_version=1.11.2.5
+pkg_version=1.13.6.2
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_license=('BSD-2-Clause')
@@ -8,7 +8,7 @@ pkg_source=https://openresty.org/download/openresty-${pkg_version}.tar.gz
 pkg_dirname=openresty-${pkg_version}
 pkg_filename=openresty-${pkg_version}.tar.gz
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=f8cc203e8c0fcd69676f65506a3417097fc445f57820aa8e92d7888d8ad657b9
+pkg_shasum=946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942
 pkg_deps=(
   core/bzip2
   core/coreutils


### PR DESCRIPTION
NOTE: Fix this points to a branch of omnibus-software; point to master before merging.

There are outstanding CVEs against 1.11, so it's time to update.

This breaks PPC/S390 builds; we'll need to figure out a workaround to before we can build for these platforms again.

See 03fce8fca265bc8e3d7faa34721644c044106af0 for details.

Signed-off-by: Mark Anderson <mark@chef.io>

### Description

Brings us up to date with OpenResty

### Issues Resolved
1.13.6.2 fixes CVE-2018-9230
