### PR TITLE
Fix azure scenario to retrieve public ip on first run

### DIFF
--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -22,11 +22,11 @@ The test scenarios require the `ARM_SSH_KEY_FILE` environment variable to be pop
 
 ### Azure Resource Manager
 
-Scenarios require that they are run against a compatible resource manager.
+Scenarios require that they are run against a compatible resource group.
 
-You may generate a compatible resource manager using the `ARM_DEPT=Eng ARM_CONTACT=csnapp make create-resource-manager` command.
+You may generate a compatible resource group using the `ARM_DEPT=Eng ARM_CONTACT=csnapp make create-resource-group` command.
 
-***NOTE:*** **There is no automatic reaping of the resource manager.  Make sure you destroy your resource manager using the** `ARM_DEPT=Eng ARM_CONTACT=csnapp make destroy-resource-manager` **command once you are finished testing scenarios and ALL server instances have been destroyed.**
+***NOTE:*** **There is no automatic reaping of the resource group.  Make sure you destroy your resource group using the** `ARM_DEPT=Eng ARM_CONTACT=csnapp make destroy-resource-group` **command once you are finished testing scenarios and ALL server instances have been destroyed.**
 
 ## Running a Scenario
 Environment variables are used to control how the scenarios are executed and can either be passed on the command line before the `make` command or set in the shell's environment (e.g. `$HOME/.bashrc`)

--- a/terraform/azure/modules/arm_instance/main.tf
+++ b/terraform/azure/modules/arm_instance/main.tf
@@ -39,8 +39,6 @@ resource "azurerm_network_security_group" "default" {
 }
 
 resource "azurerm_public_ip" "default" {
-  depends_on = [azurerm_network_security_group.default]
-
   resource_group_name = data.azurerm_resource_group.chef_resource_group.name
   location            = data.azurerm_resource_group.chef_resource_group.location
 
@@ -55,8 +53,6 @@ resource "azurerm_public_ip" "default" {
 }
 
 resource "azurerm_network_interface" "default" {
-  depends_on = [azurerm_public_ip.default]
-
   resource_group_name       = data.azurerm_resource_group.chef_resource_group.name
   location                  = data.azurerm_resource_group.chef_resource_group.location
 
@@ -76,8 +72,6 @@ resource "azurerm_network_interface" "default" {
 }
 
 resource "azurerm_virtual_machine" "default" {
-  depends_on = [azurerm_network_interface.default]
-
   resource_group_name = data.azurerm_resource_group.chef_resource_group.name
   location            = data.azurerm_resource_group.chef_resource_group.location
 
@@ -118,4 +112,13 @@ resource "azurerm_virtual_machine" "default" {
     X-Dept    = var.arm_department
     X-Contact = var.arm_contact
   }
+}
+
+# obtain the ip address after the public ip has been assigned to the virtual machine
+data "azurerm_public_ip" "default" {
+	depends_on = [azurerm_virtual_machine.default]
+
+  resource_group_name = data.azurerm_resource_group.chef_resource_group.name
+
+  name                = "${var.build_prefix}${var.name}-${local.arm_resource_group_name}"
 }

--- a/terraform/azure/modules/arm_instance/outputs.tf
+++ b/terraform/azure/modules/arm_instance/outputs.tf
@@ -7,7 +7,7 @@ output "location" {
 }
 
 output "public_ipv4_address" {
-  value = azurerm_public_ip.default.ip_address
+  value = data.azurerm_public_ip.default.ip_address
 }
 
 output "private_ipv4_address" {


### PR DESCRIPTION
### Description

This PR addresses an issue that forced the user to apply the azure scenario twice to ensure the public ip was set on the postgresql firewall.  With this fix, the azure terraform scenario can be executed once and the public ip is retrieved as expected and applied to the firewall on the first run.

### Issues Resolved

#1833 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
