### PR TITLE
update openresty

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -21,4 +21,4 @@ override :'berkshelf-no-depselector', version: '6016ca10b2f46508b1b1072642286687
 # in mainline luajit. There's forks for ppc64, and s390x, but going forward with
 # those was so far blocked by ppc64 not being supported even with the PPC64
 # fork.
-override :openresty, version: "1.13.6.2"
+override :openresty, version: "1.15.8.1"


### PR DESCRIPTION
### Description

Update openresty definition to 1.15.8.1

Signed-off-by: Mark Anderson <mark@chef.io>

[Please describe what this change achieves]

### Issues Resolved

This should replace and close #1330 and the parallel change to omnibus-software should close https://github.com/chef/omnibus-software/pull/863

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG