### PR TITLE
Allow version 6 of elasticsearch along with 2 and 5.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -103,13 +103,133 @@ class OmnibusHelper
         # Decorate any JSON parsing exception or numeric exceptions when accessing and parsing the version field.
         raise "Unable to parse elasticsearch response #{e}"
       end
-      raise "Unsupported elasticsearch version of #{version}. There is current support for the major versions of 2 and 5." if version != 5 && version != 2
-
+      raise "Unsupported elasticsearch version of #{version}. There is current support for the major versions of 2, 5 and 6." if version != 6 && version != 5 && version != 2
       version
     else
       # Elasticsearch is disabled - this configuration setting should never be used in erlang.
       0
     end
+  end
+
+  def es_index_definition
+    if node['private_chef']['elasticsearch']['first_internal_install'] == true
+      es_6_index
+    else
+      es_version = elastic_search_major_version
+      if es_version == 6
+        es_6_index
+      elsif [2, 5].include?(es_version)
+        es_5_or_2_index
+      end
+    end
+  end
+
+  def es_6_index
+    {
+      'settings' => {
+        'analysis' => {
+          'analyzer' => {
+            'default' => {
+              'type' => 'whitespace'
+            }
+          }
+        },
+        'number_of_shards' =>
+          node['private_chef']['opscode-solr4']['elasticsearch_shard_count'],
+        'number_of_replicas' =>
+          node['private_chef']['opscode-solr4']['elasticsearch_replica_count']
+      },
+      'mappings' => {
+        'object' => {
+          '_source' => { 'enabled' => false },
+          '_all' => { 'enabled' => false },
+          'properties' => {
+            'X_CHEF_database_CHEF_X' => {
+              'type' => 'keyword',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'X_CHEF_type_CHEF_X' => {
+              'type' => 'keyword',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'X_CHEF_id_CHEF_X' => {
+              'type' => 'keyword',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'data_bag' => {
+              'type' => 'keyword',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'content' => {
+              'type' => 'text'
+            }
+          }
+        }
+      }
+    }
+  end
+
+  def es_5_or_2_index
+    {
+      'settings' => {
+        'analysis' => {
+          'analyzer' => {
+            'default' => {
+              'type' => 'whitespace'
+            }
+          }
+        },
+        'number_of_shards' =>
+          node['private_chef']['opscode-solr4']['elasticsearch_shard_count'],
+        'number_of_replicas' =>
+          node['private_chef']['opscode-solr4']['elasticsearch_replica_count']
+      },
+      'mappings' => {
+        'object' => {
+          '_source' => { 'enabled' => false },
+          '_all' => { 'enabled' => false },
+          'properties' => {
+            'X_CHEF_database_CHEF_X' => {
+              'type' => 'string',
+              'index' => 'not_analyzed',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'X_CHEF_type_CHEF_X' => {
+              'type' => 'string',
+              'index' => 'not_analyzed',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'X_CHEF_id_CHEF_X' => {
+              'type' => 'string',
+              'index' => 'not_analyzed',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'data_bag' => {
+              'type' => 'string',
+              'index' => 'not_analyzed',
+              'norms' => {
+                'enabled' => false
+              }
+            },
+            'content' => { 'type' => 'string', 'index' => 'analyzed' }
+          }
+        }
+      }
+    }
   end
 
   def solr_url

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -135,7 +135,6 @@ include_recipe 'private-chef::fix_permissions'
   redis_lb
   nginx
   rabbitmq
-  elasticsearch
 ).each do |service|
   if node['private_chef'][service]['external']
     begin

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
@@ -15,55 +15,13 @@
 # limitations under the License.
 #
 
+helper = OmnibusHelper.new(node)
 case node['private_chef']['opscode-erchef']['search_provider']
 when 'solr'
   Chef::Log.warn('External Solr Support does not include configuring the Solr schema.')
 when 'elasticsearch'
   elasticsearch_index 'chef' do
     server_url node['private_chef']['opscode-solr4']['external_url']
-    index_definition('settings' => {
-                        'analysis' => {
-                          'analyzer' => {
-                            'default' => {
-                              'type' => 'whitespace',
-                            },
-                          },
-                        },
-                        'number_of_shards' => node['private_chef']['opscode-solr4']['elasticsearch_shard_count'],
-                        'number_of_replicas' => node['private_chef']['opscode-solr4']['elasticsearch_replica_count'],
-                      },
-                     'mappings' => {
-                        'object' => {
-                          '_source' => { 'enabled' => false },
-                          '_all' => { 'enabled' => false },
-                          'properties' => {
-                            'X_CHEF_database_CHEF_X' => { 'type' => 'string',
-                                                          'index' => 'not_analyzed',
-                                                          'norms' => {
-                                                            'enabled' => false,
-                                                          },
-                                                        },
-                            'X_CHEF_type_CHEF_X' => { 'type' => 'string',
-                                                      'index' => 'not_analyzed',
-                                                      'norms' => {
-                                                        'enabled' => false,
-                                                      },
-                                                    },
-                            'X_CHEF_id_CHEF_X' => { 'type' => 'string',
-                                                    'index' => 'not_analyzed',
-                                                    'norms' => {
-                                                      'enabled' => false,
-                                                    },
-                                                  },
-                            'data_bag' => { 'type' => 'string',
-                                            'index' => 'not_analyzed',
-                                            'norms' => {
-                                              'enabled' => false,
-                                            },
-                                          },
-                            'content' => { 'type' => 'string', 'index' => 'analyzed' },
-                          },
-                        },
-                      })
+    index_definition(helper.es_index_definition)
   end
 end

--- a/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
@@ -87,8 +87,8 @@ query_body(#chef_solr_query{
 
 fields_tag() ->
     case envy:get(chef_index, solr_elasticsearch_major_version, 2, non_neg_integer) of
-        5 -> <<"stored_fields">>;
-        _ -> <<"fields">>
+        X when X >= 5 -> <<"stored_fields">>;
+        2 -> <<"fields">>
     end.
 
 query_string_query_ejson(QueryString) ->


### PR DESCRIPTION
Add changes to index as required in elasticsearch 6
Fix the verbiage around elasticsearch supported versions.

As a part of moving from internal Solr to Elasticsearch, Add support for Elasticsearch version 6 in addition to 5 and 2.

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
