### PR TITLE
Remove `/habitat` from end of `plan_path`

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,20 +1,20 @@
 [openresty-noroot]
-plan_path = "src/openresty-noroot/habitat"
+plan_path = "src/openresty-noroot"
 
 [oc_id]
-plan_path = "src/oc-id/habitat"
+plan_path = "src/oc-id"
 export_targets = ["docker"]
 
 [chef-server-nginx]
-plan_path = "src/nginx/habitat"
+plan_path = "src/nginx"
 export_targets = ["docker"]
 
 [bookshelf]
-plan_path = "src/bookshelf/habitat"
+plan_path = "src/bookshelf"
 export_targets = ["docker"]
 
 [chef-server-ctl]
-plan_path = "src/chef-server-ctl/habitat"
+plan_path = "src/chef-server-ctl"
 paths = [
   "src/chef-server-ctl/*",
   "oc-chef-pedant/*"
@@ -22,9 +22,9 @@ paths = [
 export_targets = ["docker"]
 
 [oc_bifrost]
-plan_path = "src/oc_bifrost/habitat"
+plan_path = "src/oc_bifrost"
 export_targets = ["docker"]
 
 [oc_erchef]
-plan_path = "src/oc_erchef/habitat"
+plan_path = "src/oc_erchef"
 export_targets = ["docker"]


### PR DESCRIPTION
### Description

_This is a release engineering only change_

Remove `habitat` from the end of `plan_path`. 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
