### PR TITLE
Lbaker/wip ssl external postgres

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -154,7 +154,7 @@ def define_chef_server(config, attributes)
     if vmattr["postgresql"]["start"] and vmattr["postgresql"]["use-external"]
       # TODO make this stuff common - we have these values in 2-3 places now...
       pg = { "postgresql['external']" => true,
-             "postgresql['vip']" => "\"#{IPS[:database]}\"",
+             "postgresql['vip']" => "\"#{IPS[:db]}\"",
              "postgresql['port']" => 5432,
              "postgresql['db_superuser']" => "\"#{DB_SUPERUSER}\"",
              "postgresql['db_superuser_password']" => "\"#{DB_SUPERPASS}\"",
@@ -276,13 +276,13 @@ def define_ldap_server(config, attributes)
 end
 
 def define_db_server(config, attributes)
-  config.vm.hostname = "database.#{VMName}.dev"
-  config.vm.network "private_network", ip: IPS[:database]
+  config.vm.hostname = "db.#{VMName}.dev"
+  config.vm.network "private_network", ip: IPS[:db]
   customize_vm(config, name: "database#{Variant}", memory: 512, cpus: 1)
   set_chef_zero_provisioning(config,
                              recipes: ["provisioning::hosts"],
                              json: { 'provisioning' => { 'hosts' =>  ips_to_fqdns } })
-  config.vm.provision "shell", path: "scripts/configure-postgres.sh"
+  config.vm.provision "shell", path: "scripts/provision-postgres.sh", args: "#{IPS[:cs]}"
 end
 
 def define_custom_server(config, attributes)

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -7,7 +7,8 @@ vm:
   postgresql:
     # enable a separate postgres vm but do not use it unless
     # use-vm-for-external is set.
-    start: false
+    #start: false
+    start: true
     # When this is set true, and start is true,
     # the chef-server node will be configured to use
     # this vm as an external postgresql server from the start.
@@ -298,7 +299,6 @@ quickstart:
     description: "Load up all the things used for most chef server dev: pedant, cookbooks, commands, erchef.  Starts oc_erchef without a console."
     load:
       - omnibus private-chef-cookbooks
-      - omnibus ctl-commands
       - oc-chef-pedant
       - oc_erchef
     start:

--- a/dev/dvm/lib/dvm/application.rb
+++ b/dev/dvm/lib/dvm/application.rb
@@ -142,7 +142,8 @@ module DVM
     def psql(project_name)
       ensure_project(project_name)
       database = @projects[project_name].database
-      exec "sudo -u opscode-pgsql /opt/opscode/embedded/bin/psql #{database}"
+      #exec "sudo -u opscode-pgsql /opt/opscode/embedded/bin/psql #{database}"
+      exec "sudo -u opscode-pgsql /opt/opscode/embedded/bin/psql \"dbname=#{database} sslmode=require\""
     end
 
 

--- a/dev/scripts/provision-postgres.sh
+++ b/dev/scripts/provision-postgres.sh
@@ -1,10 +1,29 @@
-echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 wget --quiet https://www.postgresql.org/media/keys/ACCC4CF8.asc
 apt-key add ACCC4CF8.asc
 apt-get update
-apt-get install postgresql-9.2 -y
-echo "host    all             all             #{IPS[:cs]}/32         md5" >> /etc/postgresql/9.2/main/pg_hba.conf
-echo "listen_addresses='*'" >> /etc/postgresql/9.2/main/postgresql.conf
+apt-get install postgresql-9.6 -y
+echo "host    all             all             $1/32         md5" >> /etc/postgresql/9.6/main/pg_hba.conf
+echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
+########################################################################
+# lincoln: incorporating prajakta's edits
+#   https://github.com/chef/chef-server/compare/zanecodes_ssl?expand=1#diff-eee84728cb317f4bee8d7dfac54ebe69R8
+#   not sure how this will work with my setup.
+#
+# To turn ssl on in the external postgresql setup uncomment the following line.
+#   lincoln: what about the existing ssl=off? is that somehow overwritten?
+#echo "ssl=on" >> /etc/postgresql/9.6/main/postgresql.conf
+
+# For the dev setup you can use the nginx certs.
+# Copy them to /var/opt/opscode/postgresql/9.6/ and chown opscode-pgsql.
+#   lincoln: will also need to chmod 0600 these files.
+#   might be better to put these in postgres's default data directory,
+#   which means we can eliminate the ssl_cert/key_file settings.
+#  no `echo <whatever> >> <file>` below?
+#  nginx certs
+#ssl_cert_file = '/var/opt/opscode/postgresql/9.6/api.chef-server.dev.crt'
+#ssl_key_file = '/var/opt/opscode/postgresql/9.6/api.chef-server.dev.key'
+########################################################################
 service postgresql restart
-export PATH=/usr/lib/postgresql/9.2/bin:$PATH
+export PATH=/usr/lib/postgresql/9.6/bin:$PATH
 sudo -u postgres psql -c "CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v0ps';"

--- a/dev/scripts/provision-postgres.sh
+++ b/dev/scripts/provision-postgres.sh
@@ -5,25 +5,13 @@ apt-get update
 apt-get install postgresql-9.6 -y
 echo "host    all             all             $1/32         md5" >> /etc/postgresql/9.6/main/pg_hba.conf
 echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
-########################################################################
-# lincoln: incorporating prajakta's edits
-#   https://github.com/chef/chef-server/compare/zanecodes_ssl?expand=1#diff-eee84728cb317f4bee8d7dfac54ebe69R8
-#   not sure how this will work with my setup.
-#
 # To turn ssl on in the external postgresql setup uncomment the following line.
-#   lincoln: what about the existing ssl=off? is that somehow overwritten?
-#echo "ssl=on" >> /etc/postgresql/9.6/main/postgresql.conf
-
+echo "ssl=on" >> /etc/postgresql/9.6/main/postgresql.conf
 # For the dev setup you can use the nginx certs.
 # Copy them to /var/opt/opscode/postgresql/9.6/ and chown opscode-pgsql.
-#   lincoln: will also need to chmod 0600 these files.
-#   might be better to put these in postgres's default data directory,
-#   which means we can eliminate the ssl_cert/key_file settings.
-#  no `echo <whatever> >> <file>` below?
-#  nginx certs
+# Will also need to chmod 0600 these files.
 #ssl_cert_file = '/var/opt/opscode/postgresql/9.6/api.chef-server.dev.crt'
-#ssl_key_file = '/var/opt/opscode/postgresql/9.6/api.chef-server.dev.key'
-########################################################################
+#ssl_key_file  = '/var/opt/opscode/postgresql/9.6/api.chef-server.dev.key'
 service postgresql restart
 export PATH=/usr/lib/postgresql/9.6/bin:$PATH
 sudo -u postgres psql -c "CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v0ps';"

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -623,7 +623,9 @@ default['private_chef']['postgresql']['wal_level'] = "minimal"
 default['private_chef']['postgresql']['archive_mode'] = "off" # "cannot be enabled when wal_level is set to minimal"
 default['private_chef']['postgresql']['archive_command'] = ""
 default['private_chef']['postgresql']['archive_timeout'] = 0 # 0 is disabled.
-default['private_chef']['postgresql']['sslmode'] = 'disable'
+# disable | allow | prefer | require | verify-ca | verify-full
+# for now: require
+default['private_chef']['postgresql']['sslmode'] = 'require'
 
 # This is based on the tuning parameters here:
 #

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -623,6 +623,7 @@ default['private_chef']['postgresql']['wal_level'] = "minimal"
 default['private_chef']['postgresql']['archive_mode'] = "off" # "cannot be enabled when wal_level is set to minimal"
 default['private_chef']['postgresql']['archive_command'] = ""
 default['private_chef']['postgresql']['archive_timeout'] = 0 # 0 is disabled.
+default['private_chef']['postgresql']['sslmode'] = 'disable'
 
 # This is based on the tuning parameters here:
 #

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -23,6 +23,7 @@ class EcPostgres
                                  'host' => postgres['vip'],
                                  'password' => postgres['db_superuser_password'],
                                  'port' => postgres['port'],
+                                 'sslmode' => postgres['sslmode'],
                                  'dbname' => database)
     rescue => e
       if retries > 0

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -19,12 +19,12 @@ class EcPostgres
     end
     max_retries = retries
     begin
