### PR TITLE
Bump bundler to 1.17.3

### DIFF
--- a/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/chef-server-deploy/recipes/omnibus_standalone.rb
@@ -178,7 +178,6 @@ end
     serveradmin: false,
   },
 }.each do |user_name, user_options|
-
   chef_user user_name do
     first_name 'Chef'
     last_name user_name.capitalize

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,7 @@
 override :erlang, version: "18.3.4.9"
 override :lua, version: "5.1.5"
 override :rubygems, version: "3.0.3"
-override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
+override :bundler, version: "1.17.3"
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v15.0.300"
 override :ohai, version: "v15.0.35"


### PR DESCRIPTION
### Description

We now enforce there being only one version of bundler in
ruby-cleanup, but the omnibus def differers from what we pull in
elsewhere.

Signed-off-by: Mark Anderson <mark@chef.io>

### Issues Resolved

Fixes broken builds (https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/279#344a6234-8a0e-468f-8317-10e30cef8dcf)

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG