### PR TITLE
[chef-server-ctl] Fix chef dependency in hab build

### DIFF
--- a/oc-chef-pedant/Gemfile
+++ b/oc-chef-pedant/Gemfile
@@ -10,7 +10,7 @@ gem 'rake'
 # We require chef internally to get the version in
 # lib/pedant/request.rb. It's really strange code and it should be
 # revisited.
-gem 'chef'
+gem 'chef', '~>15.0'
 
 # For "rake chef_zero_spec"
 #gem 'chef-zero', github: 'chef/chef-zero'

--- a/src/chef-server-ctl/Gemfile.local
+++ b/src/chef-server-ctl/Gemfile.local
@@ -1,2 +1,5 @@
-gem 'chef', '~>14.5.0'
+#
+# This is used as part of the habitat build
+#
+gem 'chef', '~>15.0'
 gem 'json', '~>2.0'


### PR DESCRIPTION
### Description

In #1671 we added a chef dependency in oc-chef-pedant because we had a
buried require for it.

This broke the habitat builds, because the Gemfile.local includes
chef, but doesn't specify a version.

Signed-off-by: Mark Anderson <mark@chef.io>

### Issues Resolved

Fixes https://buildkite.com/chef/chef-chef-server-master-habitat-build pipeline.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
