### PR TITLE
Add chef-server-ctl psql tests to terraform

### DIFF
--- a/terraform/aws/scenarios/omnibus-external-openldap/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/main.tf
@@ -149,4 +149,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_chef_server-pedant.sh"
   }
+
+  # run psql test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_psql.sh"
+  }
 }

--- a/terraform/aws/scenarios/omnibus-external-openldap/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/main.tf
@@ -154,4 +154,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_psql.sh"
   }
+
+  # run gather-logs test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_gather_logs.sh"
+  }
 }

--- a/terraform/aws/scenarios/omnibus-external-openldap/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/main.tf
@@ -114,6 +114,16 @@ resource "null_resource" "chef_server_config" {
       "echo -e '\nEND INSTALL CHEF SERVER\n'",
     ]
   }
+}
+
+resource "null_resource" "chef_server_test" {
+  depends_on = ["null_resource.chef_server_config"]
+
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
 
   # run smoke test
   provisioner "remote-exec" {

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
@@ -106,4 +106,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_psql.sh"
   }
+
+  # run gather-logs test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_gather_logs.sh"
+  }
 }

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
@@ -66,6 +66,16 @@ resource "null_resource" "chef_server_config" {
       "echo -e '\nEND UPGRADE CHEF SERVER\n'",
     ]
   }
+}
+
+resource "null_resource" "chef_server_test" {
+  depends_on = ["null_resource.chef_server_config"]
+
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
 
   # run smoke test
   provisioner "remote-exec" {

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
@@ -101,4 +101,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_chef_server-pedant.sh"
   }
+
+  # run psql test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_psql.sh"
+  }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -181,4 +181,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_psql.sh"
   }
+
+  # run gather-logs test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_gather_logs.sh"
+  }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -176,4 +176,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_chef_server-pedant.sh"
   }
+
+  # run psql test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_psql.sh"
+  }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -141,6 +141,16 @@ resource "null_resource" "front_end_config" {
       "echo -e '\nEND INSTALL CHEF SERVER (FRONT-END)\n'",
     ]
   }
+}
+
+resource "null_resource" "chef_server_test" {
+  depends_on = ["null_resource.front_end_config"]
+
+  connection {
+    type = "ssh"
+    user = "${module.front_end.ssh_username}"
+    host = "${module.front_end.public_ipv4_dns}"
+  }
 
   # run smoke test
   provisioner "remote-exec" {

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -230,4 +230,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_chef_server-pedant.sh"
   }
+
+  # run psql test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_psql.sh"
+  }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -195,6 +195,16 @@ resource "null_resource" "front_end_upgrade" {
       "echo -e '\nEND UPGRADE CHEF SERVER (FRONT-END)\n'",
     ]
   }
+}
+
+resource "null_resource" "chef_server_test" {
+  depends_on = ["null_resource.front_end_upgrade"]
+
+  connection {
+    type = "ssh"
+    user = "${module.front_end.ssh_username}"
+    host = "${module.front_end.public_ipv4_dns}"
+  }
 
   # run smoke test
   provisioner "remote-exec" {

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -235,4 +235,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_psql.sh"
   }
+
+  # run gather-logs test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_gather_logs.sh"
+  }
 }

--- a/terraform/azure/scenarios/omnibus-external-postgres/main.tf
+++ b/terraform/azure/scenarios/omnibus-external-postgres/main.tf
@@ -100,6 +100,16 @@ resource "null_resource" "chef_server_config" {
       "echo -e '\nEND INSTALL CHEF SERVER\n'",
     ]
   }
+}
+
+resource "null_resource" "chef_server_test" {
+  depends_on = ["null_resource.chef_server_config"]
+
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
 
   # run smoke test
   provisioner "remote-exec" {

--- a/terraform/azure/scenarios/omnibus-external-postgres/main.tf
+++ b/terraform/azure/scenarios/omnibus-external-postgres/main.tf
@@ -140,4 +140,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_psql.sh"
   }
+
+  # run gather-logs test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_gather_logs.sh"
+  }
 }

--- a/terraform/azure/scenarios/omnibus-external-postgres/main.tf
+++ b/terraform/azure/scenarios/omnibus-external-postgres/main.tf
@@ -135,4 +135,9 @@ resource "null_resource" "chef_server_test" {
   provisioner "remote-exec" {
     script = "${path.module}/../../../common/files/test_chef_server-pedant.sh"
   }
+
+  # run psql test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_psql.sh"
+  }
 }

--- a/terraform/common/files/test_gather_logs.sh
+++ b/terraform/common/files/test_gather_logs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -evx
+
+echo -e '\nBEGIN GATHER LOGS TEST\n'
+
+sudo chef-server-ctl gather-logs
+
+echo -e '\nEND GATHER LOGS TEST\n'

--- a/terraform/common/files/test_psql.sh
+++ b/terraform/common/files/test_psql.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -evx
+
+echo -e '\nBEGIN PSQL TEST\n'
+
+sudo chef-server-ctl psql oc_erchef <<<"SELECT * FROM users; \q"
+sudo chef-server-ctl psql oc_erchef --write <<<"UPDATE users SET email='janedoe@example.com' WHERE username='janedoe'; \q"
+sudo chef-server-ctl psql oc_erchef <<<"SELECT * FROM users; \q"
+sudo chef-server-ctl psql oc_erchef --as-admin <<<"UPDATE users SET email='janedoeadmin@example.com' WHERE username='janedoe'; \q"
+sudo chef-server-ctl psql oc_erchef <<<"SELECT * FROM users; \q"
+
+echo -e '\nEND PSQL TEST\n'


### PR DESCRIPTION
### Description

This PR just adds a few calls using `chef-server-ctl psql` to the terraform scenarios.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
