### PR TITLE
Add architecture to AMI detection to prevent false matches

### DIFF
--- a/terraform/aws/modules/aws_instance/amis.tf
+++ b/terraform/aws/modules/aws_instance/amis.tf
@@ -8,6 +8,11 @@ data "aws_ami" "rhel_6" {
   }
 
   filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }
@@ -22,6 +27,11 @@ data "aws_ami" "rhel_7" {
   filter {
     name   = "name"
     values = ["RHEL-7*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
   }
 
   filter {
@@ -42,6 +52,11 @@ data "aws_ami" "rhel_8" {
   }
 
   filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }
@@ -56,6 +71,11 @@ data "aws_ami" "ubuntu_1404" {
   filter {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
   }
 
   filter {
@@ -76,6 +96,11 @@ data "aws_ami" "ubuntu_1604" {
   }
 
   filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }
@@ -90,6 +115,11 @@ data "aws_ami" "ubuntu_1804" {
   filter {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
   }
 
   filter {
@@ -109,6 +139,11 @@ data "aws_ami" "sles_12" {
   filter {
     name   = "name"
     values = ["suse-sles-12-sp?-v????????-hvm-ssd-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
   }
 
   filter {


### PR DESCRIPTION
### Description

Recently, the Terraform AMI detection began to show errors resolving the expected RHEL-8 image due to the recent addition of a RHEL-8 image for the arm64 architecture.

This PR adds explicit identification of AMI's for the `x86_64` architecture to ensure we get the expected RHEL-8 iamge.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests`
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
