### PR TITLE
Update Gemfile.lock to include new version chef_backup

### DIFF
--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/chef/chef_backup.git
-  revision: 960b4f22ec1b27ee170290a77b3f2e3eedb335d6
+  revision: 9acce20ed0ca68890b5655449d0e2c8d99bcf12f
   specs:
-    chef_backup (0.0.1)
+    chef_backup (0.1.1)
       highline (~> 1.6, >= 1.6.9)
-      mixlib-shellout (~> 2.0)
+      mixlib-shellout (>= 2.0, < 4.0)
 
 GIT
   remote: https://github.com/chef/chef_secrets.git
@@ -25,7 +25,7 @@ PATH
   specs:
     chef-server-ctl (1.0.0)
       appbundler
-      chef (~> 15.0.300)
+      chef (~> 15.0.214)
       chef_backup
       ffi-yajl (>= 1.2.0)
       highline (~> 1.6, >= 1.6.9)
@@ -45,9 +45,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
-    appbundler (0.12.5)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    appbundler (0.13.1)
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     ast (2.4.0)
@@ -100,13 +100,13 @@ GEM
       rubocop (= 0.62.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    domain_name (0.5.20180417)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.2.4)
-    equatable (0.6.0)
+    equatable (0.6.1)
     erubis (2.7.0)
     ffi (1.11.1)
-    ffi-libarchive (0.4.6)
+    ffi-libarchive (0.4.10)
       ffi (~> 1.0)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
@@ -117,6 +117,7 @@ GEM
       builder (>= 2.1.2)
     hashie (3.6.0)
     highline (1.7.10)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.3)
@@ -136,9 +137,9 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.0904)
     mixlib-archive (1.0.1)
       mixlib-log
     mixlib-authentication (2.1.1)
@@ -146,7 +147,7 @@ GEM
     mixlib-config (3.0.1)
       tomlrb
     mixlib-log (3.0.1)
-    mixlib-shellout (2.4.4)
+    mixlib-shellout (3.0.7)
     multi_json (1.13.1)
     necromancer (0.4.0)
     net-scp (2.0.0)
@@ -161,7 +162,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     netrc (0.11.0)
     nori (2.6.0)
-    ohai (15.1.3)
+    ohai (15.3.1)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -188,13 +189,14 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.1.0)
+    public_suffix (4.0.1)
     rack (2.0.7)
     rainbow (3.0.0)
     rake (12.3.2)
     rb-readline (0.5.5)
-    redis (4.1.2)
-    rest-client (2.0.2)
+    redis (4.1.3)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -221,8 +223,8 @@ GEM
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.1)
     rubyntlm (0.6.2)
-    rubyzip (1.2.3)
-    sequel (5.21.0)
+    rubyzip (1.3.0)
+    sequel (5.24.0)
     strings (0.1.4)
       strings-ansi (~> 0.1.0)
       unicode-display_width (~> 1.4.0)
@@ -234,7 +236,7 @@ GEM
     toml (0.2.0)
       parslet (~> 1.8.0)
     tomlrb (1.2.8)
-    train-core (2.1.7)
+    train-core (2.1.19)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)


### PR DESCRIPTION
chef-server build failures were occurring due to a newer version of chef_backup gem being available while we were pinned to 0.1.0

This PR updates the Gemfile.lock to include the latest version of chef_backup (i.e. 0.1.1)