### PR TITLE
Add auto support for external search in migration for external elasticsearch

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -230,8 +230,8 @@ default['private_chef']['jetty']['log_directory'] = '/var/opt/opscode/opscode-so
 # Set this to point at a solr/cloudsearch installation
 # not controlled by chef-server
 #
-# default['private_chef']['opscode-solr4']['external'] defined in recipes/config.rb
-# default['private_chef']['opscode-solr4']['external_url'] defined in recipes/config.rb
+default['private_chef']['opscode-solr4']['external'] = false
+default['private_chef']['opscode-solr4']['external_url'] = nil
 default['private_chef']['opscode-solr4']['ha'] = false
 default['private_chef']['opscode-solr4']['dir'] = '/var/opt/opscode/opscode-solr4'
 default['private_chef']['opscode-solr4']['data_dir'] = '/var/opt/opscode/opscode-solr4/data'
@@ -298,6 +298,7 @@ elasticsearch['temp_directory'] = "#{var_base}/elasticsearch/tmp"
 elasticsearch['log_directory'] = "#{log_base}/elasticsearch"
 elasticsearch['log_rotation']['file_maxbytes'] = 104857600
 elasticsearch['log_rotation']['num_to_keep'] = 10
+elasticsearch['vip'] = '127.0.0.1'
 elasticsearch['listen'] = '127.0.0.1'
 elasticsearch['port'] = 9200
 elasticsearch['enable_gc_log'] = false

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -130,7 +130,7 @@ default['private_chef']['haproxy']['etcd_port'] = 2379
 ####
 # RabbitMQ
 ####
-default['private_chef']['rabbitmq']['enable'] = false
+# default['private_chef']['rabbitmq']['enable'] defined in recipes/config.rb
 default['private_chef']['rabbitmq']['ha'] = false
 default['private_chef']['rabbitmq']['dir'] = '/var/opt/opscode/rabbitmq'
 default['private_chef']['rabbitmq']['data_dir'] = '/var/opt/opscode/rabbitmq/db'
@@ -226,13 +226,12 @@ default['private_chef']['jetty']['log_directory'] = '/var/opt/opscode/opscode-so
 ####
 # Chef Solr 4
 ####
-default['private_chef']['opscode-solr4']['enable'] = false
-#
+# default['private_chef']['opscode-solr4']['enable'] defined in recipes/config.rb
 # Set this to point at a solr/cloudsearch installation
 # not controlled by chef-server
 #
-default['private_chef']['opscode-solr4']['external'] = true
-default['private_chef']['opscode-solr4']['external_url'] = "http://localhost:9200"
+# default['private_chef']['opscode-solr4']['external'] defined in recipes/config.rb
+# default['private_chef']['opscode-solr4']['external_url'] defined in recipes/config.rb
 default['private_chef']['opscode-solr4']['ha'] = false
 default['private_chef']['opscode-solr4']['dir'] = '/var/opt/opscode/opscode-solr4'
 default['private_chef']['opscode-solr4']['data_dir'] = '/var/opt/opscode/opscode-solr4/data'
@@ -268,7 +267,7 @@ default['private_chef']['opscode-solr4']['elasticsearch_replica_count'] = 1
 ####
 # Chef Expander
 ####
-default['private_chef']['opscode-expander']['enable'] = false
+# default['private_chef']['opscode-expander']['enable'] defined in recipes/config.rb
 default['private_chef']['opscode-expander']['ha'] = false
 default['private_chef']['opscode-expander']['dir'] = '/var/opt/opscode/opscode-expander'
 default['private_chef']['opscode-expander']['log_directory'] = '/var/log/opscode/opscode-expander'
@@ -285,7 +284,7 @@ default['private_chef']['opscode-expander']['retry_wait'] = 1
 var_base = '/var/opt/opscode'
 log_base = '/var/log/opscode'
 
-default['private_chef']['elasticsearch']['enable'] = true
+# default['private_chef']['elasticsearch']['enable'] defined in recipes/config.rb
 elasticsearch = default['private_chef']['elasticsearch']
 
 # These attributes cannot be overridden in chef-server.rb