-      connection = ::PGconn.open('user' => postgres['db_superuser'],
-                                 'host' => postgres['vip'],
-                                 'password' => postgres['db_superuser_password'],
-                                 'port' => postgres['port'],
-                                 'sslmode' => postgres['sslmode'],
-                                 'dbname' => database)
+      connection = ::PG::Connection.open('user' => postgres['db_superuser'],
+                                 'host' =>         postgres['vip'],
+                                 'password' =>     postgres['db_superuser_password'],
+                                 'port' =>         postgres['port'],
+                                 'sslmode' =>      postgres['sslmode'],
+                                 'dbname' =>       database)
     rescue => e
       if retries > 0
         sleep_time = 2**((max_retries - retries))
@@ -57,7 +57,7 @@ class EcPostgres
     require 'pg'
     postgres = node['private_chef']['postgresql']
     as_user(postgres['username']) do
-      connection = ::PGconn.open('dbname' => database, :port => postgres['port'])
+      connection = ::PG::Connection.open('dbname' => database, :port => postgres['port'])
       begin
         yield connection
       ensure

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -19,12 +19,12 @@ class EcPostgres
     end
     max_retries = retries
     begin
-      connection = ::PG::Connection.open('user' => postgres['db_superuser'],
-                                 'host' =>         postgres['vip'],
-                                 'password' =>     postgres['db_superuser_password'],
-                                 'port' =>         postgres['port'],
-                                 'sslmode' =>      postgres['sslmode'],
-                                 'dbname' =>       database)
+      connection = ::PG::Connection.open('user' =>      postgres['db_superuser'],
+                                         'host' =>      postgres['vip'],
+                                         'password' =>  postgres['db_superuser_password'],
+                                         'port' =>      postgres['port'],
+                                         'sslmode' =>   postgres['sslmode'],
+                                         'dbname' =>    database)
     rescue => e
       if retries > 0
         sleep_time = 2**((max_retries - retries))

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -28,7 +28,8 @@ action :deploy do
                deploy #{target} --verify
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
-                  "PGPASSWORD" => new_resource.password
+                  "PGPASSWORD" => new_resource.password,
+                  "PGSSLMODE" => node['private_chef']['postgresql']['sslmode']
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -29,7 +29,7 @@ action :deploy do
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
                   "PGPASSWORD" => new_resource.password,
-                  "PGSSLMODE" => node['private_chef']['postgresql']['sslmode']
+                  "PGSSLMODE" => new_resource.sslmode
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user.rb
@@ -54,8 +54,7 @@ def update_user(connection, user_info)
     pg_shadow_info = connection.exec('select passwd from pg_shadow where usename = $1', [ new_resource.username ])
     if pg_shadow_info.ntuples > 0
       pg_shadow_info = pg_shadow_info[0]
-      if new_resource.password && pg_shadow_info['passwd'] != ::PGconn.encrypt_password(new_resource.password, new_resource.username)
-      #if new_resource.password && pg_shadow_info['passwd'] != ::PG::Connection.encrypt_password(new_resource.password, new_resource.username)
+      if new_resource.password && pg_shadow_info['passwd'] != ::PG::Connection.encrypt_password(new_resource.password, new_resource.username)
         changes << '  Update password'
         sql << " ENCRYPTED PASSWORD '#{connection.escape(new_resource.password)}'"
       end

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user.rb
@@ -55,6 +55,7 @@ def update_user(connection, user_info)
     if pg_shadow_info.ntuples > 0
       pg_shadow_info = pg_shadow_info[0]
       if new_resource.password && pg_shadow_info['passwd'] != ::PGconn.encrypt_password(new_resource.password, new_resource.username)
