### PR TITLE
Restrict access to dhparams.pem (used by Nginx).

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -124,7 +124,7 @@ if node['private_chef']['nginx']['ssl_dhparam'].nil?
     generator node['private_chef']['nginx']['dhparam_generator_id']
     owner 'root'
     group 'root'
-    mode '0644'
+    mode '0600'
   end
 
   node.default['private_chef']['nginx']['ssl_dhparam'] = ssl_dhparam


### PR DESCRIPTION
This is a small change to the permissions on the dhparams created by the
private-chef cookbooks for Nginx. No other services need them, so there's
no need to modify owner/group, only mode.

Fixes: #731

Signed-off-by: Thomas J. Gallen <kaori.hinata@gmail.com>

### Description

The full description is included in the commit message above. This is a change to the private-chef cookbooks, and has been tested with a development installation of Chef Infra Server 13.1.13.

### Issues Resolved

Fixes: #731

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
