### PR TITLE
Ma/update runit

### DIFF
--- a/omnibus/files/private-chef-cookbooks/Berksfile
+++ b/omnibus/files/private-chef-cookbooks/Berksfile
@@ -2,4 +2,4 @@ source 'https://supermarket.chef.io'
 
 cookbook 'enterprise', git: 'https://github.com/chef-cookbooks/enterprise-chef-common', tag: 'v0.15.1'
 cookbook 'private-chef', path: './private-chef'
-cookbook 'runit', '>= 5.1.1'
+cookbook 'runit' # we use the version locked in enterprise-chef-common

--- a/omnibus/files/private-chef-cookbooks/Berksfile
+++ b/omnibus/files/private-chef-cookbooks/Berksfile
@@ -1,5 +1,5 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'enterprise', git: 'https://github.com/chef-cookbooks/enterprise-chef-common', tag: 'v0.14.1'
+cookbook 'enterprise', git: 'https://github.com/chef-cookbooks/enterprise-chef-common', tag: 'v0.15.1'
 cookbook 'private-chef', path: './private-chef'
-cookbook 'runit', '> 1.6.0'
+cookbook 'runit', '>= 5.1.1'

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_upgrade.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_upgrade.rb
@@ -168,12 +168,12 @@ end
 # If a pre-existing postgres service exists it will need to be shut
 # down prior to running the upgrade step.
 def shutdown_postgres
-  runit_service "postgresql" do
+  component_runit_service "postgresql" do
     action :nothing # can this just be 'action :stop'?
   end
 
   log "Shutting down PostgreSQL for update" do
-    notifies :stop, "runit_service[postgresql]", :immediately
+    notifies :stop, "component_runit_service[postgresql]", :immediately
   end
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
@@ -69,7 +69,7 @@ template bookshelf_config do
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
   variables(bookshelf_params)
-  notifies :restart, 'runit_service[bookshelf]' if is_data_master?
+  notifies :restart, 'component_runit_service[bookshelf]' if is_data_master?
 end
 
 link "/opt/opscode/embedded/service/bookshelf/sys.config" do
@@ -83,7 +83,7 @@ template vmargs_config do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
-  notifies :restart, 'runit_service[bookshelf]' if is_data_master?
+  notifies :restart, 'component_runit_service[bookshelf]' if is_data_master?
 end
 
 link "/opt/opscode/embedded/service/bookshelf/vm.args" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bootstrap.rb
@@ -36,7 +36,7 @@ ruby_block "bootstrap-chef-server-data" do
     ChefServerDataBootstrap.new(node).bootstrap
   end
   not_if { OmnibusHelper.has_been_bootstrapped? }
-  notifies :restart, 'service[opscode-erchef]'
+  notifies :restart, 'component_runit_service[opscode-erchef]'
 end
 
 file OmnibusHelper.bootstrap_sentinel_file do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -147,7 +147,7 @@ include_recipe "private-chef::fix_permissions"
     # is an externally managed version. Given that bootstrap and
     # opscode-expander are not externalizable, don't need special
     # handling for them as we do in the normal disable case below.
-    runit_service service do
+    component_runit_service service do
       action :disable
     end
   else
@@ -157,7 +157,7 @@ include_recipe "private-chef::fix_permissions"
       # bootstrap isn't a service, nothing to disable.
       next if service == 'bootstrap'
       # All non-enabled services get disabled;
-      runit_service service do
+      component_runit_service service do
         action :disable
       end
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/haproxy.rb
@@ -74,7 +74,7 @@ template File.join(haproxy_dir, "haproxy.cfg") do
   group OmnibusHelper.new(node).ownership['group']
   mode "600"
   variables(node['private_chef']['haproxy'].to_hash.merge(chef_backend_members: chef_backend_members))
-  notifies :restart, 'runit_service[haproxy]'
+  notifies :restart, 'component_runit_service[haproxy]'
 end
 
 component_runit_service "haproxy"
@@ -113,7 +113,7 @@ ruby_block "wait for haproxy status socket" do
       Kernel.exit! 1
     end
   end
