### PR TITLE
[chef-server-ctl] Add new check-config command

### DIFF
--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -48,6 +48,15 @@ build do
         ]
       )
     end
+    File.open("#{install_dir}/embedded/cookbooks/check-config.json", "w") do |f|
+      f.write FFI_Yajl::Encoder.encode(
+        run_list: [
+          'recipe[private-chef::plugin_discovery]'
+          'recipe[private-chef::plugin_config_extensions]'
+          'recipe[private-chef::config_config]'
+        ]
+      )
+    end
     File.open("#{install_dir}/embedded/cookbooks/post_upgrade_cleanup.json", "w") do |f|
       f.write FFI_Yajl::Encoder.encode(
         run_list: [

--- a/omnibus/config/software/private-chef-cookbooks.rb
+++ b/omnibus/config/software/private-chef-cookbooks.rb
@@ -53,7 +53,7 @@ build do
         run_list: [
           'recipe[private-chef::plugin_discovery]'
           'recipe[private-chef::plugin_config_extensions]'
-          'recipe[private-chef::config_config]'
+          'recipe[private-chef::config]'
         ]
       )
     end

--- a/src/chef-server-ctl/plugins/check_config.rb
+++ b/src/chef-server-ctl/plugins/check_config.rb
@@ -1,0 +1,6 @@
+add_command_under_category "check-config", "general", "Load the chef-server configuration and run all preflight checks", 1 do
+  chef_args = "-l fatal"
+  attributes_path = "#{base_path}/embedded/cookbooks/check-config.json"
+  status = run_chef(attributes_path, chef_args)
+  exit!(status.success? ? 0 : 1)
+end


### PR DESCRIPTION
This new command runs just the configuration portion of the
reconfigure cookbooks, including the preflight checks.

Signed-off-by: Steven Danna <steve@chef.io>
