### PR TITLE
Allow Chef to optionally use a different username for establishing database connections

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -301,6 +301,7 @@ default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = nil
 default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
 default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
+default['private_chef']['opscode-erchef']['sql_connection_user'] = nil
 default['private_chef']['opscode-erchef']['enable_request_logging'] = true
 
 #
@@ -607,6 +608,7 @@ default['private_chef']['postgresql']['log_rotation']['file_maxbytes'] = 1048576
 default['private_chef']['postgresql']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['postgresql']['username'] = "opscode-pgsql"
 default['private_chef']['postgresql']['db_superuser'] = 'opscode-pgsql'
+default['private_chef']['postgresql']['db_connection_superuser'] = nil
 default['private_chef']['postgresql']['shell'] = "/bin/sh"
 default['private_chef']['postgresql']['home'] = "/var/opt/opscode/postgresql"
 default['private_chef']['postgresql']['user_path'] = "/opt/opscode/embedded/bin:/opt/opscode/bin:$PATH"
@@ -675,6 +677,7 @@ default['private_chef']['oc_bifrost']['db_pool_queue_max'] = 20
 default['private_chef']['oc_bifrost']['udp_socket_pool_size'] = nil
 default['private_chef']['oc_bifrost']['sql_user'] = "bifrost"
 default['private_chef']['oc_bifrost']['sql_ro_user'] = "bifrost_ro"
+default['private_chef']['oc_bifrost']['sql_connection_user'] = nil
 default['private_chef']['oc_bifrost']['sql_db_timeout'] = 5000
 # Enable extended performance logging data for bifrost.  Setting this to false
 # will cut bifrost request log size approximately in half.
@@ -726,6 +729,7 @@ default['private_chef']['bookshelf']['db_pooler_timeout'] = 2000
 default['private_chef']['bookshelf']['sql_db_timeout'] = 5000
 default['private_chef']['bookshelf']['sql_ro_user'] = 'bookshelf_ro'
 default['private_chef']['bookshelf']['sql_user'] = 'bookshelf'
+default['private_chef']['bookshelf']['sql_connection_user'] = nil
 # Request logging (enable_request_logging)is disabled because
 # it is redendant (nginx also logs requests)
 # If debug logging is needed, enable_request_logging can be set to true
@@ -747,6 +751,7 @@ default['private_chef']['oc_id']['port'] = 9090
 default['private_chef']['oc_id']['sql_database'] = "oc_id"
 default['private_chef']['oc_id']['sql_user'] = "oc_id"
 default['private_chef']['oc_id']['sql_ro_user'] = "oc_id_ro"
+default['private_chef']['oc_id']['sql_connection_user'] = nil
 default['private_chef']['oc_id']['db_pool_size'] = '20'
 default['private_chef']['oc_id']['sentry_dsn'] = nil
 default['private_chef']['oc_id']['sign_up_url'] = nil

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -301,6 +301,7 @@ default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = nil
 default['private_chef']['opscode-erchef']['sql_user'] = "opscode_chef"
 default['private_chef']['opscode-erchef']['sql_ro_user'] = "opscode_chef_ro"
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['opscode-erchef']['sql_connection_user'] = nil
 default['private_chef']['opscode-erchef']['enable_request_logging'] = true
 
@@ -608,6 +609,9 @@ default['private_chef']['postgresql']['log_rotation']['file_maxbytes'] = 1048576
 default['private_chef']['postgresql']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['postgresql']['username'] = "opscode-pgsql"
 default['private_chef']['postgresql']['db_superuser'] = 'opscode-pgsql'
+# In certain scenarios (Azure PostgreSQL) it may be necessary to use a different username
+# for connection establishment from the username as it exists in the database.
+# This will default to the db_superuser value if left nil.
 default['private_chef']['postgresql']['db_connection_superuser'] = nil
 default['private_chef']['postgresql']['shell'] = "/bin/sh"
 default['private_chef']['postgresql']['home'] = "/var/opt/opscode/postgresql"
@@ -677,6 +681,7 @@ default['private_chef']['oc_bifrost']['db_pool_queue_max'] = 20
 default['private_chef']['oc_bifrost']['udp_socket_pool_size'] = nil
 default['private_chef']['oc_bifrost']['sql_user'] = "bifrost"
 default['private_chef']['oc_bifrost']['sql_ro_user'] = "bifrost_ro"
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['oc_bifrost']['sql_connection_user'] = nil
 default['private_chef']['oc_bifrost']['sql_db_timeout'] = 5000
 # Enable extended performance logging data for bifrost.  Setting this to false
