### PR TITLE
[ci] Add artifactory to omnibus/Gemfile

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -9,6 +9,7 @@ gem 'bundler', '>1.10'
 group :omnibus do
   gem 'omnibus', git: 'https://github.com/chef/omnibus'
   gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software'
+  gem 'artifactory'
 end
 
 group :test do


### PR DESCRIPTION
### Description

This change only affects CI. The artifactory gem is required for the publish part of the build stage.

### Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22