### PR TITLE
Remove encouragement to install deprecated Manage plugin

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/index.html
+++ b/omnibus/files/private-chef-cookbooks/private-chef/files/default/html/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
-  <title>Chef API</title>
+  <title>Chef Infra Server API</title>
   <link media="all" rel="stylesheet" type="text/css" href="/css/all.css" />
   <!--[if lt IE 7]><link rel="stylesheet" type="text/css" href="/css/lt7.css" /><![endif]-->
 </head>
@@ -17,33 +17,18 @@
     <div id="main">
       <div class="mybox">
         <div id="content">
-          <h1>Are You Looking For the Chef Server?</h1>
-
-          <p>Hello! It looks like you were trying to browse to your Chef Server but you haven't installed the Management Console.</p>
+          <h1>Are You Looking For the Chef Infra Server?</h1>
 
           <p>
-            If you prefer, you can access the server programmatically with the Chef Server API. To learn how to
-            do this, head over to our <a href="https://docs.chef.io/api_chef_server.html">API Documentation</a> pages.
+            Hello! It looks like you were trying to browse to your Chef Infra Server.
           </p>
-
           <p>
-            If you do want to use your browser to manage your server, then
-            install the Management Console. It's free for up to 25 nodes.
+            Most users interact with the Chef Infra Server using <a href="https://docs.chef.io/knife.html">knife</a> or other
+            tooling you can learn about at <a href="https://learn.chef.io">Learn Chef Rally</a>.
           </p>
-
           <p>
-            One way to install the Management Console is to log in as root and type these commands:
-            <pre> # chef-server-ctl install chef-manage </pre>
-            <pre> # chef-server-ctl reconfigure </pre>
-            <pre> # chef-manage-ctl reconfigure </pre>
-            Alternatively, you can download the Management Console as an installable package from the <a href="https://downloads.chef.io/chef-manage"> Management Console</a> downloads page.
-          </p>
-
-          <p>
-            You may also be interested in our other add-ons. These are available as packages from our
-            <a href="https://downloads.chef.io/chef-server/">Chef Server</a> downloads page or you can
-            type <code>chef-server-ctl install</code>. Without arguments, the command lists the packages
-            available for installation.
+            You can access the server programmatically with the Chef Infra Server API. To learn how
+            to do this, head over to our <a href="https://docs.chef.io/api_chef_server.html">API Documentation</a> pages.
           </p>
         </div>
       </div>
@@ -54,7 +39,7 @@
       <div class="mybox">
       </div>
       <div class="footer-bottom">
-        <span>&copy; 2010&thinsp;&ndash;&thinsp;2017 Chef Software, Inc. All Rights Reserved</span>
+        <span>&copy; 2010&thinsp;&ndash;&thinsp;2020 Chef Software, Inc. All Rights Reserved</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Signed-off-by: Shaun Mouton <sdmouton@devops.christmas>

### Description

* Remove references to Manage plugin
* Update naming to match current branding
* Update copyright date

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
