### PR TITLE
Zanecodes ssl

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -623,6 +623,7 @@ default['private_chef']['postgresql']['wal_level'] = "minimal"
 default['private_chef']['postgresql']['archive_mode'] = "off" # "cannot be enabled when wal_level is set to minimal"
 default['private_chef']['postgresql']['archive_command'] = ""
 default['private_chef']['postgresql']['archive_timeout'] = 0 # 0 is disabled.
+default['private_chef']['postgresql']['sslmode'] = 'disable'
 
 # This is based on the tuning parameters here:
 #

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -623,6 +623,9 @@ default['private_chef']['postgresql']['wal_level'] = "minimal"
 default['private_chef']['postgresql']['archive_mode'] = "off" # "cannot be enabled when wal_level is set to minimal"
 default['private_chef']['postgresql']['archive_command'] = ""
 default['private_chef']['postgresql']['archive_timeout'] = 0 # 0 is disabled.
+# see: https://www.postgresql.org/docs/9.6/libpq-ssl.html
+# allowable choices come from the PGSSLMODE environment var for libpq.
+# supported sslmode values: disable | require
 default['private_chef']['postgresql']['sslmode'] = 'disable'
 
 # This is based on the tuning parameters here:

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -23,6 +23,7 @@ class EcPostgres
                                  'host' => postgres['vip'],
                                  'password' => postgres['db_superuser_password'],
                                  'port' => postgres['port'],
+                                 'sslmode' => postgres['sslmode'],
                                  'dbname' => database)
     rescue => e
       if retries > 0

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -286,4 +286,10 @@ class OmnibusHelper
     }
     Chef::JSONCompat.to_json_pretty(content)
   end
+
+  def postgresql_sslmodes
+    # see: https://www.postgresql.org/docs/9.6/libpq-ssl.html
+    # allowable choices come from the PGSSLMODE environment var for libpq.
+    { 'disable' => false, 'require' => 'required' }
+  end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -83,6 +83,7 @@ class PreflightValidator
 
     port = cs_pg_attr.has_key?('port') ? cs_pg_attr['port'] : node_pg_attr['port']
     host = cs_pg_attr['vip']
+    sslmode = cs_pg_attr.has_key?('sslmode') ? cs_pg_attr['sslmode'] : node_pg_attr['sslmode']
     if type == :invalid_user
       user = 'chef_server_conn_test'
       password = 'invalid'
@@ -95,6 +96,7 @@ class PreflightValidator
                                                            'db_superuser_password' => password,
                                                            'vip' => host,
                                                            'port' => port,
+                                                           'sslmode' => sslmode,
                                                            'silent' => options['silent'],
                                                            'retries' => options['retries']}) do |conn|
        if block_given?

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -28,7 +28,8 @@ action :deploy do
                deploy #{target} --verify
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
-                  "PGPASSWORD" => new_resource.password
+                  "PGPASSWORD" => new_resource.password,
+                  "PGSSLMODE" => node['private_chef']['postgresql']['sslmode']
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_sqitch.rb
@@ -29,7 +29,7 @@ action :deploy do
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
                   "PGPASSWORD" => new_resource.password,
-                  "PGSSLMODE" => node['private_chef']['postgresql']['sslmode']
+                  "PGSSLMODE" => new_resource.sslmode
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -61,5 +61,6 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/oc_bifrost/db" do
   username  postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bifrost"
+  sslmode postgres_attrs['sslmode']
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf.rb
@@ -68,7 +68,7 @@ template bookshelf_config do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
-  variables(bookshelf_params)
+  variables(bookshelf_params.merge :helper => OmnibusHelper.new(node))
   notifies :restart, 'component_runit_service[bookshelf]' if is_data_master?
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
@@ -56,5 +56,6 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/bookshelf/schema" do
   username  postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "bookshelf"
+  sslmode postgres_attrs['sslmode']
   action :nothing
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -50,6 +50,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema/base
   username  postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database  "opscode_chef"
+  sslmode   postgres['sslmode']
   action :nothing
   notifies :deploy, "private_chef_pg_sqitch[/opt/opscode/embedded/service/opscode-erchef/schema]", :immediately
 end
@@ -60,6 +61,7 @@ private_chef_pg_sqitch "/opt/opscode/embedded/service/opscode-erchef/schema" do
   username  postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database "opscode_chef"
+  sslmode   postgres['sslmode']
   action :nothing
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_bifrost.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_bifrost.rb
@@ -20,6 +20,7 @@
 # Remove all traces of the legacy opscode-authz service that oc_bifrost
 # replaces.
 #
