### PR TITLE
[erchef] small optimization in chef_index_batch

### DIFF
--- a/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
@@ -285,6 +285,8 @@ handle_cast({stats_update, TotalDocs, {AvgQueueLatency,AvgSuccessLatency}, Resp}
             prometheus_counter:inc(chef_index_batch_failed_docs_total, TotalDocs),
             {noreply, State1}
     end;
+handle_cast(flush, State = #chef_idx_batch_state{item_queue = []}) ->
+    {noreply, State};
 handle_cast(flush, State) ->
     State1 = flush(State),
     prometheus_gauge:set(chef_index_batch_current_batch_size_bytes, 0),


### PR DESCRIPTION
Right now chef_index_batch handles a message at least once every 10ms
even on an idle server because of the flusher process. Special
handling the empty case here helps a bit with our idle CPU usage.

Signed-off-by: Steven Danna <steve@chef.io>