### PR TITLE
Add EXPEDITOR_ prefix to environment variables

### DIFF
--- a/.expeditor/promote_harts_and_containers.sh
+++ b/.expeditor/promote_harts_and_containers.sh
@@ -8,8 +8,8 @@ then
   exit 1
 fi
 
-# VERSION and CHANNEL are passed in via Expeditor when an omnibus package of
-# version VERSION is promoted to CHANNEL
+# EXPEDITOR_VERSION and EXPEDITOR_CHANNEL are passed in via Expeditor when an omnibus package of
+# version EXPEDITOR_VERSION is promoted to EXPEDITOR_CHANNEL
 
 # Download the manifest
 aws s3 cp "s3://chef-automate-artifacts/manifests/chef-server/${EXPEDITOR_VERSION}.json" manifest.json --profile chef-cd
@@ -44,7 +44,7 @@ jq -r -c ".packages[]" manifest.json | while read service_ident; do
     docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
     docker push "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
 
-    if [ "$CHANNEL" = "stable" ];
+    if [ "${EXPEDITOR_CHANNEL}" = "stable" ];
     then
       docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:latest"
       docker push "${pkg_origin}/${pkg_name}:latest"

--- a/.expeditor/purge_cdn.sh
+++ b/.expeditor/purge_cdn.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-TARGET_CHANNEL="${CHANNEL:-unstable}"
+target_channel="${EXPEDITOR_CHANNEL:-unstable}"
 
-echo "Purging '${TARGET_CHANNEL}/chef-server/latest' Surrogate Key group from Fastly"
-curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${TARGET_CHANNEL}/chef-server/latest
+echo "Purging '${target_channel}/chef-server/latest' Surrogate Key group from Fastly"
+curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" "https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${target_channel}/chef-server/latest"


### PR DESCRIPTION
### Description

To avoid unexpected environment variable name collisions, we now prefix env-vars supplied by Expeditor with `EXPEDITOR_`

