### PR TITLE
Lbaker/zanecodes connection user

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -308,6 +308,17 @@ vm:
     use-external: true
 ```
 
+To use an external Azure database for Chef Server, create a `config.yml` file with the following contents:
+
+```
+vm:
+  postgresql:
+    start: true
+    use-external: true
+    use-azure:    true
+    ip-azure:     <AZURE POSTGRESQL IP ADDRESS>
+```
+
 To use separate external databases for Chef Server and Chef Reporting, create a `config.yml` file with the following contents:
 
 ```

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -20,14 +20,22 @@ IPS = {
   solr: "192.168.33.157"
 }
 
+# to run a chef-server vm with external postgresql,
+# edit your config.yml file, and set postgresql start and use-external
+# to true. for external AZURE postgresql, also set postgresql use-azure
+# to true, and set postgresql ip-azure to the ip address
+# of your azure postgresql server.  see the postgresql section in
+# dev/defaults.yml for additional information.
+vmattr = load_settings['vm']
+USE_AZURE = vmattr['postgresql']['start'] && vmattr['postgresql']['use-external'] && vmattr['postgresql']['use-azure']
+IPS[:db]  = vmattr['postgresql']['ip-azure'] if USE_AZURE && vmattr['postgresql']['ip-azure']
 
 # Just in case you have a hankering to start a VM to run components on the
 # same network that don't fall into the categories above.
 # Enable it by setting config.yml value `vm.custom` to `true`,
 # then bring it up with `vagrant up custom`
-
-DB_SUPERUSER="bofh"
-DB_SUPERPASS="i1uvd3v0ps"
+DB_SUPERUSER = (vmattr['postgresql']['username-azure'] if USE_AZURE && vmattr['postgresql']['username-azure']) || 'bofh'
+DB_SUPERPASS = (vmattr['postgresql']['password-azure'] if USE_AZURE && vmattr['postgresql']['password-azure']) || 'i1uvd3v0ps'
 LDAP_PASSWORD='H0\/\/!|\/|3tY0ur|\/|0th3r'
 
 nodes_dir = File.join(File.expand_path(File.dirname(__FILE__)), 'nodes')
@@ -49,6 +57,7 @@ end
 Vagrant.configure("2") do |config|
   attributes = load_settings
 
+  config.vm.network 'public_network' if USE_AZURE
   # Use the official Ubuntu 16.04 box
   # Vagrant will auto resolve the url to download from Atlas
   config.vm.box = "bento/ubuntu-16.04"
@@ -127,6 +136,7 @@ Vagrant.configure("2") do |config|
   config.vm.define(VMName, primary: true) do |c|
     define_chef_server(c, attributes)
   end
+
 end
 
 
@@ -151,7 +161,7 @@ def define_chef_server(config, attributes)
       "provisioning" => { "hosts" => ips_to_fqdns }
     }.merge vmattr["node-attributes"]
 
-    if vmattr["postgresql"]["start"] and vmattr["postgresql"]["use-external"]
+    if vmattr["postgresql"]["start"] && vmattr["postgresql"]["use-external"]
       # TODO make this stuff common - we have these values in 2-3 places now...
       pg = { "postgresql['external']" => true,
              "postgresql['vip']" => "\"#{IPS[:db]}\"",
@@ -161,6 +171,16 @@ def define_chef_server(config, attributes)
              "opscode_erchef['db_pool_size']" => 10,
              "oc_id['db_pool_size']" => 10,
              "oc_bifrost['db_pool_size']" => 10 }
+      
+      pg.merge!({
+                  "postgresql['db_connection_superuser']" => "'#{DB_SUPERUSER}@#{IPS[:db]}'",
+                  "postgresql['sql_connection_user']" => "'#{DB_SUPERUSER}@#{IPS[:db]}'",
+                  "opscode_erchef['sql_connection_user']" => "'opscode_chef@#{IPS[:db]}'",
+                  "oc_bifrost['sql_connection_user']" => "'bifrost@#{IPS[:db]}'",
+                  "bookshelf['sql_connection_user']" => "'bookshelf@#{IPS[:db]}'",
+                  "oc_id['sql_connection_user']" => "'oc_id@#{IPS[:db]}'"
+                }) if USE_AZURE
+
       json = simple_deep_merge(json, { "provisioning" => { "chef-server-config" => pg } })
     end
 

--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -6,18 +6,22 @@ vm:
   # to use it as an externally managed postgres instance.
   postgresql:
     # enable a separate postgres vm but do not use it unless
-    # use-vm-for-external is set.
+    # use-external is set.
     start: false
     # When this is set true, and start is true,
     # the chef-server node will be configured to use
     # this vm as an external postgresql server from the start.
     use-external: true
+    # When this is set true, and start is true, and use-external is true,
+    # the chef-server node will be configured to use
+    # this vm as an external azure postgresql server from the start.
+    use-azure: false
   # Override this in config.yml if you want to bring up a separate reporting
   # postgres box, and if you want to automatically configure chef-server
   # to use it as an externally managed reporting postgres instance.
   reporting_postgresql:
     # enable a separate postgres vm but do not use it unless
