### PR TITLE
Praj/solr to es

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -130,7 +130,7 @@ default['private_chef']['haproxy']['etcd_port'] = 2379
 ####
 # RabbitMQ
 ####
-default['private_chef']['rabbitmq']['enable'] = true
+default['private_chef']['rabbitmq']['enable'] = false
 default['private_chef']['rabbitmq']['ha'] = false
 default['private_chef']['rabbitmq']['dir'] = '/var/opt/opscode/rabbitmq'
 default['private_chef']['rabbitmq']['data_dir'] = '/var/opt/opscode/rabbitmq/db'
@@ -226,13 +226,13 @@ default['private_chef']['jetty']['log_directory'] = '/var/opt/opscode/opscode-so
 ####
 # Chef Solr 4
 ####
-default['private_chef']['opscode-solr4']['enable'] = true
+default['private_chef']['opscode-solr4']['enable'] = false
 #
 # Set this to point at a solr/cloudsearch installation
 # not controlled by chef-server
 #
-default['private_chef']['opscode-solr4']['external'] = false
-default['private_chef']['opscode-solr4']['external_url'] = nil
+default['private_chef']['opscode-solr4']['external'] = true
+default['private_chef']['opscode-solr4']['external_url'] = "http://localhost:9200"
 default['private_chef']['opscode-solr4']['ha'] = false
 default['private_chef']['opscode-solr4']['dir'] = '/var/opt/opscode/opscode-solr4'
 default['private_chef']['opscode-solr4']['data_dir'] = '/var/opt/opscode/opscode-solr4/data'
@@ -268,7 +268,7 @@ default['private_chef']['opscode-solr4']['elasticsearch_replica_count'] = 1
 ####
 # Chef Expander
 ####
-default['private_chef']['opscode-expander']['enable'] = true
+default['private_chef']['opscode-expander']['enable'] = false
 default['private_chef']['opscode-expander']['ha'] = false
 default['private_chef']['opscode-expander']['dir'] = '/var/opt/opscode/opscode-expander'
 default['private_chef']['opscode-expander']['log_directory'] = '/var/log/opscode/opscode-expander'
@@ -285,8 +285,7 @@ default['private_chef']['opscode-expander']['retry_wait'] = 1
 var_base = '/var/opt/opscode'
 log_base = '/var/log/opscode'
 
-default['private_chef']['elasticsearch']['enable'] = false
-default['private_chef']['elasticsearch']['first_internal_install'] = false
+default['private_chef']['elasticsearch']['enable'] = true
 elasticsearch = default['private_chef']['elasticsearch']
 
 # These attributes cannot be overridden in chef-server.rb
@@ -444,8 +443,8 @@ default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 # general search settings used to set up chef_index
-default['private_chef']['opscode-erchef']['search_provider'] = 'solr' # solr, elasticsearch
-default['private_chef']['opscode-erchef']['search_queue_mode'] = 'rabbitmq' # rabbitmq, batch, or inline
+default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch' # solr, elasticsearch
+default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch' # rabbitmq, batch, or inline
 default['private_chef']['opscode-erchef']['search_batch_max_size'] = '5000000'
 default['private_chef']['opscode-erchef']['search_batch_max_wait'] = '10'
 # solr_service configuration for erchef. These are used to configure an opscoderl_httpc pool

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -299,6 +299,7 @@ elasticsearch['temp_directory'] = "#{var_base}/elasticsearch/tmp"
 elasticsearch['log_directory'] = "#{log_base}/elasticsearch"
 elasticsearch['log_rotation']['file_maxbytes'] = 104857600
 elasticsearch['log_rotation']['num_to_keep'] = 10
+elasticsearch['listen'] = '127.0.0.1'
 elasticsearch['port'] = 9200
 elasticsearch['enable_gc_log'] = false
 elasticsearch['initial_cluster_join_timeout'] = 90
@@ -858,7 +859,7 @@ default['private_chef']['dark_launch']['private-chef'] = true
 default['private_chef']['dark_launch']['sql_users'] = true
 default['private_chef']['dark_launch']['add_type_and_bag_to_items'] = true
 default['private_chef']['dark_launch']['reporting'] = true
