### PR TITLE
Do not create indexes for elasticsearch at compile time

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -115,6 +115,8 @@ class OmnibusHelper
     if node['private_chef']['elasticsearch']['first_internal_install'] == true
       es_6_index
     else
+      # For external elasticsearch or chef-backend elasticsearch will be running
+      # before we try to create the index
       es_version = elastic_search_major_version
       if es_version == 6
         es_6_index

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4-external.rb
@@ -22,6 +22,6 @@ when 'solr'
 when 'elasticsearch'
   elasticsearch_index 'chef' do
     server_url node['private_chef']['opscode-solr4']['external_url']
-    index_definition(helper.es_index_definition)
+    index_definition lazy { helper.es_index_definition }
   end
 end


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

To identify the major version of es we call into the es service with a rest get.
That service is unavailable at compile time.

Also, indexes should not be created at compile time.

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1082

### Issues Resolved

Fixes chef-backend.
https://buildkite.com/chef/chef-chef-server-master-integration-test/builds/65

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
