### PR TITLE
Parameterize the search_server in the habitized pedant config

### DIFF
--- a/src/chef-server-ctl/habitat/config/pedant_config.rb
+++ b/src/chef-server-ctl/habitat/config/pedant_config.rb
@@ -75,7 +75,7 @@ default_orgname nil
 # testing location, you should not specify a value for this parameter.
 # The tests will still run, albeit slower, as they will now need to
 # poll for a period to ensure they are querying committed results.
-search_server "http://elasticsearch:9200/"
+search_server "{{cfg.pedant_config.search_server}}"
 
 search_commit_url "/_refresh"
 search_url_fmt "/chef/_search?q=X_CHEF_type_CHEF_X:%{type}%%20%{query}"

--- a/src/chef-server-ctl/habitat/default.toml
+++ b/src/chef-server-ctl/habitat/default.toml
@@ -8,6 +8,13 @@ ip = "172.18.0.1"
 port = "80"
 ssl_port = "443"
 
+# In certain tests pedant wants to directly access the Solr/Elasticsearch, but
+# binding to it will create circular binds, which we want avoid.
+# The compromise is to allow users to specify the ES URL directly, but if they
+# don't it's no big deal because it is just for the pedant test suite
+[pedant_config]
+search_server = "http://elasticsearch:9200/"
+
 # the secrets namespace is initially initted to empty strings,
 # the idea is that we loop through all of these and generate them at
 # "bootstrap" time and then re-inject them into the config


### PR DESCRIPTION
Signed-off-by: Irving Popovetsky <irving@chef.io>

### Description

In certain tests pedant wants to directly access the Solr/Elasticsearch, but binding to it will create circular binds, which we want avoid.
The compromise is to allow users to specify the ES URL directly, but if they don't it's no big deal because it is just for the pedant test suite.

### Check List

- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
