### PR TITLE
Add an exception for habitat core/perl licenses.

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -22,6 +22,7 @@ allowed_licenses:
   - Apache-1.1
   - Apache-2.0
   - Artistic-2.0
+  - Artistic-1.0-Perl
   - BSD-1-Clause
   - BSD-2-Clause
   - BSD-3-Clause
@@ -184,6 +185,8 @@ exceptions:
     - name: core/libtool
       reason: Exception made by Chef Legal
     - name: core/linux-headers
+      reason: Exception made by Chef Legal
+    - name: core/perl
       reason: Exception made by Chef Legal
     - name: core/readline
       reason: Exception made by Chef Legal


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

Habitat core/perl pkg update causes license_scout to break. This change fixes it.

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
