### PR TITLE
Update scenarios to default to t3.medium

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -53,7 +53,7 @@ Environment variables are used to control how the scenarios are executed and can
 |-----------------------------|-----------------------------------------------------------------------------------------------|--------------------------------------------|
 | `AWS_DEFAULT_PROFILE` | The name of the AWS profile used to connect to an AWS account. | chef-engineering (default) |
 | `AWS_DEFAULT_REGION` | The AWS region to spawn resources within. | us-west-1 (default) |
-| `AWS_DEFAULT_INSTANCE_TYPE` | The AWS instance type that determines the amount of resources server instances are allocated. | t2.medium (default) |
+| `AWS_DEFAULT_INSTANCE_TYPE` | The AWS instance type that determines the amount of resources server instances are allocated. | t3.medium (default) |
 | `PLATFORM` | The operating system used by server instances. | rhel-6, rhel-7, rhel-8, ubuntu-16.04, ubuntu-18.04, sles-12 |
 | `ENABLE_IPV6` | Use IPv6 in the chef-server.rb config and /etc/hosts | true (default) |
 | `ENABLE_SMOKE_TEST` | Enable Chef Infra Server smoke test. | true (default) |

--- a/terraform/aws/modules/aws_instance/main.tf
+++ b/terraform/aws/modules/aws_instance/main.tf
@@ -60,7 +60,7 @@ resource "aws_security_group" "default" {
 
 resource "aws_instance" "default" {
   ami           = "${local.ami_ids[var.platform]}"
-  instance_type = "${var.aws_instance_type}"
+  instance_type = "${var.aws_instance_type == "t3.medium" && var.platform == "rhel-6" ? "t2.medium" : var.aws_instance_type}"
   key_name      = "${var.aws_ssh_key_id}"
 
   root_block_device {

--- a/terraform/aws/modules/aws_instance/variables.tf
+++ b/terraform/aws/modules/aws_instance/variables.tf
@@ -34,7 +34,7 @@ variable "aws_ssh_key_id" {
 variable "aws_instance_type" {
   type        = "string"
   description = "Name of the AWS instance type used to determine size of instances."
-  default     = "t2.medium"
+  default     = "t3.medium"
 }
 
 variable "build_prefix" {

--- a/terraform/aws/scenarios/omnibus-chef-backend/variables.tf
+++ b/terraform/aws/scenarios/omnibus-chef-backend/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-external-elasticsearch/variables.tf
+++ b/terraform/aws/scenarios/omnibus-external-elasticsearch/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-external-openldap/variables.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-external-postgresql/variables.tf
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-fips/variables.tf
+++ b/terraform/aws/scenarios/omnibus-fips/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-restore-backup/variables.tf
+++ b/terraform/aws/scenarios/omnibus-restore-backup/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-standalone-fresh-install/variables.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-fresh-install/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/variables.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/variables.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/variables.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/variables.tf
@@ -36,8 +36,8 @@ variable "aws_ssh_key_id" {
 
 variable "aws_instance_type" {
   type        = "string"
-  description = "Name of the AWS instance type used to determine size of instances (e.g. t2.medium)."
-  default     = "t2.medium"
+  description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
+  default     = "t3.medium"
 }
 
 variable "platform" {

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -49,7 +49,7 @@ Environment variables are used to control how the scenarios are executed and can
 | `ARM_TENANT_ID` | The name of the Azure tenant used to authenticate. | a2b2d6bc-afe1-4696-9c37-f97a7ac416d7 (default) |
 | `ARM_SUBSCRIPTION_ID` | The Azure subscription used for billing. |  (default) |
 | `ARM_DEFAULT_LOCATION` | Name of the Azure location to create instances in. | westus2 (default) |
-| `ARM_DEFAULT_INSTANCE_TYPE` | The Azure instance type that determines the amount of resources server instances are allocated. | t2.medium (default) |
+| `ARM_DEFAULT_INSTANCE_TYPE` | The Azure instance type that determines the amount of resources server instances are allocated. | Standard_D2_v3 (default) |
 | `PLATFORM` | The operating system used by server instances. | rhel-6, rhel-7, rhel-8, ubuntu-16.04, ubuntu-18.04, sles-12 |
 | `ENABLE_SMOKE_TEST` | Enable Chef Infra Server smoke test. | true (default) |
 | `ENABLE_PEDANT_TEST` | Enable full Chef Infra Server pedant test. | true (default) |


### PR DESCRIPTION
### Description

A recent audit of AWS usage flagged on the use of the older `t2.medium` instance type due to the additional cost as compared to running `t3.medium`.

This PR updates the default AWS instance type from `t2.medium` to `t3.medium` but still automatically downgrades to `t2.medium` for RHEL 6

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
