### PR TITLE
Match the version of Chef Infra Client for habitat with the version in omnibus_overrides.

### DIFF
--- a/doc/FrequentTasks.md
+++ b/doc/FrequentTasks.md
@@ -79,6 +79,8 @@ copying files back from the dev-vm to the host.
       around rails upgrades. We should either fix that debt or find
       another library for the Chef Server API.
 
+    - src/chef-server-ctl/Gemfile.local
+
 - Build Chef Server, and do a chef-server-ctl reconfigure. Fix any new
   warnings about deprecations and the like.
 

--- a/src/chef-server-ctl/Gemfile.local
+++ b/src/chef-server-ctl/Gemfile.local
@@ -1,5 +1,5 @@
 #
 # This is used as part of the habitat build
 #
-gem 'chef', '~>15.3'
+gem 'chef', '~>15.5'
 gem 'json', '~>2.0'


### PR DESCRIPTION


Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

Should fix hab builds broken after updating chef-infra-client to 15.5

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