+
 execute "/opt/opscode/bin/private-chef-ctl stop opscode-authz" do
   retries 20
 end
@@ -63,7 +64,7 @@ template oc_bifrost_config do
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode "644"
-  variables(node['private_chef']['oc_bifrost'].to_hash)
+  variables(node['private_chef']['oc_bifrost'].to_hash.merge :helper => OmnibusHelper.new(node))
   notifies :restart, 'component_runit_service[oc_bifrost]'
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -97,7 +97,7 @@ if is_data_master?
       2.times do |i|
         # Note that we have to include the port even for a local pipe, because the port number
         # is included in the pipe default.
-        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} postgres -t -A'`
+        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} "dbname=postgres sslmode=#{node['private_chef']['postgresql']['sslmode']}" -t -A'`
 	if $?.exitstatus != 0
           Chef::Log.fatal("Could not connect to database, retrying in 10 seconds.")
           sleep 10

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
@@ -20,7 +20,8 @@ default_action :deploy
 attribute :name,           kind_of: String, required: true, name_attribute: true
 attribute :database,       kind_of: String, required: true
 attribute :username,       kind_of: String
-attribute :password,       kind_of: String, required: false, default: ""
+attribute :password,       kind_of: String, required: false, default: ''
 attribute :target_version, kind_of: String
 attribute :hostname,       kind_of: String, required: true
 attribute :port,           kind_of: Integer, required: true
+attribute :sslmode,        kind_of: String, required: false, default: 'disable'

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -100,7 +100,7 @@
            {db_port, <%=  @postgresql['port'] %>},
            {db_user, "<%= @sql_user %>"},
            {db_name, "bookshelf" },