+      #if new_resource.password && pg_shadow_info['passwd'] != ::PG::Connection.encrypt_password(new_resource.password, new_resource.username)
         changes << '  Update password'
         sql << " ENCRYPTED PASSWORD '#{connection.escape(new_resource.password)}'"
       end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -61,5 +61,6 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
   username  postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bifrost"
+  sslmode postgres_attrs['sslmode']
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
@@ -56,5 +56,6 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/bookshelf/schema" do
   username  postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bookshelf"
+  sslmode postgres_attrs['sslmode']
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -50,6 +50,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/base
   username  postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database  "opscode_chef"
+  sslmode   postgres['sslmode']
   action :nothing
   notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema]", :immediately
 end
@@ -60,6 +61,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
   username  postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "opscode_chef"
+  sslmode   postgres['sslmode']
   action :nothing
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -97,7 +97,7 @@ if is_data_master?
       2.times do |i|
         # Note that we have to include the port even for a local pipe, because the port number
         # is included in the pipe default.
-        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} postgres -t -A'`
+        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} "dbname=postgres sslmode=#{node['private_chef']['postgresql']['sslmode']}" -t -A'`
 	if $?.exitstatus != 0
           Chef::Log.fatal("Could not connect to database, retrying in 10 seconds.")
           sleep 10

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
@@ -24,3 +24,4 @@ attribute :password,       kind_of: String, required: false, default: ""
 attribute :target_version, kind_of: String
 attribute :hostname,       kind_of: String, required: true
 attribute :port,           kind_of: Integer, required: true
+attribute :sslmode,        kind_of: String, required: false, default: "prefer"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -100,6 +100,7 @@
            {db_port, <%=  @postgresql['port'] %>},
            {db_user, "<%= @sql_user %>"},
            {db_name, "bookshelf" },
