### PR TITLE
Turn off smart builds

### DIFF
--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -1,3 +1,3 @@
 ---
 origin: chef
-smart_build: true
+smart_build: false


### PR DESCRIPTION
While the manifest generated ties together a release of automate, it is
still confusing to have components at different versions for chef
server. Also, automate depends on openresty from chef server, which
doesn't get changed often thus never picks up changes upstream.

Signed-off-by: Jay Mundrawala <jmundrawala@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
