### PR TITLE
[reindex] Handle more reindexing failure cases

### DIFF
--- a/src/oc_erchef/apps/chef_index/src/chef_index.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index.erl
@@ -122,7 +122,7 @@ add_batch(Batch) ->
                 R -> {error, R}
             end;
         {error, Results, FailedJobs} ->
-            {error, [not_ok(Results)|FailedJobs]}
+            {error, lists:append(not_ok(Results), FailedJobs)}
     end.
 
 add_batch_item_with_retries(Item) ->


### PR DESCRIPTION
Before:

```
escript: exception error: no case clause matching
                 {badrpc,
                     {'EXIT',
                         {{badmatch,
                              {<<"unknown">>,
                               [101,114,114,111,114,58,32,"[]"]}},
                          [{chef_reindex,log_failures,2,
                               [{file,
....
```

After:

```
The following objects failed to be reindexed in the last batch:

        environment[5c8b31ccd9c74533ecb25d569b146f07]: timeout
        client[5c8b31ccd9c749c529cd67bbbe258e3b]: timeout
Failed to enqueue data for pedant_testorg_api_15126!
```

Signed-off-by: Steven Danna <steve@chef.io>