### PR TITLE
Update gpg key URL

### DIFF
--- a/omnibus/config/software/gpg-key.rb
+++ b/omnibus/config/software/gpg-key.rb
@@ -30,9 +30,9 @@ version "1.0.1" do
   source md5: "369efc3a19b9118cdf51c7e87a34f266"
 end
 
-source url: "https://downloads.chef.io/packages-chef-io-public.key"
+source url: "https://packages.chef.io/chef.asc"
 
 build do
   mkdir "#{install_dir}/embedded/keys"
-  copy "#{project_dir}/packages-chef-io-public.key", "#{install_dir}/embedded/keys/packages-chef-io-public.key"
+  copy "#{project_dir}/chef.asc", "#{install_dir}/embedded/keys/packages-chef-io-public.key"
 end


### PR DESCRIPTION
### Description

The GPG key URL changed. Change updates the config to reflect this. 

Sidenote: Not sure how the key files in the target directory `#{install_dir}/embedded/keys/` are processed (ie glob `*.key`, glob `*`, etc) so without knowing if `*.asc` was valid for whatever is using the key, I intentionally left the `copy` target with the old key name. Obviously, feel free to change this.

### Issues Resolved

Closes #2053

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
