### PR TITLE
[cookbooks/elasticsearch] Bind to correct address and fix other warnings

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/files/default/elasticsearch/es_log4j2.properties
+++ b/omnibus/files/private-chef-cookbooks/private-chef/files/default/elasticsearch/es_log4j2.properties
@@ -11,4 +11,3 @@ appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%ma
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console
-rootLogger.appenderRef.rolling.ref = rolling

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -386,7 +386,7 @@ module PrivateChef
       PrivateChef['bookshelf']['listen'] ||= PrivateChef['default_listen_address']
       PrivateChef['rabbitmq']['node_ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['redis_lb']['listen'] ||= PrivateChef['default_listen_address']
-      PrivateChef['elasticsearch']['ip_address'] ||= PrivateChef['default_listen_address']
+      PrivateChef['elasticsearch']['listen'] ||= PrivateChef['default_listen_address']
       PrivateChef['opscode_solr4']['ip_address'] ||= PrivateChef['default_listen_address']
       PrivateChef['postgresql']['listen_address'] ||= '*' # PrivateChef["default_listen_address"]
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-elasticsearch-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-elasticsearch-run.erb
@@ -1,13 +1,13 @@
 #!/bin/sh
 exec 2>&1
-ulimit -n 50000
+
+ulimit -n 65536
 
 export ES_HOME=<%= node['private_chef']['elasticsearch']['dir'] %>            #/var/opt/opscode/elasticsearch
-export ES_DATA=<%= node['private_chef']['elasticsearch']['dir'] %>/data       #/var/opt/opscode/elasticsearch/data   
-export JAVA_HOME=/opt/opscode/embedded/open-jre/bin
+export ES_DATA=<%= node['private_chef']['elasticsearch']['dir'] %>/data       #/var/opt/opscode/elasticsearch/data
+export JAVA_HOME=/opt/opscode/embedded/open-jre/
 export ES_PATH_CONF=<%= node['private_chef']['elasticsearch']['dir'] %>/config
-export PATH=<%= node['private_chef']['install_path'] %>/embedded/bin:$JAVA_HOME:$ES_HOME:$PATH #/opt/opscode/embedded/bin
+export PATH=<%= node['private_chef']['install_path'] %>/embedded/bin:$JAVA_HOME/bin:$ES_HOME:$PATH #/opt/opscode/embedded/bin
 
 cd $ES_HOME
 exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> <%= node['private_chef']['install_path'] %>/embedded/elasticsearch/bin/elasticsearch
-


### PR DESCRIPTION
We were using the wrong attribute (`ip_address` instead of `listen`)
when setting the backend defaults, leading to ES only listening on
localhost on the backend.

After fixing this, I also found that we were failing bootstrap checks
that ES enforces once you are listening on a public interface.

Finally, this fixes two warning related to bad configuration we seemed
to be passing (there are more warnings remaining).

Signed-off-by: Steven Danna <steve@chef.io>