-           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[@postgresql['sslmode']] %>}]},
+           {db_options, [{ssl, <%= @helper.postgresql_sslmodes[@postgresql['sslmode']] %>}]},
            {idle_check, 10000},
            {pooler_timeout, <%= @db_pooler_timeout %>},
            {db_timeout, <%= @sql_db_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -100,6 +100,7 @@
            {db_port, <%=  @postgresql['port'] %>},
            {db_user, "<%= @sql_user %>"},
            {db_name, "bookshelf" },
+           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[@postgresql['sslmode']] %>}]},
            {idle_check, 10000},
            {pooler_timeout, <%= @db_pooler_timeout %>},
            {db_timeout, <%= @sql_db_timeout %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -101,7 +101,7 @@
           {db_port, <%= node['private_chef']['postgresql']['port'] %> },
           {db_user, "<%= node['private_chef']['oc_bifrost']['sql_user'] %>" },
           {db_name, "bifrost" },
-          {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
+          {db_options, [{ssl, <%= @helper.postgresql_sslmodes[node['private_chef']['postgresql']['sslmode']] %>}]},
           {idle_check, 10000},
           {pooler_timeout, <%= @db_pooler_timeout %>},
           {db_timeout, <%= node['private_chef']['oc_bifrost']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -101,6 +101,7 @@
           {db_port, <%= node['private_chef']['postgresql']['port'] %> },
           {db_user, "<%= node['private_chef']['oc_bifrost']['sql_user'] %>" },
           {db_name, "bifrost" },
+          {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
           {idle_check, 10000},
           {pooler_timeout, <%= @db_pooler_timeout %>},
           {db_timeout, <%= node['private_chef']['oc_bifrost']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -315,7 +315,7 @@
         {db_port, <%= node['private_chef']['postgresql']['port'] %>},
         {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
         {db_name, "opscode_chef" },
-        {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
+        {db_options, [{ssl, <%= @helper.postgresql_sslmodes[node['private_chef']['postgresql']['sslmode']] %>}]},
         {idle_check, 10000},
         {pooler_timeout, <%= @db_pooler_timeout %>},
         {db_timeout, <%= node['private_chef']['opscode-erchef']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -315,6 +315,7 @@
         {db_port, <%= node['private_chef']['postgresql']['port'] %>},
         {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
         {db_name, "opscode_chef" },
+        {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
         {idle_check, 10000},
         {pooler_timeout, <%= @db_pooler_timeout %>},
         {db_timeout, <%= node['private_chef']['opscode-erchef']['sql_db_timeout'] %>},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
@@ -9,3 +9,4 @@ production:
   database: <%= node['private_chef']['oc_id']['sql_database'] %>
   username: <%= node['private_chef']['oc_id']['sql_user'] %>
   password: <%= "\<%= Secrets.get('oc_id', 'sql_password') %\>" %>
+  sslmode: <%= node['private_chef']['postgresql']['sslmode'] %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -111,6 +111,7 @@
            {db_port, 5432},
            {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
            {db_name, "opscode_chef" },
+           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
            {idle_check, 10000},
            {db_timeout, <%= node['private_chef']['opscode-chef-mover']['sql_db_timeout'] %>},
            {prepared_statements, {oc_chef_sql, statements, [pgsql]}},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -111,7 +111,7 @@
            {db_port, 5432},
            {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
            {db_name, "opscode_chef" },
-           {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['private_chef']['postgresql']['sslmode']] %>}]},
+           {db_options, [{ssl, <%= @helper.postgresql_sslmodes[node['private_chef']['postgresql']['sslmode']] %>}]},
            {idle_check, 10000},
            {db_timeout, <%= node['private_chef']['opscode-chef-mover']['sql_db_timeout'] %>},
            {prepared_statements, {oc_chef_sql, statements, [pgsql]}},

--- a/src/bookshelf/rebar.lock
+++ b/src/bookshelf/rebar.lock
@@ -5,7 +5,7 @@
   0},
  {<<"chef_secrets">>,
   {git,"https://github.com/chef/chef_secrets",
-       {ref,"9098dd3c3ea22c11cadd7ae0a86e69ee5a105bda"}},
+       {ref,"58373899212a23e4f37070aaa6d3a751b1281492"}},
   0},
  {<<"ej">>,
   {git,"https://github.com/seth/ej",

--- a/src/chef-mover/rebar.lock
+++ b/src/chef-mover/rebar.lock
@@ -25,7 +25,7 @@
   0},
  {<<"chef_secrets">>,
   {git,"https://github.com/chef/chef_secrets",
-       {ref,"3ada796f85085bc3d6777f0bc355ce9345db7adf"}},
+       {ref,"58373899212a23e4f37070aaa6d3a751b1281492"}},
   0},
  {<<"couchbeam">>,
   {git,"git://github.com/opscode/couchbeam.git",

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -120,9 +120,12 @@ module Omnibus
     end
 
     def postgresql_connection(postgres)
-      PGconn.open('user' => postgres['db_superuser'], 'host' => postgres['vip'],
-                  'password' => credentials.get('postgresql', 'db_superuser_password'),
-                  'port' => postgres['port'], 'dbname' => 'template1')
+      PG::Connection.open('user' =>     postgres['db_superuser'],
+                          'host' =>     postgres['vip'],
+                          'password' => credentials.get('postgresql', 'db_superuser_password'),
+                          'port' =>     postgres['port'],
+                          'sslmode' =>  postgres['sslmode'],
+                          'dbname' =>   'template1')
     end
 
     def postgres_verbose_status(postgres, connection)

--- a/src/oc_bifrost/rebar.lock
+++ b/src/oc_bifrost/rebar.lock
@@ -1,7 +1,7 @@
 {"1.1.0",
 [{<<"chef_secrets">>,
   {git,"https://github.com/chef/chef_secrets",
-       {ref,"9098dd3c3ea22c11cadd7ae0a86e69ee5a105bda"}},
+       {ref,"58373899212a23e4f37070aaa6d3a751b1281492"}},
   0},
  {<<"edown">>,
   {git,"https://github.com/uwiger/edown.git",

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -21,7 +21,7 @@
   0},
  {<<"chef_secrets">>,
   {git,"https://github.com/chef/chef_secrets",
-       {ref,"9098dd3c3ea22c11cadd7ae0a86e69ee5a105bda"}},
+       {ref,"58373899212a23e4f37070aaa6d3a751b1281492"}},
   0},
  {<<"darklaunch">>,
   {git,"https://github.com/chef/opscode-darklaunch-erlang",


### PR DESCRIPTION
### Description

This change allows Chef services and omnibus cookbooks to be configured to use SSL to connect to the PostgreSQL database. This is necessary when using Azure Database for PostgreSQL as an external database securely, without disabling `Enforce SSL`.

<s>This change will not actually work until https://github.com/chef/chef_secrets/pull/27 is merged and the dependency is updated here.</s> DONE

We would like to thank zanecodes and Relativity for their contribution to this effort:
https://github.com/chef/chef-server/pull/1632

### Issues Resolved

https://github.com/chef/chef-server/issues/1559

### Potential Future Work

1) Fix ssl for migrations (if needed).

2) Expose configurables for ssl certificate files and directories.

3) 'Long usernames' for azure external postgresql support:

        [INSERT LINK HERE]

4) "Trusted root," man-in-the-middle, protection.

5) Investigate relevancy of ssl (if any) for internal Postgresql, tiered, and chef backend.

6) Fix deprecations (PGconn -> PG::Connection).


### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG