### PR TITLE
Update observer-cli SHA.

### DIFF
--- a/src/bookshelf/rebar.lock
+++ b/src/bookshelf/rebar.lock
@@ -69,7 +69,7 @@
   0},
  {<<"observer_cli">>,
   {git,"https://github.com/zhongwencool/observer_cli",
-       {ref,"4d5f96762bb525b4f857109c10a7d4d53af1a029"}},
+       {ref,"ac167efd42e9c09d047e36428a38521e3ef84672"}},
   0},
  {<<"opscoderl_wm">>,
   {git,"https://github.com/chef/opscoderl_wm.git",

--- a/src/chef-mover/rebar.lock
+++ b/src/chef-mover/rebar.lock
@@ -129,7 +129,7 @@
   2},
  {<<"observer_cli">>,
   {git,"https://github.com/zhongwencool/observer_cli",
-       {ref,"4d5f96762bb525b4f857109c10a7d4d53af1a029"}},
+       {ref,"ac167efd42e9c09d047e36428a38521e3ef84672"}},
   0},
  {<<"opscoderl_folsom">>,
   {git,"git://github.com/opscode/opscoderl_folsom.git",

--- a/src/oc_bifrost/rebar.lock
+++ b/src/oc_bifrost/rebar.lock
@@ -49,7 +49,7 @@
   0},
  {<<"observer_cli">>,
   {git,"https://github.com/zhongwencool/observer_cli",
-       {ref,"4d5f96762bb525b4f857109c10a7d4d53af1a029"}},
+       {ref,"ac167efd42e9c09d047e36428a38521e3ef84672"}},
   0},
  {<<"opscoderl_wm">>,
   {git,"https://github.com/chef/opscoderl_wm.git",

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -106,7 +106,7 @@
   0},
  {<<"observer_cli">>,
   {git,"https://github.com/zhongwencool/observer_cli",
-       {ref,"4d5f96762bb525b4f857109c10a7d4d53af1a029"}},
+       {ref,"ac167efd42e9c09d047e36428a38521e3ef84672"}},
   0},
  {<<"opscoderl_folsom">>,
   {git,"https://github.com/chef/opscoderl_folsom",


### PR DESCRIPTION
### Description

Looks like observer cli rebased/force pushed the repo, changing all of
the SHAs. This breaks the build (and any attempt at replicating past
builds). Update observer-cli.

Signed-off-by: Mark Anderson <mark@chef.io>

### Issues Resolved

Fixes build breakage of master

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
