### PR TITLE
Implement #1703 exclude data_collector from _status endpoint

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -918,6 +918,8 @@ default['private_chef']['data_collector']['http_cull_interval'] = "{1, min}"
 default['private_chef']['data_collector']['http_max_connection_duration'] = "{70,sec}"
 # Options for the ibrowse connections (see ibrowse).
 default['private_chef']['data_collector']['ibrowse_options'] = "[{connect_timeout, 10000}]"
+# Select whether data_collector affects overall status in _status endpoint
+default['private_chef']['data_collector']['health_check'] = true
 
 ##
 # Compliance Profiles

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -283,15 +283,24 @@ EOF
     let(:config) { "data_collector['health_check'] = false" }
     it "sets ['private_chef']['data_collector']['health_check'] to false" do
       rendered_config = config_for("api.chef.io")
-      expect(rendered_config["private_chef"]["data_collector"]["health_check"]).to eq(false)
+      expect(rendered_config["private_chef"]["data_collector"]["health_check"]).to be_falsey
     end
   end
-
+ 
   context "When we enable _status reporting for the data_collector endpoint" do
-    let(:config) { "data_collector['health_check'] = true" }
-    it "sets ['private_chef']['data_collector']['health_check'] to true" do
-      rendered_config = config_for("api.chef.io")
-      expect(rendered_config["private_chef"]["data_collector"]["health_check"]).to eq(true)
+    context "using a boolean" do
+      let(:config) { "data_collector['health_check'] = true" }
+      it "sets ['private_chef']['data_collector']['health_check'] truthy" do
+        rendered_config = config_for("api.chef.io")
+        expect(rendered_config["private_chef"]["data_collector"]["health_check"]).to be_truthy
+      end
+    end
+    context "using a string" do
+      let!(:config) { "data_collector['health_check'] = 'true'" }
+      it "sets ['private_chef']['data_collector']['health_check'] truthy" do
+        rendered_config = config_for("api.chef.io")
+        expect(rendered_config["private_chef"]["data_collector"]["health_check"]).to be_truthy
+      end
     end
   end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -279,6 +279,22 @@ EOF
     end
   end
 
+  context "When we disable _status reporting for the data_collector endpoint" do
+    let(:config) { "data_collector['health_check'] = false" }
+    it "sets ['private_chef']['data_collector']['health_check'] to false" do
+      rendered_config = config_for("api.chef.io")
+      expect(rendered_config["private_chef"]["data_collector"]["health_check"]).to eq(false)
+    end
+  end
+
+  context "When we enable _status reporting for the data_collector endpoint" do
+    let(:config) { "data_collector['health_check'] = true" }
+    it "sets ['private_chef']['data_collector']['health_check'] to true" do
+      rendered_config = config_for("api.chef.io")
+      expect(rendered_config["private_chef"]["data_collector"]["health_check"]).to eq(true)
+    end
+  end
+
   describe "#generate_config" do
     context "when the topology is tiered" do
       let(:config) { <<-EOF

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -129,7 +129,7 @@
         {server_version, "<%= node['private_chef']['version'] %>"},
         {health_ping_timeout, <%= node['private_chef']['opscode-erchef']['health_ping_timeout'] %>},
         {health_ping_modules, [
-            <% if node['private_chef']['data_collector']['root_url'] && node['private_chef']['data_collector']['health_check'] == true %>
+            <% if node['private_chef']['data_collector']['root_url'] && node['private_chef']['data_collector']['health_check'] %>
             data_collector,
             <% end %>
             oc_chef_authz,

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -129,7 +129,7 @@
         {server_version, "<%= node['private_chef']['version'] %>"},
         {health_ping_timeout, <%= node['private_chef']['opscode-erchef']['health_ping_timeout'] %>},
         {health_ping_modules, [
-            <% if node['private_chef']['data_collector']['root_url'] %>
+            <% if node['private_chef']['data_collector']['root_url'] && node['private_chef']['data_collector']['health_check'] == true %>
             data_collector,
             <% end %>
             oc_chef_authz,


### PR DESCRIPTION
### Description

Implements a bare bones solution for #1703 to add a configuration option to allow the `data_collector` health check to be excluded from the overall health reported by the `_status` endpoint.

Add `data_collector['health_check'] = false` to `/etc/opscode/chef-server.rb` and reconfigure to disable data_collector health checking.

### Issues Resolved

When using the _status endpoint to control which frontends are included in a load balancer pool, perfectly good frontends are removed from the pool if the data_collector endpoint (Automate 1 or 2) is down.

This causes an unnecessary Chef Server outage as all the frontends are perfectly able to service requests, but are removed anyway because overall Chef server status is FAIL.

Reported by 2 customers.

Signed-off-by: Richard Nixon rnixon@chef.io

### ToDo

* Understand if there is a better solution
* Figure out what (if any) tests need to be added (not sure what/how)
* Document the setting if this gets merged.

### Check List

- [N] New functionality includes tests
- [N/A] All tests pass
- [Y] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [MAYBE] PR title is a worthy inclusion in the CHANGELOG