### PR TITLE
Add testing of Push Jobs add-on

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,6 @@
 
 *                                @chef/chef-server-maintainers
 .expeditor/**                    @chef/jex-team
-cookbooks/chef-server-deploy/**  @chef/jex-team
-inspec/**                        @chef/jex-team
-terraform/**                     @chef/jex-team
 README.md                        @chef/docs-team
 RELEASE_NOTES.md                 @chef/docs-team
 .github/ISSUE_TEMPLATE/**        @chef/docs-team

--- a/terraform/scenarios/omnibus-standalone-upgrade-from-stable/main.tf
+++ b/terraform/scenarios/omnibus-standalone-upgrade-from-stable/main.tf
@@ -67,6 +67,27 @@ resource "null_resource" "chef_server_config" {
     ]
   }
 
+  # run smoke test
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "sudo chef-server-ctl test",
+    ]
+  }
+
+  # install push jobs and run push test
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "sudo chef-server-ctl install opscode-push-jobs-server",
+      "sudo chef-server-ctl reconfigure --chef-license=accept",
+      "sleep 30",
+      "sudo opscode-push-jobs-server-ctl reconfigure",
+      "sleep 30",
+      "sudo opscode-push-jobs-server-ctl test",
+    ]
+  }
+
   # run pedant test
   provisioner "remote-exec" {
     inline = [

--- a/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -140,12 +140,32 @@ resource "null_resource" "front_end_config" {
     ]
   }
 
-  # FIXME 20190911 - fix to run all tests rather than just smoke once tiered pedant testing is supported
   # run smoke test
   provisioner "remote-exec" {
     inline = [
       "set -evx",
       "sudo chef-server-ctl test",
+    ]
+  }
+
+  # install push jobs and run push test
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "sudo chef-server-ctl install opscode-push-jobs-server",
+      "sudo chef-server-ctl reconfigure --chef-license=accept",
+      "sleep 30",
+      "sudo opscode-push-jobs-server-ctl reconfigure",
+      "sleep 30",
+      "sudo opscode-push-jobs-server-ctl test",
+    ]
+  }
+
+  # run pedant test
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "sudo chef-server-ctl test -J pedant.xml --all --compliance-proxy-tests",
     ]
   }
 }


### PR DESCRIPTION
### Description

This adds Push Jobs add-on testing in each terraform scenario after an
initial Chef Infra Server install and smoke test.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

* #1803 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
