### PR TITLE
Add fail-over test to chef-backend scenario

### DIFF
--- a/terraform/common/files/test_chef_backend-demotion.sh
+++ b/terraform/common/files/test_chef_backend-demotion.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -evx
+
+ret=0
+
+echo -e '\nBEGIN TEST CHEF BACKEND DEMOTION\n'
+
+echo 'Original Chef Backend leader status'
+sudo chef-backend-ctl cluster-status | tee /tmp/chef-backend-status.orig
+
+echo 'Demoting current leader'
+sudo chef-backend-ctl demote >/dev/null 2>&1
+sleep 30
+
+echo 'Current Chef Backend leader status'
+sudo chef-backend-ctl cluster-status | tee /tmp/chef-backend-status.cur
+
+leaders=$(sudo awk '/leader.*leader/{print $3}' /tmp/chef-backend-status.{orig,cur} | sort -u | wc -l)
+
+if [[ $leaders -ne 2 ]]; then
+    ret=1
+
+    echo 'ERROR: Leadership transfer was not successful'
+
+    sudo diff /tmp/chef-backend-status.{orig,cur}
+fi
+
+echo -e '\nEND TEST CHEF BACKEND DEMOTION\n'
+
+exit $ret


### PR DESCRIPTION
### Description

This PR adds another test to the chef-backend scenario that demotes the currently leader and verifies that a different node takes over leadership responsibilities.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#1879 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
