### PR TITLE
Fix pedant to not be strict about cookbook artifact metadata

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) 2012-2020, Chef Software Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -253,6 +253,18 @@ module Pedant
         else
           new_cookbook_artifact_v0(name, identifier, opts)
         end
+      end
+
+      # comparison operator to use to allow for extensible metadata
+      def expect_matching_cookbook_artifact(got, expected)
+        expected = expected.dup
+        # be strict about the top level keys to start with
+        expect(got.keys.sort).to eql(expected.keys.sort)
+        metadata = expected.delete("metadata")
+        # strict checking of all the top level values other than metadata
+        expect(got).to match(hash_including(expected))
+        # lax checking of the metadata values, since those are allowed to be extensible
+        expect(got["metadata"]).to match(hash_including(metadata))
       end
 
       def delete_cookbook_artifact(requestor, name, identifier)

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/create_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/create_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# Copyright: Copyright (c) 2015-2020, Chef Software Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,7 +83,7 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
           get_response = get(request_url, requestor)
 
           expect(get_response.code.to_s).to eq("200")
-          expect(parse(get_response)).to eq(expected_get_response_data)
+          expect_matching_cookbook_artifact(parse(get_response), expected_get_response_data)
         end
       end
 

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/delete_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# Copyright: Copyright (c) 2015-2020, Chef Software Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -153,7 +153,7 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
           it "should respond with 200 (\"OK\") and be deleted" do
             delete_response = delete(request_url, admin_user)
             expect(delete_response.code).to eq(200)
-            expect(parse(delete_response)).to eq(fetched_cookbook)
+            expect_matching_cookbook_artifact(parse(delete_response), fetched_cookbook)
 
             expect(get(request_url, admin_user).code).to eq(404)
           end # it admin user returns 200

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2015 Chef Software, Inc.
+# Copyright: Copyright (c) 2015-2020, Chef Software Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -195,7 +195,7 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
           response_data[target].first.delete("url")
           response_data[target].first.delete("checksum")
 
-          expect(response_data).to eq(expected_cookbook_artifact_data)
+          expect_matching_cookbook_artifact(response_data, expected_cookbook_artifact_data)
         end
 
         # These tests verify that the pre-signed URL that comes back


### PR DESCRIPTION
This broke when I added the eager_load_libraries metadata.  The server
doesn't actually care about additional metadata (which we've done before
for years, including ohai_version, chef_version, privacy and the gem
metadata).
