### PR TITLE
Update terraform from 0.11 to latest 0.12

### DIFF
--- a/.expeditor/integration_test.pipeline.sh
+++ b/.expeditor/integration_test.pipeline.sh
@@ -127,7 +127,11 @@ setup () {
 EOF
 
   # initialize the terraform scenario
-  [[ -d .terraform ]] || terraform init
+  if [[ ! -d .terraform ]]; then
+	tfenv install min-required
+	tfenv use min-required
+	terraform init
+  fi
 
   # switch terraform workspace
   terraform workspace select "$workspace" || terraform workspace new "$workspace"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -12,6 +12,9 @@ steps:
 
 - label: lint-terraform
   command:
+    - cd /workdir/terraform/aws/modules/aws_vpc
+    - tfenv install min-required
+    - tfenv use min-required
     - cd /workdir/terraform/aws
     - make lint
     - cd /workdir/terraform/azure

--- a/terraform/aws/common/versions.tf
+++ b/terraform/aws/common/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 0.12.23"
+}
+
+provider "aws" {
+  version = "~> 2.53"
+
+  profile = var.aws_profile
+  region  = var.aws_region
+}
+
+provider "http" {
+	version = "~> 1.1"
+}
+
+provider "null" {
+	version = "~> 2.1"
+}
+
+provider "template" {
+	version = "~> 2.1"
+}