-    # use-vm-for-external is set.
+    # use-external is set.
     start: false
     # When this is set true, and start is true,
     # chef reporting will be configured to use

--- a/omnibus/Berksfile.lock
+++ b/omnibus/Berksfile.lock
@@ -1,0 +1,36 @@
+DEPENDENCIES
+  apt
+  omnibus
+  yum-centos
+  yum-epel
+  zip
+
+GRAPH
+  apt (7.2.0)
+  build-essential (8.2.1)
+    mingw (>= 1.1)
+    seven_zip (>= 0.0.0)
+  chef-ingredient (3.1.2)
+  chef-sugar (5.1.8)
+  git (10.0.0)
+  homebrew (5.0.8)
+  mingw (2.1.0)
+    seven_zip (>= 0.0.0)
+  omnibus (5.7.2)
+    build-essential (>= 6.0.0)
+    chef-ingredient (>= 0.21.4)
+    chef-sugar (>= 3.2.0)
+    git (>= 0.0.0)
+    homebrew (>= 0.0.0)
+    remote_install (>= 0.0.0)
+    seven_zip (>= 0.0.0)
+    wix (>= 0.0.0)
+  remote_install (2.0.0)
+  seven_zip (3.1.2)
+    windows (>= 0.0.0)
+  windows (6.0.1)
+  wix (5.0.0)
+    windows (>= 2.0)
+  yum-centos (3.2.0)
+  yum-epel (3.3.0)
+  zip (1.1.0)

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -364,6 +364,7 @@ default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = nil
 default['private_chef']['opscode-erchef']['sql_user'] = 'opscode_chef'
 default['private_chef']['opscode-erchef']['sql_ro_user'] = 'opscode_chef_ro'
+default['private_chef']['opscode-erchef']['sql_connection_user'] = nil
 default['private_chef']['opscode-erchef']['enable_request_logging'] = true
 
 #
@@ -669,6 +670,7 @@ default['private_chef']['postgresql']['log_rotation']['file_maxbytes'] = 1048576
 default['private_chef']['postgresql']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['postgresql']['username'] = 'opscode-pgsql'
 default['private_chef']['postgresql']['db_superuser'] = 'opscode-pgsql'
+default['private_chef']['postgresql']['db_connection_superuser'] = nil
 default['private_chef']['postgresql']['shell'] = '/bin/sh'
 default['private_chef']['postgresql']['home'] = '/var/opt/opscode/postgresql'
 default['private_chef']['postgresql']['user_path'] = '/opt/opscode/embedded/bin:/opt/opscode/bin:$PATH'
@@ -741,6 +743,7 @@ default['private_chef']['oc_bifrost']['db_pool_queue_max'] = 20
 default['private_chef']['oc_bifrost']['udp_socket_pool_size'] = nil
 default['private_chef']['oc_bifrost']['sql_user'] = 'bifrost'
 default['private_chef']['oc_bifrost']['sql_ro_user'] = 'bifrost_ro'
+default['private_chef']['oc_bifrost']['sql_connection_user'] = nil
 default['private_chef']['oc_bifrost']['sql_db_timeout'] = 5000
 # Enable extended performance logging data for bifrost.  Setting this to false
 # will cut bifrost request log size approximately in half.
@@ -792,6 +795,7 @@ default['private_chef']['bookshelf']['db_pooler_timeout'] = 2000
 default['private_chef']['bookshelf']['sql_db_timeout'] = 5000
 default['private_chef']['bookshelf']['sql_ro_user'] = 'bookshelf_ro'
 default['private_chef']['bookshelf']['sql_user'] = 'bookshelf'
+default['private_chef']['bookshelf']['sql_connection_user'] = nil
 # Request logging (enable_request_logging)is disabled because
 # it is redendant (nginx also logs requests)
 # If debug logging is needed, enable_request_logging can be set to true
@@ -813,6 +817,7 @@ default['private_chef']['oc_id']['port'] = 9090
 default['private_chef']['oc_id']['sql_database'] = 'oc_id'
 default['private_chef']['oc_id']['sql_user'] = 'oc_id'
 default['private_chef']['oc_id']['sql_ro_user'] = 'oc_id_ro'
+default['private_chef']['oc_id']['sql_connection_user'] = nil
 default['private_chef']['oc_id']['db_pool_size'] = '20'
 default['private_chef']['oc_id']['sentry_dsn'] = nil
 default['private_chef']['oc_id']['sign_up_url'] = nil

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -364,6 +364,7 @@ default['private_chef']['opscode-erchef']['bulk_fetch_batch_size'] = '5'
 default['private_chef']['opscode-erchef']['udp_socket_pool_size'] = nil
 default['private_chef']['opscode-erchef']['sql_user'] = 'opscode_chef'
 default['private_chef']['opscode-erchef']['sql_ro_user'] = 'opscode_chef_ro'
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['opscode-erchef']['sql_connection_user'] = nil
 default['private_chef']['opscode-erchef']['enable_request_logging'] = true
 
