### PR TITLE
Update Ruby from 2.6.3 to 2.6.5

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -10,7 +10,7 @@ override :bundler, version: "1.17.2"  # pin to avoid double bundle error
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v15.5.17"
 override :ohai, version: "v15.3.1"
-override :ruby, version: "2.6.3"
+override :ruby, version: "2.6.5"
 
 
 # This SHA is the last commit before the 6.0 release


### PR DESCRIPTION
This resolves multiple CVEs we should make sure we patch:

    CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test
    CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix)
    CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch?
    CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick’s Digest access authentication
    CVE-2012-6708
    CVE-2015-9251

Signed-off-by: Tim Smith <tsmith@chef.io>