### PR TITLE
Forgot to add  to a  in .bldr.toml

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -26,5 +26,5 @@ plan_path = "src/oc_bifrost/habitat"
 export_targets = ["docker"]
 
 [oc_erchef]
-plan_path = "src/oc_erchef"
+plan_path = "src/oc_erchef/habitat"
 export_targets = ["docker"]


### PR DESCRIPTION
### Description

Fix a typo in the initial migration. Per the Builder API, the `plan_path` needs to point to the directory containing the `plan.*` file. 

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
