### PR TITLE
[cookbooks] Don't generate trailing comma in solr_url

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -224,7 +224,7 @@ class OmnibusHelper
     elsif node['private_chef']['deprecated_solr_indexing']
       "http://#{vip_for_uri('opscode-solr4')}:#{node['private_chef']['opscode-solr4']['port']}/solr"
     else
-      "http://#{vip_for_uri('elasticsearch')}:#{node['private_chef']['elasticsearch']['port']}/"
+      "http://#{vip_for_uri('elasticsearch')}:#{node['private_chef']['elasticsearch']['port']}"
     end
   end
 


### PR DESCRIPTION
This trailing comma appears to break a few tests.

Signed-off-by: Steven Danna <steve@chef.io>
