### PR TITLE
Do not run /_stats endpoint tests on backend of a tiered topology.

### DIFF
--- a/oc-chef-pedant/spec/api/stats_spec.rb
+++ b/oc-chef-pedant/spec/api/stats_spec.rb
@@ -99,8 +99,8 @@ describe "/_stats API endpoint", :stats do
   end
 
   # Don't turn on any of the tests unless we have a password.
-  # and are not running on the backend of a tiered setup.
-  if Pedant::Config.pedant_platform.stats_password
+  # These test should not run on the backend of a tiered setup.
+  if Pedant::Config.pedant_platform.stats_password && !(Pedant::Config.topology == "tiered" || Pedant::Config.role == "backend")
     it "returns a list of collected statistics", :smoke do
       get(request_url, nil, auth_headers: auth_headers).should look_like({
         :status => 200,

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
@@ -69,6 +69,8 @@ template pedant_config do
     :reindex_endpoint => reindex_endpoint,
     :required_recipe_enabled => node['private_chef']['required_recipe']['enable'],
     :chef_pgsql_collector => ( node['private_chef']['postgresql']['enable'] &&
-                               !node['private_chef']['postgresql']['external'] )
+                               !node['private_chef']['postgresql']['external'] ),
+    :topology => node['private_chef']['topology'],
+    :role => node['private_chef']['role']
   }.merge(node['private_chef']['oc-chef-pedant'].to_hash))
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pedant_config.rb.erb
@@ -197,3 +197,6 @@ reindex_endpoint "<%= @reindex_endpoint %>"
 <%- end %>
 
 chef_pgsql_collector <%= @chef_pgsql_collector %>
+
+topology "<%= @topology %>"
+role "<%= @role %>"


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@opscode.com>

We see a couple of failing /_stats endpoint tests only on the backed of the tiered setup. These should not be run unless use is on standalone or the frontend of a tiered setup.

Adding config and conditionals around to ensure this behaviour.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
