### PR TITLE
Remove 12.19.* version constraint on master

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -19,12 +19,7 @@ github:
   # details from the Pull Request via the `built_in:update_changelog` merge_action.
   changelog_file: "CHANGELOG.md"
   release_branch:
-    - master:
-        # we'll have to bump this later, as globs won't let us do > 18
-        version_constraint: "12.19.*"
-    - 12-18-stable:
-        # this branch should only be active
-        version_constraint: "12.18.*"
+    - master
 
 # Habitat + Docker exporting
 


### PR DESCRIPTION
### Description

That was blocking the release of chef server 13.  Also deletes the
unneeded 12.18-stable branch. This essentially reverts the
3b3d3311baa4c3f626d72cdec08bf59cc182cf87 commit.

Signed-off-by: Mark Anderson <mark@chef.io>

### Issues Resolved

Blocking release of chef-server 13.0.16