### PR TITLE
Alter the delivery build recipe to accept the chef license.

### DIFF
--- a/.delivery/build_cookbook/recipes/deploy.rb
+++ b/.delivery/build_cookbook/recipes/deploy.rb
@@ -35,7 +35,7 @@ end
 
 # Execute a CCR on the instances to bring up Chef Server
 parallel_remote_execute "Run CCR on #{infra_node_names}" do
-  command 'sudo /opt/chef/bin/chef-client --no-fork'
+  command 'sudo CHEF_LICENSE=accept-no-persist /opt/chef/bin/chef-client --no-fork'
   hosts infra_node_names
   private_key aws_private_key
   timeout 7200 # 2 hours


### PR DESCRIPTION
### Description

Chef client has been updated to v15 on our delivery builders, and now
needs to have the license accepted. Using environment variable form
because I'm not sure if we've globally updated our system.

Signed-off-by: Mark Anderson <mark@chef.io>

### Issues Resolved

Fix delivery verify pipeline.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
