### PR TITLE
Fix the ipv6 scenario

### DIFF
--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -74,10 +74,6 @@ ifneq ($(ENABLE_GATHER_LOGS_TEST),)
     export TF_VAR_enable_gather_logs_test ?= $(ENABLE_GATHER_LOGS_TEST)
 endif
 
-ifneq ($(ENABLE_ADDON_PUSH_JOBS),)
-    export TF_VAR_enable_addon_push_jobs ?= $(ENABLE_ADDON_PUSH_JOBS)
-endif
-
 ifneq ($(ENABLE_ADDON_CHEF_MANAGE),)
     export TF_VAR_enable_addon_chef_manage ?= $(ENABLE_ADDON_CHEF_MANAGE)
 endif
@@ -106,6 +102,17 @@ else
 	export TF_VAR_platform = $(shell sed 's/.*-ipv.-//' <<<$(WORKSPACE))
 endif
 
+ifeq ($(ENABLE_ADDON_PUSH_JOBS),)
+    SCENARIO_IS_TIER = $(shell grep -q '\-tiered-' <<<$(WORKSPACE) && echo true || echo false)
+    ifeq ($(TF_VAR_enable_ipv6)$(SCENARIO_IS_TIER),truetrue)
+        export TF_VAR_enable_addon_push_jobs ?= false
+    else
+        export TF_VAR_enable_addon_push_jobs ?= true
+    endif
+else
+    export TF_VAR_enable_addon_push_jobs ?= $(ENABLE_ADDON_PUSH_JOBS)
+endif
+
 verify-aws:
 ifeq ($(TF_VAR_aws_department),)
 	$(error The department that owns the resources must be provided via the "AWS_DEPT" environment variable.)
@@ -114,6 +121,15 @@ endif
 ifeq ($(TF_VAR_aws_contact),)
 	$(error The primary contact for the resources must be provided via the "AWS_CONTACT" environment variable.)
 endif
+
+describe-workspace:
+	@echo "           SCENARIO: $(TF_VAR_scenario)"
+	@echo "           PLATFORM: $(TF_VAR_platform)"
+	@echo "INSTALL VERSION URL: $(TF_VAR_install_version_url)"
+	@echo "UPGRADE VERSION URL: $(TF_VAR_upgrade_version_url)"
+	@echo "               IPv6: $(TF_VAR_enable_ipv6)"
+	@echo "              PUSHY: $(TF_VAR_enable_addon_push_jobs)"
+	@echo "             MANAGE: $(TF_VAR_enable_addon_chef_manage)"
 
 create-vpc: verify-aws
 	@set -e; \
@@ -169,7 +185,7 @@ show: init
 	terraform workspace select "$(WORKSPACE)" && \
 	terraform show
 
-apply: init
+apply: init describe-workspace
 	@set -e; \
 	echo -e "\n\nApplying $(WORKSPACE)\n" && \
 	cd scenarios/$(TF_VAR_scenario) && \

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/main.tf
@@ -37,10 +37,10 @@ data "template_file" "hosts_config" {
   template = file("${path.module}/templates/hosts.tpl")
 
   vars = {
-    back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
-    front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
-    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
-    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
+    back_end_ip         = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
+    front_end_ip        = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    back_end_node_fqdn  = module.back_end.private_ipv4_dns
+    front_end_node_fqdn = module.front_end.private_ipv4_dns
   }
 }
 
@@ -49,12 +49,12 @@ data "template_file" "chef_server_config" {
   template = file("${path.module}/templates/chef-server.rb.tpl")
 
   vars = {
-    enable_ipv6  = var.enable_ipv6
-    back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
-    front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
-    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
-    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
-    cidr         = var.enable_ipv6 == "true" ? 64 : 32
+    enable_ipv6         = var.enable_ipv6
+    back_end_ip         = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
+    front_end_ip        = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    back_end_node_fqdn  = module.back_end.private_ipv4_dns
+    front_end_node_fqdn = module.front_end.private_ipv4_dns
+    cidr                = var.enable_ipv6 == "true" ? 64 : 32
   }
 }
 

--- a/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-fresh-install/templates/chef-server.rb.tpl
@@ -34,4 +34,7 @@ insecure_addon_compat = false
 
 data_collector['token'] = 'foobar' unless data_collector.nil?
 
+if ${enable_ipv6}
+  ip_version "ipv6"
+end
 nginx['enable_ipv6'] = ${enable_ipv6}

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -53,7 +53,7 @@ data "template_file" "chef_server_config" {
     back_end_ip         = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
     front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
     back_end_node_fqdn  = module.back_end.private_ipv4_dns
-    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
+    front_end_node_fqdn = module.front_end.private_ipv4_dns
     cidr                = var.enable_ipv6 == "true" ? 64 : 32
   }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -37,10 +37,10 @@ data "template_file" "hosts_config" {
   template = file("${path.module}/templates/hosts.tpl")
 
   vars = {
-    back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
-    front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
-    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
-    front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
+    back_end_ip         = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
+    front_end_ip        = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    back_end_node_fqdn  = module.back_end.private_ipv4_dns
+    front_end_node_fqdn = module.front_end.private_ipv4_dns
   }
 }
 
@@ -49,12 +49,12 @@ data "template_file" "chef_server_config" {
   template = file("${path.module}/templates/chef-server.rb.tpl")
 
   vars = {
-    enable_ipv6  = var.enable_ipv6
-    back_end_ip  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
+    enable_ipv6         = var.enable_ipv6
+    back_end_ip         = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
     front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
-    back_end_node_fqdn  = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_dns
+    back_end_node_fqdn  = module.back_end.private_ipv4_dns
     front_end_node_fqdn = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_dns
-    cidr         = var.enable_ipv6 == "true" ? 64 : 32
+    cidr                = var.enable_ipv6 == "true" ? 64 : 32
   }
 }
 

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/templates/chef-server.rb.tpl
@@ -34,4 +34,7 @@ insecure_addon_compat = false
 
 data_collector['token'] = 'foobar' unless data_collector.nil?
 
+if ${enable_ipv6}
+  ip_version "ipv6"
+end
 nginx['enable_ipv6'] = ${enable_ipv6}


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

The server block should always be defined with `ohai fqdn` and ohai always returns the Private IPv4 DNS.

These changes should fix the following error:
```
null_resource.back_end_config (remote-exec): [2020-05-21T00:47:46+00:00] FATAL: No server configuration found for "ip-10-0-16-5.us-west-1.compute.internal" in /etc/opscode/chef-server.rb.
null_resource.back_end_config (remote-exec): Server configuration exists for the following hostnames:

null_resource.back_end_config (remote-exec):   2600:1f1c:f66:5801:48bd:a183:39a4:cb1a
null_resource.back_end_config (remote-exec):   2600:1f1c:f66:5801:49e2:2ac:7736:ab2b
```
https://buildkite.com/chef/chef-chef-server-master-integration-test/builds/114#a557313d-9f12-4d81-8f32-8e3b78cab48f