@@ -670,6 +671,9 @@ default['private_chef']['postgresql']['log_rotation']['file_maxbytes'] = 1048576
 default['private_chef']['postgresql']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['postgresql']['username'] = 'opscode-pgsql'
 default['private_chef']['postgresql']['db_superuser'] = 'opscode-pgsql'
+# In certain scenarios (Azure PostgreSQL) it may be necessary to use a different username
+# for connection establishment from the username as it exists in the database.
+# This will default to the db_superuser value if left nil.
 default['private_chef']['postgresql']['db_connection_superuser'] = nil
 default['private_chef']['postgresql']['shell'] = '/bin/sh'
 default['private_chef']['postgresql']['home'] = '/var/opt/opscode/postgresql'
@@ -743,6 +747,7 @@ default['private_chef']['oc_bifrost']['db_pool_queue_max'] = 20
 default['private_chef']['oc_bifrost']['udp_socket_pool_size'] = nil
 default['private_chef']['oc_bifrost']['sql_user'] = 'bifrost'
 default['private_chef']['oc_bifrost']['sql_ro_user'] = 'bifrost_ro'
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['oc_bifrost']['sql_connection_user'] = nil
 default['private_chef']['oc_bifrost']['sql_db_timeout'] = 5000
 # Enable extended performance logging data for bifrost.  Setting this to false
@@ -795,6 +800,7 @@ default['private_chef']['bookshelf']['db_pooler_timeout'] = 2000
 default['private_chef']['bookshelf']['sql_db_timeout'] = 5000
 default['private_chef']['bookshelf']['sql_ro_user'] = 'bookshelf_ro'
 default['private_chef']['bookshelf']['sql_user'] = 'bookshelf'
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['bookshelf']['sql_connection_user'] = nil
 # Request logging (enable_request_logging)is disabled because
 # it is redendant (nginx also logs requests)
@@ -817,6 +823,7 @@ default['private_chef']['oc_id']['port'] = 9090
 default['private_chef']['oc_id']['sql_database'] = 'oc_id'
 default['private_chef']['oc_id']['sql_user'] = 'oc_id'
 default['private_chef']['oc_id']['sql_ro_user'] = 'oc_id_ro'
+# See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['oc_id']['sql_connection_user'] = nil
 default['private_chef']['oc_id']['db_pool_size'] = '20'
 default['private_chef']['oc_id']['sentry_dsn'] = nil

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -47,16 +47,15 @@ class ChefServerDataBootstrap
     # objects in erchef.  By separating them, we increase the chance that a
     # bootstrap failed due to an error out of bifrost can be recovered
     # by re-running it.
-    username = node['private_chef']['opscode-erchef']['sql_user']
+    username = node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user']
     password = PrivateChef.credentials.get('opscode_erchef', 'sql_password')
-    EcPostgres.with_connection(node, 'opscode_chef',
-      'db_superuser' => username,
-      'db_superuser_password' => password) do |conn|
+    # don't we need 'db_superuser' => username below also? (see: omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb)
+    EcPostgres.with_connection(node, 'opscode_chef', 'db_connection_superuser' => username, 'db_superuser_password' => password) do |conn|
         create_superuser_in_erchef(conn)
         create_server_admins_global_group_in_erchef(conn)
         create_global_container_in_erchef(conn, 'organizations', orgs_authz_id)
         create_global_container_in_erchef(conn, 'users', users_authz_id)
-      end
+    end
   end
 
   private

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -19,12 +19,12 @@ class EcPostgres
     end
     max_retries = retries
     begin
-      connection = PG::Connection.open('user' => postgres['db_superuser'],
-                                       'host' => postgres['vip'],
+      connection = PG::Connection.open('user' =>     postgres['db_connection_superuser'] || postgres['db_superuser'],
+                                       'host' =>     postgres['vip'],
                                        'password' => postgres['db_superuser_password'],
-                                       'port' => postgres['port'],
-                                       'sslmode' => postgres['sslmode'],
-                                       'dbname' => database)
+                                       'port' =>     postgres['port'],
+                                       'sslmode' =>  postgres['sslmode'],
+                                       'dbname' =>   database)
     rescue => e
       if retries > 0
         sleep_time = 2**((max_retries - retries))

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -131,8 +131,8 @@ class OmnibusHelper
   end
 
   def db_connection_uri
-    db_protocol = 'postgres'
-    db_user     = node['private_chef']['opscode-erchef']['sql_user']
+    db_protocol = "postgres"
+    db_user     = node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user']
     db_password = PrivateChef.credentials.get('opscode_erchef', 'sql_password')
     db_vip      = vip_for_uri('postgresql')
     db_name     = 'opscode_chef'
@@ -141,8 +141,8 @@ class OmnibusHelper
   end
 
   def bifrost_db_connection_uri
-    db_protocol = 'postgres'
-    db_user     = node['private_chef']['oc_bifrost']['sql_user']
+    db_protocol = "postgres"
+    db_user     = node['private_chef']['oc_bifrost']['sql_connection_user'] || node['private_chef']['oc_bifrost']['sql_user']
     db_password = PrivateChef.credentials.get('oc_bifrost', 'sql_password')
     db_vip      = vip_for_uri('postgresql')
     db_name     = 'bifrost'

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -86,21 +86,21 @@ class PreflightValidator
       user = 'chef_server_conn_test'
       password = 'invalid'
     else
-      user = cs_pg_attr['db_superuser']
+      user = cs_pg_attr['db_connection_superuser'] || cs_pg_attr['db_superuser']
       password = cs_pg_attr['db_superuser_password']
     end
     # No error handling - the caller is expected to handle any exception.
-    EcPostgres.with_connection(node, options['db_name'], 'db_superuser' => user,
-                                                         'db_superuser_password' => password,
-                                                         'vip' => host,
-                                                         'port' => port,
-                                                         'sslmode' => sslmode,
-                                                         'silent' => options['silent'],
-                                                         'retries' => options['retries']) do |conn|
-                                                           if block_given?
-                                                             yield(conn)
-                                                           end
-                                                         end
+    EcPostgres.with_connection(node, options['db_name'], { 'db_connection_superuser' => user,
+                                                           'db_superuser_password' => password,
+                                                           'vip' => host,
+                                                           'port' => port,
+                                                           'sslmode' => sslmode,
+                                                           'silent' => options['silent'],
+                                                           'retries' => options['retries']}) do |conn|
+       if block_given?
+         yield(conn)
+       end
+    end
   end
 
   # Helper function that let get the correct top-level value for a service

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -105,30 +105,35 @@ class PostgresqlPreflightValidator < PreflightValidator
     # all nodes are expected to be able to reach the database node
     # and connect to it - let's make a connection intended to fail
     # with an auth-related error just to verify connectivity to the service.
-
-    connect_as(:invalid_user, 'silent' => true, 'retries' => 0)
-  rescue ::PG::ConnectionBad => e
-    # A bit messy but PG gem does not expose error codes to us:
-    case e.message
-    when /.*Connection refused.*/
-      fail_with err_CSPG010_postgres_not_available
-    when /.*password authentication failed.*/
-      # This is what we want to see.
-    when /role .* does not exist/
-      # This indicates we were successfully able to connect to Postgres
-      # AND we authenticated! This is likely because the pg_hba is set
-      # to trust our connection. Such an example would be configuring
-      # Chef Server to use an "external" Postgres, such as Delivery's,
-      # when running on the same host.
-    when /.*no pg_hba.conf entry.*/
-      # This is also possible, depending on if they've set up pg_hba
-      # by host or user or both. This is OK, since it confirms that we're
-      # able to connect to the postgres instance.
-    else
-      # This shouldn't be possible, but we still don't want to dump an
-      # unhelpful stack trace on the screen. Let's at least catch it and
-      # fail with a meaningful error.
-      fail_with "CSPG999: #{e.message}"
+    begin
+      connect_as(:invalid_user, 'silent' => true, 'retries' => 0)
+    rescue ::PG::ConnectionBad => e
+      # A bit messy but PG gem does not expose error codes to us:
+      case e.message
+      when /.*Connection refused.*/
+        fail_with err_CSPG010_postgres_not_available
+      when /.*password authentication failed.*/
+        # This is what we want to see.
+      when /role .* does not exist/
+        # This indicates we were successfully able to connect to Postgres
+        # AND we authenticated! This is likely because the pg_hba is set
+        # to trust our connection. Such an example would be configuring
+        # Chef Server to use an "external" Postgres, such as Delivery's,
+        # when running on the same host.
+      when /.*no pg_hba.conf entry.*/
+        # This is also possible, depending on if they've set up pg_hba
+        # by host or user or both. This is OK, since it confirms that we're
+        # able to connect to the postgres instance.
+      when /.*The Username should be in <username@hostname> format.*/
+        # This is possible if the external postgres is an Azure Database
+        # for PostgreSQL instance. It's also OK, and indicates that the
+        # postgres instance can be connected to.
+      else
+        # This shouldn't be possible, but we still don't want to dump an
+        # unhelpful stack trace on the screen. Let's at least catch it and
+        # fail with a meaningful error.
+        fail_with "CSPG999: #{e.message}"
+      end
     end
   end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -266,30 +266,30 @@ class PostgresqlPreflightValidator < PreflightValidator
   end
 
   def err_CSPG011_invalid_superuser_account
-    <<~EOM
-      CSPG011: I could not authenticate to #{cs_pg_attr['vip']} as
-               #{cs_pg_attr['db_superuser']} using the password provided.
-               Please make sure that the the password you provided in
-               chef-server.rb under "postgresql['db_superuser_password'] is correct
-               for this user.
+<<EOM
+CSPG011: I could not authenticate to #{cs_pg_attr['vip']} as
+         #{cs_pg_attr['db_connection_superuser'] || cs_pg_attr['db_superuser']} using the password provided.
+         Please make sure that the the password you provided in
+         chef-server.rb under "postgresql['db_superuser_password'] is correct
+         for this user.
 
