### PR TITLE
[terraform] Fix creating tiered setup.

### DIFF
--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -39,6 +39,8 @@ data "template_file" "hosts_config" {
   vars = {
     back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
     front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
+    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
   }
 }
 
@@ -50,6 +52,8 @@ data "template_file" "chef_server_config" {
     enable_ipv6  = var.enable_ipv6
     back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
     front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
+    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
     cidr         = var.enable_ipv6 == "true" ? 64 : 32
   }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
@@ -1,18 +1,18 @@
 topology "tier"
 
-server "backend.internal",
+server "${back_end_node_fqdn}",
   :ipaddress => "${back_end_ip}/${cidr}",
   :role => "backend",
   :bootstrap => true
 
-backend_vip "backend.internal",
+backend_vip "${back_end_node_fqdn}",
   :ipaddress => "${back_end_ip}/${cidr}"
 
-server "frontend.internal",
+server "${front_end_node_fqdn}",
   :ipaddress => "${front_end_ip}/${cidr}",
   :role => "frontend"
 
-api_fqdn "frontend.internal"
+api_fqdn "${front_end_node_fqdn}"
 
 # The public IPV6 address is not bound to the network interface of the machine.
 # rhel-7 and rhel-8 are able to resolve this but the older rhel-6 is not.
@@ -21,7 +21,7 @@ require 'ipaddr'
 if IPAddr.new("${front_end_ip}/${cidr}").ipv6?
   profiles['root_url'] = 'http://[::1]:9998'
 else
-  profiles['root_url'] = 'http://frontend.internal:9998'
+  profiles['root_url'] = 'http://${front_end_node_fqdn}:9998'
 end
 
 opscode_erchef['keygen_start_size'] = 30

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/hosts.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/hosts.tpl
@@ -8,6 +8,6 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
 
-${back_end_ip} backend.internal
+${back_end_ip} ${back_end_node_fqdn} #backend.internal
 
-${front_end_ip} frontend.internal
+${front_end_ip} ${front_end_node_fqdn} #frontend.internal

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -39,6 +39,8 @@ data "template_file" "hosts_config" {
   vars = {
     back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
     front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
+    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
   }
 }
 
@@ -50,6 +52,8 @@ data "template_file" "chef_server_config" {
     enable_ipv6  = var.enable_ipv6
     back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
     front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
+    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
     cidr         = var.enable_ipv6 == "true" ? 64 : 32
   }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
@@ -1,18 +1,18 @@
 topology "tier"
 
-server "backend.internal",
+server "${back_end_node_fqdn}",
   :ipaddress => "${back_end_ip}/${cidr}",
   :role => "backend",
   :bootstrap => true
 
-backend_vip "backend.internal",
+backend_vip "${back_end_node_fqdn}",
   :ipaddress => "${back_end_ip}/${cidr}"
 
-server "frontend.internal",
+server "${front_end_node_fqdn}",
   :ipaddress => "${front_end_ip}/${cidr}",
   :role => "frontend"
 
-api_fqdn "frontend.internal"
+api_fqdn "${front_end_node_fqdn}"
 
 # The public IPV6 address is not bound to the network interface of the machine.
 # rhel-7 and rhel-8 are able to resolve this but the older rhel-6 is not.
@@ -21,7 +21,7 @@ require 'ipaddr'
 if IPAddr.new("${front_end_ip}/${cidr}").ipv6?
   profiles['root_url'] = 'http://[::1]:9998'
 else
-  profiles['root_url'] = 'http://frontend.internal:9998'
+  profiles['root_url'] = 'http://${front_end_node_fqdn}:9998'
 end
 
 opscode_erchef['keygen_start_size'] = 30

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/hosts.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/hosts.tpl
@@ -8,6 +8,6 @@ ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 ff02::3 ip6-allhosts
 
-${back_end_ip} backend.internal
+${back_end_ip} ${back_end_node_fqdn} #backend.internal
 
-${front_end_ip} frontend.internal
+${front_end_ip} ${front_end_node_fqdn} #frontend.internal


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

Ideally chef-server should respect the api_fqdn set by the user.
But it expects the `node fqdn` matching `ohai fqdn`

Updating the terraform templates for tiered scenario to provide the same.

### Issues Resolved

Should be able to create terraform tiered fresh install and upgrade scenarios.
