### PR TITLE
Build habitat packages for nginx

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -6,7 +6,7 @@ plan_path = "src/oc-id"
 export_targets = ["docker"]
 
 [chef-server-nginx]
-plan_path = "src/nginx"
+plan_path = "src/nginx/habitat"
 export_targets = ["docker"]
 
 [bookshelf]


### PR DESCRIPTION
### Description

We see that on release of chef infra server 13.0.17, the chef/chef-server-nginx packages are not built. (https://bldr.habitat.sh/#/pkgs/chef/chef-server-nginx/latest is still pinned to 12.19.36)

All packages other than the nginx package are built: https://buildkite.com/chef/chef-chef-server-master-habitat-build/builds/28

This would (?possibly) include the nginx package build process.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