-               See https://docs.chef.io/error_messages.html#cspg011-cannot-authenticate
-               for more information.
-    EOM
+         See https://docs.chef.io/error_messages.html#cspg011-cannot-authenticate
+         for more information.
+EOM
   end
 
   def err_CSPG012_invalid_pg_hba
-    <<~EOM
-      CSPG012: There is a missing or incorrect pg_hba.conf entry for the
-               user '#{cs_pg_attr['db_superuser']}' and/or this originating host.
-               Please ensure that pg_hba.conf entries exist to allow the superuser
-               account to connect from the Chef Server backend nodes, and to
-               allow the application accounts to connect from all Chef Server
-               nodes.
+<<EOM
+CSPG012: There is a missing or incorrect pg_hba.conf entry for the
+         user '#{cs_pg_attr['db_connection_superuser'] || cs_pg_attr['db_superuser']}' and/or this originating host.
+         Please ensure that pg_hba.conf entries exist to allow the superuser
+         account to connect from the Chef Server backend nodes, and to
+         allow the application accounts to connect from all Chef Server
+         nodes.
 
-               See https://docs.chef.io/error_messages.html#cspg012-incorrect-rules
-               for more information.
-    EOM
+         See https://docs.chef.io/error_messages.html#cspg012-incorrect-rules
+         for more information.
+EOM
   end
 
   def err_CSPG013_not_superuser

--- a/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/providers/pg_user_table_access.rb
@@ -16,7 +16,7 @@
 
 # NOTE:
 #
-# Uses the value of node['private_chef']['postgresql']['db_superuser'] and ['db_superuser_password]
+# Uses the value of node['private_chef']['postgresql']['db_connection_superuser'] and ['db_superuser_password]
 # to make the connection to the postgres server.
 
 action :create do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -58,7 +58,7 @@ end
 private_chef_pg_sqitch '/opt/opscode/embedded/service/oc_bifrost/db' do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
-  username postgres_attrs['db_superuser']
+  username  postgres_attrs['db_connection_superuser'] || postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database 'bifrost'
   sslmode postgres_attrs['sslmode']

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
@@ -53,7 +53,7 @@ end
 private_chef_pg_sqitch '/opt/opscode/embedded/service/bookshelf/schema' do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
-  username postgres_attrs['db_superuser']
+  username  postgres_attrs['db_connection_superuser'] || postgres_attrs['db_superuser']
   password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database 'bookshelf'
   sslmode postgres_attrs['sslmode']

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -47,7 +47,7 @@ end
 private_chef_pg_sqitch '/opt/opscode/embedded/service/opscode-erchef/schema/baseline' do
   hostname  postgres['vip']
   port      postgres['port']
-  username  postgres['db_superuser']
+  username  postgres['db_connection_superuser'] || postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database  'opscode_chef'
   sslmode   postgres['sslmode']
@@ -58,7 +58,7 @@ end
 private_chef_pg_sqitch '/opt/opscode/embedded/service/opscode-erchef/schema' do
   hostname  postgres['vip']
   port      postgres['port']
-  username  postgres['db_superuser']
+  username  postgres['db_connection_superuser'] || postgres['db_superuser']
   password  PrivateChef.credentials.get('postgresql', 'db_superuser_password')
   database 'opscode_chef'
   sslmode postgres['sslmode']

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -97,9 +97,9 @@ if is_data_master?
       2.times do |_i|
         # Note that we have to include the port even for a local pipe, because the port number
         # is included in the pipe default.
-        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_superuser']} "dbname=postgres sslmode=#{node['private_chef']['postgresql']['sslmode']}" -t -A'`
-        if $CHILD_STATUS.exitstatus != 0
-          Chef::Log.fatal('Could not connect to database, retrying in 10 seconds.')
+        `echo 'SELECT * FROM pg_database;' | su - #{node['private_chef']['postgresql']['username']} -c '/opt/opscode/embedded/bin/psql -p #{node['private_chef']['postgresql']['port']} -U #{node['private_chef']['postgresql']['db_connection_superuser'] || node['private_chef']['postgresql']['db_superuser']} "dbname=postgres sslmode=#{node['private_chef']['postgresql']['sslmode']}" -t -A'`
+	if $?.exitstatus != 0
+          Chef::Log.fatal("Could not connect to database, retrying in 10 seconds.")
           sleep 10
         else
           connectable = true

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_postgres_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_postgres_validator_spec.rb
@@ -174,8 +174,17 @@ describe PostgresqlPreflightValidator do
         end
       end
 