-# It appears that actions rabbitmq was used for oc_actions and analytics. 
+# It appears that actions rabbitmq was used for oc_actions and analytics.
 default['private_chef']['dark_launch']['actions'] = false
 
 ###

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -112,17 +112,11 @@ class OmnibusHelper
   end
 
   def es_index_definition
-    if node['private_chef']['elasticsearch']['first_internal_install'] == true
+    es_version = elastic_search_major_version
+    if elastic_search_major_version == 6
       es_6_index
-    else
-      # For external elasticsearch or chef-backend elasticsearch will be running
-      # before we try to create the index
-      es_version = elastic_search_major_version
-      if es_version == 6
-        es_6_index
-      elsif [2, 5].include?(es_version)
-        es_5_or_2_index
-      end
+    elsif [2, 5].include?(es_version)
+      es_5_or_2_index
     end
   end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -383,6 +383,8 @@ module PrivateChef
       PrivateChef['bookshelf']['listen'] ||= PrivateChef['default_listen_address']
       PrivateChef['rabbitmq']['node_ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['redis_lb']['listen'] ||= PrivateChef['default_listen_address']
+      # Should there be value for es here?
+      #PrivateChef['elasticsearch']['ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['opscode_solr4']['ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['postgresql']['listen_address'] ||= '*' # PrivateChef["default_listen_address"]
 
@@ -405,6 +407,8 @@ module PrivateChef
       PrivateChef['redis_lb']['vip'] ||= PrivateChef['backend_vips']['ipaddress']
       PrivateChef['opscode_solr4']['enable'] ||= false
       PrivateChef['opscode_solr4']['vip'] ||= PrivateChef['backend_vips']['ipaddress']
+      PrivateChef['elasticsearch']['enable'] ||= false
+      PrivateChef['elasticsearch']['vip'] ||= PrivateChef['backend_vips']['ipaddress']
       PrivateChef['opscode_expander']['enable'] ||= false
       PrivateChef['postgresql']['enable'] ||= false
       PrivateChef['postgresql']['vip'] ||= PrivateChef['backend_vips']['ipaddress']

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -383,8 +383,7 @@ module PrivateChef
       PrivateChef['bookshelf']['listen'] ||= PrivateChef['default_listen_address']
       PrivateChef['rabbitmq']['node_ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['redis_lb']['listen'] ||= PrivateChef['default_listen_address']
-      # Should there be value for es here?
-      #PrivateChef['elasticsearch']['ip_address'] ||= PrivateChef['default_listen_address']
+      PrivateChef['elasticsearch']['ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['opscode_solr4']['ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['postgresql']['listen_address'] ||= '*' # PrivateChef["default_listen_address"]
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -50,12 +50,6 @@ include_recipe 'private-chef::plugin_discovery'
 include_recipe 'private-chef::plugin_config_extensions'
 include_recipe 'private-chef::config'
 
-if node['private_chef']['elasticsearch']['first_internal_install']
-  node.override['private_chef']['opscode-solr4']['enable'] = false
-  node.override['private_chef']['rabbitmq']['enable'] = false
-  node.override['private_chef']['opscode-expander']['enable'] = false
-end
-
 if node['private_chef']['fips_enabled']
   include_recipe 'private-chef::fips'
 end
@@ -122,6 +116,9 @@ include_recipe 'private-chef::sysctl-updates'
 include_recipe 'private-chef::plugin_chef_run'
 
 if node['private_chef']['use_chef_backend']
+  # Ensure internal elasticsearch is not enabled
+  # if we are in the chef_backend configuration
+  node.override['private-chef']['elasticsearch']['enable'] = false
   include_recipe 'private-chef::haproxy'
 end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
@@ -137,5 +137,10 @@ link '/opt/opscode/embedded/elasticsearch/config' do
   to elasticsearch_conf_dir
 end
 
+directory '/opt/opscode/sv/opscode-solr4' do
+  recursive true
+  action :delete
+end
+
 # Define resource for elasticsearch component_runit_service
 component_runit_service 'elasticsearch'

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -165,6 +165,11 @@ command << " -jar '#{solr_jetty_dir}/start.jar'"
 
 node.default['private_chef']['opscode-solr4']['command'] = command
 
+directory '/opt/opscode/sv/elasticsearch' do
+  recursive true
+  action :delete
+end
+
 component_runit_service 'opscode-solr4'
 
 # log rotation is now handled by java

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch.yml.erb
@@ -10,7 +10,7 @@ cluster.name: <%= @cluster_name %>
 node.name: <%= node['fqdn'] %>
 path.data:  <%= @data_dir %>
 path.logs: <%= @log_directory %>
-network.host: <%= node['private_chef']['opscode-erchef']['vip']  %>
+network.host: <%= @listen  %>
 # Reference: http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html
 #            http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html
 #            http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html

--- a/omnibus/files/private-chef-upgrades/001/035_solr_to_elasticsearch_migration.rb
+++ b/omnibus/files/private-chef-upgrades/001/035_solr_to_elasticsearch_migration.rb
@@ -1,0 +1,37 @@
+define_upgrade do
+  if Partybus.config.bootstrap_server
+
+    es = Partybus.config.running_server["private_chef"]["elasticsearch"]
+    # Run these migrations only if elasticsearch has been enabled in the config
+    # We do not want to run this if solr is enabled
+
+    if es["enable"]
+
+      must_be_data_master
+
+      # Make sure API is down
+      stop_services(["nginx", "opscode-erchef"])
+      # Try to call chef-server-ctl reindex
+      start_services(["elasticsearch",
+                      "nginx",
+                      "oc_bifrost",
+                      "opscode-erchef",
+                      "postgresql",
+                      "redis_lb"])
+
+      sleep 30
+
+      log "All orgs are in the 503 mode..."
+      log "Migrating indexed search data..."
+      run_command("chef-server-ctl reindex -a -d -t -w")
+
+      stop_services(["elasticsearch",
+                     "nginx",
+                     "oc_bifrost",
+                     "opscode-erchef",
+                     "postgresql",
+                     "redis_lb"])
+    end
+  end
+end
+

--- a/omnibus/package-scripts/chef-server/postrm
+++ b/omnibus/package-scripts/chef-server/postrm
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# dpkg will call us with abort-upgrade if the preinst script failed.
+# Our preinst script purposefully fails based on user input.
+if [[ "$1" = "abort-upgrade" ]]; then
+    exit 0
+fi
+
 # rpm calls `postrm 0` if this is package removal; and `postrm 1` if this is an
-# upgrade. dpkg calls postrm only if it's a removal.
+# upgrade.
 # So we want to execute the rm if we're NOT rhel-ish, OR the argument is correct.
 # (See also: http://tickets.opscode.com/browse/CHEF-3022)
 if [[ ! ( -e /etc/redhat-release || -e /etc/system-release ) || "$1" == "0" ]]; then

--- a/omnibus/package-scripts/chef-server/preinst
+++ b/omnibus/package-scripts/chef-server/preinst
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Perform necessary chef-server setup steps after package is installed.
+#
+
+PROGNAME=$(basename $0)
+
+function error_exit
+{
+	echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+	exit 1
+}
+
+version=$(awk '/chef-server/{ split($2,a,"+");print a[1];exit }' /opt/opscode/version-manifest.txt)
+
+confirm () {
+  read -r -p "Do you want to continue [y/n]" response
+  case "$response" in
+        [yY][eE][sS]|[yY])
+            echo "Putting Chef Infra Server in maintenance mode for reindex."
+            ;;
+        *)
+            echo "Doing nothing. You can continue using your existing Chef Infra Server."
+            exit
+            ;;
+  esac
+}
+
+first_elasticsearch_internal_install () {
+  IFS=. read -r major minor patch <<< "$version"
+  # Installing the version of Chef Infra Server with internal es.
+  # Installing 13.3 or 13.4
+  if [ $major -ge 13 -a $minor -ge 3 ]
+  then
+    #fresh install
+    if [-f /etc/opscode/chef-server-running.json]
+    then
+      if [ -d /opt/opscode/sv/opscode-solr4 && ! -d /opt/opscode/sv/elasticsearch]
+      then
+        echo "############################ NOTICE ##################################"
+        echo "This install will replace internal solr with elasticsearch for search.\n"
+        echo "There will be a full reindex of data for elasticsearch.\n"
+        echo "It can take anywhere between a few seconds to a couple of hours\n"
+        echo "for the reindex to complete.\n"
+        echo "Services will be down for the duration of the reindex.\n"
+        echo "Please take a full backup before proceeding.\n"
+        confirm
+      fi
+    fi
+  fi
+}
+
+first_elasticsearch_internal_install
+
+exit 0

--- a/omnibus/package-scripts/chef-server/preinst
+++ b/omnibus/package-scripts/chef-server/preinst
@@ -7,49 +7,46 @@ PROGNAME=$(basename $0)
 
 function error_exit
 {
-	echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
-	exit 1
+    echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+    exit 1
 }
-
-version=$(awk '/chef-server/{ split($2,a,"+");print a[1];exit }' /opt/opscode/version-manifest.txt)
 
 confirm () {
-  read -r -p "Do you want to continue [y/n]" response
-  case "$response" in
+    read -r -p "Do you want to continue [y/n]" response
+    case "$response" in
         [yY][eE][sS]|[yY])
-            echo "Putting Chef Infra Server in maintenance mode for reindex."
+            exit 0
             ;;
         *)
