### PR TITLE
Update listen_port for newer nginx.conf syntax.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -7,7 +7,6 @@
 
     access_log <%= @helper.access_log(@server_proto) %> opscode;
     <% if @server_proto == "https" %>
-      ssl on;
       ssl_certificate <%= @ssl_certificate %>;
       ssl_certificate_key <%= @ssl_certificate_key %>;
       ssl_dhparam <%= @ssl_dhparam %>;


### PR DESCRIPTION
The old listen_port helper was designed for older nginx.conf syntax (when
"ssl on;" was necessary for HTTPS.) "ssl on;" has been removed from the
template for chef_http(s)_lb.conf, and the listen_port helper has been
updated to append the ssl option (e.g. "listen 443 ssl;") when "https" is
passed as proto.

Signed-off-by: Thomas J. Gallen <kaori.hinata@gmail.com>

### Description

The complete description of the intention of this pull request was included in the commit message (included above).

There are currently no changes to tests, as the amount of testing being done around the templated configuration was already quite low ("chef-server-ctl reconfigure" was more than happy to declare success after PR #1843's change broke the configuration file, so I'm assuming it's not doing a configuration sanity test as part of the private-chef cookbooks run.) If we'd like to sanity test the templated configuration file then we can certainly make that change though.

### Issues Resolved

This would replace PR #1843 as the solution provided by that PR was incomplete, and has now sat idle for months.

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
