### PR TITLE
Export OCTOKIT_ACCESS_TOKEN for license_scout

### DIFF
--- a/.expeditor/upload_files.sh
+++ b/.expeditor/upload_files.sh
@@ -4,6 +4,9 @@ set -eou pipefail
 
 VERSION=$(cat VERSION)
 export VERSION
+# Should ensure License Scout doesn't get rate limited
+OCTOKIT_ACCESS_TOKEN=$GITHUB_TOKEN
+export OCTOKIT_ACCESS_TOKEN
 
 # Generate the License Scout Dependency Manifest
 .expeditor/license_scout.sh


### PR DESCRIPTION
This ensures the `license_scout` scan has a higher rate limit. This env
variable is recognized by `licensee` which is used by `license_scout`
under the covers.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
