### PR TITLE
Fix two small chef-server-ctl typos

### DIFF
--- a/src/chef-server-ctl/plugins/server_admins.rb
+++ b/src/chef-server-ctl/plugins/server_admins.rb
@@ -20,7 +20,7 @@ require 'pg'
 
 PLACEHOLDER_GLOBAL_ORG_ID = "00000000000000000000000000000000"
 
-add_command_under_category "grant-server-admin-permissions", "server-admins", "Grant a user the ability to create other users by added the user to the server-admins group.", 2 do
+add_command_under_category "grant-server-admin-permissions", "server-admins", "Grant a user the ability to create other users by adding the user to the server-admins group.", 2 do
 
   cmd_args = ARGV[1..-1]
   if cmd_args.length != 1
@@ -118,7 +118,7 @@ add_command_under_category "list-server-admins", "server-admins", "List users th
   db = setup_erchef_db
   server_admins_authz_id = get_server_admins_authz_id(db)
 
-  # get all the user authz_ids for all memebers of the server-admins authz group
+  # get all the user authz_ids for all members of the server-admins authz group
   req_params = {
     method: :get,
     url: "#{::ChefServerCtl::Config.bifrost_url}/groups/#{server_admins_authz_id}",


### PR DESCRIPTION
### Description

Fixes two small typos - one grammatical error in chef-server-ctl help text and a misspelling in a comment.

### Issues Resolved

n/a

### Check List

- [n/a] New functionality includes tests
- [n/a] All buildkite tests pass
- [n/a] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
