### PR TITLE
Automatically announce release on promotion to stable

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -exou pipefail
+
+# Download the release-notes for our specific build
+curl -o release-notes.md "https://packages.chef.io/release-notes/${EXPEDITOR_PRODUCT_KEY}/${EXPEDITOR_VERSION}.md"
+
+topic_title="Chef Server $EXPEDITOR_VERSION Released!"
+topic_body=$(cat <<EOH
+We are delighted to announce the availability of version $EXPEDITOR_VERSION of Chef Server.
+$(cat release-notes.md)
+---
+## Get the Build
+
+You can download binaries directly from [downloads.chef.io](https://downloads.chef.io/$EXPEDITOR_PRODUCT_KEY/$EXPEDITOR_VERSION).
+EOH
+)
+
+# Use Expeditor's built in Bash helper to post our message: https://git.io/JvxPm
+post_discourse_release_announcement "$topic_title" "$topic_body"
+
+# Cleanup
+rm release-notes.md

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -90,15 +90,13 @@ subscriptions:
     actions:
       - bash:.expeditor/promote_harts_and_containers.sh:
           post_commit: true
-      - bash:.expeditor/purge_cdn.sh:
-          post_commit: true
+      - purge_packages_chef_io_fastly:{{target_channel}}/chef-server/latest
   - workload: artifact_published:stable:chef-server:*
     actions:
       - built_in:rollover_changelog
       - bash:.expeditor/promote_harts_and_containers.sh:
           post_commit: true
-      - bash:.expeditor/purge_cdn.sh:
-          post_commit: true
+      - purge_packages_chef_io_fastly:{{target_channel}}/chef-server/latest
       - built_in:notify_chefio_slack_channels
   - workload: schedule_triggered:chef/chef-server:master:nightly_build:*
     actions:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -96,7 +96,11 @@ subscriptions:
       - built_in:rollover_changelog
       - bash:.expeditor/promote_harts_and_containers.sh:
           post_commit: true
+      - bash:.expeditor/publish-release-notes.sh:
+          post_commit: true
       - purge_packages_chef_io_fastly:{{target_channel}}/chef-server/latest
+      - bash:.expeditor/announce-release.sh:
+          post_commit: true
       - built_in:notify_chefio_slack_channels
   - workload: schedule_triggered:chef/chef-server:master:nightly_build:*
     actions:

--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eou pipefail
+
+git clone https://x-access-token:${GITHUB_TOKEN}@github.com/chef/chef-server.wiki.git
+
+pushd ./chef-server.wiki
+  # Publish release notes to S3
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${EXPEDITOR_PRODUCT_KEY}/${EXPEDITOR_VERSION}.md" --acl public-read --content-type "text/plain" --profile chef-cd
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/${EXPEDITOR_CHANNEL}/latest/${EXPEDITOR_PRODUCT_KEY}/release-notes.md" --acl public-read --content-type "text/plain" --profile chef-cd
+
+  # Reset "Stable Release Notes" wiki page
+  cat >./Pending-Release-Notes.md <<EOH
+## New Features
+-
+## Improvements
+-
+## Bug Fixes
+-
+## Backward Incompatibilities
+-
+EOH
+
+  # Push changes back up to GitHub
+  git add .
+  git commit -m "Release Notes for promoted build $EXPEDITOR_VERSION"
+  git push origin master
+popd
+
+rm -rf chef-server.wiki

--- a/.expeditor/purge_cdn.sh
+++ b/.expeditor/purge_cdn.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -eou pipefail
-
-target_channel="${EXPEDITOR_CHANNEL:-unstable}"
-
-echo "Purging '${target_channel}/chef-server/latest' Surrogate Key group from Fastly"
-curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" "https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${target_channel}/chef-server/latest"


### PR DESCRIPTION
This commit fully brings the `chef/chef-server` repo onto our streamlined release notes process:
- Pending release notes are added to https://github.com/chef/chef-server/wiki/Pending-Release-Notes
- On the promotion to stable:
  - Release notes are published to packages.chef.io
  - A release announcement is published to https://discourse.chef.io/c/chef-release/9

Signed-off-by: Seth Chisamore <schisamo@chef.io>