### PR TITLE
Sel conn closed

### DIFF
--- a/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
@@ -165,6 +165,10 @@ describe "running configs required by Chef Server and plugins", :config do
       expect(config['opscode-erchef']['solr_http_max_connection_duration'].to_s).not_to eq ''
     end
 
+    it "opscode-erchef/solr_retry_on_conn_closed" do
+      expect(config['opscode-erchef']['solr_retry_on_conn_closed'].to_s).not_to eq ''
+    end
+
     it "opscode-erchef/solr_ibrowse_options" do
       expect(config['opscode-erchef']['solr_ibrowse_options'].to_s).not_to eq ''
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -456,6 +456,7 @@ default['private_chef']['opscode-erchef']['solr_http_max_count'] = 100
 default['private_chef']['opscode-erchef']['solr_http_cull_interval'] = '{1, min}'
 default['private_chef']['opscode-erchef']['solr_http_max_age'] = '{70, sec}'
 default['private_chef']['opscode-erchef']['solr_http_max_connection_duration'] = '{70,sec}'
+default['private_chef']['opscode-erchef']['solr_retry_on_conn_closed'] = true
 default['private_chef']['opscode-erchef']['solr_ibrowse_options'] = '[{connect_timeout, 10000}]'
 # Default: generate signed URLs based upon Host: header. Override with a url, "http:// ..."
 default['private_chef']['opscode-erchef']['base_resource_url'] = :host_header
@@ -767,6 +768,7 @@ default['private_chef']['oc_chef_authz']['http_queue_max'] = 50
 default['private_chef']['oc_chef_authz']['http_cull_interval'] = '{1, min}'
 default['private_chef']['oc_chef_authz']['http_max_age'] = '{70, sec}'
 default['private_chef']['oc_chef_authz']['http_max_connection_duration'] = '{70, sec}'
+default['private_chef']['oc_chef_authz']['http_retry_on_conn_closed'] = true
 default['private_chef']['oc_chef_authz']['ibrowse_options'] = '[{connect_timeout, 5000}]'
 
 ####
@@ -996,6 +998,8 @@ default['private_chef']['data_collector']['http_max_age'] = '{70, sec}'
 default['private_chef']['data_collector']['http_cull_interval'] = '{1, min}'
 # Maximum age of a connection before terminating it.
 default['private_chef']['data_collector']['http_max_connection_duration'] = '{70,sec}'
+# Should the request be retried on a different connection incase of receving a sel_conn_closed
+default['private_chef']['data_collector']['http_retry_on_conn_closed'] = true
 # Options for the ibrowse connections (see ibrowse).
 default['private_chef']['data_collector']['ibrowse_options'] = '[{connect_timeout, 10000}]'
 # Select whether data_collector affects overall status in _status endpoint

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -208,6 +208,7 @@
             {cull_interval, <%= node['private_chef']['oc_chef_authz']['http_cull_interval'] %>},
             {max_age, <%= node['private_chef']['oc_chef_authz']['http_max_age'] %>},
             {max_connection_duration, <%= node['private_chef']['oc_chef_authz']['http_max_connection_duration'] %>},
+            {retry_on_conn_closed, <%= node['private_chef']['oc_chef_authz']['http_retry_on_conn_closed']=%>},
             {ibrowse_options, <%= node['private_chef']['oc_chef_authz']['ibrowse_options'] %>}
         ]},
         {cleanup_batch_size, <%= node['private_chef']['opscode-erchef']['cleanup_batch_size'] %>}
@@ -240,6 +241,7 @@
             {cull_interval, <%= @solr_http_cull_interval %>},
             {max_age, <%= @solr_http_max_age %>},
             {max_connection_duration, <%= @solr_http_max_connection_duration %>},
+            {retry_on_conn_closed, <%= @solr_retry_on_conn_closed  %>},
             {ibrowse_options, <%= @solr_ibrowse_options %>}
         ]},
         {rabbitmq_index_management_service, [
@@ -295,6 +297,7 @@
         {cull_interval,           <%= node['private_chef']['data_collector']['http_cull_interval'] %>},
         {max_age,                 <%= node['private_chef']['data_collector']['http_max_age'] %>},
         {max_connection_duration, <%= node['private_chef']['data_collector']['http_max_connection_duration'] %>},
+        {retry_on_conn_closed,    <%= node['private_chef']['data_collector']['http_retry_on_conn_closed']%>},
         {ibrowse_options,         <%= node['private_chef']['data_collector']['ibrowse_options'] %>}
     ]},
     <% end %>

