### PR TITLE
[integration] temporarily remove openldap scenarios

### DIFF
--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -76,80 +76,80 @@ steps:
       executor:
         docker:
 
-  - label: ':terraform: external-openldap-ipv4-rhel-6'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: rhel-6
-      ENABLE_IPV6: false
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv4-rhel-6'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: rhel-6
+  #     ENABLE_IPV6: false
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv4-rhel-7'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: rhel-7
-      ENABLE_IPV6: false
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv4-rhel-7'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: rhel-7
+  #     ENABLE_IPV6: false
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv4-rhel-8'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: rhel-8
-      ENABLE_IPV6: false
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv4-rhel-8'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: rhel-8
+  #     ENABLE_IPV6: false
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv4-ubuntu-16.04'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: ubuntu-16.04
-      ENABLE_IPV6: false
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv4-ubuntu-16.04'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: ubuntu-16.04
+  #     ENABLE_IPV6: false
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv4-ubuntu-18.04'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: ubuntu-18.04
-      ENABLE_IPV6: false
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv4-ubuntu-18.04'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: ubuntu-18.04
+  #     ENABLE_IPV6: false
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
   - label: ':terraform: fips-ipv4-rhel-6'
     command: .expeditor/integration_test.pipeline.sh apply
@@ -546,80 +546,80 @@ steps:
       executor:
         docker:
 
-  - label: ':terraform: external-openldap-ipv6-rhel-6'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: rhel-6
-      ENABLE_IPV6: true
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv6-rhel-6'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: rhel-6
+  #     ENABLE_IPV6: true
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv6-rhel-7'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: rhel-7
-      ENABLE_IPV6: true
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv6-rhel-7'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: rhel-7
+  #     ENABLE_IPV6: true
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv6-rhel-8'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: rhel-8
-      ENABLE_IPV6: true
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv6-rhel-8'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: rhel-8
+  #     ENABLE_IPV6: true
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv6-ubuntu-16.04'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: ubuntu-16.04
-      ENABLE_IPV6: true
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv6-ubuntu-16.04'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: ubuntu-16.04
+  #     ENABLE_IPV6: true
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
-  - label: ':terraform: external-openldap-ipv6-ubuntu-18.04'
-    command: .expeditor/integration_test.pipeline.sh apply
-    artifact_paths:
-      - ./integration_test.log
-      - ./*capture_paths.tar.gz
-    env:
-      SCENARIO: omnibus-external-openldap
-      PLATFORM: ubuntu-18.04
-      ENABLE_IPV6: true
-    expeditor:
-      accounts:
-        - aws/chef-cd
-      executor:
-        docker:
+  # - label: ':terraform: external-openldap-ipv6-ubuntu-18.04'
+  #   command: .expeditor/integration_test.pipeline.sh apply
+  #   artifact_paths:
+  #     - ./integration_test.log
+  #     - ./*capture_paths.tar.gz
+  #   env:
+  #     SCENARIO: omnibus-external-openldap
+  #     PLATFORM: ubuntu-18.04
+  #     ENABLE_IPV6: true
+  #   expeditor:
+  #     accounts:
+  #       - aws/chef-cd
+  #     executor:
+  #       docker:
 
   - label: ':terraform: fips-ipv6-rhel-6'
     command: .expeditor/integration_test.pipeline.sh apply


### PR DESCRIPTION
Right now, the integration pipeline is not in good shape. To get
traction on it, we need to narrow our focus. These openldap tests have
not passed on master for a considerable amount of time, with failures
in their setup.

Signed-off-by: Steven Danna <steve@chef.io>
