### PR TITLE
Fix integration test check for FIPS being enabled

### DIFF
--- a/terraform/common/files/test_chef_server-smoke.sh
+++ b/terraform/common/files/test_chef_server-smoke.sh
@@ -4,7 +4,7 @@ set -evx
 
 echo -e '\nBEGIN SMOKE TEST\n'
 
-if grep -q 'fips true' /etc/opscode/chef-server.rb; then
+if sudo grep -q 'fips true' /etc/opscode/chef-server.rb; then
     sudo chef-server-ctl test -J pedant-fips.xml --smoke
 else
     sudo chef-server-ctl test


### PR DESCRIPTION
### Description

This is just a minor fix to the script that was failing to determine if FIPS mode was enabled due inadequate permissions to read `/etc/opscode/chef-server.rb`

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