@@ -444,8 +443,8 @@ default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 # general search settings used to set up chef_index
-default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch' # solr, elasticsearch
-default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch' # rabbitmq, batch, or inline
+# default['private_chef']['opscode-erchef']['search_provider'] defined in recipes/config.rb
+# default['private_chef']['opscode-erchef']['search_queue_mode'] defined in recipes/config.rb
 default['private_chef']['opscode-erchef']['search_batch_max_size'] = '5000000'
 default['private_chef']['opscode-erchef']['search_batch_max_wait'] = '10'
 # solr_service configuration for erchef. These are used to configure an opscoderl_httpc pool

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -121,6 +121,8 @@ module PrivateChef
 
   insecure_addon_compat true
 
+  deprecated_solr_indexing false
+
   class << self
     def from_file(filename)
       # We're overriding this here so that we can get more meaningful errors from
@@ -295,6 +297,7 @@ module PrivateChef
       set_target_array_if_not_nil(results['private_chef'], 'folsom_graphite', PrivateChef['folsom_graphite'])
       set_target_array_if_not_nil(results['private_chef'], 'profiles', PrivateChef['profiles'])
       set_target_array_if_not_nil(results['private_chef'], 'insecure_addon_compat', PrivateChef['insecure_addon_compat'])
+      set_target_array_if_not_nil(results['private_chef'], 'deprecated_solr_indexing', PrivateChef['deprecated_solr_indexing'])
       results
     end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -83,26 +83,37 @@ else
 
   # Add support for the external search case
   if PrivateChef['opscode_solr4']['external']
-    # Disable internal elasticsearch
-    node.default['private_chef']['rabbitmq']['enable'] = false
-    node.default['private_chef']['opscode-solr4']['enable'] = false
-    node.default['private_chef']['opscode-expander']['enable'] = false
+    # If the user has enabled external solr4 we keep these defaults
+    # more or less the same as they were before the change-over to
+    # Elasticsearch.
+    node.default['private_chef']['rabbitmq']['enable'] = true
+    node.default['private_chef']['opscode-solr4']['enable'] = true
+    node.default['private_chef']['opscode-expander']['enable'] = true
     node.default['private_chef']['elasticsearch']['enable'] = false
 
-    node.default['private_chef']['opscode-solr4']['external'] = false
-    node.default['private_chef']['opscode-solr4']['external_url'] = nil
+    node.default['private_chef']['opscode-erchef']['search_provider'] = 'solr' # solr, elasticsearch
+    node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'rabbitmq' # rabbitmq, batch, or inline
+  elsif PrivateChef['deprecated_solr_indexing']
+    # If the user has explicitly enabled the depcrecated solr mode, we
+    # start all services required to run the RabbitMQ -> Expander ->
+    # Solr indexing pipeline.
+    #
+    # This is the same as the block above, but we want to be explicit
+    # about it as the situation is very confusing.
+    node.default['private_chef']['rabbitmq']['enable'] = true
+    node.default['private_chef']['opscode-solr4']['enable'] = true
+    node.default['private_chef']['opscode-expander']['enable'] = true
+    node.default['private_chef']['elasticsearch']['enable'] = false
+
     node.default['private_chef']['opscode-erchef']['search_provider'] = 'solr' # solr, elasticsearch
     node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'rabbitmq' # rabbitmq, batch, or inline
   else
-    # The user does not have an external install for search;
-    # Enable internal elasticsearch
+    # Our new default of Elasticsearch indexing
     node.default['private_chef']['rabbitmq']['enable'] = false
     node.default['private_chef']['opscode-solr4']['enable'] = false
     node.default['private_chef']['opscode-expander']['enable'] = false
     node.default['private_chef']['elasticsearch']['enable'] = true
 
-    node.default['private_chef']['opscode-solr4']['external'] = true
-    node.default['private_chef']['opscode-solr4']['external_url'] = "http://localhost:9200"
     node.default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch' # solr, elasticsearch
     node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch' # rabbitmq, batch, or inline
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -87,8 +87,8 @@ else
     # more or less the same as they were before the change-over to
     # Elasticsearch.
     node.default['private_chef']['rabbitmq']['enable'] = true
-    node.default['private_chef']['opscode-solr4']['enable'] = true
     node.default['private_chef']['opscode-expander']['enable'] = true