@@ -729,6 +734,7 @@ default['private_chef']['bookshelf']['db_pooler_timeout'] = 2000
 default['private_chef']['bookshelf']['sql_db_timeout'] = 5000
 default['private_chef']['bookshelf']['sql_ro_user'] = 'bookshelf_ro'
 default['private_chef']['bookshelf']['sql_user'] = 'bookshelf'
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['bookshelf']['sql_connection_user'] = nil
 # Request logging (enable_request_logging)is disabled because
 # it is redendant (nginx also logs requests)
@@ -751,6 +757,7 @@ default['private_chef']['oc_id']['port'] = 9090
 default['private_chef']['oc_id']['sql_database'] = "oc_id"
 default['private_chef']['oc_id']['sql_user'] = "oc_id"
 default['private_chef']['oc_id']['sql_ro_user'] = "oc_id_ro"
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['oc_id']['sql_connection_user'] = nil
 default['private_chef']['oc_id']['db_pool_size'] = '20'
 default['private_chef']['oc_id']['sentry_dsn'] = nil

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -49,10 +49,10 @@ class ChefServerDataBootstrap
     # objects in erchef.  By separating them, we increase the chance that a
     # bootstrap failed due to an error out of bifrost can be recovered
     # by re-running it.
-    username = node['private_chef']['opscode-erchef']['sql_user']
+    username = node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user']
     password = PrivateChef.credentials.get('opscode_erchef', 'sql_password')
     EcPostgres.with_connection(node, 'opscode_chef',
-                               'db_superuser' => username,
+                               'db_connection_superuser' => username,
                                'db_superuser_password' => password) do |conn|
       create_superuser_in_erchef(conn)
       create_server_admins_global_group_in_erchef(conn)

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -19,7 +19,7 @@ class EcPostgres
     end
     max_retries = retries
     begin
