### PR TITLE
[terraform] Don't use quotes in the makefile

### DIFF
--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -34,7 +34,7 @@ endif
 ifneq ($(PLATFORM),)
 	export TF_VAR_platform ?= $(PLATFORM)
 else
-	export TF_VAR_platform ?= "ubuntu-18.04"
+	export TF_VAR_platform ?= ubuntu-18.04
 endif
 
 ifneq ($(INSTALL_VERSION),)
@@ -55,7 +55,7 @@ endif
 ifneq ($(ENABLE_IPV6),)
 	export TF_VAR_enable_ipv6 ?= $(ENABLE_IPV6)
 else
-	export TF_VAR_enable_ipv6 ?= "true"
+	export TF_VAR_enable_ipv6 ?= true
 endif
 
 ifneq ($(ENABLE_SMOKE_TEST),)

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
@@ -34,9 +34,4 @@ insecure_addon_compat = false
 
 data_collector['token'] = 'foobar' unless data_collector.nil?
 
-# TODO(ssd) 2020-05-20: We explicitly check that this is a boolean in
-# our configuration pedant, but don't seem to have a preflight check
-# for this. It may be too late to add a preflight check without
-# breaking some people.  We could alternatively look at making the
-# pedant tests more liberal.
-nginx['enable_ipv6'] = ${enable_ipv6} == "true"
+nginx['enable_ipv6'] = ${enable_ipv6}

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
@@ -34,9 +34,4 @@ insecure_addon_compat = false
 
 data_collector['token'] = 'foobar' unless data_collector.nil?
 
-# TODO(ssd) 2020-05-20: We explicitly check that this is a boolean in
-# our configuration pedant, but don't seem to have a preflight check
-# for this. It may be too late to add a preflight check without
-# breaking some people.  We could alternatively look at making the
-# pedant tests more liberal.
-nginx['enable_ipv6'] = ${enable_ipv6} == "true"
+nginx['enable_ipv6'] = ${enable_ipv6}


### PR DESCRIPTION
With the quotes in place, the underlying terraform vars would end up
with quotes in them, breaking a lot of the logic.  After we fix this,
we should probably undo

https://github.com/chef/chef-server/commit/e59d9cfc1141a42fc250359d1de92b195fa66812

which was me not realizing what was actually happening.

Signed-off-by: Steven Danna <steve@chef.io>