### PR TITLE
Disable actions since it was used only for oc_actions, analytics and workflow.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -858,7 +858,8 @@ default['private_chef']['dark_launch']['private-chef'] = true
 default['private_chef']['dark_launch']['sql_users'] = true
 default['private_chef']['dark_launch']['add_type_and_bag_to_items'] = true
 default['private_chef']['dark_launch']['reporting'] = true
-default['private_chef']['dark_launch']['actions'] = true
+# It appears that actions rabbitmq was used for oc_actions and analytics. 
+default['private_chef']['dark_launch']['actions'] = false
 
 ###
 # Chef Mover


### PR DESCRIPTION
All three of which are deprecated or EOL.
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/976#5c468750-4b96-49f0-b6b9-8d4964e890c1

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