-  notifies :start, 'runit_service[haproxy]', :before
+  notifies :start, 'component_runit_service[haproxy]', :before
 end
 
 ruby_block "wait for backend leader to stabilize" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -176,7 +176,7 @@ lbconf = node['private_chef']['lb'].to_hash.merge(nginx_vars).merge(
     # Note that due to JIT compile of lua resources, any
     # changes to them will require a full restart to be picked up.
     # This includes any embedded lua.
-    notifies :restart, 'runit_service[nginx]'
+    notifies :restart, 'component_runit_service[nginx]'
   end
 end
 
@@ -191,12 +191,12 @@ if node['private_chef']['opscode-erchef']['stats_auth_enable']
     owner OmnibusHelper.new(node).ownership['owner']
     group OmnibusHelper.new(node).ownership['group']
     sensitive true
-    notifies :restart, 'runit_service[nginx]'
+    notifies :restart, 'component_runit_service[nginx]'
   end
 elsif stats_passwd_file
   file stats_passwd_file do
     action :delete
-    notifies :restart, 'runit_service[nginx]'
+    notifies :restart, 'component_runit_service[nginx]'
   end
 end
 
@@ -219,7 +219,7 @@ end
       :compliance_proxy_regex => '(?:/compliance)?/organizations/([^/]+)/owners/([^/]+)/compliance(.*)'
       )
     )
-    notifies :restart, 'runit_service[nginx]'
+    notifies :restart, 'component_runit_service[nginx]'
   end
 end
 
@@ -232,7 +232,7 @@ template nginx_config do
   group 'root'
   mode '0644'
   variables(lbconf.merge(chef_lb_configs).merge(:temp_dir => nginx_tempfile_dir))
-  notifies :restart, 'runit_service[nginx]'
+  notifies :restart, 'component_runit_service[nginx]'
 end
 
 # Write out README.md for addons dir

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_bifrost.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_bifrost.rb
@@ -64,7 +64,7 @@ template oc_bifrost_config do
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
   variables(node['private_chef']['oc_bifrost'].to_hash)
-  notifies :restart, 'runit_service[oc_bifrost]'
+  notifies :restart, 'component_runit_service[oc_bifrost]'
 end
 
 link "/opt/opscode/embedded/service/oc_bifrost/sys.config" do
@@ -78,7 +78,7 @@ template vmargs_config do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
-  notifies :restart, 'runit_service[oc_bifrost]'
+  notifies :restart, 'component_runit_service[oc_bifrost]'
 end
 
 link "/opt/opscode/embedded/service/oc_bifrost/vm.args" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -102,7 +102,7 @@ file "#{oc_id_config_dir}/production.yml" do
   group OmnibusHelper.new(node).ownership['group']
   mode '640'
   content mutable_hash.to_yaml
-  notifies :restart, 'runit_service[oc_id]'
+  notifies :restart, 'component_runit_service[oc_id]'
 end
 
 #
@@ -123,7 +123,7 @@ template "#{oc_id_config_dir}/secret_token.rb" do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode '640'
-  notifies :restart, 'runit_service[oc_id]'
+  notifies :restart, 'component_runit_service[oc_id]'
 end
 
 secrets_file = "/opt/opscode/embedded/service/oc_id/config/initializers/secret_token.rb"
@@ -141,7 +141,7 @@ template "#{oc_id_config_dir}/database.yml" do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode '640'
-  notifies :restart, 'runit_service[oc_id]'
+  notifies :restart, 'component_runit_service[oc_id]'
 end
 
 database_file = "/opt/opscode/embedded/service/oc_id/config/database.yml"
@@ -227,6 +227,6 @@ end
     owner "root"
     group "root"
     mode "0644"
-    notifies :restart, 'runit_service[nginx]'
+    notifies :restart, 'component_runit_service[nginx]'
   end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-erchef.rb
@@ -70,7 +70,7 @@ template erchef_config do
                                                          :helper => helper)
   }
   notifies :run, 'execute[remove_erchef_siz_files]', :immediately
-  notifies :restart, 'runit_service[opscode-erchef]'
+  notifies :restart, 'component_runit_service[opscode-erchef]'
 end
 
 # Erchef still ultimately uses disk_log [1] for request logging, and if
@@ -101,7 +101,7 @@ template vmargs_config do
   owner helper.ownership['owner']
   group helper.ownership['group']
   mode "644"
-  notifies :restart, 'runit_service[opscode-erchef]'
+  notifies :restart, 'component_runit_service[opscode-erchef]'
 end
 
 link "/opt/opscode/embedded/service/opscode-erchef/vm.args" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-expander.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-expander.rb
@@ -38,7 +38,7 @@ template expander_config do
   mode "0644"
   options = node['private_chef']['opscode-expander'].to_hash
   variables(options)
-  notifies :restart, 'runit_service[opscode-expander]' if is_data_master?
+  notifies :restart, 'component_runit_service[opscode-expander]' if is_data_master?
 end
 
 link "/opt/opscode/embedded/service/opscode-expander/conf/opscode-expander.rb" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -65,14 +65,14 @@ cookbook_file File.join(solr_home_dir, "solr.xml") do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "0644"
-  notifies :restart, 'runit_service[opscode-solr4]' if is_data_master?
+  notifies :restart, 'component_runit_service[opscode-solr4]' if is_data_master?
 end
 
 file File.join(solr_collection_dir, "core.properties") do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "0644"
