### PR TITLE
Skip checking for the presence of the postgres data dir on the front end of a tier install

### DIFF
--- a/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
@@ -72,6 +72,9 @@ describe "running configs required by Chef Server and plugins", :config do
     it "postgresql/data_dir" do
       if config['postgresql']['external']
         skip "not used for external postgresql"
+      # These tests should not run on the frontend of a tiered setup.
+      elsif (Pedant::Config.topology == "tiered" && Pedant::Config.role == "frontend")
+        skip "no postgresql installed on frontend of a tiered install"
       else
         expect(File.exists?(config['postgresql']['data_dir'])).to be true
       end

--- a/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
@@ -102,6 +102,9 @@ describe "running configs required by chef-server-ctl", :config do
 
       if config["postgresql"]["external"]
         skip "not used for external postgresql"
+      # These tests should not run on the frontend of a tiered setup.
+      elsif (Pedant::Config.topology == "tiered" && Pedant::Config.role == "frontend")
+        skip "no postgresql installed on front-end of a tiered server"
       else
         expect(File.exist?(config["postgresql"]["data_dir"])).to eq(true)
       end

--- a/oc-chef-pedant/spec/running_configs/pushy_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/pushy_spec.rb
@@ -36,6 +36,9 @@ describe "running configs required by Pushy Server", :config do
   it "postgresql/data_dir" do
     if config['postgresql']['external']
       skip "not used for external postgresql"
+    # These tests should not run on the frontend of a tiered setup.
+    elsif (Pedant::Config.topology == "tiered" && Pedant::Config.role == "frontend")
+      skip "no postgresql installed on frontend of a tiered install"
     else
       expect(File.exists?(config['postgresql']['data_dir'])).to be true
     end

--- a/oc-chef-pedant/spec/running_configs/reporting_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/reporting_spec.rb
@@ -26,6 +26,9 @@ describe "running configs required by Reporting", :config do
     it "postgresql/data_dir" do
       if config['postgresql']['external']
         skip "not used for external postgresql"
+      # These tests should not run on the frontend of a tiered setup.
+      elsif (Pedant::Config.topology == "tiered" && Pedant::Config.role == "frontend")
+        skip "no postgresql installed on frontend of a tiered install"
       else
         expect(File.exists?(config['postgresql']['data_dir'])).to be true
       end


### PR DESCRIPTION
It is preferred to run the pedant tests on the backend of the tiered Chef Infra Server.

Signed-off-by: Prajakta Purohit <prajakta@chef.io>