### PR TITLE
Remove Ubuntu 14.04 from build matrix

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -14,8 +14,6 @@ builder-to-testers-map:
     - sles-11-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
-  ubuntu-14.04-x86_64:
-    - ubuntu-14.04-x86_64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -46,9 +46,9 @@ end
 Vagrant.configure("2") do |config|
   attributes = load_settings
 
-  # Use the official Ubuntu 14.04 box
+  # Use the official Ubuntu 16.04 box
   # Vagrant will auto resolve the url to download from Atlas
-  config.vm.box = "bento/ubuntu-14.04"
+  config.vm.box = "bento/ubuntu-16.04"
   config.ssh.forward_agent = true
 
   # This plugin allows for a much more efficient sync than the vanilla rsync-auto command


### PR DESCRIPTION
Ubuntu 14.04 hits end of life at the end of April 2019. Let's stop building it.

Signed-off-by: Mark Anderson <mark@chef.io>

### Description

Remove Ubuntu 14.04 from build matrix.

### Issues Resolved



### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
