### PR TITLE
Fix integration test security group prefix and integration test cancellation

### DIFF
--- a/.expeditor/integration_test.pipeline.sh
+++ b/.expeditor/integration_test.pipeline.sh
@@ -7,6 +7,9 @@ action=
 AWS_TOKEN_TIMEOUT=3600
 export AWS_TOKEN_TIMEOUT
 
+# point to consul backend
+export CONSUL_HTTP_ADDR='http://consul.chef.co'
+
 # verify command dependencies
 [[ "$(command -v terraform)" ]] || error 'terraform command is not available'
 

--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -961,7 +961,6 @@ steps:
     command: .expeditor/integration_test.pipeline.sh destroy-all
     env:
       ACTION: destroy-all
-      CONSUL_HTTP_ADDR: http://consul.chef.co
     expeditor:
       accounts:
         - aws/chef-cd

--- a/terraform/aws/modules/aws_instance/main.tf
+++ b/terraform/aws/modules/aws_instance/main.tf
@@ -15,7 +15,7 @@ data "aws_subnet" "chef_subnet" {
 }
 
 resource "aws_security_group" "default" {
-  name_prefix = "local.vpc_name"
+  name_prefix = local.vpc_name
   vpc_id      = data.aws_vpc.chef_vpc.id
 
   ingress {


### PR DESCRIPTION
### Description

This PR fixes:

* security group prefix name
* lack of consul environment variable when expeditor attempts to execute a destroy-all following a pipeline failure/cancellation


### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
