### PR TITLE
Latest omnibus-buildkite-plugin expects install-dir to be an absolute path

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -1,7 +1,7 @@
 ---
 project-name: chef-server
 config: omnibus/omnibus.rb
-install-dir: opscode
+install-dir: /opt/opscode
 test-path: omnibus/omnibus-test.sh
 fips-platforms:
   - el-*-x86_64


### PR DESCRIPTION
### Description

This updates the omnibus pipeline's `install-dir` setting to be an absolute path to match the expectation of the latest omnibus-buildkite-plugin release.

### Check List

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
