### PR TITLE
Add license exception for nss-myhostname

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -195,4 +195,6 @@ exceptions:
       reason: Exception made by Chef Legal
     - name: core/sqitch_pg
       reason: Exception made by Chef Legal
+    - name: core/nss-myhostname
+      reason: Exception made by Chef Legal
 


### PR DESCRIPTION
### Description

The nss-myhostname dependency changed its original LGPL-2.1 license to
a non-standard license (LGPL-2.1-or-later).  In order to fix the
verification pipeline an exception has to be added after approval from
the legal team.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
