### PR TITLE
render profiles and data-collector upstreams correctly

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -952,6 +952,3 @@ default['private_chef']['data_collector']['ibrowse_options'] = "[{connect_timeou
 default['private_chef']['profiles'] = {}
 # Fully qualified URL to the compliance profiles server:
 # default['private_chef']['profiles']['root_url'] = 'https://profiles.example.com'
-# The authentication token to pass via the header to the data collector server
-# Define the token unless already set in this file
-# default['private_chef']['data_collector']['token'] = '123456789...'

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -81,13 +81,13 @@ http {
   }
   <%- end -%>
 
-  <% if node['private_chef']['data_collector']['root_url'] && node['private_chef']['data_collector']['token'] -%>
+  <% if node['private_chef']['data_collector']['root_url'] -%>
   upstream data-collector {
     server <%= URI.parse(node['private_chef']['data_collector']['root_url']).host %>:<%= URI.parse(node['private_chef']['data_collector']['root_url']).port %>;
   }
   <% end -%>
 
-  <% if node['private_chef']['profiles']['root_url'] && node['private_chef']['data_collector']['token'] -%>
+  <% if node['private_chef']['profiles']['root_url'] -%>
   upstream compliance-profiles {
     server <%= URI.parse(node['private_chef']['profiles']['root_url']).host %>:<%= URI.parse(node['private_chef']['profiles']['root_url']).port %>;
   }

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -75,7 +75,7 @@
     }
     <% end -%>
 
-    <% if node['private_chef']['data_collector']['root_url'] && node['private_chef']['data_collector']['token'] -%>
+    <% if node['private_chef']['data_collector']['root_url'] -%>
     location ~ "^/organizations/([^/]+)/data-collector$" {
       set $request_org $1;
       access_by_lua_block { validator.validate("POST") }
@@ -106,7 +106,7 @@
     <% end -%>
     }
 
-    <% if node['private_chef']['profiles']['root_url'] && node['private_chef']['data_collector']['token'] -%>
+    <% if node['private_chef']['profiles']['root_url'] -%>
     # Compliance endpoint to forward profiles calls to the Automate API:
     #   /organizations/ORG/owners/OWNER/compliance[/PROFILE]
     # Supports the legacy(chef-gate) URLs as well:


### PR DESCRIPTION
when setting the configuration value `insecure_addon_compat`, the
chef-server library code does not render the secrets from the
secrets helper into the PrivateChef hash, which results specifically
in `data_collector['token']` not showing up there. when configured
to proxy compliance profiles and the data-collector endpoint, however,
the nginx recipe was relying on this field being present for the
upstreams to be rendered into the config. this resulted in us never
rendering the correct upstreams in `insecure_addon_compat` mode.

this change makes it so that the profiles and data-collector upstreams
will always be rendered if their root_url is configured. if, by
chance, the user doesn't have the `data_collector token` secret set,
we'll now see a 401 response code and an error message instead of a
confusing and misleading 404.

Signed-off-by: Stephen Delano <stephen@chef.io>

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

Internal support issue: https://getchef.zendesk.com/agent/tickets/21598

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
