### PR TITLE
[dev-vm] Fixup incomplete rename work.

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -166,6 +166,19 @@ you can specify it with the $INSTALLER variable. Also, you can automate the sele
 to use with $AUTOPACKAGE. So, to automatically select a custom package, set $INSTALLER to it's path
 and $AUTOPACKAGE to 1.
 
+### Multiple vms
+
+If you are fortunate enough to have a host beefy enough to run
+multiple VMs you will hit a snag; the 'chef-server' VM name is
+global, and there can only be one. To use a different name, set the
+environment variable export VAGRANT\_MACHINE\_VARIANT to add a suffix
+to the vm names.
+
+Example:
+```
+export VAGRANT_MACHINE_VARIANT='1'
+```
+
 ### Coverage Analysis
 
 Erlang has built-in support for code coverage analaysis which will

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -6,8 +6,8 @@ require "yaml"
 require "fileutils"
 load "dvmtools.rb"
 
-VMName = "chef-server-1" 
-
+Variant = ENV['VAGRANT_MACHINE_VARIANT'] ? ("-" + ENV['VAGRANT_MACHINE_VARIANT'] ) : ''
+VMName = "chef-server#{Variant}" 
 
 IPS = {
   cs: "192.168.33.100",
@@ -260,7 +260,7 @@ end
 def define_ldap_server(config, attributes)
   config.vm.hostname = "ldap.#{VMName}.dev"
   config.vm.network "private_network", ip: IPS[:ldap]
-  customize_vm(config, name: "ldap", memory: 512, cpus: 1)
+  customize_vm(config, name: "ldap#{Variant}", memory: 512, cpus: 1)
 
   config.vm.provision "chef_zero" do |chef|
     chef.node_name = config.vm.hostname
@@ -277,7 +277,7 @@ end
 def define_db_server(config, attributes)
   config.vm.hostname = "database.#{VMName}.dev"
   config.vm.network "private_network", ip: IPS[:database]
-  customize_vm(config, name: "database", memory: 512, cpus: 1)
+  customize_vm(config, name: "database#{Variant}", memory: 512, cpus: 1)
   set_chef_zero_provisioning(config,
                              recipes: ["provisioning::hosts"],
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
@@ -287,7 +287,7 @@ end
 def define_custom_server(config, attributes)
   config.vm.hostname = "custom.#{VMName}.dev"
   config.vm.network "private_network", ip: IPS[:custom]
-  customize_vm(config, name: "custom", memory: 2048, cpus: 2)
+  customize_vm(config, name: "custom#{Variant}", memory: 2048, cpus: 2)
   set_chef_zero_provisioning(config,
                              recipes: ["provisioning::hosts"],
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
@@ -296,7 +296,7 @@ end
 def define_elasticsearch_server(config, attributes)
   config.vm.hostname = "elasticsearch.#{VMName}.dev"
   config.vm.network "private_network", ip: IPS[:elasticsearch]
-  customize_vm(config, name: "elasticsearch", memory: 2048, cpus: 2)
+  customize_vm(config, name: "elasticsearch#{Variant}", memory: 2048, cpus: 2)
   set_chef_zero_provisioning(config,
                              recipes: ["provisioning::hosts"],
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
@@ -308,7 +308,7 @@ end
 def define_external_solr_server(config, attributes)
   config.vm.hostname = "solr.#{VMName}.dev"
   config.vm.network "private_network", ip: IPS[:solr]
-  customize_vm(config, name: "external_solr", memory: 2048, cpus: 2)
+  customize_vm(config, name: "external_solr#{Variant}", memory: 2048, cpus: 2)
   set_chef_zero_provisioning(config,
                              recipes: ["provisioning::hosts"],
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
@@ -323,7 +323,7 @@ def define_backend_server(config, attribute)
   provisioning, installer, installer_path = prepare('BE_INSTALLER', 'chef-backend', 'Chef Backend 1.1+')
   config.vm.hostname = "backend.#{VMName}.dev"
   config.vm.network "private_network", ip: IPS[:be]
-  customize_vm(config, name: "backend", memory: 2048, cpus: 2)
+  customize_vm(config, name: "backend#{Variant}", memory: 2048, cpus: 2)
   if provisioning
     config.vm.synced_folder installer_path, "/installers"
     set_chef_zero_provisioning(config,
@@ -339,7 +339,7 @@ end
 def define_db_server_reporting(config, attributes)
   config.vm.hostname = "reportingdb.#{VMName}.dev"
   config.vm.network "private_network", ip: IPS[:reportingdb]
-  customize_vm(config, name: "reportingdb", memory: 512, cpus: 1)
+  customize_vm(config, name: "reportingdb#{Variant}", memory: 512, cpus: 1)
   set_chef_zero_provisioning(config,
                              recipes: ["provisioning::hosts"],
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })

--- a/dev/sync
+++ b/dev/sync
@@ -71,7 +71,11 @@ BEGIN {
     # Determine our ssh args up front, so we won't need to do this on every sync.
     ssh_info = {}
     vagrant_cmd_string = ENV['VAGRANT_PATH'].nil? ? 'vagrant' : ENV['VAGRANT_PATH']
-    `#{vagrant_cmd_string} ssh-config chef-server`.split("\n").each do |line|
+
+    variant = ENV['VAGRANT_MACHINE_VARIANT'] ? ("-" + ENV['VAGRANT_MACHINE_VARIANT'] ) : ''
+    @machine_name = 'chef-server' + variant
+
+    `#{vagrant_cmd_string} ssh-config #{@machine_name}`.split("\n").each do |line|
       k, v = line.split(" ")
       ssh_info[k.strip] = v.strip
     end


### PR DESCRIPTION
### Description

PR #1670 (ma/named-dev-vm) added support for naming the dev-vm. Unfortunately it broke sync, because the name wasn't changed there.

Add an environment variable to allow configuration of this name.

Signed-off-by: Mark Anderson <mark@chef.io>

### Issues Resolved

Dev-vm sync is broken

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
