### PR TITLE
fix the chef-server.rb template for tiered setups

### DIFF
--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
@@ -1,4 +1,4 @@
-topology = "tier"
+topology "tier"
 
 server "backend.internal",
   :ipaddress => "${back_end_ip}/${cidr}",
@@ -12,7 +12,7 @@ server "frontend.internal",
   :ipaddress => "${front_end_ip}/${cidr}",
   :role => "frontend"
 
-api_fqdn = "frontend.internal"
+api_fqdn "frontend.internal"
 
 # The public IPV6 address is not bound to the network interface of the machine.
 # rhel-7 and rhel-8 are able to resolve this but the older rhel-6 is not.

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
@@ -1,4 +1,4 @@
-topology = "tier"
+topology "tier"
 
 server "backend.internal",
   :ipaddress => "${back_end_ip}/${cidr}",
@@ -12,7 +12,7 @@ server "frontend.internal",
   :ipaddress => "${front_end_ip}/${cidr}",
   :role => "frontend"
 
-api_fqdn = "frontend.internal"
+api_fqdn "frontend.internal"
 
 # The public IPV6 address is not bound to the network interface of the machine.
 # rhel-7 and rhel-8 are able to resolve this but the older rhel-6 is not.


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

The tiered environment gets setup as a standalone currently in terraform. This change will fix that.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
