### PR TITLE
[terraform/pedant] Hopefully fix LDAP integration tests

### DIFF
--- a/dev/cookbooks/provisioning/recipes/ldap-server.rb
+++ b/dev/cookbooks/provisioning/recipes/ldap-server.rb
@@ -1,7 +1,8 @@
-
 #
 # Install Packages
 #
+apt_update if node['platform'] == 'ubuntu'
+
 package 'ldap-utils' do
   action :install
 end

--- a/oc-chef-pedant/spec/api/authenticate_user_spec.rb
+++ b/oc-chef-pedant/spec/api/authenticate_user_spec.rb
@@ -2,7 +2,7 @@
 require 'pedant/rspec/common'
 require 'json'
 
-describe 'authenticate_user', :users do
+describe 'authenticate_user', :users, :ldap do
   let(:username) {
     if platform.ldap_testing
       platform.ldap[:account_name]


### PR DESCRIPTION
- Eldap (erlang library) appears to have a bug so that it doesn't
  actually work for IPv6 address.

- A subset of tests appear to fail with LDAP turned on. I think this
  is because they assume local authentication should work when in
  reality it doesn't. We should investigate this a bit further.

- Without an `apt-get update` we can't install ldap

Signed-off-by: Steven Danna <steve@chef.io>
