### PR TITLE
Allow ELASTIC_VERSION to be passed in to integration_test pipeline

### DIFF
--- a/.expeditor/integration_test.pipeline.sh
+++ b/.expeditor/integration_test.pipeline.sh
@@ -156,6 +156,9 @@ apply () {
   [[ -n "$ENABLE_ADDON_CHEF_MANAGE" ]] && export TF_VAR_enable_addon_chef_manage="$ENABLE_ADDON_CHEF_MANAGE"
   [[ -n "$ENABLE_CHEF_BACKEND_DEMOTION" ]] && export TF_VAR_enable_chef_backend_demotion="$ENABLE_CHEF_BACKEND_DEMOTION"
 
+  # Allow Elasticsearch version to be overriden
+  [[ -n "$ELASTIC_VERSION" ]] && export TF_VAR_elastic_version="$ELASTIC_VERSION"
+
   # setup the terraform workspace
   setup "$TF_VAR_scenario" "$TF_VAR_enable_ipv6" "${TF_VAR_platform}"
 

--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -86,6 +86,10 @@ ifneq ($(ENABLE_CHEF_BACKEND_DEMOTION),)
     export TF_VAR_enable_chef_backend_demotion ?= $(ENABLE_CHEF_BACKEND_DEMOTION)
 endif
 
+ifneq ($(ELASTIC_VERSION),)
+    export TF_VAR_elastic_version ?= $(ELASTIC_VERSION)
+endif
+
 ifneq ($(SCENARIO),)
 	export TF_VAR_scenario ?= $(SCENARIO)
 endif

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -63,6 +63,7 @@ Environment variables are used to control how the scenarios are executed and can
 | `ENABLE_ADDON_PUSH_JOBS` | Enable testing of Push Jobs addon. | true (default) |
 | `ENABLE_ADDON_CHEF_MANAGE` | Enable testing of Chef Manage addon. | true (default) |
 | `ENABLE_CHEF_BACKEND_DEMOTION` | Enable testing of chef-backend leadership demotion. | true (default) |
+| `ELASTIC_VERSION` | Version of Elasticsearch to install. | 2 or 5 with 6 being the default |
 
 ### Scenario Lifecycle
 

--- a/terraform/aws/scenarios/omnibus-external-elasticsearch/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-elasticsearch/main.tf
@@ -65,7 +65,7 @@ resource "null_resource" "elasticsearch_config" {
       "sudo chown root:root /tmp/hosts",
       "sudo mv /tmp/hosts /etc/hosts",
       "sudo chmod 0700 /tmp/provision-elasticsearch.sh",
-      "sudo /tmp/provision-elasticsearch.sh",
+      "sudo ELASTIC_VERSION=${var.elastic_version} /tmp/provision-elasticsearch.sh",
     ]
   }
 }

--- a/terraform/aws/scenarios/omnibus-external-elasticsearch/variables.tf
+++ b/terraform/aws/scenarios/omnibus-external-elasticsearch/variables.tf
@@ -69,6 +69,12 @@ variable "enable_ipv6" {
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
+variable "elastic_version" {
+  type        = "string"
+  description = "Version of Elasticsearch to install (e.g. options are 2 or 5 with 6 being the default)"
+  default     = "6"
+}
+
 #########################################################################
 # Optional Tests
 #########################################################################


### PR DESCRIPTION
### Description

This PR allows someone to pass the major version of Elasticsearch (e.g. 2, 5, 6, etc) to terraform to enable backwards compatibility testing via the integration_test pipeline.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
