### PR TITLE
Ma/use specific path

### DIFF
--- a/oc-chef-pedant/Gemfile
+++ b/oc-chef-pedant/Gemfile
@@ -7,6 +7,11 @@ gem 'pry-byebug'
 gem 'pry-stack_explorer'
 gem 'rake'
 
+# We require chef internally to get the version in
+# lib/pedant/request.rb. It's really strange code and it should be
+# revisited.
+gem 'chef'
+
 # For "rake chef_zero_spec"
 #gem 'chef-zero', github: 'chef/chef-zero'
 

--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -36,9 +36,13 @@ module Pedant
     # Grab the the version of Chef / Knife that's on the box in order
     # to properly set the X-Chef-Version header
     KNIFE_VERSION = begin
+                      # Historically we've not included chef in our Gemfile/lock, so this always fails.
                       require 'chef/version'
                       Chef::VERSION
                     rescue LoadError
+                      # This apparently is needed in some cases for pedant to work. We should
+                      # explore whether we can simplify this mess
+                      #
                       # Don't want Bundler to poison the shelling out :(
                       cmd = Mixlib::ShellOut.new("knife --version", :environment => {
                                                    'BUNDLE_GEMFILE' => nil,
@@ -48,8 +52,8 @@ module Pedant
                                                    'RUBYOPT' => nil
                                                  })
                       cmd.run_command
-                      cmd.stdout =~ /^Chef: (.*)$/
-                      $1 || raise("Cannot determine Chef version from output of `knife --version`: #{cmd.stdout}")
+                      cmd.stdout =~ /^Chef(?:\s+Infra Client)?: (.*)$/
+                      $1 || raise("Cannot determine Chef version from output of `knife --version`: '#{cmd.stdout}'")
                     end
 
     # Headers that are added to all requests

--- a/src/chef-server-ctl/plugins/test.rb
+++ b/src/chef-server-ctl/plugins/test.rb
@@ -14,6 +14,8 @@ add_command_under_category "test", "general", "Run the API test suite against lo
   Dir.chdir(File.join(base_path, "embedded", "service", "oc-chef-pedant"))
   pedant_config = File.join(data_path, "oc-chef-pedant", "etc", "pedant_config.rb")
   bundle = File.join(base_path, "embedded", "bin", "bundle")
+  # lock down path to exclude other installations of chef and related software.
+  ENV['PATH'] = ([File.join(base_path, "embedded", "bin"), File.join(base_path, "bin") ]).join(':')
   status = run_command("#{bundle} exec ./bin/oc-chef-pedant -c #{pedant_config} #{pedant_args.join(' ')}")
   exit status.exitstatus
 end


### PR DESCRIPTION
### Description

Pedant uses two methods to find it's chef version
1) is to require chef/version
2) is to run knife and pattern match the version string

Closes #1669 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
