### PR TITLE
Add support for testing a scenario via IPv4 or IPv6

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -34,6 +34,10 @@ ifneq ($(STABLE_VERSION),)
 	export TF_VAR_stable_version ?= $(STABLE_VERSION)
 endif
 
+ifneq ($(ENABLE_IPV6),)
+	export TF_VAR_enable_ipv6 ?= $(ENABLE_IPV6)
+endif
+
 verify-aws:
 ifeq ($(TF_VAR_aws_department),)
 	$(error The department that owns the resources must be provided via the "AWS_DEPT" environment variable.)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -54,6 +54,7 @@ Environment variables are used to control how the scenarios are executed and can
 | `AWS_DEFAULT_REGION` | The AWS region to spawn resources within. | us-west-1 (default) |
 | `AWS_DEFAULT_INSTANCE_TYPE` | The AWS instance type that determines the amount of resources server instances are allocated. | t3.medium (default) |
 | `PLATFORM` | The operating system used by server instances. | rhel-7, rhel-8, ubuntu-16.04, ubuntu-18.04 |
+| `ENABLE_IPV6` | Use IPv6 in the chef-server.rb config and /etc/hosts | true (default) |
 
 ### Scenario Lifecycle
 

--- a/terraform/scenarios/omnibus-tiered-fresh-install/README.md
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/README.md
@@ -2,6 +2,6 @@
 
 This directory contains the Terraform code used to instantiate a "back-end" Chef Infra Server followed by a "front-end" Chef Infra Server utilizing an Omnibus built artifact as the install package.
 
-Both servers receive a `/etc/opscode/chef-server.rb` configuration file that utilizes IPv6 addressing.
+Both servers receive a `/etc/opscode/chef-server.rb` configuration file that is setup with the "tier" topology.
 
 Once both servers are installed and configured, the pedant tests are run against the front-end.

--- a/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -31,10 +31,8 @@ data "template_file" "hosts_config" {
   template = "${file("${path.module}/templates/hosts.tpl")}"
 
   vars {
-    back_end_ip    = "${module.back_end.private_ipv4_address}"
-    front_end_ip   = "${module.front_end.private_ipv4_address}"
-    back_end_ipv6  = "${module.back_end.public_ipv6_address}"
-    front_end_ipv6 = "${module.front_end.public_ipv6_address}"
+    back_end_ip  = "${var.enable_ipv6 == true ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address}"
+    front_end_ip = "${var.enable_ipv6 == true ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address}"
   }
 }
 
@@ -43,8 +41,10 @@ data "template_file" "chef_server_config" {
   template = "${file("${path.module}/templates/chef-server.rb.tpl")}"
 
   vars {
-    back_end_ipv6  = "${module.back_end.public_ipv6_address}"
-    front_end_ipv6 = "${module.front_end.public_ipv6_address}"
+    enable_ipv6  = "${var.enable_ipv6}"
+    back_end_ip  = "${var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address}"
+    front_end_ip = "${var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address}"
+    cidr         = "${var.enable_ipv6 == "true" ? 64 : 32}"
   }
 }
 

--- a/terraform/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
@@ -1,15 +1,15 @@
 topology = "tier"
 
 server "backend.internal",
-  :ipaddress => "${back_end_ipv6}/64",
+  :ipaddress => "${back_end_ip}/${cidr}",
   :role => "backend",
   :bootstrap => true
 
 backend_vip "backend.internal",
-  :ipaddress => "${back_end_ipv6}/64"
+  :ipaddress => "${back_end_ip}/${cidr}"
 
 server "frontend.internal",
-  :ipaddress => "${front_end_ipv6}/64",
+  :ipaddress => "${front_end_ip}/${cidr}",
   :role => "frontend"
 
 api_fqdn = "frontend.internal"
@@ -24,4 +24,4 @@ insecure_addon_compat = false
 
 data_collector['token'] = 'foobar'
 
-nginx['enable_ipv6'] = true
+nginx['enable_ipv6'] = ${enable_ipv6}

--- a/terraform/scenarios/omnibus-tiered-fresh-install/templates/hosts.tpl
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/templates/hosts.tpl
@@ -8,6 +8,6 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
 
-${back_end_ipv6} backend.internal
+${back_end_ip} backend.internal
 
-${front_end_ipv6} frontend.internal
+${front_end_ip} frontend.internal

--- a/terraform/scenarios/omnibus-tiered-fresh-install/variables.tf
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/variables.tf
@@ -53,3 +53,9 @@ variable "unstable_version" {
   type        = "string"
   description = "The version of chef server build artifact to install (e.g. 13.0.38+20190904060033)"
 }
+
+variable "enable_ipv6" {
+  type        = "string"
+  description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
+  default     = "true"
+}


### PR DESCRIPTION
### Description
Tiered scenarios will use IPv6 addressing by default.

This PR enables a developer to set the `ENABLE_IPV6` variable to `false` to force the scenario to use IPv4 addressing.

### Issues Resolved

#1787 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
