### PR TITLE
Dvm changes to get external postgres working.

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -154,7 +154,7 @@ def define_chef_server(config, attributes)
     if vmattr["postgresql"]["start"] and vmattr["postgresql"]["use-external"]
       # TODO make this stuff common - we have these values in 2-3 places now...
       pg = { "postgresql['external']" => true,
-             "postgresql['vip']" => "\"#{IPS[:database]}\"",
+             "postgresql['vip']" => "\"#{IPS[:db]}\"",
              "postgresql['port']" => 5432,
              "postgresql['db_superuser']" => "\"#{DB_SUPERUSER}\"",
              "postgresql['db_superuser_password']" => "\"#{DB_SUPERPASS}\"",
@@ -276,13 +276,13 @@ def define_ldap_server(config, attributes)
 end
 
 def define_db_server(config, attributes)
-  config.vm.hostname = "database.#{VMName}.dev"
-  config.vm.network "private_network", ip: IPS[:database]
+  config.vm.hostname = "db.#{VMName}.dev"
+  config.vm.network "private_network", ip: IPS[:db]
   customize_vm(config, name: "database#{Variant}", memory: 512, cpus: 1)
   set_chef_zero_provisioning(config,
                              recipes: ["provisioning::hosts"],
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
-  config.vm.provision "shell", path: "scripts/configure-postgres.sh"
+  config.vm.provision "shell", path: "scripts/provision-postgres.sh", args: "#{IPS[:cs]}"
 end
 
 def define_custom_server(config, attributes)

--- a/dev/scripts/provision-postgres.sh
+++ b/dev/scripts/provision-postgres.sh
@@ -1,10 +1,10 @@
-echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 wget --quiet https://www.postgresql.org/media/keys/ACCC4CF8.asc
 apt-key add ACCC4CF8.asc
 apt-get update
-apt-get install postgresql-9.2 -y
-echo "host    all             all             #{IPS[:cs]}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
-echo "listen_addresses='*'" >> /etc/postgresql/9.2/main/postgresql.conf
+apt-get install postgresql-9.6 -y
+echo "host    all             all            $1/32         md5" >> /etc/postgresql/9.6/main/pg_hba.conf
+echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
 service postgresql restart
-export PATH=/usr/lib/postgresql/9.2/bin:$PATH
+export PATH=/usr/lib/postgresql/9.6/bin:$PATH
 sudo -u postgres psql -c "CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v0ps';"

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -19,7 +19,7 @@ class EcPostgres
     end
     max_retries = retries
     begin
-      connection = ::PGconn.open('user' => postgres['db_superuser'],
+      connection = PG::Connection.open('user' => postgres['db_superuser'],
                                  'host' => postgres['vip'],
                                  'password' => postgres['db_superuser_password'],
                                  'port' => postgres['port'],


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Currently external-postgresql does not work in the chef-server dvm setup.
Minor changes to fix it.

Output of running `chef-server-ctl test` and `chef-server-ctl status`
```
Finished in 51.44 seconds (files took 3.54 seconds to load)
172 examples, 0 failures, 2 pending

root@api:~# chef-server-ctl status
-------------------
 Internal Services
-------------------
run: bookshelf: (pid 14601) 297s; run: log: (pid 8954) 357s
run: nginx: (pid 14446) 299s; run: log: (pid 9378) 338s
run: oc_bifrost: (pid 14354) 300s; run: log: (pid 8646) 377s
run: oc_id: (pid 14439) 300s; run: log: (pid 8686) 371s
run: opscode-erchef: (pid 14678) 296s; run: log: (pid 9124) 351s
run: opscode-expander: (pid 14499) 297s; run: log: (pid 8816) 361s
run: opscode-solr4: (pid 14466) 298s; run: log: (pid 8751) 365s
run: rabbitmq: (pid 15112) 290s; run: log: (pid 9739) 332s
run: redis_lb: (pid 9288) 342s; run: log: (pid 9287) 342s
-------------------
 External Services
-------------------
The PGconn, PGresult, and PGError constants are deprecated, and will be
removed as of version 1.0.

You should use PG::Connection, PG::Result, and PG::Error instead, respectively.

Called from /opt/opscode/embedded/lib/ruby/gems/2.5.0/gems/chef-server-ctl-1.0.0/bin/chef-server-ctl:123:in `postgresql_connection'
run: postgresql: connected OK to 192.168.33.150:5432
```

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG