### PR TITLE
Add sleep and license acceptance to chef-run in openldap scenario

### DIFF
--- a/terraform/aws/scenarios/omnibus-external-openldap/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/main.tf
@@ -72,7 +72,7 @@ resource "null_resource" "ldap_cookbook" {
   depends_on = [null_resource.ldap_config]
 
   provisioner "local-exec" {
-    command = "chef-run --user ${module.ldap.ssh_username} ${module.ldap.public_ipv4_dns} ${path.module}/../../../../dev/cookbooks/provisioning/recipes/ldap-server.rb"
+    command = "sleep 30; chef-run --chef-license=accept --user ${module.ldap.ssh_username} ${module.ldap.public_ipv4_dns} ${path.module}/../../../../dev/cookbooks/provisioning/recipes/ldap-server.rb"
   }
 }
 


### PR DESCRIPTION
### Description

The openldap scenario has been failing in the integration test pipeline due to the lack of a chef-workstation license acceptance.

The fix is demonstrated via this integration test run:

https://buildkite.com/chef/chef-chef-server-master-integration-test/builds/153

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
