### PR TITLE
Fix terraform rhel-6 tiered-upgrade compliance tests

### DIFF
--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
@@ -14,7 +14,15 @@ server "frontend.internal",
 
 api_fqdn = "frontend.internal"
 
-profiles['root_url'] = 'http://frontend.internal:9998'
+# The public IPV6 address is not bound to the network interface of the machine.
+# rhel-7 and rhel-8 are able to resolve this but the older rhel-6 is not.
+# Using the ipv6 localhost instead of the public IP to fix this.
+require 'ipaddr'
+if IPAddr.new("${front_end_ip}/${cidr}").ipv6?
+  profiles['root_url'] = 'http://[::1]:9998'
+else
+  profiles['root_url'] = 'http://frontend.internal:9998'
+end
 
 opscode_erchef['keygen_start_size'] = 30
 


### PR DESCRIPTION
### Description

The `profiles['root_url']` config needs to use ipv6 localhost instead of the public IP address.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
