### PR TITLE
Update HAProxy configuration

### DIFF
--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -12,7 +12,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: rhel-6
       ENABLE_IPV6: false
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -25,7 +24,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: rhel-7
       ENABLE_IPV6: false
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -38,7 +36,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: rhel-8
       ENABLE_IPV6: false
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -51,7 +48,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: ubuntu-16.04
       ENABLE_IPV6: false
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -64,7 +60,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: ubuntu-18.04
       ENABLE_IPV6: false
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -454,7 +449,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: rhel-6
       ENABLE_IPV6: true
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -467,7 +461,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: rhel-7
       ENABLE_IPV6: true
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -480,7 +473,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: rhel-8
       ENABLE_IPV6: true
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -493,7 +485,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: ubuntu-16.04
       ENABLE_IPV6: true
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -506,7 +497,6 @@ steps:
       SCENARIO: omnibus-chef-backend
       PLATFORM: ubuntu-18.04
       ENABLE_IPV6: true
-      ENABLE_CHEF_BACKEND_DEMOTION: false
     expeditor:
       accounts:
         - aws/chef-cd

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
@@ -1,5 +1,32 @@
 global
         stats socket /var/opt/opscode/haproxy/haproxy.sock mode 600
+        # Timeout for connect() calls to the backend servers. This
+        # value is likely a bit high but our backends may be far away
+        # unfortunately.
+        timeout connect 5s
+        # Inactivity timeout for bi-directional communication. This is the
+        # how long a long-lived connection is allowed to stayl idle.  We
+        # likely want to keep this high to avoid unnecessarily killing
+        # long-lived SQL connections used by low-request-rate services.
+        timeout tunnel 300s
+        # Client inactivity connections for where the server has
+        # closed the connection and but the client has not. The
+        # HAProxy documentation recommends setting this whenever
+        # `timeout tunnel` is also set.
+        timeout client-fin 1s
+        # NOTE(ssd) 2019-07-10: The HAProxy documentation says that this
+        # setting should not be needed; however, we have observed that
+        # when a postgresql client disconnects uncleanly, HAProxy does not
+        # immediately close the backend until the connection times out. If
+        # a service is failing in a loop, this can quickly lead to the
+        # exhaustion of available ports.
+        timeout server-fin 1s
+        # Client and server inactivity timeouts. Per the HAProxy
+        # documentation, the tunnel timeout above superceeds these once
+        # bidirection communication is established.
+        timeout client 50s
+        timeout server 50s
+
 
 frontend postgresql
          bind <%= @listen %>:<%= @local_postgresql_port %>
@@ -14,7 +41,7 @@ frontend elasticsearch
 backend chef_backend_postgresql
         mode tcp
         option httpchk GET /leader HTTP/1.1\r\nHost:localhost:<%= @leaderl_healthcheck_port %>\r\n\r\n
-        default-server inter 2s rise 1 fall 1
+        default-server inter 2s rise 1 fall 1 on-marked-down shutdown-sessions
         <% @chef_backend_members.each do |name, ip| -%>
         server <%= name %> <%= ip %>:<%= @remote_postgresql_port %> check port <%= @leaderl_healthcheck_port %>
         <% end -%>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/haproxy.cfg.erb
@@ -1,5 +1,7 @@
 global
         stats socket /var/opt/opscode/haproxy/haproxy.sock mode 600
+
+defaults
         # Timeout for connect() calls to the backend servers. This
         # value is likely a bit high but our backends may be far away
         # unfortunately.


### PR DESCRIPTION
This makes a number of changes to our HAProxy configuration based on
experience in other projects.

The configuration is from a combination of the chef/automate project
and our private automate cluster project.

- Set connect, client, server, and tunnel timeouts to reasonable
  defaults.

- Set client-fin and server-fin to try to mitigate connection pile-ups
  in the case of failing frontend services.

- Set `on-marked-down shutdown-session` to avoid stale sessions to
  previous leaders living longer than they need to.

Signed-off-by: Steven Danna <steve@chef.io>