### PR TITLE
[terraform] Set ip_version in postgresql-ipv6 tests, disable pushy

### DIFF
--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -179,6 +179,7 @@ steps:
     env:
       SCENARIO: omnibus-standalone-upgrade
       PLATFORM: ubuntu-18.04
+      ENABLE_ADDON_PUSH_JOBS: false
       ENABLE_IPV6: true
     expeditor:
       accounts:
@@ -228,6 +229,7 @@ steps:
     env:
       SCENARIO: omnibus-external-elasticsearch
       PLATFORM: ubuntu-18.04
+      ENABLE_ADDON_PUSH_JOBS: false
       ENABLE_IPV6: true
     expeditor:
       accounts:

--- a/.expeditor/integration_test_full.pipeline.yml
+++ b/.expeditor/integration_test_full.pipeline.yml
@@ -555,6 +555,7 @@ steps:
       SCENARIO: omnibus-external-openldap
       PLATFORM: rhel-6
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -570,6 +571,7 @@ steps:
       SCENARIO: omnibus-external-openldap
       PLATFORM: rhel-7
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -585,6 +587,7 @@ steps:
       SCENARIO: omnibus-external-openldap
       PLATFORM: rhel-8
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -600,6 +603,7 @@ steps:
       SCENARIO: omnibus-external-openldap
       PLATFORM: ubuntu-16.04
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -615,6 +619,7 @@ steps:
       SCENARIO: omnibus-external-openldap
       PLATFORM: ubuntu-18.04
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -630,6 +635,7 @@ steps:
       SCENARIO: omnibus-fips
       PLATFORM: rhel-6
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -645,6 +651,7 @@ steps:
       SCENARIO: omnibus-fips
       PLATFORM: rhel-7
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -660,6 +667,7 @@ steps:
       SCENARIO: omnibus-fips
       PLATFORM: rhel-8
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -755,6 +763,7 @@ steps:
       SCENARIO: omnibus-standalone-upgrade
       PLATFORM: rhel-6
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -770,6 +779,7 @@ steps:
       SCENARIO: omnibus-standalone-upgrade
       PLATFORM: rhel-7
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -785,6 +795,7 @@ steps:
       SCENARIO: omnibus-standalone-upgrade
       PLATFORM: ubuntu-16.04
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -800,6 +811,7 @@ steps:
       SCENARIO: omnibus-standalone-upgrade
       PLATFORM: ubuntu-18.04
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -959,6 +971,7 @@ steps:
       SCENARIO: omnibus-external-elasticsearch
       PLATFORM: rhel-6
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -974,6 +987,7 @@ steps:
       SCENARIO: omnibus-external-elasticsearch
       PLATFORM: rhel-7
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -989,6 +1003,7 @@ steps:
       SCENARIO: omnibus-external-elasticsearch
       PLATFORM: rhel-8
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -1004,6 +1019,7 @@ steps:
       SCENARIO: omnibus-external-elasticsearch
       PLATFORM: ubuntu-16.04
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd
@@ -1019,6 +1035,7 @@ steps:
       SCENARIO: omnibus-external-elasticsearch
       PLATFORM: ubuntu-18.04
       ENABLE_IPV6: true
+      ENABLE_ADDON_PUSH_JOBS: false
     expeditor:
       accounts:
         - aws/chef-cd

--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -103,8 +103,7 @@ else
 endif
 
 ifeq ($(ENABLE_ADDON_PUSH_JOBS),)
-    SCENARIO_IS_TIER = $(shell grep -q '\-tiered-' <<<$(WORKSPACE) && echo true || echo false)
-    ifeq ($(TF_VAR_enable_ipv6)$(SCENARIO_IS_TIER),truetrue)
+    ifeq ($(TF_VAR_enable_ipv6),true)
         export TF_VAR_enable_addon_push_jobs ?= false
     else
         export TF_VAR_enable_addon_push_jobs ?= true

--- a/terraform/aws/scenarios/omnibus-external-postgresql/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/main.tf
@@ -46,6 +46,7 @@ data "template_file" "chef_server_rb" {
   template = file("${path.module}/templates/chef-server.rb.tpl")
 
   vars = {
+    enable_ipv6 = var.enable_ipv6
     postgresql_ip = var.enable_ipv6 == "true" ? module.postgresql.public_ipv6_address : module.postgresql.private_ipv4_address
   }
 }

--- a/terraform/aws/scenarios/omnibus-external-postgresql/templates/chef-server.rb.tpl
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/templates/chef-server.rb.tpl
@@ -20,3 +20,8 @@ postgresql['max_connections']=350
 opscode_erchef['db_pool_size']=20
 oc_id['db_pool_size']=20
 oc_bifrost['db_pool_size']=20
+
+if ${enable_ipv6}
+  ip_version "ipv6"
+end
+nginx['enable_ipv6'] = ${enable_ipv6}


### PR DESCRIPTION
We need to set `ip_version` to ensure that the right options get set
in the erchef configuration for sqerl.

We currently have an open bug (#2019) to further investigate pushy on
IPv6. Until we address that, for consistency, we avoid running pushy
in any of the IPv6 tests.

Signed-off-by: Steven Danna <steve@chef.io>