-  notifies :restart, 'runit_service[opscode-solr4]' if is_data_master?
+  notifies :restart, 'component_runit_service[opscode-solr4]' if is_data_master?
   content <<EOF
 name=collection1
 EOF
@@ -84,7 +84,7 @@ template File.join(solr_conf_dir, "solrconfig.xml") do
   group OmnibusHelper.new(node).ownership['group']
   mode "0644"
   variables(node['private_chef']['opscode-solr4'].to_hash)
-  notifies :restart, 'runit_service[opscode-solr4]' if is_data_master?
+  notifies :restart, 'component_runit_service[opscode-solr4]' if is_data_master?
 end
 
 cookbook_file File.join(solr_conf_dir, "schema.xml") do
@@ -92,7 +92,7 @@ cookbook_file File.join(solr_conf_dir, "schema.xml") do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "0644"
-  notifies :restart, 'runit_service[opscode-solr4]' if is_data_master?
+  notifies :restart, 'component_runit_service[opscode-solr4]' if is_data_master?
 end
 
 template File.join(solr_jetty_dir, "etc", "jetty.xml") do
@@ -101,7 +101,7 @@ template File.join(solr_jetty_dir, "etc", "jetty.xml") do
   mode "0644"
   source "solr4/jetty.xml.erb"
   variables(node['private_chef']['opscode-solr4'].to_hash.merge(node['private_chef']['logs'].to_hash))
-  notifies :restart, 'runit_service[opscode-solr4]' if is_data_master?
+  notifies :restart, 'component_runit_service[opscode-solr4]' if is_data_master?
 end
 
 template File.join(solr_jetty_dir, "contexts", "solr-jetty-context.xml") do
@@ -109,7 +109,7 @@ template File.join(solr_jetty_dir, "contexts", "solr-jetty-context.xml") do
   group OmnibusHelper.new(node).ownership['group']
   mode "0644"
   source "solr4/solr-jetty-context.xml.erb"
-  notifies :restart, 'runit_service[opscode-solr4]' if is_data_master?
+  notifies :restart, 'component_runit_service[opscode-solr4]' if is_data_master?
 end
 
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -64,17 +64,17 @@ end
 # Upgrade the cluster if you gotta
 private_chef_pg_upgrade "upgrade_if_necessary"
 
+component_runit_service "postgresql" do
+  control ['t']
+end
+
 private_chef_pg_cluster postgresql_data_dir do
-  notifies :restart, 'component_runit_service[postgresql]' if is_data_master?
+  notifies :restart, 'component_runit_service[postgresql]', :delayed if is_data_master?
 end
 
 link postgresql_data_dir_symlink do
   to postgresql_data_dir
   not_if { postgresql_data_dir == postgresql_data_dir_symlink }
-end
-
-component_runit_service "postgresql" do
-  control ['t']
 end
 
 # NOTE: These recipes are written idempotently, but require a running

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -68,6 +68,9 @@ component_runit_service "postgresql" do
   control ['t']
 end
 
+#
+# This is delayed because we sometimes need to restart oc_erchef and other clients to release the connections and allow a restart.
+#
 private_chef_pg_cluster postgresql_data_dir do
   notifies :restart, 'component_runit_service[postgresql]', :delayed if is_data_master?
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -65,7 +65,7 @@ end
 private_chef_pg_upgrade "upgrade_if_necessary"
 
 private_chef_pg_cluster postgresql_data_dir do
-  notifies :restart, 'runit_service[postgresql]' if is_data_master?
+  notifies :restart, 'component_runit_service[postgresql]' if is_data_master?
 end
 
 link postgresql_data_dir_symlink do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/rabbitmq.rb
@@ -242,14 +242,14 @@ if is_data_master?
       user opc_username
       not_if rabbitmq_management_is_up
       # management plugin needs a rabbit restart
-      notifies :restart, 'runit_service[rabbitmq]', :delayed
+      notifies :restart, 'component_runit_service[rabbitmq]', :delayed
       retries 10
     end
   else
     execute "#{rmq_plugins} disable rabbitmq_management" do
       environment (rabbitmq_env)
       user opc_username
-      notifies :restart, 'runit_service[rabbitmq]', :delayed
+      notifies :restart, 'component_runit_service[rabbitmq]', :delayed
       only_if rabbitmq_management_is_up
       retries 10
     end


### PR DESCRIPTION
### Description

Update to newest runit and enterprise-chef-common cookbooks. Necessary to be able to move to Chef 15. Still a bit broken, work in progress.

Built on top of ma/remove_drbd, because the new enterprise_chef_common cookbook removes some drbd/keepalived logic

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