-            echo "Doing nothing. You can continue using your existing Chef Infra Server."
-            exit
+            error_exit "Doing nothing. You can continue using your existing Chef Infra Server."
             ;;
-  esac
+    esac
 }
 
-first_elasticsearch_internal_install () {
-  IFS=. read -r major minor patch <<< "$version"
-  # Installing the version of Chef Infra Server with internal es.
-  # Installing 13.3 or 13.4
-  if [ $major -ge 13 -a $minor -ge 3 ]
-  then
-    #fresh install
-    if [-f /etc/opscode/chef-server-running.json]
-    then
-      if [ -d /opt/opscode/sv/opscode-solr4 && ! -d /opt/opscode/sv/elasticsearch]
-      then
-        echo "############################ NOTICE ##################################"
-        echo "This install will replace internal solr with elasticsearch for search.\n"
-        echo "There will be a full reindex of data for elasticsearch.\n"
-        echo "It can take anywhere between a few seconds to a couple of hours\n"
-        echo "for the reindex to complete.\n"
-        echo "Services will be down for the duration of the reindex.\n"
-        echo "Please take a full backup before proceeding.\n"
-        confirm
-      fi
+warn_about_search_reindex() {
+    # If this is a fresh install, we don't need to worry about the
+    # solr migration
+    if [ ! -e /etc/opscode/chef-server-running.json ]; then
+        return
     fi
-  fi
+
+    if [ -d /opt/opscode/sv/opscode-solr4 ]; then
+        echo "############################ NOTICE ##################################"
+        echo ""
+        echo "It appears that this Chef Infra Server has Solr enabled."
+        echo ""
+        echo "By default, Chef Infra Server now uses Elasticsearch. To migrate to elasticsearch"
+        echo "requires a full data reindex."
+        echo ""
+        echo "The reindex can take a long time if you have a large amount of data. Your chef server"
+        echo "will be down for the duration of the reindex."
+        echo ""
+        echo "We recommend taking a full backend before proceeding."
+        echo ""
+        echo "############################ NOTICE ##################################"
+        confirm
+    fi
 }
 
-first_elasticsearch_internal_install
-
+warn_about_search_reindex
 exit 0


### PR DESCRIPTION
### Description

This change adds capability to replace internal solr(for searching) with elasticsearch.
The solr, rabbitmq and opscode-expander services are shutdown.

By default the internal search will be with elasticsearch.

```
default['private_chef']['opscode-solr4']['external'] = true
default['private_chef']['opscode-solr4']['external_url'] = 'http://localhost:9200'

default['private_chef']['elasticsearch']['enable'] = true

default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch' # solr, elasticsearch
default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch' # rabbitmq, batch, or inline
```

### Issues Resolved

#1732 

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
