### PR TITLE
Disable auto-ipv6 allocation if ENABLE_IPV6=false

### DIFF
--- a/terraform/aws_instance/main.tf
+++ b/terraform/aws_instance/main.tf
@@ -67,6 +67,8 @@ resource "aws_instance" "default" {
     volume_size = 50
   }
 
+  ipv6_address_count = "${var.enable_ipv6 == true ? 1 : 0}"
+
   subnet_id = "${data.aws_subnet.chef_subnet.id}"
 
   vpc_security_group_ids = [

--- a/terraform/aws_instance/outputs.tf
+++ b/terraform/aws_instance/outputs.tf
@@ -15,7 +15,7 @@ output "private_ipv4_dns" {
 }
 
 output "public_ipv6_address" {
-  value = "${element(aws_instance.default.ipv6_addresses, 0)}"
+  value = "${var.enable_ipv6 == true ? element(concat(aws_instance.default.ipv6_addresses, list("")), 0) : ""}"
 }
 
 output "ssh_username" {

--- a/terraform/aws_instance/variables.tf
+++ b/terraform/aws_instance/variables.tf
@@ -37,6 +37,11 @@ variable "aws_instance_type" {
   default     = "t2.medium"
 }
 
+variable "enable_ipv6" {
+  type        = "string"
+  description = "Allocate an IPv6 address in addition to IPv4 address."
+}
+
 variable "platform" {
   type        = "string"
   description = "Operating System of the instance to be created."

--- a/terraform/aws_vpc/main.tf
+++ b/terraform/aws_vpc/main.tf
@@ -23,7 +23,7 @@ resource "aws_subnet" "default" {
   map_public_ip_on_launch = true
 
   ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)}"
-  assign_ipv6_address_on_creation = true
+  assign_ipv6_address_on_creation = false
 
   tags = {
     Name      = "${local.vpc_name}"

--- a/terraform/scenarios/omnibus-standalone-upgrade-from-stable/main.tf
+++ b/terraform/scenarios/omnibus-standalone-upgrade-from-stable/main.tf
@@ -8,6 +8,7 @@ module "chef_server" {
   aws_contact       = "${var.aws_contact}"
   aws_ssh_key_id    = "${var.aws_ssh_key_id}"
   aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
   platform          = "${var.platform}"
   name              = "${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }

--- a/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -8,6 +8,7 @@ module "back_end" {
   aws_contact       = "${var.aws_contact}"
   aws_ssh_key_id    = "${var.aws_ssh_key_id}"
   aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
   platform          = "${var.platform}"
   name              = "backend-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
@@ -22,6 +23,7 @@ module "front_end" {
   aws_contact       = "${var.aws_contact}"
   aws_ssh_key_id    = "${var.aws_ssh_key_id}"
   aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
   platform          = "${var.platform}"
   name              = "frontend-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }


### PR DESCRIPTION
### Description

Previously ENABLE_IPV6 only controlled templated configurationfiles
(e.g. /etc/hosts, /etc/opscode/chef-server.rb).

This commit modifies the `aws_instance` module to avoid allocating an
IPv6 address if `ENABLE+IPV6=false`.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>