### PR TITLE
Fix logins to zendesk when user signups with a single name

### DIFF
--- a/src/oc-id/lib/zendesk_sso_url.rb
+++ b/src/oc-id/lib/zendesk_sso_url.rb
@@ -38,7 +38,7 @@ class ZendeskSSOURL
     JWT.encode({
       iat: iat,
       jti: jti,
-      name: [user.first_name, user.last_name].join(' '),
+      name: [user.first_name, user.last_name].compact.join(' '),
       email: user.email,
     }, settings.shared_secret)
   end

--- a/src/oc-id/lib/zendesk_sso_url.rb
+++ b/src/oc-id/lib/zendesk_sso_url.rb
@@ -38,7 +38,7 @@ class ZendeskSSOURL
     JWT.encode({
       iat: iat,
       jti: jti,
-      name: user.first_name,
+      name: [user.first_name, user.last_name].join(' '),
       email: user.email,
     }, settings.shared_secret)
   end

--- a/src/oc-id/spec/lib/zendesk_sso_url_spec.rb
+++ b/src/oc-id/spec/lib/zendesk_sso_url_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe ZendeskSSOURL do
   subject(:zendesk_sso_url) { described_class.new(user, return_to, settings) }
-  let(:user) { double(email: 'test@test.com', first_name: 'Testy') }
+  let(:user) { double(email: 'test@test.com', first_name: 'Testy', last_name: 'Tester') }
   let(:return_to) { 'test/return/to' }
   let(:settings) { double(subdomain: 'testsubdomain', shared_secret: 'shhhhh') }
 


### PR DESCRIPTION
## Description

When a user signs up for an account at https://manage.chef.io/signup and
only enters a single name only the last name field is populated.
This causes an error when trying to zendesk because the name we send is
blank.

Signed-off-by: Will Fisher <wfisher@chef.io>