### PR TITLE
Enable LDAP Testing in pedant_config

### DIFF
--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -154,7 +154,7 @@ destroy: init
 	terraform destroy -auto-approve && \
 	terraform workspace select default && \
 	terraform workspace delete $(WORKSPACE) && \
-	(rmdir terraform.tfstate.d 2>/dev/null && rm -rf .terraform)
+	(rmdir terraform.tfstate.d 2>/dev/null && rm -rf .terraform) || true
 
 destroy-all:
 	@set -e; \

--- a/terraform/aws/scenarios/omnibus-external-openldap/files/pedant_config.rb
+++ b/terraform/aws/scenarios/omnibus-external-openldap/files/pedant_config.rb
@@ -1,0 +1,18 @@
+ldap_testing true
+
+ldap(
+  "display_name": "User One",
+  "first_name": "User",
+  "last_name": "One",
+  "common_name": "User One",
+  "country": "unknown",
+  "city": "unknown",
+  "email": "user1@chef-server.dev",
+  "username": "user1",
+  "external_authentication_uid": "user1",
+  "recovery_authentication_enabled": false,
+  "account_name": "user1",
+  "account_password": "password",
+  "status": "unlinked"
+)
+

--- a/terraform/aws/scenarios/omnibus-external-openldap/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/main.tf
@@ -96,6 +96,11 @@ resource "null_resource" "chef_server_config" {
     destination = "/tmp/dhparam.pem"
   }
 
+  provisioner "file" {
+    source      = "${path.module}/files/pedant_config.rb"
+    destination = "/tmp/pedant_config.rb"
+  }
+
   # install chef-server
   provisioner "remote-exec" {
     inline = [
@@ -109,6 +114,7 @@ resource "null_resource" "chef_server_config" {
       "sudo chown root:root /tmp/dhparam.pem",
       "sudo mv /tmp/chef-server.rb /etc/opscode",
       "sudo mv /tmp/dhparam.pem /etc/opscode",
+      "cat /tmp/pedant_config.rb | sudo tee -a /opt/opscode/embedded/cookbooks/private-chef/templates/default/pedant_config.rb.erb",
       "sudo chef-server-ctl reconfigure --chef-license=accept",
       "sleep 120",
       "echo -e '\nEND INSTALL CHEF SERVER\n'",

--- a/terraform/aws/scenarios/omnibus-external-postgresql/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/main.tf
@@ -33,8 +33,8 @@ data "template_file" "hosts_config" {
   template = "${file("${path.module}/templates/hosts.tpl")}"
 
   vars {
-    chef_server_ip = "${var.enable_ipv6 == true ? module.chef_server.public_ipv6_address : module.chef_server.private_ipv4_address}"
-    external_postgresql_ip  = "${var.enable_ipv6 == true ? module.external_postgresql.public_ipv6_address : module.external_postgresql.private_ipv4_address}"
+    chef_server_ip         = "${var.enable_ipv6 == true ? module.chef_server.public_ipv6_address : module.chef_server.private_ipv4_address}"
+    external_postgresql_ip = "${var.enable_ipv6 == true ? module.external_postgresql.public_ipv6_address : module.external_postgresql.private_ipv4_address}"
   }
 }
 
@@ -75,7 +75,7 @@ resource "null_resource" "external_postgresql_config" {
       "echo 'host    all             all            ${module.chef_server.private_ipv4_address}/32         md5' | sudo tee -a /etc/postgresql/9.6/main/pg_hba.conf",
       "echo \"listen_addresses='*'\" | sudo tee -a /etc/postgresql/9.6/main/postgresql.conf",
       "sudo systemctl restart postgresql",
-      "sudo -u postgres psql -c \"CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v0ps';\""
+      "sudo -u postgres psql -c \"CREATE USER bofh SUPERUSER ENCRYPTED PASSWORD 'i1uvd3v0ps';\"",
     ]
   }
 }
@@ -97,7 +97,7 @@ resource "null_resource" "chef_server_config" {
   }
 
   provisioner "file" {
-    content    = "${data.template_file.chef_server_rb.rendered}"
+    content     = "${data.template_file.chef_server_rb.rendered}"
     destination = "/tmp/chef-server.rb"
   }
 


### PR DESCRIPTION
### Description

This PR enables LDAP testing by injecting a configuration change to the `pedant_config.rb.erb` prior to `chef-server-ctl reconfigure`.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#1815 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