-      context 'when we receive an unexpected error' do
-        let (:pg_exception) { PG::ConnectionBad.new('FATAL: something funky happened') }
+      context "when we connect to Azure PostgreSQL" do
+        let (:pg_exception) { PG::ConnectionBad.new('FATAL:  Invalid Username specified. Please check the Username and retry connection. The Username should be in <username@hostname> format.') }
+
+        it "does not raise an error" do
+          expect(postgres_validator).to_not receive(:fail_with)
+          expect { postgres_validator.connectivity_validation }.to_not raise_error
+        end
+      end
+
+      context "when we receive an unexpected error" do
+        let (:pg_exception) { PG::ConnectionBad.new("FATAL: something funky happened") }
 
         it 'raises a CSPG999 error' do
           expect(postgres_validator).to receive(:fail_with).with('CSPG999: FATAL: something funky happened')

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/bookshelf.config.erb
@@ -98,7 +98,7 @@
            %% Database connection parameters
            {db_host, "<%= @postgresql['vip'] %>"},
            {db_port, <%=  @postgresql['port'] %>},
-           {db_user, "<%= @sql_user %>"},
+           {db_user, "<%= @sql_connection_user || @sql_user %>"},
            {db_name, "bookshelf" },
            {db_options, [{ssl, <%= @helper.postgresql_sslmodes[@postgresql['sslmode']] %>}]},
            {idle_check, 10000},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_bifrost.config.erb
@@ -99,7 +99,7 @@
           {ip_mode, [ <%=PrivateChef['use_ipv6'] ? "ipv6,ipv4" : "ipv4" %> ] },
           {db_host, "<%= node['private_chef']['postgresql']['vip'] %>" },
           {db_port, <%= node['private_chef']['postgresql']['port'] %> },
-          {db_user, "<%= node['private_chef']['oc_bifrost']['sql_user'] %>" },
+          {db_user, "<%= node['private_chef']['oc_bifrost']['sql_connection_user'] || node['private_chef']['oc_bifrost']['sql_user'] %>" },
           {db_name, "bifrost" },
           {db_options, [{ssl, <%= @helper.postgresql_sslmodes[node['private_chef']['postgresql']['sslmode']] %>}]},
           {idle_check, 10000},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -313,7 +313,7 @@
         %% Database connection parameters
         {db_host, "<%= node['private_chef']['postgresql']['vip'] %>"},
         {db_port, <%= node['private_chef']['postgresql']['port'] %>},
