### PR TITLE
Update nginx ssl config

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -7,7 +7,7 @@
 
     access_log <%= @helper.access_log(@server_proto) %> opscode;
     <% if @server_proto == "https" %>
-      ssl on;
+      listen 443 ssl;
       ssl_certificate <%= @ssl_certificate %>;
       ssl_certificate_key <%= @ssl_certificate_key %>;
       ssl_dhparam <%= @ssl_dhparam %>;


### PR DESCRIPTION
Nginx has changed the syntax on this, old version is throwing warnings like this
nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /var/opt/opscode/nginx/etc/chef_https_lb.conf:9

Signed-off-by: Nathan Haneysmith <nathan@chef.io>

### Description
Update Nginx config to modern syntax.
[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
