### PR TITLE
Add testing of Chef Manage add-on

### DIFF
--- a/terraform/scenarios/omnibus-standalone-upgrade-from-stable/main.tf
+++ b/terraform/scenarios/omnibus-standalone-upgrade-from-stable/main.tf
@@ -88,6 +88,18 @@ resource "null_resource" "chef_server_config" {
     ]
   }
 
+  # install chef-manage
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "sudo chef-server-ctl install chef-manage",
+      "sudo chef-server-ctl reconfigure --chef-license=accept",
+      "sleep 30",
+      "sudo chef-manage-ctl reconfigure --accept-license",
+      "sleep 30",
+    ]
+  }
+
   # run pedant test
   provisioner "remote-exec" {
     inline = [

--- a/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -161,6 +161,18 @@ resource "null_resource" "front_end_config" {
     ]
   }
 
+  # install chef-manage
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "sudo chef-server-ctl install chef-manage",
+      "sudo chef-server-ctl reconfigure --chef-license=accept",
+      "sleep 30",
+      "sudo chef-manage-ctl reconfigure --accept-license",
+      "sleep 30",
+    ]
+  }
+
   # run pedant test
   provisioner "remote-exec" {
     inline = [


### PR DESCRIPTION
### Description

This adds Chef Manage add-on testing in each terraform scenario after an initial Chef Infra Server install and smoke test.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#1804 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