+    node.default['private_chef']['opscode-solr4']['enable'] = false
     node.default['private_chef']['elasticsearch']['enable'] = false
 
     node.default['private_chef']['opscode-erchef']['search_provider'] = 'solr' # solr, elasticsearch

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -81,6 +81,32 @@ else
     PrivateChef.from_file(chef_server_path)
   end
 
+  # Add support for the external search case
+  if PrivateChef['opscode_solr4']['external']
+    # Disable internal elasticsearch
+    node.default['private_chef']['rabbitmq']['enable'] = false
+    node.default['private_chef']['opscode-solr4']['enable'] = false
+    node.default['private_chef']['opscode-expander']['enable'] = false
+    node.default['private_chef']['elasticsearch']['enable'] = false
+
+    node.default['private_chef']['opscode-solr4']['external'] = false
+    node.default['private_chef']['opscode-solr4']['external_url'] = nil
+    node.default['private_chef']['opscode-erchef']['search_provider'] = 'solr' # solr, elasticsearch
+    node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'rabbitmq' # rabbitmq, batch, or inline
+  else
+    # The user does not have an external install for search;
+    # Enable internal elasticsearch
+    node.default['private_chef']['rabbitmq']['enable'] = false
+    node.default['private_chef']['opscode-solr4']['enable'] = false
+    node.default['private_chef']['opscode-expander']['enable'] = false
+    node.default['private_chef']['elasticsearch']['enable'] = true
+
+    node.default['private_chef']['opscode-solr4']['external'] = true
+    node.default['private_chef']['opscode-solr4']['external_url'] = "http://localhost:9200"
+    node.default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch' # solr, elasticsearch
+    node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch' # rabbitmq, batch, or inline
+  end
+
   # Bail out if something is wrong in our configuration.
   # NOTE: Over time, we can move the validation done in private_chef.rb
   #       here as well.

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
@@ -141,6 +141,10 @@ link '/opt/opscode/embedded/elasticsearch/config' do
   to elasticsearch_conf_dir
 end
 
+component_runit_service 'opscode-solr4' do
+  action :disable
+end
+
 directory '/opt/opscode/sv/opscode-solr4' do
   recursive true
   action :delete
@@ -148,3 +152,5 @@ end
 
 # Define resource for elasticsearch component_runit_service
 component_runit_service 'elasticsearch'
+
+include_recipe 'private-chef::elasticsearch_index'

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch_index.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch_index.rb
@@ -1,5 +1,5 @@
 # Author:: Steven Danna
-# Copyright:: 2015-2018 Chef Software, Inc.
+# Copyright:: 2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 helper = OmnibusHelper.new(node)
-case node['private_chef']['opscode-erchef']['search_provider']
-when 'solr'
-  Chef::Log.warn('External Solr Support does not include configuring the Solr schema.')
-when 'elasticsearch'
-  include_recipe 'private-chef::elasticsearch_index'
+elasticsearch_index 'chef' do
+  server_url lazy { helper.solr_url }
+  index_definition lazy { helper.es_index_definition }
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-solr4.rb
@@ -165,6 +165,10 @@ command << " -jar '#{solr_jetty_dir}/start.jar'"
 
 node.default['private_chef']['opscode-solr4']['command'] = command
 
+component_runit_service 'elasticsearch' do
+  action :disable
+end
+
 directory '/opt/opscode/sv/elasticsearch' do
   recursive true
   action :delete

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
@@ -117,8 +117,7 @@ describe OmnibusHelper do
     let(:client) { double(Chef::HTTP) }
 
     context 'when elastic search is disabled' do
-      let(:external) { false }
-      let(:external_url) { nil }
+      let(:provider) { 'solr' }
       let(:elastic_version) { '50.0' }
 
       it 'should return a default version 0' do


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

With the current preflight checks (https://github.com/chef/chef-server/pull/1984)
If the user is on external elasticsearch, he will need to add `elasticsearch['enable'] = false` to chef-server.rb to get through installing 13.3.

This takes care of that condition by default.

TODO:
- Edit / Delete that preflight check change that enforces adding of this config.
- Check that the check_config ctl command works as expected. 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
