### PR TITLE
Ma/generalize pedant version check

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -48,7 +48,7 @@ module Pedant
                                                    'RUBYOPT' => nil
                                                  })
                       cmd.run_command
-                      cmd.stdout =~ /^Chef(?:\w+Infra)?: (.*)$/ /^Chef(?:\s+Infra)?: (.*)$/
+                      cmd.stdout =~ /^Chef(?:\s+Infra)?: (.*)$/
                       $1 || raise("Cannot determine Chef version from output of `knife --version`: '#{cmd.stdout}'")
                     end
 

--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -48,8 +48,8 @@ module Pedant
                                                    'RUBYOPT' => nil
                                                  })
                       cmd.run_command
-                      cmd.stdout =~ /^Chef: (.*)$/
-                      $1 || raise("Cannot determine Chef version from output of `knife --version`: #{cmd.stdout}")
+                      cmd.stdout =~ /^Chef(?:\w+Infra)?: (.*)$/ /^Chef(?:\s+Infra)?: (.*)$/
+                      $1 || raise("Cannot determine Chef version from output of `knife --version`: '#{cmd.stdout}'")
                     end
 
     # Headers that are added to all requests

--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -48,7 +48,7 @@ module Pedant
                                                    'RUBYOPT' => nil
                                                  })
                       cmd.run_command
-                      cmd.stdout =~ /^Chef(?:\s+Infra)?: (.*)$/
+                      cmd.stdout =~ /^Chef(?:\s+Infra Client)?: (.*)$/
                       $1 || raise("Cannot determine Chef version from output of `knife --version`: '#{cmd.stdout}'")
                     end
 


### PR DESCRIPTION
### Description

This lets pedant work with Chef 14/15. We've started pulling in 15 as part of our CI routines, and probably should control the path pedant sees via chef-server-ctl better. 

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
