### PR TITLE
Add scenario for chef-backend

### DIFF
--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -41,6 +41,12 @@ ifneq ($(UPGRADE_VERSION),)
 	export TF_VAR_upgrade_version_url ?= $(shell platform=$(TF_VAR_platform); for channel in unstable current stable; do mixlib-install download chef-server --url -c $$channel -a x86_64 -p $$(echo $${platform%-*} | sed 's/rhel/el/') -l $${platform\#\#*-} -v $(UPGRADE_VERSION) 2>/dev/null && break; done | head -n1)
 endif
 
+ifneq ($(BACKEND_VERSION),)
+	export TF_VAR_backend_version_url ?= $(shell platform=$(TF_VAR_platform); for channel in unstable current stable; do mixlib-install download chef-backend --url -c $$channel -a x86_64 -p $$(echo $${platform%-*} | sed 's/rhel/el/') -l $${platform\#\#*-} -v $(BACKEND_VERSION) 2>/dev/null && break; done | head -n1)
+else
+	export TF_VAR_backend_version_url ?= $(shell platform=$(TF_VAR_platform); mixlib-install download chef-backend --url -c current -a x86_64 -p $$(echo $${platform%-*} | sed 's/rhel/el/') -l $${platform\#\#*-} 2>/dev/null)
+endif
+
 ifneq ($(ENABLE_IPV6),)
 	export TF_VAR_enable_ipv6 ?= $(ENABLE_IPV6)
 else

--- a/terraform/aws/scenarios/omnibus-chef-backend/README.md
+++ b/terraform/aws/scenarios/omnibus-chef-backend/README.md
@@ -1,0 +1,7 @@
+# Omnibus Chef Backend
+
+This directory contains the Terraform code used to instantiate three Chef Backend servers followed by a Chef Infra Server utilizing an Omnibus built artifact downloaded from `$upgrade_version_url` as the install package.
+
+The Chef Infra Server will receive a `/etc/opscode/chef-server.rb` configuration file that is setup to use the Chef Backend servers.
+
+Once both servers are installed and configured, the pedant tests are run against the Chef Infra Server.

--- a/terraform/aws/scenarios/omnibus-chef-backend/main.tf
+++ b/terraform/aws/scenarios/omnibus-chef-backend/main.tf
@@ -1,0 +1,264 @@
+module "chef_server" {
+  source = "../../modules/aws_instance"
+
+  aws_profile       = "${var.aws_profile}"
+  aws_region        = "${var.aws_region}"
+  aws_vpc_name      = "${var.aws_vpc_name}"
+  aws_department    = "${var.aws_department}"
+  aws_contact       = "${var.aws_contact}"
+  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
+  aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
+  platform          = "${var.platform}"
+  name              = "chefserver-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
+}
+
+module "backend1" {
+  source = "../../modules/aws_instance"
+
+  aws_profile       = "${var.aws_profile}"
+  aws_region        = "${var.aws_region}"
+  aws_vpc_name      = "${var.aws_vpc_name}"
+  aws_department    = "${var.aws_department}"
+  aws_contact       = "${var.aws_contact}"
+  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
+  aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
+  platform          = "${var.platform}"
+  name              = "backend1-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
+}
+
+module "backend2" {
+  source = "../../modules/aws_instance"
+
+  aws_profile       = "${var.aws_profile}"
+  aws_region        = "${var.aws_region}"
+  aws_vpc_name      = "${var.aws_vpc_name}"
+  aws_department    = "${var.aws_department}"
+  aws_contact       = "${var.aws_contact}"
+  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
+  aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
+  platform          = "${var.platform}"
+  name              = "backend2-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
+}
+
+module "backend3" {
+  source = "../../modules/aws_instance"
+
+  aws_profile       = "${var.aws_profile}"
+  aws_region        = "${var.aws_region}"
+  aws_vpc_name      = "${var.aws_vpc_name}"
+  aws_department    = "${var.aws_department}"
+  aws_contact       = "${var.aws_contact}"
+  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
+  aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
+  platform          = "${var.platform}"
+  name              = "backend3-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
+}
+
+# generate static hosts configuration
+data "template_file" "hosts_config" {
+  template = "${file("${path.module}/templates/hosts.tpl")}"
+
+  vars {
+    chef_server_ip = "${var.enable_ipv6 == true ? module.chef_server.public_ipv6_address : module.chef_server.private_ipv4_address}"
+    backend1_ip    = "${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address}"
+    backend2_ip    = "${var.enable_ipv6 == true ? module.backend2.public_ipv6_address : module.backend2.private_ipv4_address}"
+    backend3_ip    = "${var.enable_ipv6 == true ? module.backend3.public_ipv6_address : module.backend3.private_ipv4_address}"
+  }
+}
+
+# generate chef-backend configuration
+data "template_file" "backend_config" {
+  template = "${file("${path.module}/templates/chef-backend.rb.tpl")}"
+
+  vars {
+    backend1_ip = "${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address}"
+  }
+}
+
+# update backend1 server
+resource "null_resource" "backend1_config" {
+  # provide some connection info
+  connection {
+    type = "ssh"
+    user = "${module.backend1.ssh_username}"
+    host = "${module.backend1.public_ipv4_dns}"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.hosts_config.rendered}"
+    destination = "/tmp/hosts"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.backend_config.rendered}"
+    destination = "/tmp/chef-backend.rb"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "echo -e '\nBEGIN INSTALL CHEF BACKEND1\n'",
+      "sudo chown root:root /tmp/hosts",
+      "sudo mv /tmp/hosts /etc/hosts",
+      "curl -vo /tmp/${replace(var.backend_version_url, "/^.*\\//", "")} ${var.backend_version_url}",
+      "sudo ${replace(var.backend_version_url, "rpm", "") != var.backend_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.backend_version_url, "/^.*\\//", "")}",
+      "sudo chown root:root /tmp/chef-backend.rb",
+      "sudo mv /tmp/chef-backend.rb /etc/chef-backend",
+      "sudo chef-backend-ctl create-cluster --accept-license --yes --quiet",
+      "sudo cat /etc/chef-backend/chef-backend-secrets.json | ssh -o 'UserKnownHostsFile=/dev/null' -o 'StrictHostKeyChecking=no' ${module.backend2.ssh_username}@${module.backend2.public_ipv4_dns} 'cat > /tmp/chef-backend-secrets.json'",
+      "sudo cat /etc/chef-backend/chef-backend-secrets.json | ssh -o 'UserKnownHostsFile=/dev/null' -o 'StrictHostKeyChecking=no' ${module.backend3.ssh_username}@${module.backend3.public_ipv4_dns} 'cat > /tmp/chef-backend-secrets.json'",
+      "sudo chef-backend-ctl gen-server-config chefserver.internal > /tmp/chef-server.rb",
+      "echo -e \"\nprofiles['root_url'] = 'http://chefserver.internal:9998'\" | sudo tee -a /tmp/chef-server.rb",
+      "scp -o 'UserKnownHostsFile=/dev/null' -o 'StrictHostKeyChecking=no' /tmp/chef-server.rb ${module.chef_server.ssh_username}@${module.chef_server.public_ipv4_dns}:/tmp",
+      "echo -e '\nEND INSTALL CHEF BACKEND1\n'",
+    ]
+  }
+}
+
+# update backend2 server
+resource "null_resource" "backend2_config" {
+  depends_on = ["null_resource.backend1_config"]
+
+  # provide some connection info
+  connection {
+    type = "ssh"
+    user = "${module.backend2.ssh_username}"
+    host = "${module.backend2.public_ipv4_dns}"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.hosts_config.rendered}"
+    destination = "/tmp/hosts"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "echo -e '\nBEGIN INSTALL CHEF BACKEND2\n'",
+      "sudo chown root:root /tmp/hosts",
+      "sudo mv /tmp/hosts /etc/hosts",
+      "curl -vo /tmp/${replace(var.backend_version_url, "/^.*\\//", "")} ${var.backend_version_url}",
+      "sudo ${replace(var.backend_version_url, "rpm", "") != var.backend_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.backend_version_url, "/^.*\\//", "")}",
+      "sudo chef-backend-ctl join-cluster --accept-license --yes --quiet ${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address} -p ${var.enable_ipv6 == true ? module.backend2.public_ipv6_address : module.backend2.private_ipv4_address} -s /tmp/chef-backend-secrets.json",
+      "echo -e '\nEND INSTALL CHEF BACKEND2\n'",
+    ]
+  }
+}
+
+# update backend2 server
+resource "null_resource" "backend3_config" {
+  depends_on = ["null_resource.backend2_config"]
+
+  # provide some connection info
+  connection {
+    type = "ssh"
+    user = "${module.backend3.ssh_username}"
+    host = "${module.backend3.public_ipv4_dns}"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.hosts_config.rendered}"
+    destination = "/tmp/hosts"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "echo -e '\nBEGIN INSTALL CHEF BACKEND3\n'",
+      "sudo chown root:root /tmp/hosts",
+      "sudo mv /tmp/hosts /etc/hosts",
+      "curl -vo /tmp/${replace(var.backend_version_url, "/^.*\\//", "")} ${var.backend_version_url}",
+      "sudo ${replace(var.backend_version_url, "rpm", "") != var.backend_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.backend_version_url, "/^.*\\//", "")}",
+      "sudo chef-backend-ctl join-cluster --accept-license --yes --quiet ${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address} -p ${var.enable_ipv6 == true ? module.backend3.public_ipv6_address : module.backend3.private_ipv4_address} -s /tmp/chef-backend-secrets.json",
+      "echo -e '\nEND INSTALL CHEF BACKEND3\n'",
+    ]
+  }
+}
+
+# update chef server
+resource "null_resource" "chef_server_config" {
+  depends_on = ["null_resource.backend3_config"]
+
+  # provide some connection info
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.hosts_config.rendered}"
+    destination = "/tmp/hosts"
+  }
+
+  # install chef-server
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "echo -e '\nBEGIN INSTALL CHEF SERVER\n'",
+      "sudo chown root:root /tmp/hosts",
+      "sudo mv /tmp/hosts /etc/hosts",
+      "curl -vo /tmp/${replace(var.upgrade_version_url, "/^.*\\//", "")} ${var.upgrade_version_url}",
+      "sudo ${replace(var.upgrade_version_url, "rpm", "") != var.upgrade_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.upgrade_version_url, "/^.*\\//", "")}",
+      "sudo chown root:root /tmp/chef-server.rb",
+      "sudo mv /tmp/chef-server.rb /etc/opscode",
+      "sudo chef-server-ctl reconfigure --chef-license=accept",
+      "sleep 120",
+      "echo -e '\nEND INSTALL CHEF SERVER\n'",
+    ]
+  }
+
+  # add user + organization
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/add_user.sh"
+  }
+}
+
+resource "null_resource" "chef_server_test" {
+  depends_on = ["null_resource.chef_server_config"]
+
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
+
+  # run smoke test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_chef_server-smoke.sh"
+  }
+
+  # install push jobs addon
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/install_addon_push_jobs.sh"
+  }
+
+  # test push jobs addon
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_addon_push_jobs.sh"
+  }
+
+  # install chef manage addon
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/install_addon_chef_manage.sh"
+  }
+
+  # run pedant test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_chef_server-pedant.sh"
+  }
+
+  # run psql test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_psql.sh"
+  }
+
+  # run gather-logs test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_gather_logs.sh"
+  }
+}

