### PR TITLE
Update README.md

### DIFF
--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -163,7 +163,7 @@ command.
 Please either use ChefDK or install the latest test-kitchen from Rubygems.
 
 ```shell
-$ kitchen converge ubuntu-1204
+$ kitchen converge ubuntu-1604
 ```
 
 Test Kitchen uses a regex syntax to match on plaforms, so for example ubuntu 10.04
@@ -174,9 +174,10 @@ Then login to the instance and build the project as described in the Usage
 section:
 
 ```shell
-$ kitchen login ubuntu-1204
+$ kitchen login ubuntu-1604
 [vagrant@ubuntu...] $ . load-omnibus-toolchain.sh
 [vagrant@ubuntu...] $ cd chef-server/omnibus
+[vagrant@ubuntu...] $ sudo chown -R vagrant ~/.bundle/ 
 [vagrant@ubuntu...] $ bundle install --binstubs
 ...
 [vagrant@ubuntu...] $ bin/omnibus build chef-server -l internal
@@ -184,9 +185,10 @@ $ kitchen login ubuntu-1204
 or if you prefer not to use binstubs and to use bundle exec instead:
 
 ```shell
-$ kitchen login ubuntu-1204
+$ kitchen login ubuntu-1604
 [vagrant@ubuntu...] $ . load-omnibus-toolchain.sh
 [vagrant@ubuntu...] $ cd chef-server/omnibus
+[vagrant@ubuntu...] $ sudo chown -R vagrant ~/.bundle/
 [vagrant@ubuntu...] $ bundle install
 ...
 [vagrant@ubuntu...] $ bundle exec omnibus build chef-server -l internal


### PR DESCRIPTION
### Description

Sometimes the user gets the following error while following the kitchen build instructions.  This change adds an additional instruction to the instruction set so that the error is not encountered:
```
...
vagrant@default-ubuntu-1604:~/chef-server/omnibus$ bundle install --binstubs
Following files may not be writable, so sudo is needed:
  /opt/omnibus-toolchain/embedded/bin
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/bin
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/build_info
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/build_info/mini_portile2-2.4.0.info
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/build_info/nokogiri-1.10.3.info
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/bundler
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/cache
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/doc
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/extensions
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/gems
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.6.0/specifications
There was an error while trying to write to `/home/vagrant/.bundle/cache/compact_index/rubygems.org.443.29b0360b937aa4d161703e6160654e47/info`. It is likely
that you need to grant write permissions for that path.
```

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
