### PR TITLE
Speed up Terraform Push Jobs tests

### DIFF
--- a/terraform/common/files/install_addon_push_jobs.sh
+++ b/terraform/common/files/install_addon_push_jobs.sh
@@ -5,6 +5,8 @@ set -evx
 echo -e '\nBEGIN INSTALL PUSH JOBS ADDON\n'
 
 sudo chef-server-ctl install opscode-push-jobs-server
+sudo mkdir -p /etc/opscode-push-jobs-server
+printf -- "opscode_pushy_server['heartbeat_interval'] = 1000" | sudo tee /etc/opscode-push-jobs-server/opscode-push-jobs-server.rb
 sudo chef-server-ctl reconfigure --chef-license=accept
 sleep 30
 sudo opscode-push-jobs-server-ctl reconfigure


### PR DESCRIPTION
This PR adjusts the `heartbeat_interval` in terraform installs to speed up testing.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
