### PR TITLE
Point to Chef-owned Hoax repo

### DIFF
--- a/src/chef-mover/rebar.config
+++ b/src/chef-mover/rebar.config
@@ -65,7 +65,7 @@
     {test, [
         {deps, [
             {hoax, ".*",
-                {git, "git://github.com/lbakerchef/hoax.git", {branch, "lbaker/fixes-for-erlang20"}}},
+                {git, "git://github.com/chef/hoax.git",         {branch, "lbaker/fixes-for-erlang20"}}},
             {cth_readable,
                 {git, "git://github.com/ferd/cth_readable.git", {branch, "master"}}}
                 ]}
@@ -80,8 +80,8 @@
 {ct_opts, [{ct_hooks, [cth_readable_shell]}]}.
 
 {pre_hooks, [
-             {clean, "make version_clean"},
-             {compile, "make VERSION"}
+             {clean,    "make version_clean"},
+             {compile,  "make VERSION"}
 ]}.
 
 {plugins, [{pc, "1.8.0"}]}. % Locked to avoid fallout related to: https://github.com/blt/port_compiler/issues/43
@@ -91,8 +91,8 @@
         {plugins, [pc]},
         {provider_hooks, [
             {post, [
-                {compile, {pc, compile}},
-                {clean, {pc, clean}}
+                {compile,   {pc, compile}},
+                {clean,     {pc, clean}}
             ]}
         ]}
     ]},


### PR DESCRIPTION
We had been temporarily pointed to a private Hoax repo since the Erlang 20 upgrade work.  This commit points us back to a chef-owned Hoax repo.
