### PR TITLE
[nginx] Don't log 404s to the error log

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -20,6 +20,10 @@ http {
                     '"$request" $status "$request_time" $body_bytes_sent '
                     '"$http_referer" "$http_user_agent" "$upstream_addr" "$upstream_status" "$upstream_response_time" "$http_x_chef_version" "$http_x_ops_sign" "$http_x_ops_userid" "$http_x_ops_timestamp" "$http_x_ops_content_hash" $request_length "$http_x_remote_request_id"';
 
+  # In the Chef API a 404 is not an error. These 404s will still be
+  # logged to the request log.
+  log_not_found off;
+
   server_names_hash_bucket_size <%= @server_names_hash_bucket_size %>;
 
   sendfile <%= @sendfile %>;


### PR DESCRIPTION
In the Chef API, 404s are typically not errors. Rather they are often
the expected response about an object that doesn't exist.

The log_not_found directive stops nginx from logging 404s as errors;
however, they should still be logged to the request log
(i.e. access.log).

References:

- http://nginx.org/en/docs/http/ngx_http_core_module.html#log_not_found

Signed-off-by: Steven Danna <steve@chef.io>