### PR TITLE
Remove Ruby 2.5.6 Pinning

### DIFF
--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -5,11 +5,6 @@ set -eou pipefail
 if [[ "${EXPEDITOR:-false}" == "true" ]]; then
   apt-get update
   apt-get install -y libpq-dev libsqlite3-dev
-  # Pin ruby to 2.5.6 since chef-server tests heavily depend
-  asdf install ruby 2.5.6
-  asdf local ruby 2.5.6
-  # Install gem for 2.5.6 path
-  gem install license_scout
 fi
 
 bundle_install_dirs=(

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -80,7 +80,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - ELIXIR_VERSION=1.4
@@ -99,7 +99,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - ELIXIR_VERSION=1.4
@@ -107,8 +107,6 @@ steps:
 
 - label: oc-id
   command:
-    - asdf install ruby 2.5.6
-    - asdf local ruby 2.5.6
     - apt-get update -y && apt-get install -y libsqlite3-dev
     - /workdir/scripts/bk_tests/bk_install.sh
     - cd /workdir/src/oc-id; make install
@@ -130,7 +128,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - COMPONENT=src/chef-mover
@@ -145,7 +143,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - COMPONENT=src/oc_bifrost
@@ -160,7 +158,7 @@ steps:
       docker:
         image: "chefes/a1-buildkite"
         environment:
-          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin:/opt/asdf/installs/ruby/2.5.6/bin
+          - PATH=/opt/asdf/shims:/opt/asdf/bin:/opt/ci-studio-common/bin:/go/bin:/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chefdk/bin
           - PERL5LIB=~/perl5/lib/perl5/x86_64-linux-gnu-thread-multi:~/perl5/lib/perl5:/etc/perl:/usr/local/lib/perl/5.14.2:/usr/local/share/perl/5.14.2:/usr/lib/perl5:/usr/share/perl5:/usr/lib/perl/5.14:/usr/share/perl/5.14:/usr/local/lib/site_perl
           - LUALIB=~/.luarocks/lib/lua/5.2
           - COMPONENT=src/bookshelf

--- a/scripts/bk_tests/bk_install.sh
+++ b/scripts/bk_tests/bk_install.sh
@@ -3,7 +3,6 @@ apt-get update -y && apt-get install -y lua5.1 luarocks postgresql-9.6
 cp /workdir/scripts/bk_tests/pb_hba.conf /etc/postgresql/9.6/main/pg_hba.conf
 asdf local erlang 20.3
 erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().' -noshell
-asdf local ruby 2.5.6
 gem install bundler --version '~> 1.17' --no-document
 export LUALIB=~/.luarocks/lib/lua/5.2
 luarocks install --local lpeg

--- a/src/oc-id/spec/support/monkeypatch.rb
+++ b/src/oc-id/spec/support/monkeypatch.rb
@@ -1,0 +1,18 @@
+# This patch is only required when using rails 4.2 with ruby 2.6
+#
+# https://github.com/rails/rails/issues/34790
+
+if RUBY_VERSION>='2.6.0'
+  if Rails.version < '5'
+    class ActionController::TestResponse < ActionDispatch::TestResponse
+      def recycle!
+        # hack to avoid MonitorMixin double-initialize error:
+        @mon_mutex_owner_object_id = nil
+        @mon_mutex = nil
+        initialize
+      end
+    end
+  else
+    puts "Monkeypatch for ActionController::TestResponse no longer needed"
+  end
+end


### PR DESCRIPTION
### Description

The build environment no longer manages multiple versions of Ruby.
   
By removing the pinning to a specific version of Ruby, we will always use the latest version supplied by the build environment.

Unfortunately, `oc-id` is built on Rails `4.2.11` which fails its verification tests with `ThreadError: already initialized`.

To allow Rails `4.2.11` to work with Ruby `>2.6.0` we need a small patch added via `src/oc-id/spec/support/monkeypatch.rb` to prevent rails from reusing `ActionController::TestResponse` object in tests.
    
Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
