### PR TITLE
Revert the only change between versions failing tests with command not found on vagrant.

### DIFF
--- a/oc-chef-pedant/lib/pedant/config.rb
+++ b/oc-chef-pedant/lib/pedant/config.rb
@@ -103,7 +103,7 @@ module Pedant
       format_args = if junit_file
                       %W[-r rspec_junit_formatter -f RspecJunitFormatter -o #{junit_file} -f documentation]
                     else
-                      %w[ --color --tty]
+                      %w[ --color -f documentation --tty]
                     end
       format_args + %w(--require rspec-rerun/formatter --format RSpec::Rerun::Formatter)
     end


### PR DESCRIPTION
The chef-server-ctl test command fails with the following error on vagrant following the merge of #1469
 
```
Running tests from the following directories:
/opt/opscode/embedded/service/oc-chef-pedant/spec/api
/opt/opscode/embedded/service/oc-chef-pedant/spec/running_configs
/opt/opscode/embedded/service/oc-chef-pedant/spec/api/knife/nodes/delete_spec.rb:33: warning: key :stderr is duplicated and overwritten on line 34
/opt/opscode/embedded/service/oc-chef-pedant/spec/api/knife/roles/delete_spec.rb:33: warning: key :stderr is duplicated and overwritten on line 34
Run options:
  include {:focus=>true, :smoke=>true}
  exclude {:intermittent_failure=>true, :cleanup=>true}
Creating org test-org-1858_47024828
Deleting organization test-org-1858_47024828 ...
Creating org pedant-otherorg-1858
Deleting organization pedant-otherorg-1858 ...
Creating org test-org-76929623
Deleting organization test-org-76929623 ...
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
awk: not found
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
sh: 1: awk: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 1: /opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: dirname: not found
/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl: 20: .: Can't open /rabbitmq-env
/opt/opscode/embedded/service/oc-chef-pedant/spec/api/server_api_version_spec.rb:9: warning: constant ::Fixnum is deprecated
/opt/opscode/embedded/service/oc-chef-pedant/spec/api/server_api_version_spec.rb:10: warning: constant ::Fixnum is deprecated
Deleting organization pedant_testorg_api_1858 ...
```
This PR reverts the change that causes this.

Currently passing in buildkite at: https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/605#a580c904-6114-48a0-a5af-103e91082646

Tested locally on vagrant and passes with:
```Deleting organization pedant_testorg_api_1316 ...

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) opscode-account user association user not in org can be invited to the org by an admin when the inviting admin is removed from the org, invites issued by that admin cannot be accepted
     # Known failure: passes w/ 200 b/c no USAG cleanup performed for deleted user
     # ./spec/api/account/account_association_spec.rb:662

  2) opscode-account user association user not in org can be invited to the org by an admin when the inviting admin is removed from the system, invites issued by that admin can't by accepted
     # Known failure: passes w/ 200 b/c no USAG or other group cleanup performed for deleted user
     # ./spec/api/account/account_association_spec.rb:671


Finished in 53.1 seconds (files took 3.91 seconds to load)
172 examples, 0 failures, 2 pending
```

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
