### PR TITLE
Use expeditor's default promote config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -148,11 +148,3 @@ subscriptions:
   - workload: schedule_triggered:chef/chef-server:master:nightly_build:*
     actions:
       - trigger_pipeline:omnibus/adhoc
-
-promote:
-  actions:
-    - built_in:promote_artifactory_artifact
-  channels:
-    - unstable
-    - current
-    - stable


### PR DESCRIPTION
There's no need to explicitly define Expeditor's default promote config so let's remove it.