--- a/terraform/aws/scenarios/omnibus-chef-backend/templates/chef-backend.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-chef-backend/templates/chef-backend.rb.tpl
@@ -1,0 +1,1 @@
+publish_address '${backend1_ip}'

--- a/terraform/aws/scenarios/omnibus-chef-backend/templates/hosts.tpl
+++ b/terraform/aws/scenarios/omnibus-chef-backend/templates/hosts.tpl
@@ -1,0 +1,15 @@
+127.0.0.1 localhost localhost.localdomain localhost4 localhost4.localdomain4
+
+# The following lines are desirable for IPv6 capable hosts
+::1       localhost.localdomain localhost6 localhost6.localdomain6 ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts
+
+${chef_server_ip} chefserver.internal
+
+${backend1_ip} backend1.internal
+${backend2_ip} backend2.internal
+${backend3_ip} backend3.internal

--- a/terraform/aws/scenarios/omnibus-chef-backend/variables.tf
+++ b/terraform/aws/scenarios/omnibus-chef-backend/variables.tf
@@ -1,0 +1,69 @@
+#########################################################################
+# AWS
+#########################################################################
+variable "aws_profile" {
+  type        = "string"
+  description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
+  default     = "chef-engineering"
+}
+
+variable "aws_region" {
+  type        = "string"
+  description = "Name of the AWS region to create instances in (e.g. us-west-2)."
+  default     = "us-west-1"
+}
+
+variable "aws_vpc_name" {
+  type        = "string"
+  description = "Name of the AWS virtual private cloud where tests will be run."
+  default     = ""
+}
+
+variable "aws_department" {
+  type        = "string"
+  description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
+}
+
+variable "aws_contact" {
+  type        = "string"
+  description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
+}
+
+variable "aws_ssh_key_id" {
+  type        = "string"
+  description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
+}
+
+variable "aws_instance_type" {
+  type        = "string"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
+  default     = "t2.medium"
+}
+
+variable "platform" {
+  type        = "string"
+  description = "Operating System of the instance to be created."
+}
+
+#########################################################################
+# Chef Server
+#########################################################################
+variable "scenario" {
+  type        = "string"
+  description = "The name of the scenario being executed."
+}
+
+variable "backend_version_url" {
+  type        = "string"
+  description = "The URL to a chef-backend used during install."
+}
+
+variable "upgrade_version_url" {
+  type        = "string"
+  description = "The URL to a chef-server used during initial install."
+}
+
+variable "enable_ipv6" {
+  type        = "string"
+  description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
+}


### PR DESCRIPTION
### Description

This commit adds a Terraform AWS scenario that stands up three backend
servers before installing and configuring a frontend chef-server.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#1827 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
