### PR TITLE
Add preflight checks

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -19,6 +19,9 @@ class PreflightValidationFailed < StandardError
 end
 
 class PreflightValidator
+  CHEF_SERVER_NAME = "Chef Infra Server"
+  CHEF_SERVER_CONFIG_FILE = "/etc/opscode/chef-server.rb"
+
   attr_reader :node, :previous_run, :helper
   attr_reader :cs_pg_attr, :node_pg_attr
   def initialize(node)

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
@@ -16,48 +16,140 @@
 require_relative './preflight_checks.rb'
 
 class SolrPreflightValidator < PreflightValidator
-  attr_reader :cs_solr_attr, :node_solr_attr, :cs_erchef_attr, :node_erchef_attr
+  # The cs_*attr variables hold the user-defined configuration
+  attr_reader :cs_solr_attr, :cs_erchef_attr,
+              :cs_elasticsearch_attr, :cs_rabbitmq_attr,
+              :cs_opscode_expander_attr
+
+  # The node_*attr variables hold the default configuration
+  attr_reader :node_solr_attr, :node_elasticsearch_attr, :node_erchef_attr
 
   def initialize(node)
     super
+
     @cs_solr_attr = PrivateChef['opscode_solr4']
     @cs_erchef_attr = PrivateChef['opscode_erchef']
+    @cs_elasticsearch_attr = PrivateChef['elasticsearch']
+    @cs_rabbitmq_attr = PrivateChef['rabbitmq']
+    @cs_opscode_expander_attr = PrivateChef['opscode_expander']
+
     @node_erchef_attr = node['private_chef']['opscode-erchef']
     @node_solr_attr = node['private_chef']['opscode-solr4']
+    @node_elasticsearch_attr = node['private_chef']['elasticsearch']
   end
 
   def run!
-    verify_sane_reindex_sleep_times
+    verify_consistent_reindex_sleep_times
+
+    verify_one_search_provider
+    verify_es_disabled_if_user_set_external_solr
+    verify_unused_services_are_disabled_if_using_internal_es
+    verify_no_explicit_external_disable_when_es_enabled
+
     warn_unchanged_external_flag
     verify_external_url
     verify_erchef_config
   end
 
-  def verify_sane_reindex_sleep_times
+  def verify_consistent_reindex_sleep_times
     final_min = cs_erchef_attr['reindex_sleep_min_ms'] || node_erchef_attr['reindex_sleep_min_ms']
     final_max = cs_erchef_attr['reindex_sleep_max_ms'] || node_erchef_attr['reindex_sleep_max_ms']
     if final_min > final_max
-      fail_with <<~EOM
+      fail_with err_SOLR001_failed_validation(final_min, final_max)
+    end
+  end
 
