### PR TITLE
[cookbook] Quote ES host in template

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch.yml.erb
@@ -10,7 +10,9 @@ cluster.name: <%= @cluster_name %>
 node.name: <%= node['fqdn'] %>
 path.data:  <%= @data_dir %>
 path.logs: <%= @log_directory %>
-network.host: <%= @listen  %>
+# NOTE(ssd) 2020-05-21: This value must be quoted to handle values
+# such as ::
+network.host: "<%= @listen %>"
 # Reference: http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html
 #            http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html
 #            http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html


### PR DESCRIPTION
We may want this configuration item set to "::" which causes the
following error without quotes:

```
2020-05-21_08:29:36.45180 SettingsException[Failed to load settings from [elasticsearch.yml]]; nested: MarkedYAMLException[mapping values are not allowed here
2020-05-21_08:29:36.45183  in 'reader', line 9, column 16:
2020-05-21_08:29:36.45183     network.host: ::
2020-05-21_08:29:36.45183                    ^
2020-05-21_08:29:36.45184
```

Signed-off-by: Steven Danna <steve@chef.io>