### PR TITLE
Update github templates, add lock config, and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,6 @@
 cookbooks/chef-server-deploy/**  @chef/jex-team
 inspec/**                        @chef/jex-team
 terraform/**                     @chef/jex-team
+README.md                        @chef/docs-team
+RELEASE_NOTES.md                 @chef/docs-team
 .github/ISSUE_TEMPLATE/**        @chef/docs-team

--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -1,14 +1,8 @@
 ---
 name: 🐛 Bug Report
 about: If something isn't working as expected 🤔.
-
+labels: "Status: Untriaged"
 ---
-
-NOTE:
-We use GitHub issues to track bugs and feature requests. If you need help please post to our Mailing List or join the Chef Community Slack.
-
- * Chef Community Slack at http://community-slack.chef.io/.
- * Chef Mailing List https://discourse.chef.io/
 
 
 ### Chef Server Version

--- a/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
@@ -1,0 +1,40 @@
+---
+name: Design Proposal
+about: I have a significant change I would like to propose and discuss before starting
+labels: "Status: Untriaged"
+---
+
+### When a Change Needs a Design Proposal
+
+A design proposal should be opened any time a change meets one of the following qualifications:
+
+- Significantly changes the user experience of a project in a way that impacts users.
+- Significantly changes the underlying architecture of the project in a way that impacts other developers.
+- Changes the development or testing process of the project such as a change of CI systems or test frameworks.
+
+### Why We Use This Process
+
+- Allows all interested parties (including any community member) to discuss large impact changes to a project.
+- Serves as a durable paper trail for discussions regarding project architecture.
+- Forces design discussions to occur before PRs are created.
+- Reduces PR refactoring and rejected PRs.
+
+---
+
+<!---  Proposal description and rationale.  -->
+
+## Motivation
+
+<!---
+    As a <<user_profile>>,
+    I want to <<functionality>>,
+    so that <<benefit>>.
+ -->
+
+## Specification
+
+<!---  A detailed description of the planned implementation. -->
+
+## Downstream Impact
+
+<!---  Which other tools will be impacted by this work?  -->

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST_TEMPLATE.md
@@ -1,18 +1,17 @@
 ---
 name: 🚀 Enhancement Request
 about: I have a suggestion (and may want to implement it 🙂)!
-
+labels: "Status: Untriaged"
 ---
 
 ### Describe the Enhancement:
-[What you are trying to achieve that you can't?]
+<!---  What you are trying to achieve that you can't? -->
 
 ### Describe the Need:
-
-[What kind of user do you believe would utilize this enhancement, and how many users might want this functionality]
+<!---  What kind of user do you believe would utilize this enhancement, and how many users might want this functionality -->
 
 ### Current Alternative
-[Is there a current alternative that you can utilize to workaround the lack of this enhancement]
+<!--- Is there a current alternative that you can utilize to workaround the lack of this enhancement -->
 
 ### Can We Help You Implement This?:
-[The best way to ensure your enhancement is built is to help implement the enhancement yourself. If you're interested in helping out we'd love to give you a hand to make this possible. Let us know if there's something you need.]
+<!---  The best way to ensure your enhancement is built is to help implement the enhancement yourself. If you're interested in helping out we'd love to give you a hand to make this possible. Let us know if there's something you need. -->

--- a/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
@@ -1,7 +1,6 @@
 ---
 name: 🤗 Support Question
 about: If you have a question 💬, please check out our Slack!
-
 ---
 
 We use GitHub issues to track bugs and feature requests. If you need help please post to our Mailing List or join the Chef Community Slack.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,11 @@
 ### Issues Resolved
 
 [List any existing issues this PR resolves, or any Discourse or
-StackOverflow discussion that's relevant]
+StackOverflow discussions that are relevant]
 
 ### Check List
 
 - [ ] New functionality includes tests
 - [ ] All tests pass
 - [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
+- [ ] PR title is a worthy inclusion in the CHANGELOG

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,1 @@
+daysUntilLock: 60


### PR DESCRIPTION
Add a lock config to 60 days
Update all our github issue / PR templates
Add docs as codeowners for the markdown files

Signed-off-by: Tim Smith <tsmith@chef.io>