--- a/terraform/aws/modules/aws_instance/locals.tf
+++ b/terraform/aws/modules/aws_instance/locals.tf
@@ -6,15 +6,15 @@ data "http" "workstation-ipv4" {
 locals {
   workstation-ipv4-cidr = "${chomp(data.http.workstation-ipv4.body)}/32"
 
-  vpc_name = "${var.aws_vpc_name != "" ? var.aws_vpc_name : "${var.aws_contact}-chef_server-test"}"
+  vpc_name = var.aws_vpc_name != "" ? var.aws_vpc_name : "${var.aws_contact}-chef_server-test"
 
   ami_ids = {
-    rhel-6       = "${data.aws_ami.rhel_6.id}"
-    rhel-7       = "${data.aws_ami.rhel_7.id}"
-    rhel-8       = "${data.aws_ami.rhel_8.id}"
-    ubuntu-14.04 = "${data.aws_ami.ubuntu_1404.id}"
-    ubuntu-16.04 = "${data.aws_ami.ubuntu_1604.id}"
-    ubuntu-18.04 = "${data.aws_ami.ubuntu_1804.id}"
-    sles-12      = "${data.aws_ami.sles_12.id}"
+    rhel-6       = data.aws_ami.rhel_6.id
+    rhel-7       = data.aws_ami.rhel_7.id
+    rhel-8       = data.aws_ami.rhel_8.id
+    "ubuntu-14.04" = data.aws_ami.ubuntu_1404.id
+    "ubuntu-16.04" = data.aws_ami.ubuntu_1604.id
+    "ubuntu-18.04" = data.aws_ami.ubuntu_1804.id
+    sles-12      = data.aws_ami.sles_12.id
   }
 }

--- a/terraform/aws/modules/aws_instance/main.tf
+++ b/terraform/aws/modules/aws_instance/main.tf
@@ -1,40 +1,35 @@
-provider "aws" {
-  profile = "${var.aws_profile}"
-  region  = "${var.aws_region}"
-}
-
 data "aws_vpc" "chef_vpc" {
   tags = {
-    Name      = "${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    Name      = local.vpc_name
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }
 
 data "aws_subnet" "chef_subnet" {
   tags = {
-    Name      = "${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    Name      = local.vpc_name
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }
 
 resource "aws_security_group" "default" {
-  name_prefix = "${local.vpc_name}"
-  vpc_id      = "${data.aws_vpc.chef_vpc.id}"
+  name_prefix = "local.vpc_name"
+  vpc_id      = data.aws_vpc.chef_vpc.id
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${cidrsubnet(data.aws_vpc.chef_vpc.cidr_block, 4, 1)}", "${local.workstation-ipv4-cidr}"]
+    cidr_blocks = [cidrsubnet(data.aws_vpc.chef_vpc.cidr_block, 4, 1), local.workstation-ipv4-cidr]
   }
 
   ingress {
     from_port        = 0
     to_port          = 0
     protocol         = "-1"
-    ipv6_cidr_blocks = ["${cidrsubnet(data.aws_vpc.chef_vpc.ipv6_cidr_block, 8, 1)}"]
+    ipv6_cidr_blocks = [cidrsubnet(data.aws_vpc.chef_vpc.ipv6_cidr_block, 8, 1)]
   }
 
   egress {
@@ -53,31 +48,31 @@ resource "aws_security_group" "default" {
 
   tags = {
     Name      = "${var.build_prefix}${var.name}-${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }
 
 resource "aws_instance" "default" {
-  ami           = "${local.ami_ids[var.platform]}"
-  instance_type = "${var.aws_instance_type == "t3.medium" && var.platform == "rhel-6" ? "t2.medium" : var.aws_instance_type}"
-  key_name      = "${var.aws_ssh_key_id}"
+  ami           = local.ami_ids[var.platform]
+  instance_type = var.aws_instance_type == "t3.medium" && var.platform == "rhel-6" ? "t2.medium" : var.aws_instance_type
+  key_name      = var.aws_ssh_key_id
 
   root_block_device {
     volume_size = 50
   }
 
-  ipv6_address_count = "${var.enable_ipv6 == true ? 1 : 0}"
+  ipv6_address_count = var.enable_ipv6 == "true" ? 1 : 0
 
-  subnet_id = "${data.aws_subnet.chef_subnet.id}"
+  subnet_id = data.aws_subnet.chef_subnet.id
 
   vpc_security_group_ids = [
-    "${aws_security_group.default.id}",
+    aws_security_group.default.id,
   ]
 
   tags = {
     Name      = "${var.build_prefix}${var.name}-${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }

--- a/terraform/aws/modules/aws_instance/outputs.tf
+++ b/terraform/aws/modules/aws_instance/outputs.tf
@@ -1,27 +1,27 @@
 output "id" {
-  value = "${aws_instance.default.id}"
+  value = aws_instance.default.id
 }
 
 output "public_ipv4_address" {
-  value = "${aws_instance.default.public_ip}"
+  value = aws_instance.default.public_ip
 }
 
 output "public_ipv4_dns" {
-  value = "${aws_instance.default.public_dns}"
+  value = aws_instance.default.public_dns
 }
 
 output "private_ipv4_address" {
-  value = "${aws_instance.default.private_ip}"
+  value = aws_instance.default.private_ip
 }
 
 output "private_ipv4_dns" {
-  value = "${aws_instance.default.private_dns}"
+  value = aws_instance.default.private_dns
 }
 
 output "public_ipv6_address" {
-  value = "${var.enable_ipv6 == true ? element(concat(aws_instance.default.ipv6_addresses, list("")), 0) : ""}"
+  value = var.enable_ipv6 == "true" ? element(concat(aws_instance.default.ipv6_addresses, list("")), 0) : ""
 }
 
 output "ssh_username" {
-  value = "${replace(var.platform, "/ubuntu-.*/", "ubuntu") == "ubuntu" ? "ubuntu" : "ec2-user"}"
+  value = replace(var.platform, "/ubuntu-.*/", "ubuntu") == "ubuntu" ? "ubuntu" : "ec2-user"
 }

--- a/terraform/aws/modules/aws_instance/variables.tf
+++ b/terraform/aws/modules/aws_instance/variables.tf
@@ -1,59 +1,59 @@
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances."
   default     = "t3.medium"
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Allocate an IPv6 address in addition to IPv4 address."
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name of the instance to be created."
 }

--- a/terraform/aws/modules/aws_instance/versions.tf
+++ b/terraform/aws/modules/aws_instance/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/modules/aws_vpc/locals.tf
+++ b/terraform/aws/modules/aws_vpc/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  vpc_name = "${var.aws_vpc_name != "" ? var.aws_vpc_name : "${var.aws_contact}-chef_server-test"}"
+  vpc_name = var.aws_vpc_name != "" ? var.aws_vpc_name : "${var.aws_contact}-chef_server-test"
 }

--- a/terraform/aws/modules/aws_vpc/main.tf
+++ b/terraform/aws/modules/aws_vpc/main.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  profile = "${var.aws_profile}"
-  region  = "${var.aws_region}"
-}
-
 resource "aws_vpc" "default" {
   enable_dns_support               = true
   enable_dns_hostnames             = true
@@ -10,59 +5,59 @@ resource "aws_vpc" "default" {
   cidr_block                       = "10.0.0.0/16"
 
   tags = {
-    Name      = "${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    Name      = local.vpc_name
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }
 
 resource "aws_subnet" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
-  cidr_block              = "${cidrsubnet(aws_vpc.default.cidr_block, 4, 1)}"
+  cidr_block              = cidrsubnet(aws_vpc.default.cidr_block, 4, 1)
   map_public_ip_on_launch = true
 
-  ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)}"
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = false
 
   tags = {
-    Name      = "${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    Name      = local.vpc_name
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }
 
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
   tags = {
-    Name      = "${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    Name      = local.vpc_name
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }
 
 resource "aws_default_route_table" "default" {
-  default_route_table_id = "${aws_vpc.default.default_route_table_id}"
+  default_route_table_id = aws_vpc.default.default_route_table_id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.default.id}"
+    gateway_id = aws_internet_gateway.default.id
   }
 
   route {
     ipv6_cidr_block = "::/0"
-    gateway_id      = "${aws_internet_gateway.default.id}"
+    gateway_id      = aws_internet_gateway.default.id
   }
 
   tags = {
-    Name      = "${local.vpc_name}"
-    X-Dept    = "${var.aws_department}"
-    X-Contact = "${var.aws_contact}"
+    Name      = local.vpc_name
+    X-Dept    = var.aws_department
+    X-Contact = var.aws_contact
   }
 }
 
 resource "aws_route_table_association" "default" {
-  subnet_id      = "${aws_subnet.default.id}"
-  route_table_id = "${aws_default_route_table.default.id}"
+  subnet_id      = aws_subnet.default.id
+  route_table_id = aws_default_route_table.default.id
 }

--- a/terraform/aws/modules/aws_vpc/outputs.tf
+++ b/terraform/aws/modules/aws_vpc/outputs.tf
@@ -1,19 +1,20 @@
 output "vpc_id" {
-  value = "${aws_vpc.default.id}"
+  value = aws_vpc.default.id
 }
 
 output "subnet_id" {
-  value = "${aws_subnet.default.id}"
+  value = aws_subnet.default.id
 }
 
 output "ipv4_cidr_block" {
-  value = "${cidrsubnet(aws_vpc.default.cidr_block, 4, 1)}"
+  value = cidrsubnet(aws_vpc.default.cidr_block, 4, 1)
 }
 
 output "ipv6_cidr_block" {
-  value = "${cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)}"
+  value = cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)
 }
 
 output "region" {
-  value = "${var.aws_region}"
+  value = var.aws_region
 }
+

--- a/terraform/aws/modules/aws_vpc/variables.tf
+++ b/terraform/aws/modules/aws_vpc/variables.tf
@@ -1,27 +1,27 @@
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }

--- a/terraform/aws/modules/aws_vpc/versions.tf
+++ b/terraform/aws/modules/aws_vpc/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-chef-backend/main.tf
+++ b/terraform/aws/scenarios/omnibus-chef-backend/main.tf
@@ -1,86 +1,86 @@
 module "chef_server" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "chefserver-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 module "backend1" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "backend1-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 module "backend2" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "backend2-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 module "backend3" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "backend3-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 # generate static hosts configuration
 data "template_file" "hosts_config" {
-  template = "${file("${path.module}/templates/hosts.tpl")}"
+  template = file("${path.module}/templates/hosts.tpl")
 
-  vars {
-    chef_server_ip = "${var.enable_ipv6 == true ? module.chef_server.public_ipv6_address : module.chef_server.private_ipv4_address}"
-    backend1_ip    = "${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address}"
-    backend2_ip    = "${var.enable_ipv6 == true ? module.backend2.public_ipv6_address : module.backend2.private_ipv4_address}"
-    backend3_ip    = "${var.enable_ipv6 == true ? module.backend3.public_ipv6_address : module.backend3.private_ipv4_address}"
+  vars = {
+    chef_server_ip = var.enable_ipv6 == "true" ? module.chef_server.public_ipv6_address : module.chef_server.private_ipv4_address
+    backend1_ip    = var.enable_ipv6 == "true" ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address
+    backend2_ip    = var.enable_ipv6 == "true" ? module.backend2.public_ipv6_address : module.backend2.private_ipv4_address
+    backend3_ip    = var.enable_ipv6 == "true" ? module.backend3.public_ipv6_address : module.backend3.private_ipv4_address
   }
 }
 
 # generate chef-backend configuration
 data "template_file" "backend_config" {
-  template = "${file("${path.module}/templates/chef-backend.rb.tpl")}"
+  template = file("${path.module}/templates/chef-backend.rb.tpl")
 
-  vars {
-    ip_version = "${var.enable_ipv6 == true ? "ipv6" : "ipv4"}"
-    backend_ip = "${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address}"
+  vars = {
+    ip_version = var.enable_ipv6 == "true" ? "ipv6" : "ipv4"
+    backend_ip = var.enable_ipv6 == "true" ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address
   }
 }
 
@@ -89,17 +89,17 @@ resource "null_resource" "backend1_config" {
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.backend1.ssh_username}"
-    host = "${module.backend1.public_ipv4_dns}"
+    user = module.backend1.ssh_username
+    host = module.backend1.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
   provisioner "file" {
-    content     = "${data.template_file.backend_config.rendered}"
+    content     = data.template_file.backend_config.rendered
     destination = "/tmp/chef-backend.rb"
   }
 
@@ -123,17 +123,17 @@ resource "null_resource" "backend1_config" {
 
 # update backend2 server
 resource "null_resource" "backend2_config" {
-  depends_on = ["null_resource.backend1_config"]
+  depends_on = [null_resource.backend1_config]
 
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.backend2.ssh_username}"
-    host = "${module.backend2.public_ipv4_dns}"
+    user = module.backend2.ssh_username
+    host = module.backend2.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
@@ -145,7 +145,7 @@ resource "null_resource" "backend2_config" {
       "sudo mv /tmp/hosts /etc/hosts",
       "curl -vo /tmp/${replace(var.backend_version_url, "/^.*\\//", "")} ${var.backend_version_url}",
       "sudo ${replace(var.backend_version_url, "rpm", "") != var.backend_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.backend_version_url, "/^.*\\//", "")}",
-      "sudo chef-backend-ctl join-cluster --accept-license --yes --quiet ${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address} -p ${var.enable_ipv6 == true ? module.backend2.public_ipv6_address : module.backend2.private_ipv4_address} -s /tmp/chef-backend-secrets.json",
+      "sudo chef-backend-ctl join-cluster --accept-license --yes --quiet ${var.enable_ipv6 == "true" ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address} -p ${var.enable_ipv6 == "true" ? module.backend2.public_ipv6_address : module.backend2.private_ipv4_address} -s /tmp/chef-backend-secrets.json",
       "echo -e '\nEND INSTALL CHEF BACKEND2\n'",
     ]
   }
@@ -153,17 +153,17 @@ resource "null_resource" "backend2_config" {
 
 # update backend3 server
 resource "null_resource" "backend3_config" {
-  depends_on = ["null_resource.backend2_config"]
+  depends_on = [null_resource.backend2_config]
 
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.backend3.ssh_username}"
-    host = "${module.backend3.public_ipv4_dns}"
+    user = module.backend3.ssh_username
+    host = module.backend3.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
@@ -175,7 +175,7 @@ resource "null_resource" "backend3_config" {
       "sudo mv /tmp/hosts /etc/hosts",
       "curl -vo /tmp/${replace(var.backend_version_url, "/^.*\\//", "")} ${var.backend_version_url}",
       "sudo ${replace(var.backend_version_url, "rpm", "") != var.backend_version_url ? "rpm -U" : "dpkg -iEG"} /tmp/${replace(var.backend_version_url, "/^.*\\//", "")}",
-      "sudo chef-backend-ctl join-cluster --accept-license --yes --quiet ${var.enable_ipv6 == true ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address} -p ${var.enable_ipv6 == true ? module.backend3.public_ipv6_address : module.backend3.private_ipv4_address} -s /tmp/chef-backend-secrets.json",
+      "sudo chef-backend-ctl join-cluster --accept-license --yes --quiet ${var.enable_ipv6 == "true" ? module.backend1.public_ipv6_address : module.backend1.private_ipv4_address} -p ${var.enable_ipv6 == "true" ? module.backend3.public_ipv6_address : module.backend3.private_ipv4_address} -s /tmp/chef-backend-secrets.json",
       "sudo chef-backend-ctl gen-server-config chefserver.internal > /tmp/chef-server.rb",
       "echo \"profiles['root_url'] = 'http://chefserver.internal:9998'\" | sudo tee -a /tmp/chef-server.rb",
       "scp -o 'UserKnownHostsFile=/dev/null' -o 'StrictHostKeyChecking=no' /tmp/chef-server.rb ${module.chef_server.ssh_username}@${module.chef_server.public_ipv4_dns}:/tmp",
@@ -186,17 +186,17 @@ resource "null_resource" "backend3_config" {
 
 # update chef server
 resource "null_resource" "chef_server_config" {
-  depends_on = ["null_resource.backend3_config"]
+  depends_on = [null_resource.backend3_config]
 
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
@@ -224,12 +224,12 @@ resource "null_resource" "chef_server_config" {
 }
 
 resource "null_resource" "chef_server_test1" {
-  depends_on = ["null_resource.chef_server_config"]
+  depends_on = [null_resource.chef_server_config]
 
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   # upload smoke test script
@@ -248,13 +248,13 @@ resource "null_resource" "chef_server_test1" {
 }
 
 resource "null_resource" "chef_backend_test" {
-  depends_on = ["null_resource.chef_server_test1"]
+  depends_on = [null_resource.chef_server_test1]
 
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.backend1.ssh_username}"
-    host = "${module.backend1.public_ipv4_dns}"
+    user = module.backend1.ssh_username
+    host = module.backend1.public_ipv4_dns
   }
 
   provisioner "file" {
@@ -272,12 +272,12 @@ resource "null_resource" "chef_backend_test" {
 }
 
 resource "null_resource" "chef_server_test2" {
-  depends_on = ["null_resource.chef_backend_test"]
+  depends_on = [null_resource.chef_backend_test]
 
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   # upload test scripts

--- a/terraform/aws/scenarios/omnibus-chef-backend/variables.tf
+++ b/terraform/aws/scenarios/omnibus-chef-backend/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,22 +55,22 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "backend_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-backend used during install."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -79,43 +79,43 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }
 
 variable "enable_chef_backend_demotion" {
-  type        = "string"
+  type        = string
   description = "Enable testing of chef-backend leadership demotion."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-chef-backend/versions.tf
+++ b/terraform/aws/scenarios/omnibus-chef-backend/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-external-elasticsearch/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-elasticsearch/main.tf
@@ -1,42 +1,42 @@
 module "chef_server" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "chefserver-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 module "elasticsearch" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
   platform          = "ubuntu-18.04"
-  build_prefix      = "${var.build_prefix}"
+  build_prefix      = var.build_prefix
   name              = "elasticsearch-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 # generate static hosts configuration
 data "template_file" "hosts_config" {
-  template = "${file("${path.module}/templates/hosts.tpl")}"
+  template = file("${path.module}/templates/hosts.tpl")
 
-  vars {
-    chef_server_ip   = "${var.enable_ipv6 == true ? module.chef_server.public_ipv6_address : module.chef_server.private_ipv4_address}"
-    elasticsearch_ip = "${var.enable_ipv6 == true ? module.elasticsearch.public_ipv6_address : module.elasticsearch.private_ipv4_address}"
+  vars = {
+    chef_server_ip   = var.enable_ipv6 == "true" ? module.chef_server.public_ipv6_address : module.chef_server.private_ipv4_address
+    elasticsearch_ip = var.enable_ipv6 == "true" ? module.elasticsearch.public_ipv6_address : module.elasticsearch.private_ipv4_address
   }
 }
 
@@ -45,12 +45,12 @@ resource "null_resource" "elasticsearch_config" {
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.elasticsearch.ssh_username}"
-    host = "${module.elasticsearch.public_ipv4_dns}"
+    user = module.elasticsearch.ssh_username
+    host = module.elasticsearch.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
@@ -72,17 +72,17 @@ resource "null_resource" "elasticsearch_config" {
 
 # update chef server
 resource "null_resource" "chef_server_config" {
-  depends_on = ["null_resource.elasticsearch_config"]
+  depends_on = [null_resource.elasticsearch_config]
 
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
@@ -122,12 +122,12 @@ resource "null_resource" "chef_server_config" {
 }
 
 resource "null_resource" "chef_server_test" {
-  depends_on = ["null_resource.chef_server_config"]
+  depends_on = [null_resource.chef_server_config]
 
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   # upload test scripts

--- a/terraform/aws/scenarios/omnibus-external-elasticsearch/variables.tf
+++ b/terraform/aws/scenarios/omnibus-external-elasticsearch/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,22 +55,22 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
 variable "elastic_version" {
-  type        = "string"
+  type        = string
   description = "Version of Elasticsearch to install (e.g. options are 2 or 5 with 6 being the default)"
   default     = "6"
 }
@@ -80,37 +80,37 @@ variable "elastic_version" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-external-elasticsearch/versions.tf
+++ b/terraform/aws/scenarios/omnibus-external-elasticsearch/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-external-openldap/variables.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,17 +55,17 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -74,37 +74,37 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-external-openldap/versions.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-external-postgresql/variables.tf
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,17 +55,17 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -74,37 +74,37 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-external-postgresql/versions.tf
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-fips/main.tf
+++ b/terraform/aws/scenarios/omnibus-fips/main.tf
@@ -1,24 +1,24 @@
 module "chef_server" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 resource "null_resource" "chef_server_fips" {
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   # enable fips mode
@@ -42,12 +42,12 @@ resource "null_resource" "chef_server_fips" {
 }
 
 resource "null_resource" "chef_server_config" {
-  depends_on = ["null_resource.chef_server_fips"]
+  depends_on = [null_resource.chef_server_fips]
 
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   provisioner "file" {
@@ -86,12 +86,12 @@ resource "null_resource" "chef_server_config" {
 }
 
 resource "null_resource" "chef_server_test" {
-  depends_on = ["null_resource.chef_server_config"]
+  depends_on = [null_resource.chef_server_config]
 
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   # upload test scripts

--- a/terraform/aws/scenarios/omnibus-fips/variables.tf
+++ b/terraform/aws/scenarios/omnibus-fips/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,22 +55,22 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "install_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server artifact used during upgrades."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -79,37 +79,37 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-fips/versions.tf
+++ b/terraform/aws/scenarios/omnibus-fips/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-restore-backup/main.tf
+++ b/terraform/aws/scenarios/omnibus-restore-backup/main.tf
@@ -1,24 +1,24 @@
 module "chef_server" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 resource "null_resource" "chef_server_config" {
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   provisioner "file" {
@@ -52,7 +52,7 @@ resource "null_resource" "chef_server_config" {
   # Copy across existing backup. This is very dependent on matching the version of chef-server the backup
   # was generated from.
   provisioner "file" {
-    source      = "${var.backup_location}"
+    source      = var.backup_location
     destination = "/tmp/chef-backup.tgz"
   }
 

--- a/terraform/aws/scenarios/omnibus-restore-backup/variables.tf
+++ b/terraform/aws/scenarios/omnibus-restore-backup/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,27 +55,27 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "install_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server artifact used during upgrades."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
 variable "backup_location" {
-  type        = "string"
+  type        = string
   description = "full path to local backup"
 }
 
@@ -84,37 +84,37 @@ variable "backup_location" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-restore-backup/versions.tf
+++ b/terraform/aws/scenarios/omnibus-restore-backup/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-standalone-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-fresh-install/main.tf
@@ -1,24 +1,24 @@
 module "chef_server" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 resource "null_resource" "chef_server_config" {
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   provisioner "file" {
@@ -55,12 +55,12 @@ resource "null_resource" "chef_server_config" {
 }
 
 resource "null_resource" "chef_server_test" {
-  depends_on = ["null_resource.chef_server_config"]
+  depends_on = [null_resource.chef_server_config]
 
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   # upload test scripts

--- a/terraform/aws/scenarios/omnibus-standalone-fresh-install/variables.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-fresh-install/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,22 +55,22 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "install_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server artifact used during upgrades."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -79,37 +79,37 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-standalone-fresh-install/versions.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-fresh-install/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/main.tf
@@ -1,24 +1,24 @@
 module "chef_server" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 resource "null_resource" "chef_server_config" {
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   provisioner "file" {
@@ -70,12 +70,12 @@ resource "null_resource" "chef_server_config" {
 }
 
 resource "null_resource" "chef_server_test" {
-  depends_on = ["null_resource.chef_server_config"]
+  depends_on = [null_resource.chef_server_config]
 
   connection {
     type = "ssh"
-    user = "${module.chef_server.ssh_username}"
-    host = "${module.chef_server.public_ipv4_dns}"
+    user = module.chef_server.ssh_username
+    host = module.chef_server.public_ipv4_dns
   }
 
   # upload test scripts

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/variables.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,22 +55,22 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "install_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server artifact used during upgrades."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -79,37 +79,37 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-standalone-upgrade/versions.tf
+++ b/terraform/aws/scenarios/omnibus-standalone-upgrade/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -1,54 +1,54 @@
 module "back_end" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "backend-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 module "front_end" {
   source = "../../modules/aws_instance"
 
-  aws_profile       = "${var.aws_profile}"
-  aws_region        = "${var.aws_region}"
-  aws_vpc_name      = "${var.aws_vpc_name}"
-  aws_department    = "${var.aws_department}"
-  aws_contact       = "${var.aws_contact}"
-  aws_ssh_key_id    = "${var.aws_ssh_key_id}"
-  aws_instance_type = "${var.aws_instance_type}"
-  enable_ipv6       = "${var.enable_ipv6}"
-  platform          = "${var.platform}"
-  build_prefix      = "${var.build_prefix}"
+  aws_profile       = var.aws_profile
+  aws_region        = var.aws_region
+  aws_vpc_name      = var.aws_vpc_name
+  aws_department    = var.aws_department
+  aws_contact       = var.aws_contact
+  aws_ssh_key_id    = var.aws_ssh_key_id
+  aws_instance_type = var.aws_instance_type
+  enable_ipv6       = var.enable_ipv6
+  platform          = var.platform
+  build_prefix      = var.build_prefix
   name              = "frontend-${var.scenario}-${var.enable_ipv6 ? "ipv6" : "ipv4"}-${var.platform}"
 }
 
 # generate static hosts configuration
 data "template_file" "hosts_config" {
-  template = "${file("${path.module}/templates/hosts.tpl")}"
+  template = file("${path.module}/templates/hosts.tpl")
 
-  vars {
-    back_end_ip  = "${var.enable_ipv6 == true ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address}"
-    front_end_ip = "${var.enable_ipv6 == true ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address}"
+  vars = {
+    back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
+    front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
   }
 }
 
 # generate chef-server.rb configuration
 data "template_file" "chef_server_config" {
-  template = "${file("${path.module}/templates/chef-server.rb.tpl")}"
+  template = file("${path.module}/templates/chef-server.rb.tpl")
 
-  vars {
-    enable_ipv6  = "${var.enable_ipv6}"
-    back_end_ip  = "${var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address}"
-    front_end_ip = "${var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address}"
-    cidr         = "${var.enable_ipv6 == "true" ? 64 : 32}"
+  vars = {
+    enable_ipv6  = var.enable_ipv6
+    back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
+    front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    cidr         = var.enable_ipv6 == "true" ? 64 : 32
   }
 }
 
@@ -57,17 +57,17 @@ resource "null_resource" "back_end_config" {
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.back_end.ssh_username}"
-    host = "${module.back_end.public_ipv4_dns}"
+    user = module.back_end.ssh_username
+    host = module.back_end.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
   provisioner "file" {
-    content     = "${data.template_file.chef_server_config.rendered}"
+    content     = data.template_file.chef_server_config.rendered
     destination = "/tmp/chef-server.rb"
   }
 
@@ -114,17 +114,17 @@ resource "null_resource" "back_end_config" {
 
 # update front-end chef server
 resource "null_resource" "front_end_config" {
-  depends_on = ["null_resource.back_end_config"]
+  depends_on = [null_resource.back_end_config]
 
   # provide some connection info
   connection {
     type = "ssh"
-    user = "${module.front_end.ssh_username}"
-    host = "${module.front_end.public_ipv4_dns}"
+    user = module.front_end.ssh_username
+    host = module.front_end.public_ipv4_dns
   }
 
   provisioner "file" {
-    content     = "${data.template_file.hosts_config.rendered}"
+    content     = data.template_file.hosts_config.rendered
     destination = "/tmp/hosts"
   }
 
@@ -146,12 +146,12 @@ resource "null_resource" "front_end_config" {
 }
 
 resource "null_resource" "chef_server_test" {
-  depends_on = ["null_resource.front_end_config"]
+  depends_on = [null_resource.front_end_config]
 
   connection {
     type = "ssh"
-    user = "${module.front_end.ssh_username}"
-    host = "${module.front_end.public_ipv4_dns}"
+    user = module.front_end.ssh_username
+    host = module.front_end.public_ipv4_dns
   }
 
   # upload test scripts

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/variables.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,17 +55,17 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -74,37 +74,37 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/versions.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/variables.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/variables.tf
@@ -2,51 +2,51 @@
 # AWS
 #########################################################################
 variable "aws_profile" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS profile used for authentication (e.g. chef-engineering)."
   default     = "chef-engineering"
 }
 
 variable "aws_region" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS region to create instances in (e.g. us-west-2)."
   default     = "us-west-1"
 }
 
 variable "aws_vpc_name" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS virtual private cloud where tests will be run."
   default     = ""
 }
 
 variable "aws_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "aws_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "aws_ssh_key_id" {
-  type        = "string"
+  type        = string
   description = "AWS ID of the SSH key used to access the instance (e.g. csnapp)."
 }
 
 variable "aws_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the AWS instance type used to determine size of instances (e.g. t3.medium)."
   default     = "t3.medium"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -55,22 +55,22 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "install_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server artifact used during upgrades."
 }
 
 variable "enable_ipv6" {
-  type        = "string"
+  type        = string
   description = "Use IPv6 in the chef-server.rb config and /etc/hosts."
 }
 
@@ -79,37 +79,37 @@ variable "enable_ipv6" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/versions.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/azure/common/versions.tf
+++ b/terraform/azure/common/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 0.12.23"
+}
+
+provider "azurerm" {
+  version = "~> 2.1"
+  features {}
+
+  subscription_id = var.arm_subscription_id
+  tenant_id       = var.arm_tenant_id
+}
+
+provider "http" {
+	version = "~> 1.1"
+}
+
+provider "null" {
+	version = "~> 2.1"
+}
+
+provider "template" {
+	version = "~> 2.1"
+}

--- a/terraform/azure/modules/arm_instance/locals.tf
+++ b/terraform/azure/modules/arm_instance/locals.tf
@@ -6,7 +6,7 @@ data "http" "workstation-ipv4" {
 locals {
   workstation-ipv4-cidr = "${chomp(data.http.workstation-ipv4.body)}/32"
 
-  arm_resource_group_name = "${var.arm_resource_group_name != "" ? var.arm_resource_group_name : "${var.arm_contact}-chef_server-test"}"
+  arm_resource_group_name = var.arm_resource_group_name != "" ? var.arm_resource_group_name : "${var.arm_contact}-chef_server-test"
 
   storage_images = {
     rhel-6 = {
@@ -30,14 +30,14 @@ locals {
       version   = "latest"
     }
 
-    ubuntu-16.04 = {
+    "ubuntu-16.04" = {
       publisher = "Canonical"
       offer     = "UbuntuServer"
       sku       = "16.04-LTS"
       version   = "latest"
     }
 
-    ubuntu-18.04 = {
+    "ubuntu-18.04" = {
       publisher = "Canonical"
       offer     = "UbuntuServer"
       sku       = "18.04-LTS"

--- a/terraform/azure/modules/arm_instance/main.tf
+++ b/terraform/azure/modules/arm_instance/main.tf
@@ -1,27 +1,22 @@
-provider "azurerm" {
-  subscription_id = "${var.arm_subscription_id}"
-  tenant_id       = "${var.arm_tenant_id}"
-}
-
 data "azurerm_resource_group" "chef_resource_group" {
-  name = "${local.arm_resource_group_name}"
+  name = local.arm_resource_group_name
 }
 
 data "azurerm_virtual_network" "chef_virtual_network" {
-  resource_group_name = "${data.azurerm_resource_group.chef_resource_group.name}"
-  name                = "${local.arm_resource_group_name}"
+  resource_group_name = data.azurerm_resource_group.chef_resource_group.name
+  name                = local.arm_resource_group_name
 }
 
 data "azurerm_subnet" "chef_subnet" {
-  resource_group_name  = "${data.azurerm_resource_group.chef_resource_group.name}"
-  virtual_network_name = "${data.azurerm_virtual_network.chef_virtual_network.name}"
+  resource_group_name  = data.azurerm_resource_group.chef_resource_group.name
+  virtual_network_name = data.azurerm_virtual_network.chef_virtual_network.name
 
   name = "${local.arm_resource_group_name}"
 }
 
 resource "azurerm_network_security_group" "default" {
-  resource_group_name = "${data.azurerm_resource_group.chef_resource_group.name}"
-  location            = "${data.azurerm_resource_group.chef_resource_group.location}"
+  resource_group_name = data.azurerm_resource_group.chef_resource_group.name
+  location            = data.azurerm_resource_group.chef_resource_group.location
 
   name = "${var.build_prefix}${var.name}-${local.arm_resource_group_name}"
 
@@ -33,63 +28,62 @@ resource "azurerm_network_security_group" "default" {
     protocol                   = "*"
     source_port_range          = "*"
     destination_port_range     = "*"
-    source_address_prefix      = "${local.workstation-ipv4-cidr}"
+    source_address_prefix      = local.workstation-ipv4-cidr
     destination_address_prefix = "*"
   }
 
   tags = {
-    X-Dept    = "${var.arm_department}"
-    X-Contact = "${var.arm_contact}"
+    X-Dept    = var.arm_department
+    X-Contact = var.arm_contact
   }
 }
 
 resource "azurerm_public_ip" "default" {
-  depends_on = ["azurerm_network_security_group.default"]
+  depends_on = [azurerm_network_security_group.default]
 
-  resource_group_name = "${data.azurerm_resource_group.chef_resource_group.name}"
-  location            = "${data.azurerm_resource_group.chef_resource_group.location}"
+  resource_group_name = data.azurerm_resource_group.chef_resource_group.name
+  location            = data.azurerm_resource_group.chef_resource_group.location
 
   name = "${var.build_prefix}${var.name}-${local.arm_resource_group_name}"
 
   allocation_method = "Dynamic"
 
   tags = {
-    X-Dept    = "${var.arm_department}"
-    X-Contact = "${var.arm_contact}"
+    X-Dept    = var.arm_department
+    X-Contact = var.arm_contact
   }
 }
 
 resource "azurerm_network_interface" "default" {
-  depends_on = ["azurerm_public_ip.default"]
+  depends_on = [azurerm_public_ip.default]
 
-  resource_group_name       = "${data.azurerm_resource_group.chef_resource_group.name}"
-  location                  = "${data.azurerm_resource_group.chef_resource_group.location}"
-  network_security_group_id = "${azurerm_network_security_group.default.id}"
+  resource_group_name       = data.azurerm_resource_group.chef_resource_group.name
+  location                  = data.azurerm_resource_group.chef_resource_group.location
 
   name = "${var.build_prefix}${var.name}-${local.arm_resource_group_name}"
 
   ip_configuration {
     name                          = "${var.build_prefix}${var.name}-${local.arm_resource_group_name}"
-    subnet_id                     = "${data.azurerm_subnet.chef_subnet.id}"
+    subnet_id                     = data.azurerm_subnet.chef_subnet.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = "${azurerm_public_ip.default.id}"
+    public_ip_address_id          = azurerm_public_ip.default.id
   }
 
   tags = {
-    X-Dept    = "${var.arm_department}"
-    X-Contact = "${var.arm_contact}"
+    X-Dept    = var.arm_department
+    X-Contact = var.arm_contact
   }
 }
 
 resource "azurerm_virtual_machine" "default" {
-  depends_on = ["azurerm_network_interface.default"]
+  depends_on = [azurerm_network_interface.default]
 
-  resource_group_name = "${data.azurerm_resource_group.chef_resource_group.name}"
-  location            = "${data.azurerm_resource_group.chef_resource_group.location}"
+  resource_group_name = data.azurerm_resource_group.chef_resource_group.name
+  location            = data.azurerm_resource_group.chef_resource_group.location
 
   name                          = "${var.build_prefix}${var.name}-${local.arm_resource_group_name}"
-  vm_size                       = "${var.arm_instance_type}"
-  network_interface_ids         = ["${azurerm_network_interface.default.id}"]
+  vm_size                       = var.arm_instance_type
+  network_interface_ids         = [azurerm_network_interface.default.id]
   delete_os_disk_on_termination = true
 
   storage_os_disk {
@@ -100,10 +94,10 @@ resource "azurerm_virtual_machine" "default" {
   }
 
   storage_image_reference {
-    publisher = "${lookup(local.storage_images[var.platform], "publisher")}"
-    offer     = "${lookup(local.storage_images[var.platform], "offer")}"
-    sku       = "${lookup(local.storage_images[var.platform], "sku")}"
-    version   = "${lookup(local.storage_images[var.platform], "version")}"
+    publisher = lookup(local.storage_images[var.platform], "publisher")
+    offer     = lookup(local.storage_images[var.platform], "offer")
+    sku       = lookup(local.storage_images[var.platform], "sku")
+    version   = lookup(local.storage_images[var.platform], "version")
   }
 
   os_profile {
@@ -116,12 +110,12 @@ resource "azurerm_virtual_machine" "default" {
 
     ssh_keys {
       path     = "/home/azure/.ssh/authorized_keys"
-      key_data = "${file(var.arm_ssh_key_file)}"
+      key_data = file(var.arm_ssh_key_file)
     }
   }
 
   tags = {
-    X-Dept    = "${var.arm_department}"
-    X-Contact = "${var.arm_contact}"
+    X-Dept    = var.arm_department
+    X-Contact = var.arm_contact
   }
 }

--- a/terraform/azure/modules/arm_instance/outputs.tf
+++ b/terraform/azure/modules/arm_instance/outputs.tf
@@ -1,17 +1,17 @@
 output "resource_group_name" {
-  value = "${data.azurerm_resource_group.chef_resource_group.name}"
+  value = data.azurerm_resource_group.chef_resource_group.name
 }
 
 output "location" {
-  value = "${data.azurerm_resource_group.chef_resource_group.location}"
+  value = data.azurerm_resource_group.chef_resource_group.location
 }
 
 output "public_ipv4_address" {
-  value = "${azurerm_public_ip.default.ip_address}"
+  value = azurerm_public_ip.default.ip_address
 }
 
 output "private_ipv4_address" {
-  value = "${azurerm_network_interface.default.private_ip_address}"
+  value = azurerm_network_interface.default.private_ip_address
 }
 
 output "ssh_username" {

--- a/terraform/azure/modules/arm_instance/variables.tf
+++ b/terraform/azure/modules/arm_instance/variables.tf
@@ -1,63 +1,63 @@
 # default tenant is "Chef (getchef.onmicrosoft.com)"
 variable "arm_tenant_id" {
-  type        = "string"
+  type        = string
   description = "Unique identifier of the Azure tenant used for authentication."
   default     = "a2b2d6bc-afe1-4696-9c37-f97a7ac416d7"
 }
 
 # default subscription is "Engineering Dev/Test"
 variable "arm_subscription_id" {
-  type        = "string"
+  type        = string
   description = "Unique identifier of the Azure subscription used for billing."
   default     = "80b824de-ec53-4116-9868-3deeab10b0cd"
 }
 
 variable "arm_location" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure location to create instances in."
   default     = "westus2"
 }
 
 variable "arm_resource_group_name" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure resource group where tests will be run."
   default     = ""
 }
 
 variable "arm_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "arm_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "arm_ssh_key_file" {
-  type        = "string"
+  type        = string
   description = "File location of the SSH public key used to access the instance."
   default     = "~/.ssh/id_rsa.pub"
 }
 
 variable "arm_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure instance type used to determine size of instances."
   default     = "Standard_D2_v3"
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Name of the instance to be created."
 }

--- a/terraform/azure/modules/arm_instance/versions.tf
+++ b/terraform/azure/modules/arm_instance/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/azure/modules/arm_resource_group/locals.tf
+++ b/terraform/azure/modules/arm_resource_group/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  arm_resource_group_name = "${var.arm_resource_group_name != "" ? var.arm_resource_group_name : "${var.arm_contact}-chef_server-test"}"
+  arm_resource_group_name = var.arm_resource_group_name != "" ? var.arm_resource_group_name : "${var.arm_contact}-chef_server-test"
 }

--- a/terraform/azure/modules/arm_resource_group/main.tf
+++ b/terraform/azure/modules/arm_resource_group/main.tf
@@ -1,35 +1,30 @@
-provider "azurerm" {
-  subscription_id = "${var.arm_subscription_id}"
-  tenant_id       = "${var.arm_tenant_id}"
-}
-
 resource "azurerm_resource_group" "default" {
-  name     = "${local.arm_resource_group_name}"
-  location = "${var.arm_location}"
+  name     = local.arm_resource_group_name
+  location = var.arm_location
 
   tags = {
-    X-Dept    = "${var.arm_department}"
-    X-Contact = "${var.arm_contact}"
+    X-Dept    = var.arm_department
+    X-Contact = var.arm_contact
   }
 }
 
 resource "azurerm_virtual_network" "default" {
-  resource_group_name = "${azurerm_resource_group.default.name}"
-  location            = "${azurerm_resource_group.default.location}"
+  resource_group_name = azurerm_resource_group.default.name
+  location            = azurerm_resource_group.default.location
 
-  name          = "${local.arm_resource_group_name}"
+  name          = local.arm_resource_group_name
   address_space = ["10.0.0.0/16"]
 
   tags = {
-    X-Dept    = "${var.arm_department}"
-    X-Contact = "${var.arm_contact}"
+    X-Dept    = var.arm_department
+    X-Contact = var.arm_contact
   }
 }
 
 resource "azurerm_subnet" "default" {
-  resource_group_name  = "${azurerm_resource_group.default.name}"
-  virtual_network_name = "${azurerm_virtual_network.default.name}"
+  resource_group_name  = azurerm_resource_group.default.name
+  virtual_network_name = azurerm_virtual_network.default.name
 
-  name           = "${local.arm_resource_group_name}"
+  name           = local.arm_resource_group_name
   address_prefix = "10.0.1.0/24"
 }

--- a/terraform/azure/modules/arm_resource_group/outputs.tf
+++ b/terraform/azure/modules/arm_resource_group/outputs.tf
@@ -1,11 +1,11 @@
 output "resource_group_id" {
-  value = "${azurerm_resource_group.default.id}"
+  value = azurerm_resource_group.default.id
 }
 
 output "virtual_network_id" {
-  value = "${azurerm_virtual_network.default.id}"
+  value = azurerm_virtual_network.default.id
 }
 
 output "virtual_network_address_space" {
-  value = "${azurerm_virtual_network.default.address_space}"
+  value = azurerm_virtual_network.default.address_space
 }

--- a/terraform/azure/modules/arm_resource_group/variables.tf
+++ b/terraform/azure/modules/arm_resource_group/variables.tf
@@ -1,35 +1,35 @@
 # default tenant is "Chef (getchef.onmicrosoft.com)"
 variable "arm_tenant_id" {
-  type        = "string"
+  type        = string
   description = "Unique identifier of the Azure tenant used for authentication."
   default     = "a2b2d6bc-afe1-4696-9c37-f97a7ac416d7"
 }
 
 # default subscription is "Engineering Dev/Test"
 variable "arm_subscription_id" {
-  type        = "string"
+  type        = string
   description = "Unique identifier of the Azure subscription used for billing."
   default     = "80b824de-ec53-4116-9868-3deeab10b0cd"
 }
 
 variable "arm_location" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure location to create instances in."
   default     = "westus2"
 }
 
 variable "arm_resource_group_name" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure resource group where tests will be run."
   default     = ""
 }
 
 variable "arm_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "arm_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }

--- a/terraform/azure/modules/arm_resource_group/versions.tf
+++ b/terraform/azure/modules/arm_resource_group/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/terraform/azure/scenarios/omnibus-external-postgresql/variables.tf
+++ b/terraform/azure/scenarios/omnibus-external-postgresql/variables.tf
@@ -3,59 +3,59 @@
 #########################################################################
 # default tenant is "Chef (getchef.onmicrosoft.com)"
 variable "arm_tenant_id" {
-  type        = "string"
+  type        = string
   description = "Unique identifier of the Azure tenant used for authentication."
   default     = "a2b2d6bc-afe1-4696-9c37-f97a7ac416d7"
 }
 
 # default subscription is "Engineering Dev/Test"
 variable "arm_subscription_id" {
-  type        = "string"
+  type        = string
   description = "Unique identifier of the Azure subscription used for billing."
   default     = "80b824de-ec53-4116-9868-3deeab10b0cd"
 }
 
 variable "arm_location" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure location to create instances in."
   default     = "westus2"
 }
 
 variable "arm_resource_group_name" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure resource group where tests will be run."
   default     = ""
 }
 
 variable "arm_department" {
-  type        = "string"
+  type        = string
   description = "Department that owns the resources should be one of: EngServ, Operations, Eng, Training, Solutions, Sales, BD, Success or Partner"
 }
 
 variable "arm_contact" {
-  type        = "string"
+  type        = string
   description = "The primary contact for the resources, this should be the IAM username and must be able to receive email by appending @chef.io to it (this person can explain what/why, might not be the business owner)."
 }
 
 variable "arm_ssh_key_file" {
-  type        = "string"
+  type        = string
   description = "File location of the SSH public key used to access the instance."
   default     = "~/.ssh/id_rsa.pub"
 }
 
 variable "arm_instance_type" {
-  type        = "string"
+  type        = string
   description = "Name of the Azure instance type used to determine size of instances."
   default     = "Standard_D2_v3"
 }
 
 variable "platform" {
-  type        = "string"
+  type        = string
   description = "Operating System of the instance to be created."
 }
 
 variable "build_prefix" {
-  type        = "string"
+  type        = string
   description = "Optional build identifier for differentiating scenario runs."
   default     = ""
 }
@@ -64,12 +64,12 @@ variable "build_prefix" {
 # Chef Server
 #########################################################################
 variable "scenario" {
-  type        = "string"
+  type        = string
   description = "The name of the scenario being executed."
 }
 
 variable "upgrade_version_url" {
-  type        = "string"
+  type        = string
   description = "The URL to a chef-server used during initial install."
 }
 
@@ -78,37 +78,37 @@ variable "upgrade_version_url" {
 #########################################################################
 
 variable "enable_smoke_test" {
-  type        = "string"
+  type        = string
   description = "Enable Chef Infra Server smoke test."
   default     = "true"
 }
 
 variable "enable_pedant_test" {
-  type        = "string"
+  type        = string
   description = "Enable full Chef Infra Server pedant test."
   default     = "true"
 }
 
 variable "enable_psql_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server PostgreSQL database."
   default     = "true"
 }
 
 variable "enable_gather_logs_test" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Infra Server gathering logs."
   default     = "true"
 }
 
 variable "enable_addon_push_jobs" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Push Jobs addon."
   default     = "true"
 }
 
 variable "enable_addon_chef_manage" {
-  type        = "string"
+  type        = string
   description = "Enable testing of Chef Manage addon."
   default     = "true"
 }

--- a/terraform/azure/scenarios/omnibus-external-postgresql/versions.tf
+++ b/terraform/azure/scenarios/omnibus-external-postgresql/versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf


### PR DESCRIPTION
### Description

This PR brings the Terraform code up to the latest current version of Terraform (0.12.23).

Most of the changes are simply syntax differences between `0.11` and `0.12` but there are two implementation changes worth noting:

1. Terraform versions are specified in a new `common/versions.tf` file that is symlinked into the modules and scenarios so we can manage the versions of plugins as well as the Terraform version itself.

2. The `.expeditor/integration_test.pipeline.sh` has been modified to manage the installation of the correct version of Terraform (based on the value defined in `common/versions.tf`) when executed in the Buildkite pipeline.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#1886 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
