### PR TITLE
Support index creation in all supported topologies and configurations.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -287,6 +287,9 @@ log_base = '/var/log/opscode'
 
 default['private_chef']['elasticsearch']['enable'] = false
 default['private_chef']['elasticsearch']['first_internal_install'] = false
+default['private_chef']['elasticsearch']['internal_install'] = false
+default['private_chef']['elasticsearch']['install_major_version'] = 6
+
 elasticsearch = default['private_chef']['elasticsearch']
 
 # These attributes cannot be overridden in chef-server.rb

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -112,15 +112,20 @@ class OmnibusHelper
   end
 
   def es_index_definition
-    if node['private_chef']['elasticsearch']['first_internal_install'] == true
-      es_6_index
-    else
-      es_version = elastic_search_major_version
-      if es_version == 6
-        es_6_index
-      elsif [2, 5].include?(es_version)
+    use_version = node['private_chef']['elasticsearch']['install_major_version']
+    # If installing with chef-backend default to the version of chef-backend
+    if node['private_chef']['use_chef_backend'] == true
         es_5_or_2_index
-      end
+    # If install using internal elasticsearch
+    # node['private_chef']['elasticsearch']['install_major_version']
+    # is populated in the default.rb
+    # If install using external elasticsearch
+    # node['private_chef']['elasticsearch']['install_major_version']
+    # should be defined by the user
+    elsif use_version == 6
+        es_6_index
+    elsif [2, 5].include?(use_version)
+        es_5_or_2_index
     end
   end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -51,6 +51,7 @@ include_recipe 'private-chef::plugin_config_extensions'
 include_recipe 'private-chef::config'
 
 if node['private_chef']['elasticsearch']['first_internal_install']
+  node.override['private_chef']['elasticsearch']['install_major_verison'] = 6
   node.override['private_chef']['opscode-solr4']['enable'] = false
   node.override['private_chef']['rabbitmq']['enable'] = false
   node.override['private_chef']['opscode-expander']['enable'] = false


### PR DESCRIPTION
Namely chef-backend, internal elasticsearch and external elasticsearch.
We also support version 2,5 6 for elasticsearch.

The indexes are being created at compile time (which might be another discussion). At this time none of the services are available. Trying to get the version of es from running elasticsearch will fail if this is not the fist_internal_install of elasticsearch.

To fix this, trying to get the version of es statically, or from the user.

Henceforth, in chef-server.rb the user can specify
```
elasticsearch['install_major_version'] = 6 #options are 2, 5, or 6
```
This also fixes the chef-backend scenario.

Adhoc build:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1081

Integration test pipeline:
https://buildkite.com/chef/chef-chef-server-master-integration-test/builds/66

Signed-off-by: Prajakta Purohit <prajakta@chef.io>


- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
