### PR TITLE
Pin perl to 5.18.1

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -11,6 +11,7 @@ override :'omnibus-ctl', version: "master"
 override :chef, version: "v15.5.17"
 override :ohai, version: "v15.3.1"
 override :ruby, version: "2.6.5"
+override :perl, version: "5.18.1"
 
 
 # This SHA is the last commit before the 6.0 release


### PR DESCRIPTION
Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Description

Chef Infra Server builds break with the error:
```

D \| 2019-12-12T20:34:28+00:00 \| OK
--
  | D \| 2019-12-12T20:34:28+00:00 \| Successfully installed libintl-perl-1.23
  | D \| 2019-12-12T20:34:28+00:00 \| 1 distribution installed
  | [Builder: libintl-perl] I \| 2019-12-12T20:34:28+00:00 \| Execute: `cpanm -v --notest .': 2.7946s
  | [Builder: libintl-perl] I \| 2019-12-12T20:34:28+00:00 \| Build libintl-perl: 2.7958s
  | [Builder: libintl-perl] I \| 2019-12-12T20:34:28+00:00 \| Finished build
  | [Software: sqitch] D \| 2019-12-12T20:34:28+00:00 \| Forcing build because git caching is off
  | [NetFetcher: sqitch] I \| 2019-12-12T20:34:28+00:00 \| Cleaning project directory `/var/cache/omnibus/chef-server/src/sqitch'
  | [NetFetcher: sqitch] I \| 2019-12-12T20:34:28+00:00 \| Extracting `/var/cache/omnibus/chef-server/cache/app-sqitch-0.973.tar.gz' to `/var/cache/omnibus/chef-server/src/sqitch'
  | [NetFetcher: sqitch] I \| 2019-12-12T20:34:28+00:00 \| $ gtar zxf /var/cache/omnibus/chef-server/cache/app-sqitch-0.973.tar.gz -C/var/cache/omnibus/chef-server/src/sqitch
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \| Starting build
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \| Cached builder checksum before build: 72a1f9e101b27d089c8b5556b714561fd9510ad6f81352560b247711ff97bf30
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \| Environment:
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   CFLAGS="-I/opt/opscode/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   CPPFLAGS="-I/opt/opscode/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   CXXFLAGS="-I/opt/opscode/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   LDFLAGS="-Wl,-rpath,/opt/opscode/embedded/lib -L/opt/opscode/embedded/lib"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   LD_RUN_PATH="/opt/opscode/embedded/lib"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   OMNIBUS_INSTALL_DIR="/opt/opscode"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   PATH="/opt/opscode/bin:/opt/opscode/embedded/bin:/var/lib/buildkite-agent/builds/buildkite-omnibus-sles-12-x86-64-i-03aafd7c39bf5376c-1/chef/chef-chef-server-master-omnibus-adhoc/omnibus/vendor/bundle/ruby/2.6.0/bin:/opt/omnibus-toolchain/bin:/usr/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   PERL_MM_OPT="PUREPERL_ONLY=1"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \|   PKG_CONFIG_PATH="/opt/opscode/embedded/lib/pkgconfig"
  | [Builder: sqitch] I \| 2019-12-12T20:34:28+00:00 \| $ perl Build.PL
  | D \| 2019-12-12T20:34:28+00:00 \| Can't locate Module/Build.pm in @INC (you may need to install the Module::Build module) (@INC contains: /opt/opscode/embedded/lib/perl5/site_perl/5.30.0/x86_64-linux-thread-multi /opt/opscode/embedded/lib/perl5/site_perl/5.30.0 /opt/opscode/embedded/lib/perl5/5.30.0/x86_64-linux-thread-multi /opt/opscode/embedded/lib/perl5/5.30.0) at Build.PL line 5.
  | D \| 2019-12-12T20:34:28+00:00 \| BEGIN failed--compilation aborted at Build.PL line 5.
  | [Builder: sqitch] W \| 2019-12-12T20:34:28+00:00 \| [1/3] Failed to execute command. Retrying in 10 seconds...
```
Pinning to the last working version perl.

https://github.com/chef/chef-server/issues/1863


### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