-        opscode_erchef['reindex_sleep_min_ms'] (#{final_min}) is greater than
-        opscode_erchef['reindex_sleep_max_ms'] (#{final_max})
+  def verify_one_search_provider
+    if elasticsearch_enabled? && solr_enabled?
+      fail_with err_SOLR002_failed_validation
+    end
+  end
 
-        The maximum sleep time should be greater or equal to the minimum sleep
-        time.
-      EOM
+  # If an external search provider (ES or Solr) was explicitly enabled
+  # by the user, then we expect that both internal search services
+  # should be disabled.
+  def verify_es_disabled_if_user_set_external_solr
+    # NOTE(ssd) 2020-05-13: This might impact the people who we gave
+    # pre-release access to.
+    if cs_solr_attr['external'] && elasticsearch_enabled?
+      fail_with err_SOLR003_failed_validation
+    end
+
+    if solr_enabled? && external?
+      fail_with err_SOLR004_failed_validation
+    end
+  end
+
+  # The user might have a combination of solr, rabbitmq or
+  # opscode-expander explicitly enabled in their config.
+  #
+  # If we are using the new internal elasticsearch, this is an
+  # unsupported configuration.
+  #
+  def verify_unused_services_are_disabled_if_using_internal_es
+    if elasticsearch_enabled?
+      msg = []
+      if cs_solr_attr['enable']
+        msg << err_SOLR005_failed_validation
+      end
+
+      if cs_rabbitmq_attr['enable']
+        msg << err_SOLR006_failed_validation
+      end
+
+      if cs_opscode_expander_attr['enable']
+        msg << err_SOLR007_failed_validation
+      end
+      unless msg.empty?
+        fail_with msg.join("\n")
+      end
+    end
+  end
+
+  def verify_no_explicit_external_disable_when_es_enabled
+    return if cs_solr_attr['external'].nil?
+
+    # TODO(ssd) 2020-05-13: Rather than this check, we could just
+    # ignore that configuration when parsing the configuration.
+    if !cs_solr_attr['external'] && elasticsearch_enabled?
+      fail_with err_SOLR008_failed_validation
+    end
+  end
+
+  def external?
+    if cs_solr_attr['external'].nil?
+      node_solr_attr['external']
+    else
+      cs_solr_attr['external']
+    end
+  end
+
+  def elasticsearch_enabled?
+    # TODO(ssd) 2020-05-13: This currently lives in another PR, but to
+    # facilitate updates for chef-backend users without a
+    # configuration change, we are going to explicitly set
+    # elasticsearch to disabled at runtime.
+    return false if PrivateChef['use_chef_backend']
+
+    if cs_elasticsearch_attr['enable'].nil?
+      node_elasticsearch_attr['enable']
+    else
+      cs_elasticsearch_attr['enable']
+    end
+  end
+
+  def solr_enabled?
+    if cs_solr_attr['enable'].nil?
+      node_solr_attr['enable']
+    else
+      cs_solr_attr['enable']
     end
   end
 
   def warn_unchanged_external_flag
     if OmnibusHelper.has_been_bootstrapped? && backend? && previous_run
       if cs_solr_attr.key?('external') && (cs_solr_attr['external'] != previous_run['opscode-solr4']['external'])
-        Chef::Log.warn <<~EOM
-
-          The value of opscode_solr4['external'] has been changed.  Search
-          results against the new external search index may be incorrect. Please
-          run `chef-server-ctl reindex --all` to ensure correct results
-
-        EOM
+        Chef::Log.warn err_SOLR009_warn_validation
       end
     else
       true
@@ -66,13 +158,7 @@ class SolrPreflightValidator < PreflightValidator
 
   def verify_external_url
     if cs_solr_attr['external'] & !cs_solr_attr['external_url']
-      fail_with <<~EOM
-
-        No external url specified for Solr depsite opscode_solr4['external']
-        being set to true. To use an external solr instance, please set
-        opscode_solr4['external_url'] to the external solr endpoint.
-
-      EOM
+      fail_with err_SOLR010_failed_validation
     end
   end
 
@@ -83,26 +169,171 @@ class SolrPreflightValidator < PreflightValidator
     case provider
     when 'elasticsearch'
       unless %w(batch inline).include?(@cs_erchef_attr['search_queue_mode'])
-        fail_with <<~EOM
-
-          The elasticsearch provider is only supported by the batch or inline
-          queue modes. To use the elasticsearch provider, please also set:
-
-          opscode_erchef['search_queue_mode'] = 'batch'
-
-          in /etc/opscode/chef-server.rb
-
-        EOM
+        fail_with err_SOLR011_failed_validation
       end
     when 'solr'
     else
-      fail_with <<~EOM
-        The specified search provider (#{provider}) is not currently supported.
-        Please choose from one of the following search providers:
-
-        solr
-        elasticsearch
-      EOM
+      fail_with err_SOLR012_failed_validation
     end
+  end
+
+  def err_SOLR001_failed_validation(final_min, final_max)
+    <<~EOM
+
+      SOLR001: opscode_erchef['reindex_sleep_min_ms'] (#{final_min}) is greater than
+               opscode_erchef['reindex_sleep_max_ms'] (#{final_max})
+
+               The maximum sleep time should be greater or equal to the minimum sleep
+               time.
+    EOM
+  end
+
+  def err_SOLR002_failed_validation
+    <<~EOM
+
+      SOLR002: The #{CHEF_SERVER_NAME} is configured to enable both
+               Elasticsearch and Solr. This is an unsupported configuration.
+
+               Please update #{CHEF_SERVER_CONFIG_FILE} such that only one
+               search provider is enabled.
+      EOM
+  end
+
+  def err_SOLR003_failed_validation
+    <<~EOM
+
+      SOLR003: The #{CHEF_SERVER_NAME} is configured to use an external search
+               index but the internal Elasticsearch is still enabled. This is
+               an unsupported configuration.
+
+               To disable the internal Elasticsearch, add the following to #{CHEF_SERVER_CONFIG_FILE}:
+
+                   elasticsearch['enable'] = false
+
+               To use the internal Elasticsearch, consider removing the configuration
+               entry for opscode_solr4['external'].
+
+     EOM
+  end
+
+  def err_SOLR004_failed_validation
+    <<~EOM
+
+      SOLR004: The #{CHEF_SERVER_NAME} is configured to use an external search
+               provider but the internal Solr is still enabled. This is an
+               unsupported configuration.
+
+               To disable the internal Solr, add the following to #{CHEF_SERVER_CONFIG_FILE}:
+
+                   opscode_solr4['enable'] = false
+
+               Alternatively, if you are attempting to use the internal Solr,
+               add the following to #{CHEF_SERVER_CONFIG_FILE}:
+
+                   opscode_solr4['enable'] = true
+                   opscode_solr4['external'] = false
+
+    EOM
+  end
+
+  def err_SOLR005_failed_validation
+    <<~EOM
+
+      SOLR005: The #{CHEF_SERVER_NAME} is configured to use its internal
+               Elasticsearch installation, but opscode_solr4 has been manually
+               enabled. This is an unsupported configuration.
+
+               Please update #{CHEF_SERVER_CONFIG_FILE} to ensure that
+               opscode_solr4 is disabled:
+
+                   opscode_solr4['enable'] = false
+
+    EOM
+  end
+
+  def err_SOLR006_failed_validation
+    <<~EOM
+
+      SOLR006: The #{CHEF_SERVER_NAME} is configured to use its internal
+               Elasticsearch installation, but RabbitMQ has been manually
+               enabled. This is an unsupported configuration.
+
+               Please update #{CHEF_SERVER_CONFIG_FILE} to ensure that
+               rabbitmq is disabled:
+
+                   rabbitmq['enable'] = false
+
+    EOM
+  end
+
+  def err_SOLR007_failed_validation
+    <<~EOM
+
+      SOLR007: The #{CHEF_SERVER_NAME} is configured to use its internal
+               Elasticsearch installation, but opscode-expander has been
+               manually enabled. This is an unsupported configuration.
+
+               Please update #{CHEF_SERVER_CONFIG_FILE} to ensure that
+               opscode-expander is disabled:
+
+                   opscode_expander['enable'] = false
+
+    EOM
+  end
+
+  def err_SOLR008_failed_validation
+    <<~EOM
+
+      SOLR008: The #{CHEF_SERVER_NAME} is configured with
+
+                   opscode_solr4['external'] = false
+
+               but this is incompatible with elasticsearch being enabled.
+
+               Please remove this line from #{CHEF_SERVER_CONFIG_FILE}.
+    EOM
+  end
+
+  def err_SOLR009_warn_validation
+    <<~EOM
+
+       SOLR009: The value of opscode_solr4['external'] has been changed.  Search
+                results against the new external search index may be incorrect. Please
+                run `chef-server-ctl reindex --all` to ensure correct results
+
+    EOM
+  end
+
+  def err_SOLR010_failed_validation
+    <<~EOM
+
+      SOLR010: No external url specified for Solr depsite opscode_solr4['external']
+               being set to true. To use an external solr instance, please set
+               opscode_solr4['external_url'] to the external solr endpoint.
+
+    EOM
+  end
+
+  def err_SOLR011_failed_validation
+    <<~EOM
+
+      SOLR011: The elasticsearch provider is only supported by the batch or inline
+               queue modes. To use the elasticsearch provider, please also set:
+
+               opscode_erchef['search_queue_mode'] = 'batch'
+
+               in #{CHEF_SERVER_CONFIG_FILE}
+
+    EOM
+  end
+
+  def err_SOLR012_failed_validation
+    <<~EOM
+      SOLR012: The specified search provider (#{provider}) is not currently supported.
+               Please choose from one of the following search providers:
+
+               solr
+               elasticsearch
+    EOM
   end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_solr_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_solr_validator_spec.rb
@@ -29,10 +29,16 @@ describe SolrPreflightValidator do
     s
   end
 
+  before(:each) do
+    allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
+    allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
+    allow(PrivateChef).to receive(:[]).with('elasticsearch').and_return({})
+    allow(PrivateChef).to receive(:[]).with('rabbitmq').and_return({})
+    allow(PrivateChef).to receive(:[]).with('opscode_expander').and_return({})
+  end
+
   context 'when min and max sleep time has been given in the config' do
     before(:each) do
-      allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
-      allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
       allow(PrivateChef).to receive(:[]).with('opscode_erchef').and_return(
         'reindex_sleep_min_ms' => min_sleep_time,
         'reindex_sleep_max_ms' => max_sleep_time
@@ -44,15 +50,13 @@ describe SolrPreflightValidator do
       let(:max_sleep_time) { 2 }
 
       it 'raises an error' do
-        expect(solr_preflight.verify_sane_reindex_sleep_times).to eq(:i_failed)
+        expect(solr_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
       end
     end
   end
 
   context 'when only min sleep time has been given in the config' do
     before(:each) do
-      allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
-      allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
       allow(PrivateChef).to receive(:[]).with('opscode_erchef').and_return(
         'reindex_sleep_min_ms' => min_sleep_time
       )
@@ -62,15 +66,13 @@ describe SolrPreflightValidator do
       let(:min_sleep_time) { 2001 }
 
       it 'raises an error' do
-        expect(solr_preflight.verify_sane_reindex_sleep_times).to eq(:i_failed)
+        expect(solr_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
       end
     end
   end
 
   context 'when only max sleep time has been given in the config' do
     before(:each) do
-      allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
-      allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
       allow(PrivateChef).to receive(:[]).with('opscode_erchef').and_return(
         'reindex_sleep_max_ms' => max_sleep_time
       )
@@ -80,7 +82,7 @@ describe SolrPreflightValidator do
       let(:max_sleep_time) { 499 }
 
       it 'raises an error' do
-        expect(solr_preflight.verify_sane_reindex_sleep_times).to eq(:i_failed)
+        expect(solr_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
       end
     end
   end


### PR DESCRIPTION
 Check for some of the conditions that might disrupt
 expected behaviour of internal elasticsearch install

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

preflight check verify_es_disabled_if_user_set_external_solr
checks that if user has selected external search; 
the internal es service is turned off

preflight check verify_unused_services_are_disabled_if_using_internal_es
opscode_solr4, rabbitmq and opscode-expander services
should be turned off if using internal elasticsearch.

Question:
```
opscode_solr4['external'] = false
elasticsearch['enable'] = false
no error - is that ok?
```

```
Config:
opscode_solr4['enable'] = true
opscode_solr4['external'] = true
rabbitmq['enable'] = true
opscode_expander['enable'] = true

Reconfigure:
-----------------------------------------------------------------------
SOLR002: The Chef Infra Server is configured to enable both
         Elasticsearch and Solr. This is an unsupported configuration.
         Please update /etc/opscode/chef-server.rb such that only one
         search provider is enabled.
-----------------------------------------------------------------------

Config:
#opscode_solr4['enable'] = true
opscode_solr4['external'] = true
rabbitmq['enable'] = true
opscode_expander['enable'] = true

Reconfigure:
-----------------------------------------------------------------------
SOLR003: The Chef Infra Server is configured to use an external search
         index but the internal Elasticsearch is still enabled. This is
         an unsupported configuration.
         To disable the internal Elasticsearch, add the following to /etc/opscode/chef-server.rb:
             elasticsearch['enable'] = false
         To use the internal Elasticsearch, consider removing the configuration
         entry for opscode_solr4['external'].
-----------------------------------------------------------------------

Config:
opscode_solr4['enable'] = true
opscode_solr4['external'] = true
#rabbitmq['enable'] = true
#opscode_expander['enable'] = true
elasticsearch['enable'] = false

Reconfigure:
-----------------------------------------------------------------------
SOLR004: The Chef Infra Server is configured to use an external search
         provider but the internal Solr is still enabled. This is an
         unsupported configuration.
         To disable the internal Solr, add the following to /etc/opscode/chef-server.rb:
             opscode_solr4['enable'] = false
         Alternatively, if you are attempting to use the internal Solr,
         add the following to /etc/opscode/chef-server.rb:
             opscode_solr4['enable'] = true
             opscode_solr4['external'] = false
-----------------------------------------------------------------------

Config:
#opscode_solr4['enable'] = true
opscode_solr4['external'] = false
rabbitmq['enable'] = true
opscode_expander['enable'] = true
elasticsearch['enable'] = true

Reconfigure:
-----------------------------------------------------------------------
SOLR006: The Chef Infra Server is configured to use its internal
         Elasticsearch installation, but RabbitMQ has been manually
         enabled. This is an unsupported configuration.
         Please update /etc/opscode/chef-server.rb to ensure that
         rabbitmq is disabled:
             rabbitmq['enable'] = false

SOLR007: The Chef Infra Server is configured to use its internal
         Elasticsearch installation, but opscode-expander has been
         manually enabled. This is an unsupported configuration.
         Please update /etc/opscode/chef-server.rb to ensure that
         opscode-expander is disabled:
             opscode_expander['enable'] = false
-----------------------------------------------------------------------

Config:
#opscode_solr4['enable'] = true
opscode_solr4['external'] = false
#rabbitmq['enable'] = true
#opscode_expander['enable'] = true
elasticsearch['enable'] = true

Reconfigure:
-----------------------------------------------------------------------
SOLR008: The Chef Infra Server is configured with
             opscode_solr4['external'] = false
         but this is incompatible with elasticsearch being enabled.
         Please remove this line from /etc/opscode/chef-server.rb.
-----------------------------------------------------------------------

Config:
#opscode_solr4['enable'] = true
opscode_solr4['external'] = true
rabbitmq['enable'] = true
opscode_expander['enable'] = true
elasticsearch['enable'] = false

Reconfigure:
-----------------------------------------------------------------------
SOLR010: No external url specified for Solr depsite opscode_solr4['external']
         being set to true. To use an external solr instance, please set
         opscode_solr4['external_url'] to the external solr endpoint.
-----------------------------------------------------------------------
```

Todo:
- Do we want to add any chef-backend preflight scenarios?

Notes:
Created https://github.com/chef/chef-server/issues/1986 with a gist from all the comments in the code.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
