### PR TITLE
Fix integration test cancellation

### DIFF
--- a/.expeditor/integration_test.pipeline.sh
+++ b/.expeditor/integration_test.pipeline.sh
@@ -293,8 +293,12 @@ destroy-all () {
 
   echo "--- Destroying all Terraform workspaces associated with build number $BUILD_NUMBER"
 
-  # verify command dependencies
-  [[ "$(command -v consul)" ]] || error 'consul command is not available'
+  # ensure consul is installed
+  if [[ ! "$(command -v consul)" ]]; then
+    asdf plugin-add consul
+    asdf install consul 1.6.2
+    asdf local consul 1.6.2
+  fi
 
   # iterate across workspaces left in consul
   for workspace in $(consul kv get -keys terraform/chef-server/ | sed -n "/${BUILD_NUMBER}/{s/.*:\(${BUILD_NUMBER}-.*$\)/\1/;s/\///;p;}" | sort -u); do

--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -958,11 +958,7 @@ steps:
     continue_on_failure: true
 
   - label: ':terraform: destroy-all'
-    command:
-      - asdf plugin-add consul
-      - asdf install consul 1.6.2
-      - asdf local consul 1.6.2
-      - .expeditor/integration_test.pipeline.sh destroy-all
+    command: .expeditor/integration_test.pipeline.sh destroy-all
     env:
       ACTION: destroy-all
       CONSUL_HTTP_ADDR: http://consul.chef.co


### PR DESCRIPTION
### Description

This PR fixes the integration test pipeline failing to cleanup instances that were orphaned during a pipeline cancellation.  The issue was that expeditor's container environment does not have `consul` installed.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
