### PR TITLE
Build packages for Ubuntu 20.04

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -16,3 +16,4 @@ builder-to-testers-map:
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
+    - ubuntu-20.04-x86_64


### PR DESCRIPTION
We have testers for Ubuntu 20.04 now and it has some pretty serious
performance improvements that would make it the ideal release for
customers running Chef on Ubuntu.

Signed-off-by: Tim Smith <tsmith@chef.io>
