### PR TITLE
Update the ldap test fixtures

### DIFF
--- a/oc-chef-pedant/pedant_config.rb
+++ b/oc-chef-pedant/pedant_config.rb
@@ -109,6 +109,8 @@ ldap({
        :last_name => "Lastname",
        # Your display name in AD, likely "Firstname Lastname"
        :display_name => "Firstname Lastname",
+       # Your common name in AD, likely "Firstname Lastname"
+       :common_name => "Firstname Lastname",
        # Your email in AD
        :email => "your@email.com",
        # Likely nil

--- a/oc-chef-pedant/spec/api/authenticate_user_spec.rb
+++ b/oc-chef-pedant/spec/api/authenticate_user_spec.rb
@@ -29,6 +29,7 @@ describe 'authenticate_user', :users do
           'first_name' => platform.ldap[:first_name],
           'last_name' => platform.ldap[:last_name],
           'display_name' => platform.ldap[:display_name],
+          'common_name' => platform.ldap[:common_name],
           'email' => platform.ldap[:email],
           'username' => platform.ldap[:account_name],
           'city' => platform.ldap[:city],
@@ -203,7 +204,8 @@ describe 'authenticate_user', :users do
           response.should look_like({
             :status => 401
           })
-          /^Failed to authenticate: Could not locate a record with distinguished name/.should match(JSON.parse(response)["error"])
+          #Reponse Body: {"error":["Failed to authenticate: Username and password incorrect"]}
+          /^Failed to authenticate: (Could not locate a record with distinguished name)|(Username and password incorrect)/.should match(JSON.parse(response)["error"][0])
         else
           response = post(request_url, superuser, :payload => body)
           response.should look_like({


### PR DESCRIPTION
- common_name was a field returned by the api which needed to be added
into the response_body
- The ldap error if user unauthenticated can be of 2 different formats
- Match on the value in the array for error rather than the whole array.

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/734#54c72f28-9f98-49c5-b8d5-31845d65e3e5

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
