### PR TITLE
[chef-server-ctl] Add root check

### DIFF
--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -253,6 +253,11 @@ EOM
   end
 end
 
+if Process.euid != 0
+  puts "This command must be run as root"
+  exit 1
+end
+
 # This replaces the default bin/omnibus-ctl command
 require 'pathname'
 file_path = Pathname.new(__FILE__)


### PR DESCRIPTION
This root check was lost when we moved to an app-bundled executable.
Nearly all chef-server-ctl commands require root. Without this check,
the user gets a strack trace and a permissions error.

Signed-off-by: Steven Danna <steve@chef.io>