### PR TITLE
Pin to chef-cli 3.0.1

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,11 @@
 source 'https://rubygems.org'
 
 gem 'rake'
+
 gem 'chefspec'
+# chef-cli >=3.0.4 requires Ruby version >= 2.7 which chef-server isn't ready for
+gem 'chef-cli', '=3.0.1'
+
 gem 'berkshelf'
 gem 'bundler', '>1.10'
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/Gemfile
+++ b/omnibus/files/private-chef-cookbooks/private-chef/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 # Used for rspec testing only
 gem 'chefspec'
+# chef-cli >=3.0.4 requires Ruby version >= 2.7 which chef-server isn't ready for
+gem 'chef-cli', '=3.0.1'
 gem 'veil', git: 'https://github.com/chef/chef_secrets.git'


### PR DESCRIPTION
### Description

chef-server marks a direct dependency on chefspec

chefspec depends on chef-cli > 0

chef-cli >=3.0.4 requires Ruby version >= 2.7 which chef-server isn't ready for

Once chef-server moves to ruby 2.7 we should remove this direct dependency on chef-cli

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>


### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
