### PR TITLE
Add an exception for habitat core/binutils

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -164,6 +164,8 @@ exceptions:
       reason: Exception made by Chef Legal
     - name: core/bash
       reason: Exception made by Chef Legal
+    - name: core/binutils
+      reason: Exception made by Chef Legal
     - name: core/busybox-static
       reason: Exception made by Chef Legal
     - name: core/coreutils


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

Adds exception for habitat core/binutils pkg. 
+---------+-------------------------------------+------------------+-------------+
| Type    | Dependency                          | License(s)       | Results     |
+---------+-------------------------------------+------------------+-------------+
| habitat | core/binutils (2.32-20200305174809) | GPL-2.0-or-later | Not Allowed |
+---------+-------------------------------------+------------------+-------------+

### Issues Resolved

https://logs.cd.chef.co/raw/chef-chef-server-master-buildkite_hab_build_group_published-chef-chef-server-master-chef-chef-server-master-habitat-build-2020-04-28t17-13-43-00-00

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
