### PR TITLE
Bump omnibus chef-infra to 15.4.20

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -7,7 +7,7 @@ override :lua, version: "5.1.5"
 override :rubygems, version: "3.0.3"
 override :bundler, version: "1.17.2"  # pin to avoid double bundle error
 override :'omnibus-ctl', version: "master"
-override :chef, version: "v15.3.14"
+override :chef, version: "v15.4.20"
 override :ohai, version: "v15.3.1"
 override :ruby, version: "2.6.3"
 


### PR DESCRIPTION
chef-server builds began breaking when chef/omnibus-software#1099 introduced an appbundle of the inspec binary.

The issue is that chef-server is pinned to the latest stable release of chef-infra (15.3.14) which is dependent on `inspec-core-bin` (4.16.0) that causes the following error:

```
There was an error parsing `Gemfile`: There are no gemspecs at /opt/opscode/embedded/lib/ruby/gems/2.6.0/gems/inspec-core-bin-4.16.0.  Bundler cannot continue.
```

This fix should be considered temporary and we should ensure it gets updated to the next stable version of chef infra when possible.