### PR TITLE
Adding scenario for restoring from a local backup

### DIFF
--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -27,6 +27,10 @@ ifneq ($(AWS_DEFAULT_INSTANCE_TYPE),)
 	export TF_VAR_aws_instance_type ?= $(AWS_DEFAULT_INSTANCE_TYPE)
 endif
 
+ifneq ($(CHEF_SERVER_BACKUP_LOCATION),)
+	export TF_VAR_backup_location ?= $(CHEF_SERVER_BACKUP_LOCATION)
+endif
+
 ifneq ($(PLATFORM),)
 	export TF_VAR_platform ?= $(PLATFORM)
 else
@@ -37,6 +41,7 @@ ifneq ($(INSTALL_VERSION),)
 	export TF_VAR_install_version_url ?= $(shell platform=$(TF_VAR_platform); for channel in unstable current stable; do mixlib-install download chef-server --url -c $$channel -a x86_64 -p $$(echo $${platform%-*} | sed 's/rhel/el/') -l $${platform\#\#*-} -v $(INSTALL_VERSION) 2>/dev/null && break; done | head -n1)
 endif
 
+export UPGRADE_VERSION ?= $(INSTALL_VERSION)
 ifneq ($(UPGRADE_VERSION),)
 	export TF_VAR_upgrade_version_url ?= $(shell platform=$(TF_VAR_platform); for channel in unstable current stable; do mixlib-install download chef-server --url -c $$channel -a x86_64 -p $$(echo $${platform%-*} | sed 's/rhel/el/') -l $${platform\#\#*-} -v $(UPGRADE_VERSION) 2>/dev/null && break; done | head -n1)
 endif

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -46,7 +46,7 @@ Environment variables are used to control how the scenarios are executed and can
 | `SCENARIO` | The name of the sub-directory within `scenarios` containing the test you'd like to run. | omnibus-tiered-fresh-install |
 | `INSTALL_VERSION` | The version number of the artifact you want to install first. | 12.19.31 |
 | `UPGRADE_VERSION` | The version number of the artifact you want to upgrade to. | 13.0.40+20190923060037 |
-| `CHEF_SERVER_BACKUP_LOCATION` | Location of the backup if running the omnibus-rest-rebackup scenario | /tmp/chef-backup-2019-12-27-16-54-38.tgz |
+| `CHEF_SERVER_BACKUP_LOCATION` | Location of the backup if running the omnibus-restore-backup scenario | /tmp/chef-backup-2019-12-27-16-54-38.tgz |
 
 ### Optional Environment Variables
 | Environment Variable | Description | Example |

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -46,6 +46,7 @@ Environment variables are used to control how the scenarios are executed and can
 | `SCENARIO` | The name of the sub-directory within `scenarios` containing the test you'd like to run. | omnibus-tiered-fresh-install |
 | `INSTALL_VERSION` | The version number of the artifact you want to install first. | 12.19.31 |
 | `UPGRADE_VERSION` | The version number of the artifact you want to upgrade to. | 13.0.40+20190923060037 |
+| `CHEF_SERVER_BACKUP_LOCATION` | Location of the backup if running the omnibus-rest-rebackup scenario | /tmp/chef-backup-2019-12-27-16-54-38.tgz |
 
 ### Optional Environment Variables
 | Environment Variable | Description | Example |
@@ -87,5 +88,5 @@ To destroy all active scenarios you may run either the `make destroy-all` or `ma
 ## Adding a new Scenario
 
 1. Duplicate an existing scenario directory that is similar to the one you desire. For example, if you wanted to add a
-   `omnibus-tiered-upgrade`, you could start with the `omnibus-tiered-fresh-install` scenario file.   
+   `omnibus-tiered-upgrade`, you could start with the `omnibus-tiered-fresh-install` scenario file.
 2. Update the `main.tf` file to reflect the scenario name as well as any additional test changes you require.

--- a/terraform/aws/modules/aws_instance/amis.tf
+++ b/terraform/aws/modules/aws_instance/amis.tf
@@ -49,6 +49,23 @@ data "aws_ami" "rhel_8" {
   owners = ["309956199498"]
 }
 
+# identify ubuntu 14.04 ami
+data "aws_ami" "ubuntu_1404" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"]
+}
+
 # identify ubuntu 16.04 ami
 data "aws_ami" "ubuntu_1604" {
   most_recent = true

--- a/terraform/aws/modules/aws_instance/locals.tf
+++ b/terraform/aws/modules/aws_instance/locals.tf
@@ -12,6 +12,7 @@ locals {
     rhel-6       = "${data.aws_ami.rhel_6.id}"
     rhel-7       = "${data.aws_ami.rhel_7.id}"
     rhel-8       = "${data.aws_ami.rhel_8.id}"
+    ubuntu-14.04 = "${data.aws_ami.ubuntu_1404.id}"
     ubuntu-16.04 = "${data.aws_ami.ubuntu_1604.id}"
     ubuntu-18.04 = "${data.aws_ami.ubuntu_1804.id}"
     sles-12      = "${data.aws_ami.sles_12.id}"

--- a/terraform/aws/modules/aws_vpc/outputs.tf
+++ b/terraform/aws/modules/aws_vpc/outputs.tf
@@ -13,3 +13,7 @@ output "ipv4_cidr_block" {
 output "ipv6_cidr_block" {
   value = "${cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)}"
 }
+
+output "region" {
+  value = "${var.aws_region}"
+}

--- a/terraform/aws/scenarios/omnibus-external-openldap/files/chef-server.rb
+++ b/terraform/aws/scenarios/omnibus-external-openldap/files/chef-server.rb
@@ -4,9 +4,9 @@ opscode_erchef['keygen_cache_size'] = 60
 
 nginx['ssl_dhparam'] = '/etc/opscode/dhparam.pem'
 
-data_collector['token'] = 'foobar'
+data_collector['token'] = 'foobar' unless data_collector.nil?
 
-profiles['root_url'] = 'http://localhost:9998'
+profiles['root_url'] = 'http://localhost:9998' unless profiles.nil?
 
 ldap['base_dn'] = 'ou=chefs,dc=chef-server,dc=dev'
 ldap['bind_dn'] = 'cn=admin,dc=chef-server,dc=dev'

--- a/terraform/aws/scenarios/omnibus-external-postgresql/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/templates/chef-server.rb.tpl
@@ -4,9 +4,9 @@ opscode_erchef['keygen_cache_size'] = 60
 
 nginx['ssl_dhparam'] = '/etc/opscode/dhparam.pem'
 
-data_collector['token'] = 'foobar'
+data_collector['token'] = 'foobar' unless data_collector.nil?
 
-profiles['root_url'] = 'http://localhost:9998'
+profiles['root_url'] = 'http://localhost:9998' unless profiles.nil?
 
 postgresql['external'] = true
 

--- a/terraform/aws/scenarios/omnibus-restore-backup/README.md
+++ b/terraform/aws/scenarios/omnibus-restore-backup/README.md
@@ -1,4 +1,4 @@
-# Omnibus Standalone Fresh Install
+# Omnibus Restore Existing Backup
 
 This directory contains the Terraform code used to instantiate a single Chef Infra Server utilizing an Omnibus built artifact downloaded from `$upgrade_version_url` as the install package.
 

--- a/terraform/aws/scenarios/omnibus-restore-backup/README.md
+++ b/terraform/aws/scenarios/omnibus-restore-backup/README.md
@@ -1,0 +1,6 @@
+# Omnibus Standalone Fresh Install
+
+This directory contains the Terraform code used to instantiate a single Chef Infra Server utilizing an Omnibus built artifact downloaded from `$upgrade_version_url` as the install package.
+
+Once the server has been installed and configured, the specified backup is copied from the workstation to the server
+and restored.

--- a/terraform/aws/scenarios/omnibus-restore-backup/files/chef-server.rb
+++ b/terraform/aws/scenarios/omnibus-restore-backup/files/chef-server.rb
@@ -1,0 +1,11 @@
+opscode_erchef['keygen_start_size'] = 30
+
+opscode_erchef['keygen_cache_size']=60
+
+nginx['ssl_dhparam']='/etc/opscode/dhparam.pem'
+
+insecure_addon_compat false
+
+data_collector['token'] = 'foobar' unless data_collector.nil?
+
+profiles['root_url'] = 'http://localhost:9998' unless profiles.nil?

--- a/terraform/aws/scenarios/omnibus-restore-backup/main.tf
+++ b/terraform/aws/scenarios/omnibus-restore-backup/main.tf
@@ -1,0 +1,66 @@
+module "chef_server" {
+  source = "../../modules/aws_instance"
+
+  aws_profile       = "${var.aws_profile}"
+  aws_region        = "${var.aws_region}"
+  aws_vpc_name      = "${var.aws_vpc_name}"
+  aws_department    = "${var.aws_department}"
+  aws_contact       = "${var.aws_contact}"
+  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
+  aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
+  platform          = "${var.platform}"
+  build_prefix      = "${var.build_prefix}"
+  name              = "${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
+}
+
+resource "null_resource" "chef_server_config" {
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/files/chef-server.rb"
+    destination = "/tmp/chef-server.rb"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/../../../common/files/dhparam.pem"
+    destination = "/tmp/dhparam.pem"
+  }
+
+  # install chef-server
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "echo -e '\nBEGIN INSTALL CHEF SERVER\n'",
+      "curl -vo /tmp/${replace(var.upgrade_version_url, "/^.*\\//", "")} ${var.upgrade_version_url}",
+      "sudo ${replace(var.upgrade_version_url, "rpm", "") != var.upgrade_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.upgrade_version_url, "/^.*\\//", "")}",
+      "sudo chown root:root /tmp/chef-server.rb",
+      "sudo chown root:root /tmp/dhparam.pem",
+      "sudo mv /tmp/chef-server.rb /etc/opscode",
+      "sudo mv /tmp/dhparam.pem /etc/opscode",
+      "export CHEF_LICENSE=accept",
+      "sudo chef-server-ctl reconfigure",
+      "sleep 120",
+      "echo -e '\nEND INSTALL CHEF SERVER\n'",
+    ]
+  }
+
+  # Copy across existing backup. This is very dependent on matching the version of chef-server the backup
+  # was generated from.
+  provisioner "file" {
+    source      = "${var.backup_location}"
+    destination = "/tmp/chef-backup.tgz"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo -e '\nBEGIN RESTORE BACKUP\n'",
+      "sudo chef-server-ctl restore /tmp/chef-backup.tgz",
+      "echo -e '\nEND RESTORE BACKUP\n'",
+    ]
+  }
+}

--- a/terraform/aws/scenarios/omnibus-restore-backup/variables.tf
+++ b/terraform/aws/scenarios/omnibus-restore-backup/variables.tf
@@ -1,0 +1,80 @@
+#########################################################################
+# AWS
+#########################################################################
+variable "aws_profile" {
+  type        = "string"
+  description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
+  default     = "chef-engineering"
+}
+
+variable "aws_region" {
+  type        = "string"
+  description = "Name of the AWS region to create instances in (e.g. us-west-2)."
+  default     = "us-west-1"
+}
+
+variable "aws_vpc_name" {
+  type        = "string"
+  description = "Name of the AWS virtual private cloud where tests will be run."
+  default     = ""
+}
+
+variable "aws_department" {
+  type        = "string"
+  description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
+}
+
+variable "aws_contact" {
+  type        = "string"
+  description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
+}
+
+variable "aws_ssh_key_id" {
+  type        = "string"
+  description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
+}
+
+variable "aws_instance_type" {
+  type        = "string"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
+  default     = "t2.medium"
+}
+
+variable "platform" {
+  type        = "string"
+  description = "Operating System of the instance to be created."
+}
+
+variable "build_prefix" {
+  type        = "string"
+  description = "Optional build identifier for differentiating scenario runs."
+  default     = ""
+}
+
+#########################################################################
+# Chef Server
+#########################################################################
+variable "scenario" {
+  type        = "string"
+  description = "The name of the scenario being executed."
+}
+
+variable "install_version_url" {
+  type        = "string"
+  description = "The URL to a chef-server used during initial install."
+}
+
+variable "upgrade_version_url" {
+  type        = "string"
+  description = "The URL to a chef-server artifact used during upgrades."
+}
+
+variable "enable_ipv6" {
+  type        = "string"
+  description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
+}
+
+variable "backup_location" {
+  type        = "string"
+  description = "full path to local backup"
+}

--- a/terraform/aws/scenarios/omnibus-standalone-fresh-install/files/chef-server.rb
+++ b/terraform/aws/scenarios/omnibus-standalone-fresh-install/files/chef-server.rb
@@ -6,6 +6,6 @@ nginx['ssl_dhparam']='/etc/opscode/dhparam.pem'
 
 insecure_addon_compat false
 
-data_collector['token'] = 'foobar'
+data_collector['token'] = 'foobar' unless data_collector.nil?
 
-profiles['root_url'] = 'http://localhost:9998'
+profiles['root_url'] = 'http://localhost:9998' unless profiles.nil?

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/files/chef-server.rb
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/files/chef-server.rb
@@ -6,6 +6,6 @@ nginx['ssl_dhparam']='/etc/opscode/dhparam.pem'
 
 insecure_addon_compat false
 
-data_collector['token'] = 'foobar'
+data_collector['token'] = 'foobar' unless data_collector.nil?
 
-profiles['root_url'] = 'http://localhost:9998'
+profiles['root_url'] = 'http://localhost:9998' unless profiles.nil?

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
@@ -32,6 +32,6 @@ nginx['ssl_dhparam'] = '/etc/opscode/dhparam.pem'
 
 insecure_addon_compat = false
 
-data_collector['token'] = 'foobar'
+data_collector['token'] = 'foobar' unless data_collector.nil?
 
 nginx['enable_ipv6'] = ${enable_ipv6}

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
@@ -32,6 +32,6 @@ nginx['ssl_dhparam'] = '/etc/opscode/dhparam.pem'
 
 insecure_addon_compat = false
 
-data_collector['token'] = 'foobar'
+data_collector['token'] = 'foobar' unless data_collector.nil?
 
 nginx['enable_ipv6'] = ${enable_ipv6}


### PR DESCRIPTION
### Description

Copies the standalone-fresh-install scenario. But instead of running the pedant tests, restore an existing backup. This facilitates some testing we are trying to perform for the
`chef analyze` command.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