+           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[@postgresql['sslmode']] %>}]},
            {idle_check, 10000},
            {pooler_timeout, <%= @db_pooler_timeout %>},
            {db_timeout, <%= @sql_db_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -101,6 +101,7 @@
           {db_port, <%= node['private_chef']['postgresql']['port'] %> },
           {db_user, "<%= node['private_chef']['oc_bifrost']['sql_user'] %>" },
           {db_name, "bifrost" },
+          {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
           {idle_check, 10000},
           {pooler_timeout, <%= @db_pooler_timeout %>},
           {db_timeout, <%= node['private_chef']['oc_bifrost']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -315,6 +315,7 @@
         {db_port, <%= node['private_chef']['postgresql']['port'] %>},
         {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
         {db_name, "opscode_chef" },
+        {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
         {idle_check, 10000},
         {pooler_timeout, <%= @db_pooler_timeout %>},
         {db_timeout, <%= node['private_chef']['opscode-erchef']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
@@ -9,3 +9,4 @@ production:
   database: <%= node['private_chef']['oc_id']['sql_database'] %>
   username: <%= node['private_chef']['oc_id']['sql_user'] %>
   password: <%= "\<%= Secrets.get('oc_id', 'sql_password') %\>" %>
+  sslmode: <%= node['private_chef']['postgresql']['sslmode'] %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -111,6 +111,7 @@
            {db_port, 5432},
            {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
            {db_name, "opscode_chef" },
+           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
            {idle_check, 10000},
            {db_timeout, <%= node['private_chef']['opscode-chef-mover']['sql_db_timeout'] %>},
            {prepared_statements, {oc_chef_sql, statements, [pgsql]}},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
@@ -78,14 +78,24 @@ max_connections = <%= node['private_chef']['postgresql']['max_connections'] %>		
 
 #authentication_timeout = 1min		# 1s-600s
 
-ssl = on				        # off | on (change requires restart)
+# currently untested because this doesn't render/sync to anything on the database vm;
+# it has its own postgresql.conf
+<%=
+    if node['private_chef']['postgresql']['sslmode'] == 'disable'
+'ssl = off'
+    else
+# this will be much cleaner after we implement how to handle certs
+"ssl = on				        # off | on (change requires restart)
 # certs for external postgresql setup (should probably move to postgresql data directory and eliminate these settings)
 # not sure what effect these have (if any) on internal postgresql setup
 ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'          # (change requires restart)
 ssl_key_file =  '/etc/ssl/private/ssl-cert-snakeoil.key'        # (change requires restart)
 # certs for internal postgresql setup (should probably move to postgresql data directory and eliminate these settings)
 #ssl_cert_file = '/host/src/ssl-sync/api.chef-server.dev.crt'
-#ssl_key_file  = '/host/src/ssl-sync/api.chef-server.dev.key'
+#ssl_key_file  = '/host/src/ssl-sync/api.chef-server.dev.key'"
+    end
+%>
+
 
 #ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
 					# (change requires restart)

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
@@ -77,7 +77,16 @@ max_connections = <%= node['private_chef']['postgresql']['max_connections'] %>		
 # - Security and Authentication -
 
 #authentication_timeout = 1min		# 1s-600s
-#ssl = off				# (change requires restart)
+
+ssl = on				        # off | on (change requires restart)
+# certs for external postgresql setup (should probably move to postgresql data directory and eliminate these settings)
+# not sure what effect these have (if any) on internal postgresql setup
+ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'          # (change requires restart)
+ssl_key_file =  '/etc/ssl/private/ssl-cert-snakeoil.key'        # (change requires restart)
+# certs for internal postgresql setup (should probably move to postgresql data directory and eliminate these settings)
+#ssl_cert_file = '/host/src/ssl-sync/api.chef-server.dev.crt'
+#ssl_key_file  = '/host/src/ssl-sync/api.chef-server.dev.key'
+
 #ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
 					# (change requires restart)
 #ssl_renegotiation_limit = 512MB	# amount of data between renegotiations

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/postgresql.conf.erb
@@ -78,24 +78,15 @@ max_connections = <%= node['private_chef']['postgresql']['max_connections'] %>		
 
 #authentication_timeout = 1min		# 1s-600s
 
-# currently untested because this doesn't render/sync to anything on the database vm;
-# it has its own postgresql.conf
 <%=
-    if node['private_chef']['postgresql']['sslmode'] == 'disable'
-'ssl = off'
-    else
-# this will be much cleaner after we implement how to handle certs
-"ssl = on				        # off | on (change requires restart)
-# certs for external postgresql setup (should probably move to postgresql data directory and eliminate these settings)
-# not sure what effect these have (if any) on internal postgresql setup
-ssl_cert_file = '/etc/ssl/certs/ssl-cert-snakeoil.pem'          # (change requires restart)
-ssl_key_file =  '/etc/ssl/private/ssl-cert-snakeoil.key'        # (change requires restart)
-# certs for internal postgresql setup (should probably move to postgresql data directory and eliminate these settings)
-#ssl_cert_file = '/host/src/ssl-sync/api.chef-server.dev.crt'
-#ssl_key_file  = '/host/src/ssl-sync/api.chef-server.dev.key'"
-    end
+if node['private_chef']['postgresql']['sslmode'] == 'disable'
+    'ssl = off  # off | on (change requires restart)'
+else
+    "ssl = on   # off | on (change requires restart)
+#ssl_cert_file = '<PATH-TO-DEFAULT-INTERNAL-POSTGRESQL-DATA-DIRECTORY>/api.chef-server.dev.crt'
+#ssl_key_file  = '<PATH-TO-DEFAULT-INTERNAL-POSTGRESQL-DATA-DIRECTORY>/api.chef-server.dev.key'"
+end
 %>
-
 
 #ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'	# allowed SSL ciphers
 					# (change requires restart)

--- a/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
+++ b/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
@@ -12,12 +12,14 @@ define_upgrade do
     running_config = JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
     pc = running_config['private_chef']
     keyname = pc['opscode-erchef'].has_key?('sql_user') ? 'opscode-erchef' : 'postgresql'
-    connection = ::PGconn.open('user' => pc[keyname]['sql_user'],
-    # connection = ::PG::Connnection.open('user' => pc[keyname]['sql_user'],
+    connection = ::PG::Connection.open('user' => pc[keyname]['sql_user'],
                                'host' => pc['postgresql']['vip'],
                                'password' => Partybus.config.secrets.get('opscode_erchef', 'sql_password'),
                                'port' => pc['postgresql']['port'],
-                               # 'sslmode' => postgres['sslmode'],
+                               'sslmode' => 'require',
+                               #'sslmode' => postgres['sslmode'],
+                               #'sslmode' => pc['postgresql']['sslmode'],
+                               #Partybus.config.secrets.get('SOMETHING', 'sslmode'),
                                'dbname' => 'opscode_chef')
     begin
       connection.exec("select migrate_keys();")

--- a/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
+++ b/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
@@ -13,9 +13,11 @@ define_upgrade do
     pc = running_config['private_chef']
     keyname = pc['opscode-erchef'].has_key?('sql_user') ? 'opscode-erchef' : 'postgresql'
     connection = ::PGconn.open('user' => pc[keyname]['sql_user'],
+    # connection = ::PG::Connnection.open('user' => pc[keyname]['sql_user'],
                                'host' => pc['postgresql']['vip'],
                                'password' => Partybus.config.secrets.get('opscode_erchef', 'sql_password'),
                                'port' => pc['postgresql']['port'],
+                               # 'sslmode' => postgres['sslmode'],
                                'dbname' => 'opscode_chef')
     begin
       connection.exec("select migrate_keys();")

--- a/omnibus/partybus/lib/partybus/migration_api/v1.rb
+++ b/omnibus/partybus/lib/partybus/migration_api/v1.rb
@@ -130,9 +130,11 @@ EOF
         require 'pg'
         options = default_opts_for_service(service).merge(opts)
         ::PGconn.open({'user' => options[:username],
+        #::PG::Connection.open({'user' => options[:username],
                       'password' => options[:password],
                       'dbname' => options[:database],
                       'host' => Partybus.config.postgres['vip'],
+                      #'sslmode' => postgres['sslmode'],
                       'port' => Partybus.config.postgres['port']})
       end
 

--- a/omnibus/partybus/lib/partybus/migration_api/v1.rb
+++ b/omnibus/partybus/lib/partybus/migration_api/v1.rb
@@ -104,6 +104,7 @@ EOF
       # :database, and/or :path.
       def run_sqitch(target, service, opts = {})
         options = default_opts_for_service(service).merge(opts)
+        # sslmode below ???
         command = <<-EOM.gsub(/\s+/," ").strip!
           sqitch --engine pg
             --db-name #{options[:database]}
@@ -129,12 +130,14 @@ EOF
       def pg_conn_for(service, opts = {})
         require 'pg'
         options = default_opts_for_service(service).merge(opts)
-        ::PGconn.open({'user' => options[:username],
-        #::PG::Connection.open({'user' => options[:username],
+        ::PG::Connection.open({'user' => options[:username],
                       'password' => options[:password],
                       'dbname' => options[:database],
                       'host' => Partybus.config.postgres['vip'],
+                      'sslmode' => 'require',
                       #'sslmode' => postgres['sslmode'],
+                      #'sslmode' => Partybus.config.postgres['sslmode'],
+                      #'sslmode' => options['sslmode'],
                       'port' => Partybus.config.postgres['port']})
       end
 

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,10 @@
 override :erlang, version: "18.3.4.9"
 override :lua, version: "5.1.5"
 override :rubygems, version: "3.0.3"
-override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
+
+# hack to workaround bundler conflict... while doing a build?
+override :bundler, version: "1.17.3" # currently pinned to what ships in Ruby to prevent double bundler
+
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v15.0.300"
 override :ohai, version: "v15.0.35"

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -120,9 +120,10 @@ module Omnibus
     end
 
     def postgresql_connection(postgres)
-      PGconn.open('user' => postgres['db_superuser'], 'host' => postgres['vip'],
+      PG::Connection.open('user' => postgres['db_superuser'], 'host' => postgres['vip'],
                   'password' => credentials.get('postgresql', 'db_superuser_password'),
-                  'port' => postgres['port'], 'dbname' => 'template1')
+                  'port' => postgres['port'], 'sslmode' => postgres['sslmode'],
+                  'dbname' => 'template1')
     end
 
     def postgres_verbose_status(postgres, connection)

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -120,10 +120,12 @@ module Omnibus
     end
 
     def postgresql_connection(postgres)
-      PG::Connection.open('user' => postgres['db_superuser'], 'host' => postgres['vip'],
-                  'password' => credentials.get('postgresql', 'db_superuser_password'),
-                  'port' => postgres['port'], 'sslmode' => postgres['sslmode'],
-                  'dbname' => 'template1')
+      PG::Connection.open('user' => postgres['db_superuser'],
+                          'host' =>       postgres['vip'],
+                          'password' =>   credentials.get('postgresql', 'db_superuser_password'),
+                          'port' =>       postgres['port'],
+                          'sslmode' =>    postgres['sslmode'],
+                          'dbname' =>     'template1')
     end
 
     def postgres_verbose_status(postgres, connection)

--- a/src/oc_erchef/habitat/config/chef_server_data_bootstrap.rb
+++ b/src/oc_erchef/habitat/config/chef_server_data_bootstrap.rb
@@ -43,7 +43,6 @@ class EcPostgres
                                          'host' => postgres['vip'],
                                          'password' => postgres['db_superuser_password'],
                                          'port' => postgres['port'],
-                                         #'sslmode' => postgres['sslmode'],
                                          'dbname' => database)
     rescue => e
       if retries > 0

--- a/src/oc_erchef/habitat/config/chef_server_data_bootstrap.rb
+++ b/src/oc_erchef/habitat/config/chef_server_data_bootstrap.rb
@@ -43,6 +43,7 @@ class EcPostgres
                                          'host' => postgres['vip'],
                                          'password' => postgres['db_superuser_password'],
                                          'port' => postgres['port'],
+                                         #'sslmode' => postgres['sslmode'],
                                          'dbname' => database)
     rescue => e
       if retries > 0


### PR DESCRIPTION
### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Dev environment notes

Two VMs:  database, and chef-server

Currently, nothing on the database vm is configurable from the host or sync'd over from the host.  Ssl is simply wired to be 'on' in the database vm.  Configurability applies to the chef-server vm.  It is envisioned that the customer will configure his own external postgres.

1) postgresql.conf on database vm is currently not affected (rendered) by postgresql.conf.erb on host; rather 'ssl=on' is hardwired in the database vm from its own postgresql.conf.  However postgresql.conf.erb would configure an internal postgres.

2) SSL certs are 'automatically' available on the database vm and working.  For testing this with internal postgres (currently hasn't been done), certs ownership and permissions will currently need to be done by hand (see postgres.conf.erb for the location).

3) pg_hba.conf needs to be hand-edited on the database vm each time it is created.

### Resolved

Chef-HA won't be supported.

### Outstanding Issues/Questions

1) How much of this work applies to internal postgres?  What would it take to get that going?

2) What about tiered?  Can (or does) tiered work with an external postgres setup?

3) How much (or how little) does any of this apply to Chef backend?

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG