### PR TITLE
Fix terraform tiered pedant tests

### DIFF
--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
@@ -14,6 +14,8 @@ server "frontend.internal",
 
 api_fqdn = "frontend.internal"
 
+profiles['root_url'] = 'http://frontend.internal:9998'
+
 opscode_erchef['keygen_start_size'] = 30
 
 opscode_erchef['keygen_cache_size'] = 60

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
@@ -14,6 +14,8 @@ server "frontend.internal",
 
 api_fqdn = "frontend.internal"
 
+profiles['root_url'] = 'http://frontend.internal:9998'
+
 opscode_erchef['keygen_start_size'] = 30
 
 opscode_erchef['keygen_cache_size'] = 60


### PR DESCRIPTION
### Description

This PR fixes the terraform pedant compliance tests failing on tiered scenarios because the `profiles['root_url']` configuration was missing from `/etc/opscode/chef-server.rb`.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
