### PR TITLE
Allow Chef to optionally use SSL for establishing database connections

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -623,6 +623,7 @@ default['private_chef']['postgresql']['wal_level'] = "minimal"
 default['private_chef']['postgresql']['archive_mode'] = "off" # "cannot be enabled when wal_level is set to minimal"
 default['private_chef']['postgresql']['archive_command'] = ""
 default['private_chef']['postgresql']['archive_timeout'] = 0 # 0 is disabled.
+default['private_chef']['postgresql']['sslmode'] = 'disable'
 
 # This is based on the tuning parameters here:
 #

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -23,6 +23,7 @@ class EcPostgres
                                  'host' => postgres['vip'],
                                  'password' => postgres['db_superuser_password'],
                                  'port' => postgres['port'],
+                                 'sslmode' => postgres['sslmode'],
                                  'dbname' => database)
     rescue => e
       if retries > 0

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -28,7 +28,8 @@ action :deploy do
                deploy #{target} --verify
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
-                  "PGPASSWORD" => new_resource.password
+                  "PGPASSWORD" => new_resource.password,
+                  "PGSSLMODE" => node['private_chef']['postgresql']['sslmode']
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -29,7 +29,7 @@ action :deploy do
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
                   "PGPASSWORD" => new_resource.password,
-                  "PGSSLMODE" => node['private_chef']['postgresql']['sslmode']
+                  "PGSSLMODE" => new_resource.sslmode
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -61,5 +61,6 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
   username  postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bifrost"
+  sslmode postgres_attrs['sslmode']
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
@@ -56,5 +56,6 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/bookshelf/schema" do
   username  postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bookshelf"
+  sslmode postgres_attrs['sslmode']
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -50,6 +50,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/base
   username  postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database  "opscode_chef"
+  sslmode   postgres['sslmode']
   action :nothing
   notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema]", :immediately
 end
@@ -60,6 +61,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
   username  postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "opscode_chef"
+  sslmode   postgres['sslmode']
   action :nothing
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -94,7 +94,7 @@ if is_data_master?
       2.times do |i|
         # Note that we have to include the port even for a local pipe, because the port number
         # is included in the pipe default.
-        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} postgres -t -A'`
+        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} "dbname=postgres sslmode=#{node['private_chef']['postgresql']['sslmode']}" -t -A'`
 	if $?.exitstatus != 0
           Chef::Log.fatal("Could not connect to database, retrying in 10 seconds.")
           sleep 10

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
@@ -24,3 +24,4 @@ attribute :password,       kind_of: String, required: false, default: ""
 attribute :target_version, kind_of: String
 attribute :hostname,       kind_of: String, required: true
 attribute :port,           kind_of: Integer, required: true
+attribute :sslmode,        kind_of: String, required: false, default: "prefer"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -100,6 +100,7 @@
            {db_port, <%=  @postgresql['port'] %>},
            {db_user, "<%= @sql_user %>"},
            {db_name, "bookshelf" },
+           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[@postgresql['sslmode']] %>}]},
            {idle_check, 10000},
            {pooler_timeout, <%= @db_pooler_timeout %>},
            {db_timeout, <%= @sql_db_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -101,6 +101,7 @@
           {db_port, <%= node['private_chef']['postgresql']['port'] %> },
           {db_user, "<%= node['private_chef']['oc_bifrost']['sql_user'] %>" },
           {db_name, "bifrost" },
+          {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
           {idle_check, 10000},
           {pooler_timeout, <%= @db_pooler_timeout %>},
           {db_timeout, <%= node['private_chef']['oc_bifrost']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -315,6 +315,7 @@
         {db_port, <%= node['private_chef']['postgresql']['port'] %>},
         {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
         {db_name, "opscode_chef" },
+        {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
         {idle_check, 10000},
         {pooler_timeout, <%= @db_pooler_timeout %>},
         {db_timeout, <%= node['private_chef']['opscode-erchef']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
@@ -9,3 +9,4 @@ production:
   database: <%= node['private_chef']['oc_id']['sql_database'] %>
   username: <%= node['private_chef']['oc_id']['sql_user'] %>
   password: <%= "\<%= Secrets.get('oc_id', 'sql_password') %\>" %>
+  sslmode: <%= node['private_chef']['postgresql']['sslmode'] %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -111,6 +111,7 @@
            {db_port, 5432},
            {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
            {db_name, "opscode_chef" },
+           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
            {idle_check, 10000},
            {db_timeout, <%= node['private_chef']['opscode-chef-mover']['sql_db_timeout'] %>},
            {prepared_statements, {oc_chef_sql, statements, [pgsql]}},


### PR DESCRIPTION
### Description

This change allows Chef services and omnibus cookbooks to be configured to use SSL to connect to the PostgreSQL database. This is necessary when using Azure Database for PostgreSQL as an external database securely, without disabling `Enforce SSL`.
This change will not actually work until https://github.com/chef/chef_secrets/pull/26 is merged and the dependency is updated here.

### Issues Resolved

#1559 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
