### PR TITLE
Modify security group name to include build_prefix and scenario

### DIFF
--- a/terraform/aws/modules/aws_instance/main.tf
+++ b/terraform/aws/modules/aws_instance/main.tf
@@ -15,7 +15,7 @@ data "aws_subnet" "chef_subnet" {
 }
 
 resource "aws_security_group" "default" {
-  name_prefix = local.vpc_name
+  name_prefix = "${var.build_prefix}${var.name}-${local.vpc_name}"
   vpc_id      = data.aws_vpc.chef_vpc.id
 
   ingress {


### PR DESCRIPTION
### Description

This PR addresses an issue where a race condition could potentially cause a conflict when the pipeline is instantiating many security groups at the same time and and a naming collision occurs with the following error:

```
Error: Error creating Security Group: InvalidGroup.Duplicate: The security group 'chef-eng-team-chef_server-test20200521151929923300000001' already exists for VPC 'vpc-045624eb52c7f7689'
```
Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
