### PR TITLE
fix X-Forwared-For typo

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -68,7 +68,7 @@
     location "/data-collector/" {
       proxy_set_header        Host           $http_host;
       proxy_set_header        X-Real-IP      $remote_addr;
-      proxy_set_header        X-Forwared-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_pass_request_headers on;
       proxy_redirect off;
       proxy_pass <%= node['private_chef']['data_collector']['root_url'] %>;

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -66,9 +66,9 @@
 
     <% if node['private_chef']['data_collector']['proxy'] -%>
     location "/data-collector/" {
-      proxy_set_header        Host           $http_host;
-      proxy_set_header        X-Real-IP      $remote_addr;
-      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_pass_request_headers on;
       proxy_redirect off;
       proxy_pass <%= node['private_chef']['data_collector']['root_url'] %>;


### PR DESCRIPTION
### Description

Fixes a typo spotted in the success clack's `#chef-server` channel.

### Issues Resolved

None 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
