### PR TITLE
Add nightly integration test run

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -27,6 +27,10 @@ schedules:
     description: "Run a nightly build in the omnibus/adhoc pipeline"
     cronline: "0 6 * * *"
 
+  - name: nightly_integration_test
+    description: "Run a nightly integration test against latest current"
+    cronline: "0 9 * * *"
+
   - name: cleanup_orphaned_test_resources
     description: Cleanup orphaned test resources
     cronline: "0 5 * * *" # every day at 5am
@@ -109,6 +113,9 @@ subscriptions:
   - workload: schedule_triggered:chef/chef-server:master:nightly_build:*
     actions:
       - trigger_pipeline:omnibus/adhoc
+  - workload: schedule_triggered:chef/chef-server:master:nightly_integration_test:*
+    actions:
+      - trigger_pipeline:integration_test
   # Run these actions when the freshly built Habitat packages have been uploaded to Depot
   - workload: buildkite_hab_build_group_published:{{agent_id}}:*
     actions:


### PR DESCRIPTION


### Description
This PR simply adds a nightly run of the integration test pipeline allowing it to determine the default versions to be tested (i.e. INSTALL_VERSION = latest stable, UPGRADE_VERSION = latest current)

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
