### PR TITLE
Add FIPS scenario to integration tests

### DIFF
--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -126,6 +126,42 @@ steps:
       executor:
         docker:
 
+  - label: ':terraform: fips-ipv4-rhel-6'
+    command: .expeditor/integration_test.pipeline.sh apply
+    env:
+      SCENARIO: omnibus-fips
+      PLATFORM: rhel-6
+      ENABLE_IPV6: false
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        docker:
+
+  - label: ':terraform: fips-ipv4-rhel-7'
+    command: .expeditor/integration_test.pipeline.sh apply
+    env:
+      SCENARIO: omnibus-fips
+      PLATFORM: rhel-7
+      ENABLE_IPV6: false
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        docker:
+
+  - label: ':terraform: fips-ipv4-rhel-8'
+    command: .expeditor/integration_test.pipeline.sh apply
+    env:
+      SCENARIO: omnibus-fips
+      PLATFORM: rhel-8
+      ENABLE_IPV6: false
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        docker:
+
   - label: ':terraform: external-postgresql-ipv4-rhel-6'
     command: .expeditor/integration_test.pipeline.sh apply
     env:
@@ -515,6 +551,42 @@ steps:
     env:
       SCENARIO: omnibus-external-openldap
       PLATFORM: ubuntu-18.04
+      ENABLE_IPV6: true
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        docker:
+
+  - label: ':terraform: fips-ipv6-rhel-6'
+    command: .expeditor/integration_test.pipeline.sh apply
+    env:
+      SCENARIO: omnibus-fips
+      PLATFORM: rhel-6
+      ENABLE_IPV6: true
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        docker:
+
+  - label: ':terraform: fips-ipv6-rhel-7'
+    command: .expeditor/integration_test.pipeline.sh apply
+    env:
+      SCENARIO: omnibus-fips
+      PLATFORM: rhel-7
+      ENABLE_IPV6: true
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        docker:
+
+  - label: ':terraform: fips-ipv6-rhel-8'
+    command: .expeditor/integration_test.pipeline.sh apply
+    env:
+      SCENARIO: omnibus-fips
+      PLATFORM: rhel-8
       ENABLE_IPV6: true
     expeditor:
       accounts:

--- a/terraform/aws/modules/aws_instance/outputs.tf
+++ b/terraform/aws/modules/aws_instance/outputs.tf
@@ -1,3 +1,7 @@
+output "id" {
+  value = "${aws_instance.default.id}"
+}
+
 output "public_ipv4_address" {
   value = "${aws_instance.default.public_ip}"
 }

--- a/terraform/aws/scenarios/omnibus-fips/README.md
+++ b/terraform/aws/scenarios/omnibus-fips/README.md
@@ -1,0 +1,7 @@
+# Omnibus FIPS
+
+This directory contains the Terraform code used to instantiate a single Chef Infra Server conforming to Federal Information Processing Standards (FIPS) utilizing an Omnibus built artifact downloaded from `$upgrade_version_url` as the install package.
+
+Once the server has been installed and configured, the pedant tests are run against the server.
+
+NOTE: This scenario can only be run against RHEL distributions.

--- a/terraform/aws/scenarios/omnibus-fips/files/chef-server.rb
+++ b/terraform/aws/scenarios/omnibus-fips/files/chef-server.rb
@@ -1,0 +1,13 @@
+opscode_erchef['keygen_start_size'] = 30
+
+opscode_erchef['keygen_cache_size']=60
+
+nginx['ssl_dhparam']='/etc/opscode/dhparam.pem'
+
+insecure_addon_compat false
+
+data_collector['token'] = 'foobar'
+
+profiles['root_url'] = 'http://localhost:9998'
+
+fips true

