### PR TITLE
Add ruby 2.5.6 to verify pipeline

### DIFF
--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -6,6 +6,7 @@ if [[ "${EXPEDITOR:-false}" == "true" ]]; then
   apt-get update
   apt-get install -y libpq-dev libsqlite3-dev
   # Pin ruby to 2.5.6 since chef-server tests heavily depend
+  asdf install ruby 2.5.6
   asdf local ruby 2.5.6
   # Install gem for 2.5.6 path
   gem install license_scout

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -107,6 +107,8 @@ steps:
 
 - label: oc-id
   command:
+    - asdf install ruby 2.5.6
+    - asdf local ruby 2.5.6
     - apt-get update -y && apt-get install -y libsqlite3-dev
     - /workdir/scripts/bk_tests/bk_install.sh
     - cd /workdir/src/oc-id; make install


### PR DESCRIPTION
### Description

This PR fixes the verify pipeline following chef/release-engineering#944
removing older versions of ruby (including 2.5.6) from the docker image.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
