### PR TITLE
Fix Elasticsearch scenario failing to consistently install + start elasticsearch

### DIFF
--- a/dev/scripts/provision-elasticsearch.sh
+++ b/dev/scripts/provision-elasticsearch.sh
@@ -11,9 +11,25 @@ fi
 
 apt-get update
 
-apt-get install openjdk-8-jdk -y
+apt-get install openjdk-8-jdk openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk-headless -y
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 apt-get install elasticsearch -y
-echo "http.host: 0.0.0.0" > /etc/elasticsearch/elasticsearch.yml
-service elasticsearch start
+
+mkdir -p /var/data/elasticsearch
+chown elasticsearch: /var/data/elasticsearch
+
+cat > /etc/elasticsearch/elasticsearch.yml <<'EOF'
+http.host: 0.0.0.0
+path.data: /var/data/elasticsearch
+path.logs: /var/log/elasticsearch
+EOF
+
+sed -i '/START_DAEMON/{s/^#//;}' /etc/default/elasticsearch
+
+systemctl restart elasticsearch
+
+sleep 30
+
+# check to see that elasticsearch started properly
+netstat -nap | grep -q java || { echo 'ERROR: Elasticsearch is NOT running!'; exit 1; }

--- a/terraform/aws/scenarios/omnibus-external-elasticsearch/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-elasticsearch/main.tf
@@ -25,7 +25,7 @@ module "elasticsearch" {
   aws_ssh_key_id    = "${var.aws_ssh_key_id}"
   aws_instance_type = "${var.aws_instance_type}"
   enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "ubuntu-16.04"
+  platform          = "ubuntu-18.04"
   build_prefix      = "${var.build_prefix}"
   name              = "elasticsearch-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }


### PR DESCRIPTION
### Description

This PR addresses two intermittent failures the Elasticsearch scenario was exhibiting:

1. OpenJDK would sometimes fail to install
2. Elasticsearch would sometimes fail to start leading to chef-server errors due to connection failures

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