--- a/terraform/aws/scenarios/omnibus-fips/main.tf
+++ b/terraform/aws/scenarios/omnibus-fips/main.tf
@@ -1,0 +1,132 @@
+module "chef_server" {
+  source = "../../modules/aws_instance"
+
+  aws_profile       = "${var.aws_profile}"
+  aws_region        = "${var.aws_region}"
+  aws_vpc_name      = "${var.aws_vpc_name}"
+  aws_department    = "${var.aws_department}"
+  aws_contact       = "${var.aws_contact}"
+  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
+  aws_instance_type = "${var.aws_instance_type}"
+  enable_ipv6       = "${var.enable_ipv6}"
+  platform          = "${var.platform}"
+  build_prefix      = "${var.build_prefix}"
+  name              = "${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
+}
+
+resource "null_resource" "chef_server_fips" {
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
+
+  # enable fips mode
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "echo -e '\nFIPS STATUS:\n'",
+      "sudo sysctl crypto.fips_enabled",
+      "echo -e '\nBEGIN ENABLING FIPS MODE\n'",
+      "sudo yum install -y dracut-fips",
+      "sudo dracut -f",
+      "sudo sed -i '/GRUB_CMDLINE_LINUX/{s/=\"/=\"fips=1 /;}' /etc/default/grub",
+      "sudo grub2-mkconfig -o /boot/grub2/grub.cfg",
+      "echo -e '\nEND ENABLING FIPS MODE\n'",
+    ]
+  }
+
+  # reboot instance for fips to take effect
+  provisioner "local-exec" {
+    command = "aws ec2 reboot-instances --instance-ids ${module.chef_server.id}"
+  }
+}
+
+resource "null_resource" "chef_server_config" {
+  depends_on = ["null_resource.chef_server_fips"]
+
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/files/chef-server.rb"
+    destination = "/tmp/chef-server.rb"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/../../../common/files/dhparam.pem"
+    destination = "/tmp/dhparam.pem"
+  }
+
+  # install chef-server
+  provisioner "remote-exec" {
+    inline = [
+      "set -evx",
+      "echo -e '\nFIPS STATUS:\n'",
+      "sudo sysctl crypto.fips_enabled",
+      "echo -e '\nBEGIN INSTALL CHEF SERVER\n'",
+      "curl -vo /tmp/${replace(var.upgrade_version_url, "/^.*\\//", "")} ${var.upgrade_version_url}",
+      "sudo ${replace(var.upgrade_version_url, "rpm", "") != var.upgrade_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.upgrade_version_url, "/^.*\\//", "")}",
+      "sudo chown root:root /tmp/chef-server.rb",
+      "sudo chown root:root /tmp/dhparam.pem",
+      "sudo mv /tmp/chef-server.rb /etc/opscode",
+      "sudo mv /tmp/dhparam.pem /etc/opscode",
+      "sudo chef-server-ctl reconfigure --chef-license=accept",
+      "sleep 120",
+      "echo -e '\nEND INSTALL CHEF SERVER\n'",
+    ]
+  }
+
+  # add user + organization
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/add_user.sh"
+  }
+}
+
+resource "null_resource" "chef_server_test" {
+  depends_on = ["null_resource.chef_server_config"]
+
+  connection {
+    type = "ssh"
+    user = "${module.chef_server.ssh_username}"
+    host = "${module.chef_server.public_ipv4_dns}"
+  }
+
+  # run smoke test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_chef_server-smoke.sh"
+  }
+
+  # install push jobs addon
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/install_addon_push_jobs.sh"
+  }
+
+  # test push jobs addon
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_addon_push_jobs.sh"
+  }
+
+  # install chef manage addon
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/install_addon_chef_manage.sh"
+  }
+
+  # run pedant test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_chef_server-pedant.sh"
+  }
+
+  # run psql test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_psql.sh"
+  }
+
+  # run gather-logs test
+  provisioner "remote-exec" {
+    script = "${path.module}/../../../common/files/test_gather_logs.sh"
+  }
+}

--- a/terraform/aws/scenarios/omnibus-fips/variables.tf
+++ b/terraform/aws/scenarios/omnibus-fips/variables.tf
@@ -1,0 +1,75 @@
+#########################################################################
+# AWS
+#########################################################################
+variable "aws_profile" {
+  type        = "string"
+  description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
+  default     = "chef-engineering"
+}
+
+variable "aws_region" {
+  type        = "string"
+  description = "Name of the AWS region to create instances in (e.g. us-west-2)."
+  default     = "us-west-1"
+}
+
+variable "aws_vpc_name" {
+  type        = "string"
+  description = "Name of the AWS virtual private cloud where tests will be run."
+  default     = ""
+}
+
+variable "aws_department" {
+  type        = "string"
+  description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
+}
+
+variable "aws_contact" {
+  type        = "string"
+  description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
+}
+
+variable "aws_ssh_key_id" {
+  type        = "string"
+  description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
+}
+
+variable "aws_instance_type" {
+  type        = "string"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
+  default     = "t2.medium"
+}
+
+variable "platform" {
+  type        = "string"
+  description = "Operating System of the instance to be created."
+}
+
+variable "build_prefix" {
+  type        = "string"
+  description = "Optional build identifier for differentiating scenario runs."
+  default     = ""
+}
+
+#########################################################################
+# Chef Server
+#########################################################################
+variable "scenario" {
+  type        = "string"
+  description = "The name of the scenario being executed."
+}
+
+variable "install_version_url" {
+  type        = "string"
+  description = "The URL to a chef-server used during initial install."
+}
+
+variable "upgrade_version_url" {
+  type        = "string"
+  description = "The URL to a chef-server artifact used during upgrades."
+}
+
+variable "enable_ipv6" {
+  type        = "string"
+  description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
+}

--- a/terraform/common/files/test_chef_server-smoke.sh
+++ b/terraform/common/files/test_chef_server-smoke.sh
@@ -4,6 +4,10 @@ set -evx
 
 echo -e '\nBEGIN SMOKE TEST\n'
 
-sudo chef-server-ctl test
+if grep -q 'fips true' /etc/opscode/chef-server.rb; then
+    sudo chef-server-ctl test -J pedant-fips.xml --smoke
+else
+    sudo chef-server-ctl test
+fi
 
 echo -e '\nEND SMOKE TEST\n'


### PR DESCRIPTION
### Description

This PR adds a FIPS scenario that supports spinning up a RHEL instance, modifying the instance to enable FIPS mode, rebooting, then performing the same install & test steps as the `standalone-upgrade` scenario.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#1881 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