-      connection = ::PGconn.open('user' => postgres['db_superuser'],
+      connection = ::PGconn.open('user' => postgres['db_connection_superuser'] || postgres['db_superuser'],
                                  'host' => postgres['vip'],
                                  'password' => postgres['db_superuser_password'],
                                  'port' => postgres['port'],

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -130,7 +130,7 @@ class OmnibusHelper
 
   def db_connection_uri
     db_protocol = "postgres"
-    db_user     = node['private_chef']['opscode-erchef']['sql_user']
+    db_user     = node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user']
     db_password = PrivateChef.credentials.get('opscode_erchef', 'sql_password')
     db_vip      = vip_for_uri('postgresql')
     db_name     = "opscode_chef"
@@ -140,7 +140,7 @@ class OmnibusHelper
 
   def bifrost_db_connection_uri
     db_protocol = "postgres"
-    db_user     = node['private_chef']['oc_bifrost']['sql_user']
+    db_user     = node['private_chef']['oc_bifrost']['sql_connection_user'] || node['private_chef']['oc_bifrost']['sql_user']
     db_password = PrivateChef.credentials.get('oc_bifrost', 'sql_password')
     db_vip      = vip_for_uri('postgresql')
     db_name     = "bifrost"

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -87,11 +87,11 @@ class PreflightValidator
       user = 'chef_server_conn_test'
       password = 'invalid'
     else
-      user = cs_pg_attr['db_superuser']
+      user = cs_pg_attr['db_connection_superuser'] || cs_pg_attr['db_superuser']
       password = cs_pg_attr['db_superuser_password']
     end
     # No error handling - the caller is expected to handle any exception.
-    EcPostgres.with_connection(node, options['db_name'], { 'db_superuser' => user,
+    EcPostgres.with_connection(node, options['db_name'], { 'db_connection_superuser' => user,
                                                            'db_superuser_password' => password,
                                                            'vip' => host,
                                                            'port' => port,

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -272,7 +272,7 @@ EOM
   def err_CSPG011_invalid_superuser_account
 <<EOM
 CSPG011: I could not authenticate to #{cs_pg_attr['vip']} as
-         #{cs_pg_attr['db_superuser']} using the password provided.
+         #{cs_pg_attr['db_connection_superuser'] || cs_pg_attr['db_superuser']} using the password provided.
          Please make sure that the the password you provided in
          chef-server.rb under "postgresql['db_superuser_password'] is correct
          for this user.
@@ -285,7 +285,7 @@ EOM
   def err_CSPG012_invalid_pg_hba
 <<EOM
 CSPG012: There is a missing or incorrect pg_hba.conf entry for the
-         user '#{cs_pg_attr['db_superuser']}' and/or this originating host.
+         user '#{cs_pg_attr['db_connection_superuser'] || cs_pg_attr['db_superuser']}' and/or this originating host.
          Please ensure that pg_hba.conf entries exist to allow the superuser
          account to connect from the Chef Server backend nodes, and to
          allow the application accounts to connect from all Chef Server

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -125,6 +125,10 @@ class PostgresqlPreflightValidator < PreflightValidator
         # This is also possible, depending on if they've set up pg_hba
         # by host or user or both. This is OK, since it confirms that we're
         # able to connect to the postgres instance.
+      when /.*The Username should be in <username@hostname> format.*/
+        # This is possible if the external postgres is an Azure Database
+        # for PostgreSQL instance. It's also OK, and indicates that the
+        # postgres instance can be connected to.
       else
         # This shouldn't be possible, but we still don't want to dump an
         # unhelpful stack trace on the screen. Let's at least catch it and

--- a/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@chef.io"
 license           "Apache-2.0"
 description       "Installs and configures Chef Server from Omnibus"
 long_description  "Installs and configures Chef Server from Omnibus"
-version           "0.1.1"
+version           "0.2.0"
 recipe            "chef-server", "Configures the Chef Server from Omnibus"
 
 %w{ ubuntu debian redhat centos oracle scientific fedora amazon }.each do |os|

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
@@ -16,7 +16,7 @@
 
 # NOTE:
 #
-# Uses the value of node['private_chef']['postgresql']['db_superuser'] and ['db_superuser_password]
+# Uses the value of node['private_chef']['postgresql']['db_connection_superuser'] and ['db_superuser_password]
 # to make the connection to the postgres server.
 
 action :create do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -58,7 +58,7 @@ end
 private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
-  username  postgres_attrs['db_superuser']
+  username  postgres_attrs['db_connection_superuser'] || postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bifrost"
   action :nothing

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
@@ -53,7 +53,7 @@ end
 private_chef_pg_sqitch "/opt/opscode/embedded/service/bookshelf/schema" do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
-  username  postgres_attrs['db_superuser']
+  username  postgres_attrs['db_connection_superuser'] || postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bookshelf"
   action :nothing

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -47,7 +47,7 @@ end
 private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/baseline" do
   hostname  postgres['vip']
   port      postgres['port']
-  username  postgres['db_superuser']
+  username  postgres['db_connection_superuser'] || postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database  "opscode_chef"
   action :nothing
@@ -57,7 +57,7 @@ end
 private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
   hostname  postgres['vip']
   port      postgres['port']
-  username  postgres['db_superuser']
+  username  postgres['db_connection_superuser'] || postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "opscode_chef"
   action :nothing

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -94,7 +94,7 @@ if is_data_master?
       2.times do |i|
         # Note that we have to include the port even for a local pipe, because the port number
         # is included in the pipe default.
-        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} postgres -t -A'`
+        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_connection_superuser'] || node['private_chef']['postgresql']['db_superuser']} postgres -t -A'`
 	if $?.exitstatus != 0
           Chef::Log.fatal("Could not connect to database, retrying in 10 seconds.")
           sleep 10

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_postgres_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_postgres_validator_spec.rb
@@ -174,6 +174,15 @@ describe PostgresqlPreflightValidator do
         end
       end
 
+      context "when we connect to Azure PostgreSQL" do
+        let (:pg_exception) { PG::ConnectionBad.new('FATAL:  Invalid Username specified. Please check the Username and retry connection. The Username should be in <username@hostname> format.') }
+
+        it "does not raise an error" do
+          expect(postgres_validator).to_not receive(:fail_with)
+          expect { postgres_validator.connectivity_validation }.to_not raise_error
+        end
+      end
+
       context "when we receive an unexpected error" do
         let (:pg_exception) { PG::ConnectionBad.new("FATAL: something funky happened") }
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -98,7 +98,7 @@
            %% Database connection parameters
            {db_host, "<%= @postgresql['vip'] %>"},
            {db_port, <%=  @postgresql['port'] %>},
-           {db_user, "<%= @sql_user %>"},
+           {db_user, "<%= @sql_connection_user || @sql_user %>"},
            {db_name, "bookshelf" },
            {idle_check, 10000},
            {pooler_timeout, <%= @db_pooler_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -99,7 +99,7 @@
           {ip_mode, [ <%=PrivateChef['use_ipv6'] ? "ipv6,ipv4" : "ipv4" %> ] },
           {db_host, "<%= node['private_chef']['postgresql']['vip'] %>" },
           {db_port, <%= node['private_chef']['postgresql']['port'] %> },
-          {db_user, "<%= node['private_chef']['oc_bifrost']['sql_user'] %>" },
+          {db_user, "<%= node['private_chef']['oc_bifrost']['sql_connection_user'] || node['private_chef']['oc_bifrost']['sql_user'] %>" },
           {db_name, "bifrost" },
           {idle_check, 10000},
           {pooler_timeout, <%= @db_pooler_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -313,7 +313,7 @@
         %% Database connection parameters
         {db_host, "<%= node['private_chef']['postgresql']['vip'] %>"},
         {db_port, <%= node['private_chef']['postgresql']['port'] %>},
-        {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
+        {db_user, "<%= node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user']  %>"},
         {db_name, "opscode_chef" },
         {idle_check, 10000},
         {pooler_timeout, <%= @db_pooler_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
@@ -7,5 +7,5 @@ production:
   host: <%= node['private_chef']['postgresql']['vip'] %>
   port: <%= node['private_chef']['postgresql']['port'] %>
   database: <%= node['private_chef']['oc_id']['sql_database'] %>
-  username: <%= node['private_chef']['oc_id']['sql_user'] %>
+  username: <%= node['private_chef']['oc_id']['sql_connection_user'] || node['private_chef']['oc_id']['sql_user'] %>
   password: <%= "\<%= Secrets.get('oc_id', 'sql_password') %\>" %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -109,7 +109,7 @@
            {config_cb, {chef_secrets_sqerl, config, [{<<"opscode_erchef">>, <<"sql_password">>}]}},
            {db_host, "<%= node['private_chef']['postgresql']['vip'] %>"},
            {db_port, 5432},
-           {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
+           {db_user, "<%= node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user'] %>"},
            {db_name, "opscode_chef" },
            {idle_check, 10000},
            {db_timeout, <%= node['private_chef']['opscode-chef-mover']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pg_hba.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pg_hba.conf.erb
@@ -64,7 +64,7 @@
 # "local" is for Unix domain socket connections only
 local   all         <%= node['private_chef']['postgresql']['username'] %>                               peer
 
-host    all         <%= node['private_chef']['postgresql']['db_superuser'] %>         samehost           md5
+host    all         <%= node['private_chef']['postgresql']['db_connection_superuser'] || node['private_chef']['postgresql']['db_superuser'] %>         samehost           md5
 
 <% node['private_chef']['postgresql']['md5_auth_cidr_addresses'].each do |cidr| %>
 host    all         all         <%= cidr %>           md5

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -119,7 +119,7 @@ module Omnibus
     end
 
     def postgresql_connection(postgres)
-      PGconn.open('user' => postgres['db_superuser'], 'host' => postgres['vip'],
+      PGconn.open('user' => postgres['db_connection_superuser'] || postgres['db_superuser'], 'host' => postgres['vip'],
                   'password' => credentials.get('postgresql', 'db_superuser_password'),
                   'port' => postgres['port'], 'dbname' => 'template1')
     end

--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -123,7 +123,7 @@ module ChefServerCtl
                               ENV['CSC_BIFROST_DB_URI']
                             else
                               pg_config = @@ctl.running_service_config('postgresql')
-                              user = pg_config['db_superuser']
+                              user = pg_config['db_connection_superuser'] || pg_config['db_superuser']
                               password = @@ctl.credentials.get('postgresql', 'db_superuser_password')
                               make_connection_string('bifrost', user, password)
                             end
@@ -137,7 +137,7 @@ module ChefServerCtl
                              ENV['CSC_ERCHEF_DB_URI']
                            else
                              erchef_config = @@ctl.running_service_config('opscode-erchef')
-                             user = erchef_config['sql_user']
+                             user = erchef_config['sql_connection_user'] || erchef_config['sql_user']
                              password = @@ctl.credentials.get('opscode_erchef', 'sql_password')
                              make_connection_string('opscode_chef', user, password)
                            end

--- a/src/chef-server-ctl/lib/chef_server_ctl/version.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/version.rb
@@ -1,3 +1,3 @@
 module ChefServerCtl
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
### Description

This change allows Chef to optionally use a different username for establishing database connections than is used within database queries. This is necessary when using Azure Database for PostgreSQL as an external database.

### Issues Resolved

#1559 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
