### PR TITLE
Point elasticsearch to OpenJDK

### DIFF
--- a/omnibus/config/software/elasticsearch.rb
+++ b/omnibus/config/software/elasticsearch.rb
@@ -17,7 +17,7 @@
 name "elasticsearch"
 default_version "6.8.1"
 
-dependency "server-jre"
+dependency "server-open-jre"
 
 license "Apache-2.0"
 license_file "LICENSE.txt"

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-solr4-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-opscode-solr4-run.erb
@@ -3,4 +3,4 @@ exec 2>&1
 ulimit -n 50000
 
 cd /opt/opscode/embedded/service/opscode-solr4/jetty
-exec chpst -P -o 50000 -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> /usr/bin/env TZ=UTC PATH=/opt/opscode/embedded/bin:/opt/opscode/bin:/opt/opscode/embedded/open-jre/bin:$PATH JAVA_HOME=/opt/opscode/embedded/open-jre <%= node['private_chef']['opscode-solr4']['command'] %>
+exec chpst -P -o 50000 -U <%= node['private_chef']['user']['username'] %> -u <%= node['private_chef']['user']['username'] %> /usr/bin/env TZ=UTC PATH=/opt/opscode/embedded/bin:/opt/opscode/bin:/opt/opscode/embedded/jre/bin:$PATH JAVA_HOME=/opt/opscode/embedded/jre <%= node['private_chef']['opscode-solr4']['command'] %>


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

We would like to move off of OracleJDK and point to AdoptOpenJDK.
Starting with pointing only elasticsearch to OpenJDK.

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/969#198c02df-7c1d-42cd-9468-9accc24d6155

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
