### PR TITLE
[chef-server-ctl] Fix rabbitmq fail on first reconfigure

### DIFF
--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -50,7 +50,8 @@ y/8SReCpC71R+Vl6d4+Dw6GFdL+6k6W558dPfq3UeV8HPWQEaM7/jXDUKJZ0tB6a
 -----END DH PARAMETERS-----
 " | sudo tee /etc/opscode/dhparam.pem
 
-sudo chef-server-ctl reconfigure --chef-license=accept-no-persist || true
+# At least for now we want to fail if reconfigure fails
+sudo chef-server-ctl reconfigure --chef-license=accept-no-persist
 sleep 120
 
 echo "--- Running verification for $channel $product $version"
@@ -58,14 +59,7 @@ echo "--- Running verification for $channel $product $version"
 echo "Sleeping even longer (120 seconds) to let the system settle"
 sleep 120
 
-if [[ "$(uname -m)" == "s390x" ]]; then
-  # FIX ME FIX ME FIX ME
-  # This is to see if we can get the build passing at all on the s390x platform
-  # FIX ME FIX ME FIX ME
-  sudo chef-server-ctl test -J pedant.xml --smoke --compliance-proxy-tests
-else
-  sudo chef-server-ctl test -J pedant.xml --all --compliance-proxy-tests
-fi
+sudo chef-server-ctl test -J pedant.xml --all --compliance-proxy-tests
 
 if [[ "${OMNIBUS_FIPS_MODE:-false}" == "true" ]]; then
   echo "fips true" | sudo tee -a /etc/opscode/chef-server.rb


### PR DESCRIPTION
### Description

As described in issue #1690, the first run of `chef-server-ctl
reconfigure` fails with a timeout at the very end of run, when executing delayed restarts:

    STDOUT: timeout: run: /opt/opscode/service/rabbitmq: (pid 7674) 68s

Successive runs of reconfigure work fine.

This appears to be a problem buried deep inside the rabbitmq restart logic; we weren't able to make much progress with the root cause.

As an experiment were replacing the restart action on the rabbitmq service with stop, then start actions.

If this doesn't work, a few other options suggest themselves.

We can add a execute block with default action nothing that aggressively shuts down rabbitmq (normal shutdown followed by pkill if that doesn't work), then waits, then starts up rabbitmq again. Instead of sending a restart action (or the stop/start here) we send the execute action to this block.

The sv_timeout parameter might also be used to lengthen the timeout before we fail. However that seems less than ideal if we're really stuck; we could just hang longer before failing.

See also:

https://wiki.openstack.org/wiki/OpsGuide-Maintenance-RabbitMQ#RabbitMQ_service_hangs


### Issues Resolved

#1690 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
