### PR TITLE
Update pointers to erlware_commons

### DIFF
--- a/src/bookshelf/rebar.lock
+++ b/src/bookshelf/rebar.lock
@@ -25,7 +25,7 @@
   0},
  {<<"erlware_commons">>,
   {git,"git://github.com/chef/erlware_commons.git",
-       {ref,"e15195cd6be824715f66eb1bbfab1bef33f11086"}},
+       {ref,"20c611d8c457edfc84a915cf1026f22980a83e00"}},
   0},
  {<<"goldrush">>,
   {git,"git://github.com/basho/goldrush.git",

--- a/src/chef-mover/rebar.lock
+++ b/src/chef-mover/rebar.lock
@@ -69,7 +69,7 @@
   0},
  {<<"erlware_commons">>,
   {git,"git://github.com/chef/erlware_commons.git",
-       {ref,"e15195cd6be824715f66eb1bbfab1bef33f11086"}},
+       {ref,"20c611d8c457edfc84a915cf1026f22980a83e00"}},
   2},
  {<<"folsom">>,
   {git,"git://github.com/boundary/folsom.git",

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -53,7 +53,7 @@
   1},
  {<<"erlware_commons">>,
   {git,"https://github.com/chef/erlware_commons.git",
-       {ref,"e15195cd6be824715f66eb1bbfab1bef33f11086"}},
+       {ref,"20c611d8c457edfc84a915cf1026f22980a83e00"}},
   0},
  {<<"folsom">>,
   {git,"git://github.com/boundary/folsom.git",


### PR DESCRIPTION
The erlware_commons branch we are pointing to was rebased and a commit
was squashed.  This change points us to the updated erlware_commons commit.