### PR TITLE
Fix erlang version and db config for habitat build

### DIFF
--- a/src/bookshelf/habitat/plan.sh
+++ b/src/bookshelf/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=chef
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_deps=(
-  core/erlang18
+  core/erlang20
   core/cacerts
   core/coreutils
   core/gcc-libs

--- a/src/oc_bifrost/habitat/plan.sh
+++ b/src/oc_bifrost/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=chef
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_deps=(
-  core/erlang18
+  core/erlang20
   core/cacerts
   core/coreutils
   core/curl

--- a/src/oc_erchef/habitat/config/sys.config
+++ b/src/oc_erchef/habitat/config/sys.config
@@ -299,10 +299,10 @@
     {{/if ~}}
   {{/eachAlive ~}}
 {{else ~}}
-          {db_host, "{{cfg.database_host}}"},
-          {db_port, 5432},
-          {db_user, "hab"},
-          {db_pass, "chefrocks" },
+          {db_host, "{{cfg.sqerl.db_host}}"},
+          {db_port, {{cfg.sqerl.db_port}} },
+          {db_user, "{{cfg.sqerl.db_user}}"},
+          {db_pass, "{{cfg.sqerl.db_pass}}"},
 {{/if ~}}
         {db_name, "opscode_chef" },
         {idle_check, 10000},

--- a/src/oc_erchef/habitat/plan.sh
+++ b/src/oc_erchef/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=chef
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_deps=(
-  core/erlang18
+  core/erlang20
   core/cacerts
   core/coreutils
   core/curl


### PR DESCRIPTION
### Description

- Update the habitat build to use erlang 20 as building with erlang 18 no longer works
- Fix the habitat database configuration for external database

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
