### PR TITLE
1949: Add dist.rb Wordmarks

### DIFF
--- a/.expeditor/create_manifest.rb
+++ b/.expeditor/create_manifest.rb
@@ -63,12 +63,12 @@ manifest["packages"] = []
 
 pkg_origin = "chef"
 
-%w{
+%W{
   openresty-noroot
   oc_id
-  chef-server-nginx
+  #{Chef::Dist::Server::SHORT}-nginx
   bookshelf
-  chef-server-ctl
+  #{Chef::Dist::Server::CTL}
   oc_bifrost
   oc_erchef
 }.each do |pkg_name|

--- a/dev/cookbooks/provisioning/attributes/default.rb
+++ b/dev/cookbooks/provisioning/attributes/default.rb
@@ -1,7 +1,7 @@
 
-default['provisioning']['chef-server-config'] = {}
+default['provisioning']["#{Chef::Dist::Server::SHORT}-config"] = {}
 
-default['ldap']['basedn']   = 'dc=chef-server,dc=dev'
-default['ldap']['ssl_key']  = '/etc/ldap/ssl/chef-server_dev.key'
-default['ldap']['ssl_cert'] = '/etc/ldap/ssl/chef-server_dev.crt'
+default['ldap']['basedn']   = "dc=#{Chef::Dist::Server::SHORT},dc=dev"
+default['ldap']['ssl_key']  = "/etc/ldap/ssl/#{Chef::Dist::Server::SHORT}_dev.key"
+default['ldap']['ssl_cert'] = "/etc/ldap/ssl/#{Chef::Dist::Server::SHORT}_dev.crt"
 default['ldap']['password']   = 'H0\/\/!|\/|3tY0ur|\/|0th3r'

--- a/dev/cookbooks/provisioning/recipes/chef-server-rb.rb
+++ b/dev/cookbooks/provisioning/recipes/chef-server-rb.rb
@@ -1,7 +1,7 @@
 # Note that we do not run reconfigure at this time
 # We will allow the dvm recipe to handle when that should occur.
-template "/etc/opscode/chef-server.rb" do
-  source "chef-server.rb.erb"
+template "/etc/opscode/#{Chef::Dist::Server::SHORT}.rb" do
+  source "#{Chef::Dist::Server::SHORT}.rb.erb"
   owner "root"
   group "root"
   action :create

--- a/dev/cookbooks/provisioning/recipes/hosts.rb
+++ b/dev/cookbooks/provisioning/recipes/hosts.rb
@@ -4,7 +4,7 @@ template "/etc/hosts" do
   group "root"
   action :create
   mode  "0644"
-  variables({"fqdns" => ["api.chef-server.dev",  "manage.chef-server.dev"],
+  variables({"fqdns" => ["api.#{Chef::Dist::Server::SHORT}.dev",  "manage.#{Chef::Dist::Server::SHORT}.dev"],
              "global_fqdns" => node['provisioning']['hosts']})
 
 end

--- a/dev/dvm/lib/dvm/populate.rb
+++ b/dev/dvm/lib/dvm/populate.rb
@@ -30,7 +30,7 @@ module DVM
       if File.exists? validator
         puts "Validator for #{name} exists, skipping org creation"
       else
-        `chef-server-ctl org-create #{name} #{name} > #{validator}`
+        `#{Chef::Dist::Server::CTL} org-create #{name} #{name} > #{validator}`
       end
       org.users.each do |user|
         make_user(user)
@@ -48,7 +48,7 @@ module DVM
         return
       end
       File.mkdir_p userdir
-      `chef-server-ctl org-user-add #{orgname} #{username} -a #{admin}`
+      `#{Chef::Dist::Server::CTL} org-user-add #{orgname} #{username} -a #{admin}`
 
     end
     def make_user(user)
@@ -57,7 +57,7 @@ module DVM
         puts "Skipping user #{user}, key already exists"
       else
         # TODO we probably should care if this fails...
-        `chef-server-ctl user-create #{user} #{user} test-user #{username}@dvm.com password > #{key}`
+        `#{Chef::Dist::Server::CTL} user-create #{user} #{user} test-user #{username}@dvm.com password > #{key}`
       end
     end
     def user_key_path(username)

--- a/dev/dvm/lib/dvm/project/erlang.rb
+++ b/dev/dvm/lib/dvm/project/erlang.rb
@@ -58,7 +58,7 @@ module DVM
     def stop
       raise DVMArgumentError, <<-EOM unless is_running?
 "#{name} does not seem to be running from a loaded instance.
-If you want to stop the global instance, use chef-server-ctl stop #{service['name']}'"
+If you want to stop the global instance, use #{Chef::Dist::Server::CTL} stop #{service['name']}'"
 EOM
       run_command("bin/#{name} stop", "Stopping #{name}", :cwd => relpath)
     end
@@ -130,12 +130,12 @@ EOM
           end
         else
           # UGH _ note we're still stuck on not having /do-not-use - because if we clone to external-deps it will not get nuked!
-          raise DVMArgumentError, "Project not available. Clone or link it into chef-server/external-deps directory onto your host machine, or update the project git settings."
+          raise DVMArgumentError, "Project not available. Clone or link it into #{Chef::Dist::Server::SHORT}/external-deps directory onto your host machine, or update the project git settings."
         end
       end
 
       raise DVMArgumentError, "Project already loaded. Use --force to proceed." if loaded? and not options[:force]
-      run_command("chef-server-ctl stop  #{service['name']}", "Stopping #{service['name']}")
+      run_command("#{Chef::Dist::Server::CTL} stop  #{service['name']}", "Stopping #{service['name']}")
       do_build unless options[:no_build]
       disable_service
       link
@@ -158,7 +158,7 @@ EOM
       run_command("sv s #{svname}", "Enabling packaged #{name}")
       # TODO sv s should be starting it (it thinks it is) but is not.  Take a look at why
       # this extra step is needed
-      run_command("chef-server-ctl start #{svname}", "Starting packaged #{name}")
+      run_command("#{Chef::Dist::Server::CTL} start #{svname}", "Starting packaged #{name}")
 
     end
     def unload

--- a/dev/dvm/lib/dvm/project/omnibus_dep.rb
+++ b/dev/dvm/lib/dvm/project/omnibus_dep.rb
@@ -10,7 +10,7 @@ module DVM
       @path = @source_path
       @reconfigure_on_load = config['reconfigure_on_load']
       @available = true
-      @ctl_name  = config['ctl-name'] || 'chef-server-ctl'
+      @ctl_name  = config['ctl-name'] || Chef::Dist::Server::CTL
       @bundler = config['bundler']
     end
     def unload

--- a/dev/dvm/lib/dvm/project/project.rb
+++ b/dev/dvm/lib/dvm/project/project.rb
@@ -69,7 +69,7 @@ module DVM
 
     def load(build)
       if (external and !File.exists?(project_dir))
-        say(HighLine.color("Please check out or symlink #{name} into chef-server/external-deps on your host before attempting to load it.", :yellow))
+        say(HighLine.color("Please check out or symlink #{name} into #{Chef::Dist::Server::SHORT}/external-deps on your host before attempting to load it.", :yellow))
       end
       do_load(build)
     end

--- a/dev/dvm/lib/dvm/project/rails.rb
+++ b/dev/dvm/lib/dvm/project/rails.rb
@@ -45,7 +45,7 @@ module DVM
     def stop
       raise DVMArgumentError, <<-EOM unless is_running?
 "#{name} does not seem to be running from a loaded instance.
-If you want to stop the global instance, use chef-server-ctl stop #{service['name']}'"
+If you want to stop the global instance, use #{Chef::Dist::Server::CTL} stop #{service['name']}'"
 EOM
       run_command("kill -9 $(cat tmp/pids/server.pid)", "Stopping #{service['name']} Rails Server", cwd: project_dir)
     end
@@ -96,11 +96,11 @@ EOM
     end
 
     def enable_service
-      run_command("chef-server-ctl start #{service['name']}", "Starting #{omnibus_project} #{service['name']}")
+      run_command("#{Chef::Dist::Server::CTL} start #{service['name']}", "Starting #{omnibus_project} #{service['name']}")
     end
 
     def disable_service
-      run_command("chef-server-ctl stop #{service['name']}", "Stopping #{omnibus_project} #{service['name']}")
+      run_command("#{Chef::Dist::Server::CTL} stop #{service['name']}", "Stopping #{omnibus_project} #{service['name']}")
     end
 
     def is_running?

--- a/dev/dvm/lib/dvm/project/ruby.rb
+++ b/dev/dvm/lib/dvm/project/ruby.rb
@@ -54,7 +54,7 @@ module DVM
 
     def run(args)
       if @project['system']
-        raise DVM::DVMArgumentError, 'Run not supported for system ruby projects - just use it normally via chef-server-ctl or otherwise, as it has been loaded into the server gemset.'
+        raise DVM::DVMArgumentError, "Run not supported for system ruby projects - just use it normally via #{Chef::Dist::Server::CTL} or otherwise, as it has been loaded into the server gemset."
       else
         exec "cd #{@project_dir} && #{helper} -- #{@project['run']} #{args.join(" ")}", close_others: false
       end

--- a/dev/dvm/lib/dvm/tools.rb
+++ b/dev/dvm/lib/dvm/tools.rb
@@ -70,7 +70,7 @@ module DVM
     end
 
     def clone(name, uri)
-      run_command("git clone '#{uri}' '#{name}'", "Cloning #{name} to host. For future reference, you may also symlink it into chef-server/external-deps from another location on the host.",
+      run_command("git clone '#{uri}' '#{name}'", "Cloning #{name} to host. For future reference, you may also symlink it into #{Chef::Dist::Server::SHORT}/external-deps from another location on the host.",
                   cwd: host_external_deps_dir)
     end
 

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -85,8 +85,8 @@ module Pedant
   end
 
   def self.create_platform
-    superuser_key = ENV['CHEF_SECRET_CHEF-SERVER.SUPERUSER_KEY'] || ENV['SUPERUSER_KEY']
-    webui_key = ENV['CHEF_SECRET_CHEF-SERVER.WEBUI_KEY'] || ENV['WEBUI_KEY']
+    superuser_key = ENV["#{ChefConfig::Dist::SHORT.upcase}_SECRET_#{ChefConfig::Dist::SERVER.upcase}.SUPERUSER_KEY"] || ENV['SUPERUSER_KEY']
+    webui_key = ENV["#{ChefConfig::Dist::SHORT.upcase}_SECRET_#{ChefConfig::Dist::SERVER.upcase}.WEBUI_KEY"] || ENV['WEBUI_KEY']
     stats_password = ENV['CHEF_SECRET_OPSCODE_ERCHEF.STATS_PASSWORD'] || ENV['STATS_PASSWORD']
     config.pedant_platform = Pedant::Platform.new(config.chef_server,
                                                   superuser_key,

--- a/oc-chef-pedant/spec/running_configs/analytics_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/analytics_spec.rb
@@ -6,7 +6,7 @@ describe 'running configs required by Analytics Server', :config do
   # The analyics add-on reads from actions-source.json which is only
   # written out in some configurations.
   #
-  running_config = JSON.parse(IO.read('/etc/opscode/chef-server-running.json'))
+  running_config = JSON.parse(IO.read("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json"))
   if !(running_config['private_chef']['insecure_addon_compat'] && running_config['private_chef']['dark_launch']['actions'])
     skip 'Analytics config is only written when insecure_addon_compat = true && dark_launch["actions"] = true'
   else

--- a/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
@@ -5,7 +5,7 @@ require 'pedant/rspec/common'
 # For example, the postgres test below probably should remain even when reporting is totally gone.
 #
 describe "running configs required by Chef Server and plugins", :config do
-  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
+  let (:config) { JSON.parse(IO.read("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json"))['private_chef'] }
 
   context "basic config" do
     it "role" do

--- a/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/ctl_command_spec.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'pedant/rspec/common'
 
-describe "running configs required by chef-server-ctl", :config do
+describe "running configs required by #{Chef::Dist::Server::CTL}", :config do
   let (:complete_config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json")) }
   let (:config) { complete_config['private_chef'] }
 

--- a/oc-chef-pedant/spec/running_configs/manage_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/manage_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'pedant/rspec/common'
 
 describe "running configs required by Manages", :config do
-  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
+  let (:config) { JSON.parse(IO.read("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json"))['private_chef'] }
 
   it "lb/api_fqdn" do
     expect(config['lb']['api_fqdn'].to_s).to_not eq ''

--- a/oc-chef-pedant/spec/running_configs/pushy_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/pushy_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'pedant/rspec/common'
 
 describe "running configs required by Pushy Server", :config do
-  let (:complete_config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json")) }
+  let (:complete_config) { JSON.parse(IO.read("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json")) }
   let (:config) { complete_config['private_chef'] }
 
   it "role" do

--- a/oc-chef-pedant/spec/running_configs/reporting_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/reporting_spec.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'pedant/rspec/common'
 
 describe "running configs required by Reporting", :config do
-  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
+  let (:config) { JSON.parse(IO.read("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json"))['private_chef'] }
 
   context "oc-reporting-pedant" do
 

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -8,6 +8,7 @@ gem 'chef-cli', '=3.0.1'
 
 gem 'berkshelf'
 gem 'bundler', '>1.10'
+gem 'chef-config'
 
 # Install omnibus software
 group :omnibus do

--- a/omnibus/config/projects/chef-server-fips.rb
+++ b/omnibus/config/projects/chef-server-fips.rb
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-chef_server_path = File.expand_path('../chef-server.rb', __FILE__)
+chef_server_path = File.expand_path("../#{Chef::Dist::Server::SHORT}.rb", __FILE__)
 instance_eval(IO.read(chef_server_path), chef_server_path)
 
-name "chef-server-fips"
-package_name "chef-server-fips-core"
+name "#{Chef::Dist::Server::SHORT}-fips"
+package_name "#{Chef::Dist::Server::SHORT}-fips-core"
 
 # Use chef's scripts for everything.
-resources_path "#{resources_path}/../chef-server"
-package_scripts_path "#{package_scripts_path}/../chef-server"
+resources_path "#{resources_path}/../#{Chef::Dist::Server::SHORT}"
+package_scripts_path "#{package_scripts_path}/../#{Chef::Dist::Server::SHORT}"

--- a/omnibus/config/projects/chef-server.rb
+++ b/omnibus/config/projects/chef-server.rb
@@ -14,13 +14,15 @@
 # limitations under the License.
 #
 
-name "chef-server"
+require_relative '../../dist.rb'
+
+name "#{Chef::Dist::Server::SHORT}"
 maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage   "https://www.chef.io"
 license "Chef EULA"
 license_file "CHEF-EULA.md"
 
-package_name    "chef-server-core"
+package_name    "#{Chef::Dist::Server::SHORT}-core"
 replace         "private-chef"
 conflict        "private-chef"
 install_dir     "/opt/opscode"

--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-name "chef-server-ctl"
+# TODO: jgitlin does this need to be changed?
+name "chef-server-ctl" # "#{Chef::Dist::Server::CTL}"
 
 source path: "#{project.files_path}/../../src/chef-server-ctl"
 
@@ -34,16 +35,22 @@ build do
   # on installing
   bundle "install", env: env
 
+  # TODO: @jgitlin changing this breaks the build, fix?
+  #gem "build #{Chef::Dist::Server::CTL}.gemspec", env: env
   gem "build chef-server-ctl.gemspec", env: env
 
   # Hack: install binaries in /tmp because we don't actually want them at all
+  # TODO: @jgitlin changing this breaks the build, fix?
+  #gem "install #{Chef::Dist::Server::CTL}-*.gem --no-document --verbose --bindir=/tmp", env: env
   gem "install chef-server-ctl-*.gem --no-document --verbose --bindir=/tmp", env: env
 
+  # TODO: jgitlin fix, same as above
+  #appbundle "#{Chef::Dist::Server::CTL}", env: env
   appbundle "chef-server-ctl", env: env
 
-  link "#{install_dir}/bin/chef-server-ctl", "#{install_dir}/bin/private-chef-ctl"
+  link "#{install_dir}/bin/#{Chef::Dist::Server::CTL}", "#{install_dir}/bin/private-#{ChefConfig::Dist::SHORT}-ctl"
 
   # These are necessary until we remove all hardcoded references to embedded/bin/*-ctl
-  link "#{install_dir}/bin/chef-server-ctl", "#{install_dir}/embedded/bin/chef-server-ctl"
-  link "#{install_dir}/bin/chef-server-ctl", "#{install_dir}/embedded/bin/private-chef-ctl"
+  link "#{install_dir}/bin/#{Chef::Dist::Server::CTL}", "#{install_dir}/embedded/bin/#{Chef::Dist::Server::CTL}"
+  link "#{install_dir}/bin/#{Chef::Dist::Server::CTL}", "#{install_dir}/embedded/bin/private-#{ChefConfig::Dist::SHORT}-ctl"
 end

--- a/omnibus/dist.rb
+++ b/omnibus/dist.rb
@@ -1,0 +1,22 @@
+class Chef
+  class Dist
+    class Server
+      # This class is not fully implemented, depending on it is not recommended!
+      # When referencing a product directly, like Chef (Now Chef Infra)
+      PRODUCT = "Chef Infra Server".freeze
+
+      # A short designation for the product, used in Windows event logs
+      # and some nomenclature.
+      SHORT = "chef-server".freeze
+
+      # product website address
+      WEBSITE = "https://github.com/chef/chef-server".freeze
+
+      # The configuration directory
+      CONF_DIR = "/etc/chef-server".freeze
+
+      # The server's configuration utility
+      CTL = "chef-server-ctl".freeze
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/chef_server_data_bootstrap.rb
@@ -96,7 +96,7 @@ class ChefServerDataBootstrap
   def create_superuser_in_erchef(conn)
     require 'openssl'
 
-    raw_key = PrivateChef.credentials.get('chef-server', 'superuser_key')
+    raw_key = PrivateChef.credentials.get("#{Chef::Dist::Server::SHORT}", 'superuser_key')
     public_key = OpenSSL::PKey::RSA.new(raw_key).public_key.to_s
 
     user_id = SecureRandom.uuid.gsub('-', '')

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_provider.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/oc_id_application_provider.rb
@@ -32,7 +32,7 @@ class Chef
 
       def create!
         @attributes ||= begin
-                          env_helper = 'veil-env-helper --use-file -s chef-server.webui_key -s oc_id.sql_password -s oc_id.secret_key_base'
+                          env_helper = "veil-env-helper --use-file -s #{Chef::Dist::Server::SHORT}.webui_key -s oc_id.sql_password -s oc_id.secret_key_base"
                           rails_script = <<~EOF
                             app = Doorkeeper::Application.find_or_create_by(:name => "#{new_resource.name}");
                             app.update_attributes(:redirect_uri => "#{new_resource.redirect_uri}");

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_bootstrap_validator.rb
@@ -84,7 +84,7 @@ class BootstrapPreflightValidator < PreflightValidator
   end
 
   def secrets_contains_pivotal?
-    PrivateChef.credentials.exist?('chef-server', 'superuser_key')
+    PrivateChef.credentials.exist?("#{Chef::Dist::Server::SHORT}", 'superuser_key')
   end
 
   def pivotal_key_exists?

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -52,8 +52,8 @@ class PreflightValidator
   # we'll be able to make this better...
   def secrets_exists?
     len = PrivateChef.credentials.length
-    len -= 1 if PrivateChef.credentials.exist?('chef-server', 'webui_key')
-    len -= 1 if PrivateChef.credentials.exist?('chef-server', 'superuser_key')
+    len -= 1 if PrivateChef.credentials.exist?("#{Chef::Dist::Server::SHORT}", 'webui_key')
+    len -= 1 if PrivateChef.credentials.exist?("#{Chef::Dist::Server::SHORT}", 'superuser_key')
     len > 0
   end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -215,7 +215,7 @@ class PostgresqlPreflightValidator < PreflightValidator
   def err_CSPG001_cannot_change_external_flag
     <<~EOM
       CSPG001: The value of postgresql['external'] must be set prior to the initial
-               run of chef-server-ctl reconfigure and cannot be changed.
+               run of #{Chef::Dist::Server::CTL} reconfigure and cannot be changed.
 
                See https://docs.chef.io/error_messages.html#cspg001-changed-setting
                for more information on how you can transition an existing chef-server
@@ -228,7 +228,7 @@ class PostgresqlPreflightValidator < PreflightValidator
       CSPG002: You have not set a database superuser name under
                "postgresql['db_superuser']" in chef-server.rb.  This is required
                for external database support - please set it now and
-               then re-run 'chef-server-ctl reconfigure'.
+               then re-run '#{Chef::Dist::Server::CTL} reconfigure'.
 
                See https://docs.chef.io/server_components.html#postgresql-settings
                for more information.
@@ -238,9 +238,9 @@ class PostgresqlPreflightValidator < PreflightValidator
   def err_CSPG003_missing_superuser_password
     <<~EOM
       CSPG003: You have not set a database superuser password using
-               chef-server-ctl set-db-superuser-password. This is required
+               #{Chef::Dist::Server::CTL} set-db-superuser-password. This is required
                for external database support - please run this now, then
-               re-run 'chef-server-ctl reconfigure'.
+               re-run '#{Chef::Dist::Server::CTL} reconfigure'.
 
                See https://docs.chef.io/server_components.html#postgresql-settings
                for more information.
@@ -263,7 +263,7 @@ class PostgresqlPreflightValidator < PreflightValidator
       CSPG010: I cannot make a connection to the host #{cs_pg_attr['vip']}.  Please
                verify that the host is online and reachable from this node, and that
                you have configured postgresql['port'] if it's not the standard
-               port 5432, then run 'chef-server-ctl reconfigure' again.
+               port 5432, then run '#{Chef::Dist::Server::CTL} reconfigure' again.
 
                See https://docs.chef.io/error_messages.html#cspg010-cannot-connect
                for more information about postgresql networking requirements.

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_required_recipe_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_required_recipe_validator.rb
@@ -41,7 +41,7 @@ class RequiredRecipePreflightValidator < PreflightValidator
         is misconfigured. Please set the `required_recipe["path"] = /path/to/recipe` in
         `/etc/opscode/chef-server.rb` and run:
 
-            chef-server-ctl reconfigure
+            #{Chef::Dist::Server::CTL} reconfigure
       EOF
     end
   end
@@ -53,7 +53,7 @@ class RequiredRecipePreflightValidator < PreflightValidator
         and reconfigure the Chef server:
 
             chown root:root #{@required_recipe['path']}
-            chef-server-ctl reconfigure
+            #{Chef::Dist::Server::CTL} reconfigure
       EOF
     end
   end
@@ -65,7 +65,7 @@ class RequiredRecipePreflightValidator < PreflightValidator
         root and reconfigure the Chef server:
 
             chown root:root #{@required_recipe['path']}
-            chef-server-ctl reconfigure
+            #{Chef::Dist::Server::CTL} reconfigure
       EOF
     end
   end
@@ -77,7 +77,7 @@ class RequiredRecipePreflightValidator < PreflightValidator
         and reconfigure the Chef server:
 
             chmod 600 #{@required_recipe['path']}
-            chef-server-ctl reconfigure
+            #{Chef::Dist::Server::CTL} reconfigure
       EOF
     end
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_solr_validator.rb
@@ -290,7 +290,7 @@ class SolrPreflightValidator < PreflightValidator
 
        SOLR009: The value of opscode_solr4['external'] has been changed.  Search
                 results against the new external search index may be incorrect. Please
-                run `chef-server-ctl reindex --all` to ensure correct results
+                run `#{Chef::Dist::Server::CTL} reindex --all` to ensure correct results
 
     EOM
   end
@@ -346,7 +346,8 @@ class SolrPreflightValidator < PreflightValidator
     <<~EOM
        SOLR014: The value of deprecated_solr_indexing has been changed. Search
                 results against the new search index may be incorrect. Please
-                run `chef-server-ctl reindex --all` to ensure correct results.
+                run `#{Chef::Dist::Server::CTL} reindex --all` to ensure correct
+                results.
     EOM
   end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -526,7 +526,7 @@ module PrivateChef
             If this is unexpected, consider removing the secret from
             chef-server.rb and setting the correct value with:
 
-                chef-server-ctl #{command_name}
+                #{Chef::Dist::Server::CTL} #{command_name}
           WARN2
         end
       elsif pass_in_config
@@ -757,8 +757,8 @@ module PrivateChef
 
     # If known private keys are on disk, add them to Veil and commit them.
     def migrate_keys
-      did_something = add_key_from_file_if_present('chef-server', 'superuser_key', '/etc/opscode/pivotal.pem')
-      did_something |= add_key_from_file_if_present('chef-server', 'webui_key', '/etc/opscode/webui_priv.pem')
+      did_something = add_key_from_file_if_present("#{Chef::Dist::Server::SHORT}", 'superuser_key', '/etc/opscode/pivotal.pem')
+      did_something |= add_key_from_file_if_present("#{Chef::Dist::Server::SHORT}", 'webui_key', '/etc/opscode/webui_priv.pem')
       # Ensure these are committed to disk before continuing -
       # the secrets recipe will delete the old files.
       credentials.save if did_something

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bootstrap.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bootstrap.rb
@@ -26,12 +26,12 @@ end
 
 # These should always be running by this point, but let's be certain.
 %w(postgresql oc_bifrost).each do |service|
-  execute "/opt/opscode/bin/chef-server-ctl start #{service}" do
+  execute "/opt/opscode/bin/#{Chef::Dist::Server::CTL} start #{service}" do
     not_if { OmnibusHelper.has_been_bootstrapped? }
   end
 end
 
-ruby_block 'bootstrap-chef-server-data' do
+ruby_block "bootstrap-#{Chef::Dist::Server::SHORT}-data" do
   block do
     ChefServerDataBootstrap.new(node).bootstrap
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/cleanup.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/cleanup.rb
@@ -38,7 +38,7 @@ end
 
 # Bootstrap is now part of the private_chef cookbook itself and is
 # no longer an additional component - remove any traces of it.
-directory '/opt/opscode/embedded/service/chef-server-bootstrap' do
+directory "/opt/opscode/embedded/service/#{Chef::Dist::Server::SHORT}-bootstrap" do
   action :delete
   recursive true
   ignore_failure true

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -20,8 +20,8 @@
 #
 # TODO: extract this into something that add-ons can use; no sense
 # cargo-culting it around everywhere
-if File.exist?('/etc/opscode/chef-server-running.json')
-  old_config = JSON.parse(IO.read('/etc/opscode/chef-server-running.json'))
+if File.exist?("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json")
+  old_config = JSON.parse(IO.read("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json"))
 
   # We're stashing these outside the "private_chef" attributes tree to
   # prevent us from carrying them along forever when we write out the
@@ -38,14 +38,14 @@ if File.exist?('/etc/opscode/chef-server-running.json')
   node.consume_attributes('previous_run' => old_config['private_chef'])
 end
 
-if File.exist?('/etc/opscode/chef-server.json') &&
-   !(File.exist?('/etc/opscode/private-chef.rb') || File.exist?('/etc/opscode/chef-server.rb'))
-  Chef::Log.fatal('Configuration via /etc/opscode/chef-server.json is not supported. Please use /etc/opscode/chef-server.rb')
+if File.exist?("/etc/opscode/#{Chef::Dist::Server::SHORT}.json") &&
+   !(File.exist?('/etc/opscode/private-chef.rb') || File.exist?("/etc/opscode/#{Chef::Dist::Server::SHORT}.rb"))
+  Chef::Log.fatal("Configuration via /etc/opscode/#{Chef::Dist::Server::SHORT}.json is not supported. Please use /etc/opscode/#{Chef::Dist::Server::SHORT}.rb")
   exit!(1)
 else
   PrivateChef[:node] = node
   private_chef_path = '/etc/opscode/private-chef.rb'
-  chef_server_path = '/etc/opscode/chef-server.rb'
+  chef_server_path = "/etc/opscode/#{Chef::Dist::Server::SHORT}.rb"
   private_chef_rb_exists = File.exist?(private_chef_path)
   private_chef_rb_not_symlink = !File.symlink?(private_chef_path)
   chef_server_rb_exists = File.exist?(chef_server_path)
@@ -59,17 +59,17 @@ else
   # chef-server.rb, then copy it over and link back.  Otherwise warn.
   if private_chef_rb_exists && private_chef_rb_not_symlink && chef_server_rb_exists &&
      chef_server_rb_not_empty
-    Chef::Log.warn('/etc/opscode/private-chef.rb is deprecated and should be removed. Using /etc/opscode/chef-server.rb')
+    Chef::Log.warn("/etc/opscode/private-chef.rb is deprecated and should be removed. Using /etc/opscode/#{Chef::Dist::Server::SHORT}.rb")
   elsif private_chef_rb_exists && private_chef_rb_not_symlink
-    Chef::Log.warn('Moving to /etc/opscode/chef-server.rb for configuration - /etc/opscode/private-chef.rb is deprecated.')
+    Chef::Log.warn("Moving to /etc/opscode/#{Chef::Dist::Server::SHORT}.rb for configuration - /etc/opscode/private-chef.rb is deprecated.")
     FileUtils.mv(private_chef_path, chef_server_path)
     FileUtils.ln_s(chef_server_path, private_chef_path)
     chef_server_rb_exists = true
   end
 
-  if File.exist?('/etc/opscode/chef-server.json')
-    Chef::Log.warn('Ignoring unsupported configuration file /etc/opscode/chef-server.json.')
-    Chef::Log.warn('Using /etc/opscode/chef-server.rb instead.')
+  if File.exist?("/etc/opscode/#{Chef::Dist::Server::SHORT}.json")
+    Chef::Log.warn("Ignoring unsupported configuration file /etc/opscode/#{Chef::Dist::Server::SHORT}.json.")
+    Chef::Log.warn("Using /etc/opscode/#{Chef::Dist::Server::SHORT}.rb instead.")
   end
 
   if chef_server_rb_exists

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/default.rb
@@ -22,7 +22,7 @@ require 'openssl'
 # Because these symlinks get removed during the postrm
 # of the chef-server and private-chef packages, we should
 # ensure that they're always here.
-%w(private-chef-ctl chef-server-ctl).each do |bin|
+%W(private-#{ChefConfig::Dist::SHORT}-ctl #{Chef::Dist::Server::SHORT}-ctl).each do |bin|
   link "/usr/bin/#{bin}" do
     to "/opt/opscode/bin/#{bin}"
   end
@@ -125,7 +125,7 @@ end
 include_recipe 'private-chef::fix_permissions'
 
 # Configure Services
-%w(
+%W(
   postgresql
   oc_bifrost
   oc_id
@@ -137,7 +137,7 @@ include_recipe 'private-chef::fix_permissions'
   nginx
   rabbitmq
   bootstrap
-  opscode-chef-mover
+  opscode-#{ChefConfig::Dist::SHORT}-mover
   redis_lb
 ).each do |service|
   if node['private_chef'][service]['external']
@@ -184,7 +184,7 @@ include_recipe 'private-chef::partybus'
 include_recipe 'private-chef::ctl_config'
 include_recipe 'private-chef::disable_chef_server_11'
 
-file '/etc/opscode/chef-server-running.json' do
+file "/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json" do
   owner OmnibusHelper.new(node).ownership['owner']
   group 'root'
   mode '0600'

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/disable_chef_server_11.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/disable_chef_server_11.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-open_source_11_sv_dir = '/opt/chef-server/sv'
+open_source_11_sv_dir = "/opt/#{Chef::Dist::Server::SHORT}/sv"
 
 return unless Dir.exist?(open_source_11_sv_dir)
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -80,7 +80,7 @@ private_chef_pg_user_table_access erchef['sql_ro_user'] do
 end
 
 # Cleanup old enterprise-chef-server-schema
-directory '/opt/opscode/embedded/service/enterprise-chef-server-schema' do
+directory "/opt/opscode/embedded/service/enterprise-#{Chef::Dist::Server::SHORT}-schema" do
   recursive true
   action :delete
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -168,7 +168,7 @@ execute "chown -R #{OmnibusHelper.new(node).ownership['owner']}:#{OmnibusHelper.
   end
 end
 
-veil_helper_args = '--use-file -s chef-server.webui_key -s oc_id.sql_password -s oc_id.secret_key_base'
+veil_helper_args = "--use-file -s #{Chef::Dist::Server::SHORT}.webui_key -s oc_id.sql_password -s oc_id.secret_key_base"
 execute 'oc_id_schema' do
   command "veil-env-helper #{veil_helper_args} -- bundle exec --keep-file-descriptors rake db:migrate"
   cwd '/opt/opscode/embedded/service/oc_id'

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/plugin_discovery.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/plugin_discovery.rb
@@ -16,7 +16,7 @@
 #
 
 # TODO: Does this go away with HA?
-BACKUP_PLUGIN_LOCATIONS = %w(/opt/opscode/chef-server-plugin.rb).freeze
+BACKUP_PLUGIN_LOCATIONS = %W(/opt/opscode/#{Chef::Dist::Server::SHORT}-plugin.rb).freeze
 
 node.default['available-plugins'] = EnterprisePluginCollection.from_glob('/var/opt/opscode/plugins/*.rb')
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -111,7 +111,7 @@ if is_data_master?
         Chef::Log.fatal <<~ERR
 
           Could not connect to the postgresql database.
-          Please check 'chef-server-ctl tail postgresql' for more information.
+          Please check '#{Chef::Dist::Server::CTL} tail postgresql' for more information.
 
         ERR
         exit!(1)

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/private_keys.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/private_keys.rb
@@ -24,9 +24,9 @@
 # present (that is, it was copied here), or will be generated because _this_
 # is the node adding the pivotal user.
 
-unless PrivateChef.credentials.exist?('chef-server', 'superuser_key')
+unless PrivateChef.credentials.exist?("#{Chef::Dist::Server::SHORT}", 'superuser_key')
   pivotal_key = OpenSSL::PKey::RSA.generate(2048)
-  PrivateChef.credentials.add('chef-server', 'superuser_key',
+  PrivateChef.credentials.add("#{Chef::Dist::Server::SHORT}", 'superuser_key',
     value: pivotal_key.to_pem,
     frozen: true)
 
@@ -35,26 +35,26 @@ unless PrivateChef.credentials.exist?('chef-server', 'superuser_key')
   PrivateChef.credentials.save
 end
 
-if !PrivateChef.credentials.exist?('chef-server', 'webui_key')
+if !PrivateChef.credentials.exist?("#{Chef::Dist::Server::SHORT}", 'webui_key')
   webui_key = OpenSSL::PKey::RSA.generate(2048)
-  PrivateChef.credentials.add('chef-server', 'webui_key',
+  PrivateChef.credentials.add("#{Chef::Dist::Server::SHORT}", 'webui_key',
     value: webui_key.to_pem,
     frozen: true)
   # Store the public key in its own key for easy access
-  PrivateChef.credentials.add('chef-server', 'webui_pub_key',
+  PrivateChef.credentials.add("#{Chef::Dist::Server::SHORT}", 'webui_pub_key',
     value: webui_key.public_key.to_s,
     frozen: true)
   PrivateChef.credentials.save
-elsif !PrivateChef.credentials.exist?('chef-server', 'webui_pub_key')
-  webui_string = PrivateChef.credentials.get('chef-server', 'webui_key')
+elsif !PrivateChef.credentials.exist?("#{Chef::Dist::Server::SHORT}", 'webui_pub_key')
+  webui_string = PrivateChef.credentials.get("#{Chef::Dist::Server::SHORT}", 'webui_key')
   webui_key = OpenSSL::PKey::RSA.new(webui_string)
-  PrivateChef.credentials.add('chef-server', 'webui_pub_key',
+  PrivateChef.credentials.add("#{Chef::Dist::Server::SHORT}", 'webui_pub_key',
     value: webui_key.public_key.to_s,
     frozen: true)
   PrivateChef.credentials.save
 end
 
-webui_key = OpenSSL::PKey::RSA.new(PrivateChef.credentials.get('chef-server', 'webui_key'))
+webui_key = OpenSSL::PKey::RSA.new(PrivateChef.credentials.get("#{Chef::Dist::Server::SHORT}", 'webui_key'))
 
 if node['private_chef']['insecure_addon_compat']
   file '/etc/opscode/pivotal.pem'  do
@@ -62,7 +62,7 @@ if node['private_chef']['insecure_addon_compat']
     group 'root'
     mode '0600'
     sensitive true
-    content PrivateChef.credentials.get('chef-server', 'superuser_key')
+    content PrivateChef.credentials.get("#{Chef::Dist::Server::SHORT}", 'superuser_key')
   end
 
   file '/etc/opscode/webui_priv.pem' do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/show_config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/show_config.rb
@@ -16,9 +16,9 @@
 # limitations under the License.
 #
 
-if File.exist?('/etc/opscode/chef-server.rb')
+if File.exist?("/etc/opscode/#{Chef::Dist::Server::SHORT}.rb")
   PrivateChef[:node] = node
-  PrivateChef.from_file('/etc/opscode/chef-server.rb')
+  PrivateChef.from_file("/etc/opscode/#{Chef::Dist::Server::SHORT}.rb")
 end
 config = PrivateChef.generate_config(node['fqdn'])
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_bootstrap_validator_spec.rb
@@ -31,9 +31,9 @@ describe BootstrapPreflightValidator do
       credentials = double(Object)
       allow(PrivateChef).to receive(:credentials).and_return(credentials)
       allow(credentials).to receive(:length).and_return(secret_count)
-      allow(credentials).to receive(:exist?).with('chef-server', anything).and_return(superuser_key_exists)
-      allow(File).to receive(:exist?).with('/etc/opscode/private-chef-secrets.json').and_return(false)
-      allow(File).to receive(:exist?).with('/etc/opscode/pivotal.pem').and_return(false)
+      allow(credentials).to receive(:exist?).with("#{Chef::Dist::Server::SHORT}", anything).and_return(superuser_key_exists)
+      allow(File).to receive(:exist?).with("/etc/opscode/private-#{ChefConfig::Dist::SHORT}-secrets.json").and_return(false)
+      allow(File).to receive(:exist?).with("/etc/opscode/pivotal.pem").and_return(false)
     end
 
     context 'when a previous run exists' do

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_checks_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_checks_spec.rb
@@ -56,7 +56,7 @@ describe PreflightChecks do
     let(:credentials) { double('Credentials') }
 
     before do
-      allow(credentials).to receive(:exist?).with('chef-server', anything).and_return keys_exist
+      allow(credentials).to receive(:exist?).with("#{Chef::Dist::Server::SHORT}", anything).and_return keys_exist
       allow(credentials).to receive(:length).and_return secret_count
       allow(PrivateChef).to receive(:credentials).and_return credentials
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/private_chef_spec.rb
@@ -493,8 +493,8 @@ EOF
 
     describe '#migrate_keys' do
       it 'should attempt to migrate known keys' do
-        expect(PrivateChef).to receive(:add_key_from_file_if_present).with('chef-server', 'superuser_key', superuser_key_path)
-        expect(PrivateChef).to receive(:add_key_from_file_if_present).with('chef-server', 'webui_key', webui_key_path)
+        expect(PrivateChef).to receive(:add_key_from_file_if_present).with("#{Chef::Dist::Server::SHORT}", 'superuser_key', superuser_key_path)
+        expect(PrivateChef).to receive(:add_key_from_file_if_present).with("#{Chef::Dist::Server::SHORT}", 'webui_key', webui_key_path)
         PrivateChef.migrate_keys
       end
     end

--- a/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
+++ b/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
@@ -9,7 +9,7 @@ define_upgrade do
     # sql user info will be in one of two places - under 'postgresql' or under 'opscode-erchef' in more
     # recent versions. If someone is upgrading from an earlier versions, it may not yet
     # have been moved to its new location.
-    running_config = JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
+    running_config = JSON.parse(File.read("/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json"))
     pc = running_config['private_chef']
     keyname = pc['opscode-erchef'].has_key?('sql_user') ? 'opscode-erchef' : 'postgresql'
     connection = ::PGconn.open('user' => pc[keyname]['sql_user'],

--- a/omnibus/partybus/lib/partybus.rb
+++ b/omnibus/partybus/lib/partybus.rb
@@ -11,7 +11,7 @@ module Partybus
   class Config
 
     SECRETS_FILE = "/etc/opscode/private-chef-secrets.json"
-    RUNNING_CONFIG_FILE = "/etc/opscode/chef-server-running.json"
+    RUNNING_CONFIG_FILE = "/etc/opscode/#{Chef::Dist::Server::SHORT}-running.json"
 
     attr_accessor :database_connection_string
     attr_accessor :database_unix_user
@@ -37,7 +37,7 @@ module Partybus
 ***
 ERROR: Cannot find #{RUNNING_CONFIG_FILE}
 ***
-Try running `chef-server-ctl reconfigure` first.
+Try running `#{Chef::Dist::Server::CTL} reconfigure` first.
 
 EOF
         exit(1)
@@ -50,7 +50,7 @@ EOF
 ***
 ERROR: Cannot find or access #{SECRETS_FILE}
 ***
-Try running `chef-server-ctl reconfigure` first.
+Try running `#{Chef::Dist::Server::CTL} reconfigure` first.
 
 EOF
         exit(1)

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -4,6 +4,7 @@ require 'rubygems'
 gem 'omnibus-ctl'
 require 'omnibus-ctl'
 require 'veil'
+require 'dist'
 require 'chef_server_ctl/log'
 require 'chef_server_ctl/config'
 require "license_acceptance/acceptor"

--- a/src/chef-server-ctl/habitat/config/pedant_config.rb
+++ b/src/chef-server-ctl/habitat/config/pedant_config.rb
@@ -17,7 +17,7 @@
 # on multiple nodes of the same chef server when the generated pedant
 # config file could have been copied across during the setup of that
 # chef server.
-chef_server_uid = "chef-server_#{Process.pid}".downcase
+chef_server_uid = "#{Chef::Dist::Server::SHORT}_#{Process.pid}".downcase
 
 # Specify a testing organization if you are testing a multi-tenant
 # instance of a Chef Server (e.g., Private Chef, Hosted Chef).  If you

--- a/src/chef-server-ctl/habitat/config/secrets-bootstrap.rb
+++ b/src/chef-server-ctl/habitat/config/secrets-bootstrap.rb
@@ -40,7 +40,7 @@ REQUIRED_SECRETS = {
     sql_password: { length: 80 },
     sql_ro_password: { length: 80 }
   },
-  'chef-server': {
+  "#{Chef::Dist::Server::SHORT}": {
                    superuser_id: { length: 32 },
                    superuser_key: { length: 2048, type: 'rsa', private: true, pub_key_name: 'superuser_pub_key' },
                    superuser_pub_key: { type: 'rsa', private: false },
@@ -56,7 +56,7 @@ REQUIRED_SECRETS = {
 }
 
 def secrets_apply_loop
-  toml_cfg = TOML.load_file('/hab/svc/chef-server-ctl/config/hab-secrets-config.toml')
+  toml_cfg = TOML.load_file("/hab/svc/#{Chef::Dist::Server::SHORT}-ctl/config/hab-secrets-config.toml")
   new_secrets = Marshal.load(Marshal.dump(toml_cfg))
   changes_to_apply = false
 
@@ -90,7 +90,7 @@ def secrets_apply_loop
     puts 'Changed Secrets need to be applied.'
     File.write('{{pkg.svc_data_path}}/hab-secrets-modified.toml', TOML::Generator.new(new_secrets).body)
     version = Time.now.getutc.to_i
-    cmd = "hab config apply chef-server-ctl.default #{version} {{pkg.svc_data_path}}/hab-secrets-modified.toml"
+    cmd = "hab config apply #{Chef::Dist::Server::SHORT}-ctl.default #{version} {{pkg.svc_data_path}}/hab-secrets-modified.toml"
     sup_listen_ctl = ENV['HAB_LISTEN_CTL']
     cmd += " --remote-sup #{sup_listen_ctl}" if sup_listen_ctl
     system cmd

--- a/src/chef-server-ctl/lib/dist.rb
+++ b/src/chef-server-ctl/lib/dist.rb
@@ -1,0 +1,22 @@
+class Chef
+  class Dist
+    class Server
+      # This class is not fully implemented, depending on it is not recommended!
+      # When referencing a product directly, like Chef (Now Chef Infra)
+      PRODUCT = "Chef Infra Server".freeze
+
+      # A short designation for the product, used in Windows event logs
+      # and some nomenclature.
+      SHORT = "chef-server".freeze
+
+      # product website address
+      WEBSITE = "https://github.com/chef/chef-server".freeze
+
+      # The configuration directory
+      CONF_DIR = "/etc/chef-server".freeze
+
+      # The server's configuration utility
+      CTL = "chef-server-ctl".freeze
+    end
+  end
+end

--- a/src/chef-server-ctl/plugins/backup.rb
+++ b/src/chef-server-ctl/plugins/backup.rb
@@ -12,7 +12,7 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
   options.config_only = false
 
   OptionParser.new do |opts|
-    opts.banner = 'Usage: chef-server-ctl backup [options]'
+    opts.banner = "Usage: #{Chef::Dist::Server::CTL} backup [options]"
 
     opts.on('-y', '--yes', 'Agree to go offline during tar based backups') do
       options.agree_to_go_offline = true
@@ -56,7 +56,7 @@ add_command_under_category 'restore', 'general', 'Restore the Chef Server from b
   options.restore_dir = nil
 
   OptionParser.new do |opts|
-    opts.banner = 'Usage: chef-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]'
+    opts.banner = "Usage: #{Chef::Dist::Server::CTL} restore $PATH_TO_BACKUP_TARBALL [options]"
 
     opts.on('-d', '--staging-dir [directory]', String, 'The path to an empty directory for use in restoration.  Ensure it has enough available space for all expanded data in the backup archive') do |staging_directory|
       options.restore_dir = File.expand_path(staging_directory)
@@ -82,7 +82,7 @@ add_command_under_category 'restore', 'general', 'Restore the Chef Server from b
 
   unless ARGV.length >= 2
     log('Invalid command', :error)
-    log('USAGE: chef-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]', :error)
+    log("USAGE: #{Chef::Dist::Server::CTL} restore $PATH_TO_BACKUP_TARBALL [options]", :error)
     exit(1)
   end
 

--- a/src/chef-server-ctl/plugins/chef12_upgrade_data_transform.rb
+++ b/src/chef-server-ctl/plugins/chef12_upgrade_data_transform.rb
@@ -15,7 +15,7 @@ add_command_under_category "chef12-upgrade-data-transform", "open-source-upgrade
     @options = OpenStruct.new
 
     opt_parser = OptionParser.new do |opts|
-      opts.banner = "Usage: chef-server-ctl chef12-upgrade-data-transform [options]"
+      opts.banner = "Usage: #{Chef::Dist::Server::CTL} chef12-upgrade-data-transform [options]"
 
       opts.on("-d", "--chef11-data-dir [directory]", String, "Directory of open source Chef 11 server data. (Will ask interactively if not passed)") do |chef11_dir|
         @options.chef11_data_dir = chef11_dir

--- a/src/chef-server-ctl/plugins/chef12_upgrade_download.rb
+++ b/src/chef-server-ctl/plugins/chef12_upgrade_download.rb
@@ -20,10 +20,10 @@ add_command_under_category "chef12-upgrade-download", "open-source-upgrade", "Do
     @options.skip_cleanup = false
     @options.chef11_server_url = "https://localhost"
     @options.chef11_admin_client_name = "admin"
-    @options.chef11_admin_client_key = "/etc/chef-server/admin.pem"
+    @options.chef11_admin_client_key = "/etc/#{Chef::Dist::Server::SHORT}/admin.pem"
 
     opt_parser = OptionParser.new do |opts|
-      opts.banner = "Usage: chef-server-ctl chef12-upgrade-download [options]"
+      opts.banner = "Usage: #{Chef::Dist::Server::SHORT}-ctl chef12-upgrade-download [options]"
 
       opts.on("-d", "--chef11-data-dir [directory]", String, "Directory to store open source Chef 11 server data. Defaults to a created tmp dir.") do |chef11_dir|
         @options.chef11_data_dir = chef11_dir

--- a/src/chef-server-ctl/plugins/chef12_upgrade_upload.rb
+++ b/src/chef-server-ctl/plugins/chef12_upgrade_upload.rb
@@ -21,7 +21,7 @@ add_command_under_category "chef12-upgrade-upload", "open-source-upgrade", "Uplo
       @options.skip_upload = false
 
       opt_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: chef-server-ctl chef12-upgrade-upload [options]"
+        opts.banner = "Usage: #{Chef::Dist::Server::CTL} chef12-upgrade-upload [options]"
 
         opts.on("-e", "--chef12-data-dir [directory]", String, "Directory where data for upload to the Chef 12 server is located (Will ask interactively if not passed)") do |chef12_dir|
           @options.chef12_data_dir = chef12_dir

--- a/src/chef-server-ctl/plugins/cleanup_bifrost.rb
+++ b/src/chef-server-ctl/plugins/cleanup_bifrost.rb
@@ -43,7 +43,7 @@ add_command_under_category "cleanup-bifrost", "cleanup", "Cleanup orphaned bifro
   options = {}
 
   OptionParser.new do |opts|
-    opts.banner = "chef-server-ctl cleanup-bifrost [options]"
+    opts.banner = "#{Chef::Dist::Server::CTL} cleanup-bifrost [options]"
     opts.on("-b SIZE", "--batch-size SIZE", "How many authz actors to delete at a time") do |b|
       options[:batch_size] = b.to_i
     end

--- a/src/chef-server-ctl/plugins/key_control.rb
+++ b/src/chef-server-ctl/plugins/key_control.rb
@@ -31,7 +31,7 @@ add_command_under_category "add-client-key", "key-rotation", "Create a new clien
   @options = OpenStruct.new
   @options.expiration_date = "infinity"
   @key = nil
-  @usage = "Usage: chef-server-ctl add-client-key ORGNAME CLIENTNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]."
+  @usage = "Usage: #{Chef::Dist::Server::CTL} add-client-key ORGNAME CLIENTNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]."
   @usage = @usage << @helper.add_key_usage
   @arg_list = ["-e", "--expiration-date", "-k", "--key-name", "-p", "--public-key-path"]
 
@@ -101,7 +101,7 @@ add_command_under_category "add-user-key", "key-rotation", "Create a new user ke
   @options = OpenStruct.new
   @options.expiration_date = "infinity"
   @key = nil
-  @usage = "Usage: chef-server-ctl add-user-key USERNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]"
+  @usage = "Usage: #{Chef::Dist::Server::CTL} add-user-key USERNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]"
   @usage = @usage << @helper.add_key_usage
   @arg_list = ["-e", "--expiration-date", "-k", "--key-name", "-p", "--public-key-path"]
   opt_parser = OptionParser.new do |opts|
@@ -166,7 +166,7 @@ add_command_under_category "list-client-keys", "key-rotation", "List keys for a 
   @helper = ::ChefServerCtl::Helpers::KeyCtlHelper.new
   @options = OpenStruct.new
   @options.show_public_keys = false
-  @usage = "Usage: chef-server-ctl list-client-keys ORGNAME CLIENTNAME [-v, --verbose]"
+  @usage = "Usage: #{Chef::Dist::Server::CTL} list-client-keys ORGNAME CLIENTNAME [-v, --verbose]"
   @arg_list = ["-v", "--verbose"]
 
   opt_parser = OptionParser.new do |opts|
@@ -208,7 +208,7 @@ add_command_under_category "list-user-keys", "key-rotation", "List keys for a us
 
   @options = OpenStruct.new
   @options.show_public_keys = false
-  @usage = "Usage: chef-server-ctl list-user-keys USERNAME [-v, --verbose]"
+  @usage = "Usage: #{Chef::Dist::Server::CTL} list-user-keys USERNAME [-v, --verbose]"
   @arg_list = ["-v", "--verbose"]
 
   opt_parser = OptionParser.new do |opts|
@@ -246,7 +246,7 @@ add_command_under_category "delete-user-key", "key-rotation", "Delete a key", 2 
   cmd_args = ARGV[1..-1]
   @helper = ::ChefServerCtl::Helpers::KeyCtlHelper.new
   @options = OpenStruct.new
-  @usage = "Usage: chef-server-ctl delete-user-key USERNAME KEYNAME"
+  @usage = "Usage: #{Chef::Dist::Server::CTL} delete-user-key USERNAME KEYNAME"
 
   @helper.get_required_arg!(@options, cmd_args, @usage, :username, "USERNAME", 1)
   @helper.get_required_arg!(@options, cmd_args, @usage, :key_name, "KEYNAME", 2)
@@ -268,7 +268,7 @@ add_command_under_category "delete-client-key", "key-rotation", "Delete a key", 
   cmd_args = ARGV[1..-1]
   @helper = ::ChefServerCtl::Helpers::KeyCtlHelper.new
   @options = OpenStruct.new
-  @usage = "Usage: chef-server-ctl delete-client-key ORGNAME CLIENTNAME KEYNAME"
+  @usage = "Usage: #{Chef::Dist::Server::CTL} delete-client-key ORGNAME CLIENTNAME KEYNAME"
 
   @helper.get_required_arg!(@options, cmd_args, @usage, :orgname, "ORGNAME", 1)
   @helper.get_required_arg!(@options, cmd_args, @usage, :clientname, "CLIENTNAME", 2)

--- a/src/chef-server-ctl/plugins/oc_id_show_app.rb
+++ b/src/chef-server-ctl/plugins/oc_id_show_app.rb
@@ -13,7 +13,7 @@ app = Doorkeeper::Application.find_by(:name => "#{app_name}");
 puts app.to_json
 EOF
 
-  env_helper = "veil-env-helper --use-file -s chef-server.webui_key -s oc_id.sql_password -s oc_id.secret_key_base"
+  env_helper = "veil-env-helper --use-file -s #{Chef::Dist::Server::SHORT}.webui_key -s oc_id.sql_password -s oc_id.secret_key_base"
   cmd = Mixlib::ShellOut.new("#{env_helper} -- bin/rails runner -e production '#{rails_script}'",
                           :cwd => '/opt/opscode/embedded/service/oc_id')
   cmd.run_command

--- a/src/chef-server-ctl/plugins/password.rb
+++ b/src/chef-server-ctl/plugins/password.rb
@@ -31,7 +31,7 @@ add_command_under_category "password", "organization-and-user-management", "Set 
       exit 1
     end
     if password == '' && ldap_authentication_enabled?
-      example_cmd = "'chef-server-ctl password #{username} --enable-external-auth'"
+      example_cmd = "'#{Chef::Dist::Server::CTL} password #{username} --enable-external-auth'"
       STDERR.puts "You entered a blank password. If you were trying to enable ldap try #{example_cmd}?"
       exit 1
     end

--- a/src/chef-server-ctl/plugins/rebuild_migration_state.rb
+++ b/src/chef-server-ctl/plugins/rebuild_migration_state.rb
@@ -4,7 +4,7 @@ add_command_under_category "rebuild-migration-state", "general", "Attempt to reb
   options = {}
 
   OptionParser.new do |opts|
-    opts.banner = "chef-server-ctl rebuild-migration-state [options]"
+    opts.banner = "#{Chef::Dist::Server::CTL} rebuild-migration-state [options]"
     opts.on("--force", "Overwrite existing migration state.") do |b|
       options[:force] = true
     end

--- a/src/chef-server-ctl/plugins/rotate_credentials.rb
+++ b/src/chef-server-ctl/plugins/rotate_credentials.rb
@@ -12,7 +12,7 @@ add_command_under_category "rotate-credentials", "Secrets Management", "Rotate C
   ensure_configured!
 
   OptionParser.new do |opts|
-    opts.banner = "Usage: chef-server-ctl rotate-credentials $service_name"
+    opts.banner = "Usage: #{Chef::Dist::Server::CTL} rotate-credentials $service_name"
 
     opts.on("-h", "--help", "Show this message") do
       puts opts
@@ -47,7 +47,7 @@ add_command_under_category "rotate-credentials", "Secrets Management", "Rotate C
     if status.success?
       remove_backup_file(backup_file)
       log("#{service}'s credentials have been rotated!", :notice)
-      log("Run 'chef-server-ctl rotate-credentials #{service}' on each Chef Server", :notice)
+      log("Run '#{Chef::Dist::Server::CTL} rotate-credentials #{service}' on each Chef Server", :notice)
       exit(0)
     else
       log("Credential rotation failed", :error)
@@ -87,7 +87,7 @@ add_command_under_category "rotate-all-credentials", "Secrets Management", "Rota
     if status.success?
       remove_backup_file(backup_file)
       log("All credentials have been rotated!", :notice)
-      log("Run 'chef-server-ctl rotate-all-credentials' on each Chef Server", :notice)
+      log("Run '#{Chef::Dist::Server::CTL} rotate-all-credentials' on each Chef Server", :notice)
       exit(0)
     else
       log("Credential rotation failed", :error)
@@ -127,7 +127,7 @@ add_command_under_category "rotate-shared-secrets", "Secrets Management", "Rotat
     if status.success?
       remove_backup_file(backup_file)
       log("The shared secrets and all service credentials have been rotated!", :notice)
-      log("Please copy #{secrets_file_path} to each Chef Server and run 'chef-server-ctl reconfigure'", :notice)
+      log("Please copy #{secrets_file_path} to each Chef Server and run '#{Chef::Dist::Server::CTL} reconfigure'", :notice)
       exit(0)
     else
       log("Shared credential rotation failed", :error)
@@ -161,7 +161,7 @@ add_command_under_category "require-credential-rotation", "Secrets Management", 
   @ui = HighLine.new
 
   OptionParser.new do |opts|
-    opts.banner = "Usage: chef-server-ctl require-credential-rotation [--yes]"
+    opts.banner = "Usage: #{Chef::Dist::Server::CTL} require-credential-rotation [--yes]"
 
     opts.on("-h", "--help", "Show this message") do
       puts opts
@@ -191,7 +191,7 @@ add_command_under_category "require-credential-rotation", "Secrets Management", 
   FileUtils.touch(credential_rotation_required_file)
 
   log("The Chef Server has been disabled until credentials have been rotated. "\
-      "Run 'sudo chef-server-ctl rotate-shared-secrets' to rotate them.")
+      "Run 'sudo #{Chef::Dist::Server::CTL} rotate-shared-secrets' to rotate them.")
 
   exit(0)
 end
@@ -200,14 +200,14 @@ add_global_pre_hook "require_credential_rotation" do
   # exit if credential rotation is not required
   return unless File.exist?(credential_rotation_required_file)
 
-  # Allow running "chef-server-ctl rotate-shared-secrets"
-  # "chef-server-ctl" is a wrapper that runs "omnibus-ctl opscode $command"
+  # Allow running "#{Chef::Dist::Server::CTL} rotate-shared-secrets"
+  # "#{Chef::Dist::Server::CTL}" is a wrapper that runs "omnibus-ctl opscode $command"
   # so we'll look for that in ARGV
   # TODO RETHINK AS PART OF GEM CONVERSION
   return if ARGV == %w{omnibus-ctl opscode rotate-shared-secrets}
 
   raise("You must rotate the Chef Server credentials to enable the Chef Server. "\
-        "Please run 'sudo chef-server-ctl rotate-shared-secrets'")
+        "Please run 'sudo #{Chef::Dist::Server::CTL} rotate-shared-secrets'")
 end
 
 def backup_secrets_file(backup_file = nil)

--- a/src/chef-server-ctl/plugins/secrets.rb
+++ b/src/chef-server-ctl/plugins/secrets.rb
@@ -33,9 +33,9 @@ SERVICES_REQUIRING_RESTART = {
   "bookshelf.access_key_id" => ["opscode-erchef", "bookshelf"],
   "bookshelf.secret_access_key" => ["opscode-erchef", "bookshelf"],
   "bookshelf.sql_password" => ["bookshelf"],
-  "chef-server.superuser_key" => ["opscode-reporting"],
-  "chef-server.webui_key" => ["oc_id"],
-  "chef-server.webui_pub_key" => ["opscode-erchef", "opscode-reporting"],
+  "#{Chef::Dist::Server::SHORT}.superuser_key" => ["opscode-reporting"],
+  "#{Chef::Dist::Server::SHORT}.webui_key" => ["oc_id"],
+  "#{Chef::Dist::Server::SHORT}.webui_pub_key" => ["opscode-erchef", "opscode-reporting"],
   "data_collector.token" => ["opscode-erchef", "nginx"],
   "ldap.bind_password" => ["opscode-erchef"],
   "manage.secret_key_base" => ["chef-manage"],
@@ -71,7 +71,7 @@ add_command_under_category "set-secret", "Secrets Management", "Set or change se
   name = ARGV[2]
 
   unless is_known_credential(group, name)
-    msg = "chef-server-ctl set-secret: Unknown credential: '#{name}' (group '#{group}')"
+    msg = "#{Chef::Dist::Server::CTL} set-secret: Unknown credential: '#{name}' (group '#{group}')"
     STDERR.puts msg
     raise SystemExit.new(1, msg)
   end
@@ -86,7 +86,7 @@ add_command_under_category "remove-secret", "Secrets Management", "Remove secret
   group = ARGV[1]
   name = ARGV[2]
 
-  confirm_continue!("WARN: Removing a secret may render your chef-server inoperable.  Are you sure?")
+  confirm_continue!("WARN: Removing a secret may render your #{Chef::Dist::Server::SHORT} inoperable.  Are you sure?")
   credentials.remove(group, name)
   credentials.save
 end

--- a/src/chef-server-ctl/plugins/test.rb
+++ b/src/chef-server-ctl/plugins/test.rb
@@ -5,8 +5,8 @@
 #
 
 add_command_under_category "test", "general", "Run the API test suite against localhost.", 2 do
-  ENV['SUPERUSER_KEY'] = credentials.get("chef-server", "superuser_key")
-  ENV['WEBUI_KEY'] = credentials.get("chef-server", "webui_key")
+  ENV['SUPERUSER_KEY'] = credentials.get("#{Chef::Dist::Server::SHORT}", "superuser_key")
+  ENV['WEBUI_KEY'] = credentials.get("#{Chef::Dist::Server::SHORT}", "webui_key")
   ENV['STATS_PASSWORD'] = credentials.get('opscode_erchef', 'stats_password')
 
   pedant_args = ARGV[1..-1]

--- a/src/chef-server-ctl/plugins/upgrade.rb
+++ b/src/chef-server-ctl/plugins/upgrade.rb
@@ -20,10 +20,10 @@ add_command_under_category "upgrade", "general", "Upgrade your private chef inst
     @options.chef12_server_url = "https://localhost"
     @options.upload_threads = 10
     @options.chef11_admin_client_name = "admin"
-    @options.chef11_admin_client_key = "/etc/chef-server/admin.pem"
+    @options.chef11_admin_client_key = "/etc/#{Chef::Dist::Server::SHORT}/admin.pem"
 
     opt_parser = OptionParser.new do |opts|
-      opts.banner = "Usage: chef-server-ctl upgrade [options]"
+      opts.banner = "Usage: #{Chef::Dist::Server::CTL} upgrade [options]"
       opts.banner = opts.banner << "\n Options only apply to open source Chef 11 server to Chef 12 server upgrades."
       opts.banner = opts.banner << "\n If upgrading from Enterprise Chef 11 server to Chef 12 server no options are needed."
 
@@ -82,7 +82,7 @@ add_command_under_category "upgrade", "general", "Upgrade your private chef inst
 
   def detect_chef11
     # Is this reliable enough?
-    File.directory?("/opt/chef-server")
+    File.directory?("/opt/#{Chef::Dist::Server::SHORT}")
   end
 
   def upgrade?

--- a/src/chef-server-ctl/plugins/version.rb
+++ b/src/chef-server-ctl/plugins/version.rb
@@ -24,9 +24,9 @@ add_command_under_category "version", "general", "Display current version of Che
     # isn't appropriate in all cases.  One option would be to ask the
     # LB for our version, but then the version command won't work when
     # we are offline.
-    if File.exist?('/hab/svc/chef-server-ctl/PID')
+    if File.exist?("/hab/svc/#{Chef::Dist::Server::SHORT}-ctl/PID")
       ident_file = File.read('../IDENT')
-      version = "chef-server #{ident_file.split('/')[2]}"
+      version = "#{Chef::Dist::Server::SHORT} #{ident_file.split('/')[2]}"
     else
       version = JSON.parse(File.read('/opt/opscode/version-manifest.json'))['build_version']
     end

--- a/src/chef-server-ctl/spec/backup_spec.rb
+++ b/src/chef-server-ctl/spec/backup_spec.rb
@@ -16,7 +16,7 @@
 
 require 'omnibus_ctl_helper'
 
-describe 'chef-server-ctl backup' do
+describe "#{Chef::Dist::Server::SHORT}-ctl backup" do
   before do
     @omnibus_ctl = OmnibusCtlHelper.new(['./plugins/backup.rb'])
     allow(@omnibus_ctl.ctl).to receive(:running_config).and_return(running_config)

--- a/src/chef-server-ctl/spec/key_control_spec.rb
+++ b/src/chef-server-ctl/spec/key_control_spec.rb
@@ -19,7 +19,7 @@ require 'chef_server_ctl/helpers/key_ctl_helper'
 require 'chef_server_ctl/config'
 require 'chef/key'
 
-describe "chef-server-ctl *key(s)*" do
+describe "#{Chef::Dist::Server::SHORT}-ctl *key(s)*" do
   before(:all) do
     @helper = OmnibusCtlHelper.new(["./plugins/key_control.rb"])
   end

--- a/src/chef-server-ctl/spec/reindex_spec.rb
+++ b/src/chef-server-ctl/spec/reindex_spec.rb
@@ -18,7 +18,7 @@ require "chef/config"
 require "chef/org"
 require "omnibus_ctl_helper"
 
-describe "chef-server-ctl reindex" do
+describe "#{Chef::Dist::Server::CTL} reindex" do
   subject(:reindex) do
     ctlHelper = OmnibusCtlHelper.new(["./plugins/reindex.rb"])
     ::ChefServerCtl::Config.init(ctlHelper.ctl)

--- a/src/chef-server-ctl/spec/rotate_credentials_spec.rb
+++ b/src/chef-server-ctl/spec/rotate_credentials_spec.rb
@@ -27,7 +27,7 @@ module Omnibus
   end
 end
 
-describe "chef-server-ctl rotate credentials" do
+describe "#{Chef::Dist::Server::CTL} rotate credentials" do
   subject do
     OmnibusCtlHelper.new(["./plugins/rotate_credentials.rb"])
   end
@@ -188,7 +188,7 @@ describe "chef-server-ctl rotate credentials" do
           .and_return(true)
       end
 
-      it "allows 'chef-server-ctl rotate-shared-secrets' to be run" do
+      it "allows '#{Chef::Dist::Server::CTL} rotate-shared-secrets' to be run" do
         expect do
           subject.run_global_pre_hooks(%w{omnibus-ctl opscode rotate-shared-secrets})
         end.to_not raise_error

--- a/src/chef-server-ctl/spec/secrets_spec.rb
+++ b/src/chef-server-ctl/spec/secrets_spec.rb
@@ -27,7 +27,7 @@ module Omnibus
   end
 end
 
-describe "chef-server-ctl set-secret" do
+describe "#{Chef::Dist::Server::CTL} set-secret" do
   subject do
     OmnibusCtlHelper.new(["./plugins/secrets.rb"])
   end

--- a/src/oc-id/config/initializers/omniauth-chef.rb
+++ b/src/oc-id/config/initializers/omniauth-chef.rb
@@ -5,7 +5,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     config.path_prefix = '/id/auth'
   end
 
-  provider :chef, Settings.chef.to_hash.merge(key_data: Secrets.get("chef-server", "webui_key"))
+  provider :chef, Settings.chef.to_hash.merge(key_data: Secrets.get("#{Chef::Dist::Server::SHORT}", "webui_key"))
 end
 
 OmniAuth.config.on_failure = proc do |env|

--- a/src/oc-id/lib/chef_resource.rb
+++ b/src/oc-id/lib/chef_resource.rb
@@ -25,7 +25,7 @@ module ChefResource
   end
 
   def key
-    Secrets.get("chef-server", "webui_key")
+    Secrets.get("#{Chef::Dist::Server::SHORT}", "webui_key")
   end
 
   def parameters

--- a/terraform/aws/scenarios/omnibus-external-openldap/files/chef-server.rb
+++ b/terraform/aws/scenarios/omnibus-external-openldap/files/chef-server.rb
@@ -8,10 +8,10 @@ data_collector['token'] = 'foobar' unless data_collector.nil?
 
 profiles['root_url'] = 'http://localhost:9998' unless profiles.nil?
 
-ldap['base_dn'] = 'ou=chefs,dc=chef-server,dc=dev'
-ldap['bind_dn'] = 'cn=admin,dc=chef-server,dc=dev'
+ldap['base_dn'] = "ou=chefs,dc=#{Chef::Dist::Server::SHORT},dc=dev"
+ldap['bind_dn'] = "cn=admin,dc=#{Chef::Dist::Server::SHORT},dc=dev"
 ldap['bind_password'] = 'H0\/\/!|\/|3tY0ur|\/|0th3r'
-ldap['host'] = 'ldap.chef-server.dev'
+ldap['host'] = "ldap.#{Chef::Dist::Server::SHORT}.dev"
 ldap['login_attribute'] = 'uid'
 
 # Use TLS for encryption against an OpenLDAP instance to avoid connection resets

--- a/terraform/aws/scenarios/omnibus-external-openldap/files/pedant_config.rb
+++ b/terraform/aws/scenarios/omnibus-external-openldap/files/pedant_config.rb
@@ -7,7 +7,7 @@ ldap(
   "common_name": "User One",
   "country": "unknown",
   "city": "unknown",
-  "email": "user1@chef-server.dev",
+  "email": "user1@#{Chef::Dist::Server::SHORT}.dev",
   "username": "user1",
   "external_authentication_uid": "user1",
   "recovery_authentication_enabled": false,


### PR DESCRIPTION
Add `dist.rb` files with "Wordmark" constants in an attempt to make
Chef Server distributable under a configurable name. This is a starting
point which replaces most of the instances of `chef-server` and
`chef-sevrer-ctl` within the Ruby code of the Chef Server repo, but
is not a complete fix for #1949

Signed-off-by: Josh Gitlin <jgitlin@pinnacle21.com>

The original PR can be found at #1976
Creating this branch to run tests.
Build:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1258#1a7de4cf-926a-4b6d-a412-0924d1da6eeb
Integration tests: