### PR TITLE
Praj/enable internal es

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -286,6 +286,7 @@ var_base = '/var/opt/opscode'
 log_base = '/var/log/opscode'
 
 default['private_chef']['elasticsearch']['enable'] = false
+default['private_chef']['elasticsearch']['first_internal_install'] = false
 elasticsearch = default['private_chef']['elasticsearch']
 
 # These attributes cannot be overridden in chef-server.rb

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_provider.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/elasticsearch_index_provider.rb
@@ -8,7 +8,7 @@ class Chef
       action :create do
         unless index_exists?
           converge_by "Creating elasticsearch index #{new_resource.index_name}" do
-            solr_server.put(new_resource.index_name, Chef::JSONCompat.to_json(new_resource.index_definition))
+            solr_server.put(new_resource.index_name, new_resource.index_definition)
           end
         end
       end
@@ -33,7 +33,7 @@ class Chef
       end
 
       def solr_server
-        @solr_server ||= Chef::HTTP.new(new_resource.server_url)
+        @solr_server ||= Chef::HTTP::SimpleJSON.new(new_resource.server_url)
       end
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -50,6 +50,12 @@ include_recipe 'private-chef::plugin_discovery'
 include_recipe 'private-chef::plugin_config_extensions'
 include_recipe 'private-chef::config'
 
+if node['private_chef']['elasticsearch']['first_internal_install']
+  node.override['private_chef']['opscode-solr4']['enable'] = false
+  node.override['private_chef']['rabbitmq']['enable'] = false
+  node.override['private_chef']['opscode-expander']['enable'] = false
+end
+
 if node['private_chef']['fips_enabled']
   include_recipe 'private-chef::fips'
 end
@@ -126,6 +132,7 @@ include_recipe 'private-chef::fix_permissions'
   postgresql
   oc_bifrost
   oc_id
+  elasticsearch
   opscode-solr4
   opscode-expander
   bookshelf

--- a/src/chef-server-ctl/plugins/reindex.rb
+++ b/src/chef-server-ctl/plugins/reindex.rb
@@ -21,7 +21,7 @@ require 'redis'
 
 def all_orgs
   Chef::Config.from_file(::ChefServerCtl::Config.knife_config_file)
-  Chef::Org.list.keys
+  Chef::Org.list.keys.sort
 end
 
 def expander_queue_size


### PR DESCRIPTION
### Description
This is not ready for deploy for production.

This change will let the user manually enable elastic search.
Make sure to take ample backups before making the following changes.

Add the following to /etc/opscode/chef-server.rb

```
opscode_solr4['external'] = true
opscode_solr4['external_url'] = 'http://localhost:9200'
elasticsearch['enable'] = true
elasticsearch['first_internal_install'] = true
opscode_erchef['search_provider'] = 'elasticsearch'
opscode_erchef['search_queue_mode'] = 'batch'
```

Manually run reindex command `chef-server-ctl reindex` after upgrade.

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1075#fb50d184-6c1a-40b2-b389-47afdd637333

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