--- a/src/oc_erchef/apps/data_collector/rebar.lock
+++ b/src/oc_erchef/apps/data_collector/rebar.lock
@@ -15,7 +15,7 @@
   0},
  {<<"opscoderl_httpc">>,
   {git,"git://github.com/chef/opscoderl_httpc.git",
-       {ref,"bab889e9165b662c2c23ae3cd5449d6875e7507c"}},
+       {ref,"d9578f44726ca69af5bdadaa602756692d3b1460"}},
   0},
  {<<"pooler">>,
   {git,"git://github.com/seth/pooler.git",

--- a/src/oc_erchef/apps/data_collector/test/data_collector_test_utils.erl
+++ b/src/oc_erchef/apps/data_collector/test/data_collector_test_utils.erl
@@ -33,6 +33,7 @@ setup(MockedModules) ->
         {cull_interval, {1, min}},
         {max_age, {70, sec}},
         {max_connection_duration, {70, sec}},
+        {retry_on_conn_closed, true},
         {ibrowse_options, [{connect_timeout, 10000}]}
     ],
     [application:set_env(data_collector, Name, Value) || {Name, Value} <- Env],

--- a/src/oc_erchef/apps/oc_chef_wm/itest/setup_helper.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/setup_helper.erl
@@ -110,6 +110,7 @@ start_server(Config) ->
                          {cull_interval, {1, min}},
                          {max_age, {70, sec}},
                          {max_connection_duration, {70, sec}},
+                         {retry_on_conn_closed, true},
                          {ibrowse_options, [{connect_timeout, 10000}]},
                          {timeout, 300}
                         ]),

--- a/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
@@ -151,6 +151,7 @@ default_config() ->
             {cull_interval, {60, sec}},
             {max_age, {70, sec}},
             {max_connection_duration, {70, sec}},
+            {retry_on_conn_closed, true},
             {ibrowse_options,
             [{connect_timeout, 10000},
                 {basic_auth,

--- a/src/oc_erchef/habitat/config/sys.config
+++ b/src/oc_erchef/habitat/config/sys.config
@@ -170,6 +170,7 @@
             {cull_interval, {1, min}},
             {max_age, {70, sec}},
             {max_connection_duration, {70, sec}},
+            {retry_on_conn_closed, true},
             {ibrowse_options, [{connect_timeout, 5000}]}
         ]},
     {{/if ~}}
@@ -185,6 +186,7 @@
             {cull_interval, {1, min}},
             {max_age, {70, sec}},
             {max_connection_duration, {70, sec}},
+            {retry_on_conn_closed, true},
             {ibrowse_options, [{connect_timeout, 5000}]}
         ]},
 {{/if ~}}
@@ -227,6 +229,7 @@
             {cull_interval, {1, min}},
             {max_age, {70, sec}},
             {max_connection_duration, {70,sec}},
+            {retry_on_conn_closed, true},
             {ibrowse_options, [{connect_timeout, 10000}]}
         ]},
         {rabbitmq_index_management_service, [
@@ -274,6 +277,7 @@
         {cull_interval,           {1, min}},
         {max_age,                 {70, sec}},
         {max_connection_duration, {70,sec}},
+        {retry_on_conn_closed, true},
         {ibrowse_options,         [{connect_timeout, 10000}]}
     ]},
 {{/if ~}}

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -117,7 +117,7 @@
   0},
  {<<"opscoderl_httpc">>,
   {git,"git://github.com/chef/opscoderl_httpc.git",
-       {ref,"bab889e9165b662c2c23ae3cd5449d6875e7507c"}},
+       {ref,"d9578f44726ca69af5bdadaa602756692d3b1460"}},
   0},
  {<<"opscoderl_wm">>,
   {git,"git://github.com/chef/opscoderl_wm.git",


### PR DESCRIPTION
This change pulls the version of opscoderl_httpc that takes an option to retry the ibrowse request on a new connection incase of a sel_conn_closed.
 
Fixes: #1947 and #1973

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1472