-        {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
+        {db_user, "<%= node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user']  %>"},
         {db_name, "opscode_chef" },
         {db_options, [{ssl, <%= @helper.postgresql_sslmodes[node['private_chef']['postgresql']['sslmode']] %>}]},
         {idle_check, 10000},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_id.database.yml.erb
@@ -7,6 +7,6 @@ production:
   host: <%= node['private_chef']['postgresql']['vip'] %>
   port: <%= node['private_chef']['postgresql']['port'] %>
   database: <%= node['private_chef']['oc_id']['sql_database'] %>
-  username: <%= node['private_chef']['oc_id']['sql_user'] %>
+  username: <%= node['private_chef']['oc_id']['sql_connection_user'] || node['private_chef']['oc_id']['sql_user'] %>
   password: <%= "\<%= Secrets.get('oc_id', 'sql_password') %\>" %>
   sslmode: <%= node['private_chef']['postgresql']['sslmode'] %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/opscode-chef-mover.config.erb
@@ -109,7 +109,7 @@
            {config_cb, {chef_secrets_sqerl, config, [{<<"opscode_erchef">>, <<"sql_password">>}]}},
            {db_host, "<%= node['private_chef']['postgresql']['vip'] %>"},
            {db_port, 5432},
-           {db_user, "<%= node['private_chef']['opscode-erchef']['sql_user'] %>"},
+           {db_user, "<%= node['private_chef']['opscode-erchef']['sql_connection_user'] || node['private_chef']['opscode-erchef']['sql_user'] %>"},
            {db_name, "opscode_chef" },
            {db_options, [{ssl, <%= @helper.postgresql_sslmodes[node['private_chef']['postgresql']['sslmode']] %>}]},
            {idle_check, 10000},

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pg_hba.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pg_hba.conf.erb
@@ -64,7 +64,7 @@
 # "local" is for Unix domain socket connections only
 local   all         <%= node['private_chef']['postgresql']['username'] %>                               peer
 
-host    all         <%= node['private_chef']['postgresql']['db_superuser'] %>         samehost           md5
+host    all         <%= node['private_chef']['postgresql']['db_connection_superuser'] || node['private_chef']['postgresql']['db_superuser'] %>         samehost           md5
 
 <% node['private_chef']['postgresql']['md5_auth_cidr_addresses'].each do |cidr| %>
 host    all         all         <%= cidr %>           md5

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -120,12 +120,12 @@ module Omnibus
     end
 
     def postgresql_connection(postgres)
-      PG::Connection.open('user' =>     postgres['db_superuser'],
-                          'host' =>     postgres['vip'],
+      PG::Connection.open('user'     => postgres['db_connection_superuser'] || postgres['db_superuser'],
+                          'host'     => postgres['vip'],
                           'password' => credentials.get('postgresql', 'db_superuser_password'),
-                          'port' =>     postgres['port'],
-                          'sslmode' =>  postgres['sslmode'],
-                          'dbname' =>   'template1')
+                          'port'     => postgres['port'],
+                          'sslmode'  => postgres['sslmode'],
+                          'dbname'   => 'template1')
     end
 
     def postgres_verbose_status(postgres, connection)

--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -123,7 +123,7 @@ module ChefServerCtl
                               ENV['CSC_BIFROST_DB_URI']
                             else
                               pg_config = @@ctl.running_service_config('postgresql')
-                              user = pg_config['db_superuser']
+                              user = pg_config['db_connection_superuser'] || pg_config['db_superuser']
                               password = @@ctl.credentials.get('postgresql', 'db_superuser_password')
                               make_connection_string('bifrost', user, password)
                             end
@@ -137,7 +137,7 @@ module ChefServerCtl
                              ENV['CSC_ERCHEF_DB_URI']
                            else
                              erchef_config = @@ctl.running_service_config('opscode-erchef')
-                             user = erchef_config['sql_user']
+                             user = erchef_config['sql_connection_user'] || erchef_config['sql_user']
                              password = @@ctl.credentials.get('opscode_erchef', 'sql_password')
                              make_connection_string('opscode_chef', user, password)
                            end

--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -164,7 +164,7 @@ module ChefServerCtl
       pg_config = @@ctl.running_service_config('postgresql')
       host = pg_config['vip']
       port = pg_config['port']
-      "postgresql://#{db_user}:#{db_password}@#{host}:#{port}/#{db_name}"
+      "postgresql:///#{db_name}?user=#{db_user}&password=#{db_password}&host=#{host}&port=#{port}"
     end
 
     def self.ssl_params

--- a/src/chef-server-ctl/lib/chef_server_ctl/version.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/version.rb
@@ -1,3 +1,3 @@
 module ChefServerCtl
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/src/chef-server-ctl/plugins/psql.rb
+++ b/src/chef-server-ctl/plugins/psql.rb
@@ -61,29 +61,30 @@ add_command_under_category "psql", "Database", "Launches an interactive psql ses
     db_config.merge!(JSON.parse(File.read("/etc/opscode-reporting/opscode-reporting-running.json")))
   end
 
-  seed=known_dbs[service_name]["hashseed"]
-  db_hash_key=known_dbs[service_name]["config_key"]
-  db_name=known_dbs[service_name]["dbname"]
+  seed =        known_dbs[service_name]["hashseed"]
+  db_hash_key = known_dbs[service_name]["config_key"]
+  db_name =     known_dbs[service_name]["dbname"]
+  db_host =     db_config[seed]['postgresql']['vip']
+  db_port =     db_config[seed]['postgresql']['port']
 
   # undocumented, but available. Intended for use primarily for
   # gather-logs to be able to do its thing correctly.
-  if (ARGV.include? "--as-admin")
+  if ARGV.include? '--as-admin'
     cfg = running_service_config('postgresql')
-    db_username=cfg['db_connection_superuser'] || cfg['db_superuser']
-    db_password=credentials.get('postgresql', 'db_superuser_password')
+    db_username = cfg['db_connection_superuser'] || cfg['db_superuser']
+    db_password = credentials.get('postgresql', 'db_superuser_password')
   else
-    if ARGV.include?(write_arg)
-      db_username=db_config[seed][db_hash_key]['sql_connection_user'] || db_config[seed][db_hash_key]['sql_user']
+    if ARGV.include? write_arg
+      db_username = db_config[seed][db_hash_key]['sql_connection_user'] || db_config[seed][db_hash_key]['sql_user']
+      db_password_string = 'sql_password'
     else
-      db_username=db_config[seed][db_hash_key]['sql_ro_user']
+      db_username = db_config[seed][db_hash_key]['sql_ro_user'] + (db_config[seed][db_hash_key]['sql_connection_user'] ? '@'+db_host : '')
+      db_password_string = 'sql_ro_password'
     end
     # Sorry.
-    db_hash_key = "opscode_erchef" if db_hash_key == "opscode-erchef"
-    db_password=credentials.get(db_hash_key, "sql_#{'ro_' if ARGV.include?(write_arg)}password")
+    db_hash_key = 'opscode_erchef' if db_hash_key == 'opscode-erchef'
+    db_password = credentials.get(db_hash_key, db_password_string)
   end
-
-  db_host = db_config[seed]['postgresql']['vip']
-  db_port = db_config[seed]['postgresql']['port']
 
   if ARGV.include?('--debug') || ARGV.include?('-vv')
     STDOUT.puts "Host: #{db_host}"


### PR DESCRIPTION
### Description

This change allows Chef to optionally use a different username for establishing database connections than is used within database queries. This is necessary when using Azure PostgreSQL as an external database.

We would like to thank https://github.com/zanecodes for their contributions to this effort.

### Issues Resolved

#1559

### Task Outline

- [X] Conduct preliminary investigation and testing, identify what is broken and where.
- [X] Procure Azure account and access.
- [X] Investigate Azure VM and database setup.
- [X] Setup development environment to make it conducive for this and future Azure work.
- [X] Investigate configuration settings.
- [X] Fix issues identified in preliminary investigation.  In particular:
- Fix `chef-server-ctl psql...` connection to use <username@hostname> format.
- Fix `psql: FATAL:  password authentication failed for user ...` for internal postgresql setup.
- Change URI format in make_connection_string to create a correctly parseable connection URI (`bad URI` error in external azure postgresql setup).
- [X] Add sql_connection_user attribute for each service to permit a different username to be used for DB connection vs DB queries.
- [X] Replace uses of sql_user and db_superuser for establishing PostgreSQL connections with corresponding connection_user attribute.
- [X] Fix private-chef preflight postgres checks to allow Azure-specific error.
- [X] Update chef-server-ctl to support differing connection and database user names.
- [X] Add ChefSpec test for Azure PostgreSQL connection validation.
- [x] Conduct 'final pass' testing for particular chef-server setups (internal postgresql, external postgresql, external postgresql on Azure, SSL=on and SSL=off modes).
- [x] Generate user documentation.
https://github.com/chef/chef-web-docs/blob/lbakerchef/server_overview1/chef_master/source/server_overview.rst.
- [x] Investigate adding `sql_ro_connection_user` (see 'Tasks Remaining...' below)
- [x] Verify pipeline green
https://buildkite.com/chef/chef-chef-server-master-verify/builds/586
- [x] adhoc pipeline green
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/541#2abd23f0-104e-41ac-bc65-3a3efde6e50b
- [x] Local build
- [x] Speak with Natham Hames and/or Will Fisher regarding use cases in `chef-server-ctl psql ...`
- [x] Make whatever changes after doing step #1
- [x] Place documentation in Vagrantfile or other regarding dev env changes and usage
- [x] Test Tiered without ssl (not with External/Azure enabled) - thanks @christopher-snapp 
- [x] Test HA (with chef-backend, External/Azure not enabled)

### Preliminary Investigation

**Build/Install**

Kitchen + Ad hoc builds: YES
Local install: YES

**Internal PostgreSQL**

`chef-server-ctl reconfigure` PASSES
`chef-server-ctl test` SSL=off PASSES
<s>`chef-server-ctl test` SSL=on</s> N/A (SSL Internal PostgreSQL incomplete)
<s>`chef-server-ctl psql ...` FAILS</s> FIXED

**External PostgreSQL**

`chef-server-ctl reconfigure` PASSES
`chef-server-ctl test` SSL=off PASSES
`chef-server-ctl test` SSL=on PASSES
<s>`chef-server-ctl psql ...` FAILS</s> FIXED

### External Azure PostgreSQL

investigate deployment/setup/config:  DONE
<s>`chef-server-ctl reconfigure` FAILS</s> FIXED
<s>`chef-server-ctl test` SSL=off FAILS</s> FIXED
<s>`chef-server-ctl test` SSL=on FAILS</s> FIXED
<s>`chef-server-ctl psql ...` FAILS</s> FIXED
<s>various connections failing</s>  FIXED

### Configuration Settings Investigation

Completed

### Dev Environment Modifications

Completed

### Final Pass

**internal postgres ssl=off**

`chef-server-ctl reconfigure` PASSED
`chef-server-ctl test` PASSED
`chef-server-ctl psql ...` PASSED
`chef-server-ctl status` PASSED
`chef-server-ctl list-server-admins` PASSED
`chef-server-ctl cleanup-bifrost` PASSED

**external postgres ssl=off**

`chef-server-ctl reconfigure` PASSED
`chef-server-ctl test` PASSED
`chef-server-ctl psql ...` PASSED
`chef-server-ctl status` PASSED
`chef-server-ctl list-server-admins` PASSED
`chef-server-ctl cleanup-bifrost` PASSED

**external postgres ssl=on**

`chef-server-ctl reconfigure` PASSED
`chef-server-ctl test` PASSED
`chef-server-ctl psql ...` PASSED
`chef-server-ctl status` PASSED
`chef-server-ctl list-server-admins` PASSED
`chef-server-ctl cleanup-bifrost` PASSED

**external postgres azure local chef-server ssl=off**

`chef-server-ctl reconfigure` PASSED
`chef-server-ctl test` PASSED
`chef-server-ctl psql ...` PASSED
`chef-server-ctl status` PASSED
`chef-server-ctl list-server-admins` PASSED
`chef-server-ctl cleanup-bifrost` PASSED

**external postgres azure local chef-server ssl=on**

`chef-server-ctl reconfigure` PASSED
`chef-server-ctl test` PASSED
`chef-server-ctl psql ...` PASSED
`chef-server-ctl status` PASSED
`chef-server-ctl list-server-admins` PASSED
`chef-server-ctl cleanup-bifrost` PASSED

### User Manual / Instructions

Finished