### PR TITLE
Update tests to use ruby 2.5.6

### DIFF
--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -5,9 +5,9 @@ set -eou pipefail
 if [[ "${EXPEDITOR:-false}" == "true" ]]; then
   apt-get update
   apt-get install -y libpq-dev libsqlite3-dev
-  # Pin ruby to 2.5.5 since chef-server tests heavily depend
-  asdf local ruby 2.5.5
-  # Install gem for 2.5.5 path
+  # Pin ruby to 2.5.6 since chef-server tests heavily depend
+  asdf local ruby 2.5.6
+  # Install gem for 2.5.6 path
   gem install license_scout
 fi
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -87,7 +87,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.5/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - ELIXIR_VERSION=1.4
@@ -107,7 +107,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.5/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - ELIXIR_VERSION=1.4
@@ -139,7 +139,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.5/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - ERLANG_VERSION=18.3
@@ -155,7 +155,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.5/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - ERLANG_VERSION=18.3
@@ -171,7 +171,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.5/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - COMPONENT=src/bookshelf

--- a/scripts/bk_tests/bk_install.sh
+++ b/scripts/bk_tests/bk_install.sh
@@ -2,7 +2,7 @@ apt-get --purge remove -y postgresql-9.3
 apt-get update -y && apt-get install -y lua5.1 luarocks postgresql-9.6
 cp /workdir/scripts/bk_tests/pb_hba.conf /etc/postgresql/9.6/main/pg_hba.conf
 asdf local erlang 18.3
-asdf local ruby 2.5.5
+asdf local ruby 2.5.6
 gem install bundler --version '~> 1.17' --no-document
 export LUALIB=~/.luarocks/lib/lua/5.2
 luarocks install --local lpeg


### PR DESCRIPTION
The docker environment used by the verify pipeline bumped the ruby version from 2.5.5 to 2.5.6 which broke chef-server's verify testing since it was pinned to 2.5.5.

This build shows this PR fixes the verify pipeline:

https://buildkite.com/chef/chef-chef-server-master-verify/builds/457