### PR TITLE
Fix 502 gateway timeout errors in terraform

### DIFF
--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
@@ -42,7 +42,7 @@ resource "null_resource" "chef_server_config" {
       "sudo mv /tmp/chef-server.rb /etc/opscode",
       "sudo mv /tmp/dhparam.pem /etc/opscode",
       "sudo chef-server-ctl reconfigure --chef-license=accept",
-      "sleep 30",
+      "sleep 120",
       "echo -e '\nEND INSTALL CHEF SERVER\n'",
     ]
   }

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -88,7 +88,7 @@ resource "null_resource" "back_end_config" {
       "sudo mv /tmp/dhparam.pem /etc/opscode",
       "sudo mv /tmp/hosts /etc/hosts",
       "sudo chef-server-ctl reconfigure --chef-license=accept",
-      "sleep 30",
+      "sleep 120",
       "echo -e '\nEND INSTALL CHEF SERVER (BACK-END)\n'",
     ]
   }

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -88,7 +88,7 @@ resource "null_resource" "back_end_config" {
       "sudo mv /tmp/dhparam.pem /etc/opscode",
       "sudo mv /tmp/hosts /etc/hosts",
       "sudo chef-server-ctl reconfigure --chef-license=accept",
-      "sleep 30",
+      "sleep 120",
       "echo -e '\nEND INSTALL CHEF SERVER (BACK-END)\n'",
     ]
   }


### PR DESCRIPTION
### Description
This PR just bumps the wait time after a terraform scenario finishes the `chef-server-ctl reconfigure` to 120 seconds to all time for the services to settle.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
