### PR TITLE
Add Chef Server 13 release branch

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -15,7 +15,10 @@ github:
   # details from the Pull Request via the `built_in:update_changelog` merge_action.
   changelog_file: "CHANGELOG.md"
   release_branch:
-    - master
+    - master:
+        version_constraint: 14*
+    - chef-server-13:
+        version_constraint: 13*
 
 # Habitat + Docker exporting
 


### PR DESCRIPTION
Chef Server 14 is under development on master. In the meantime, we
want to be able to ship Chef Server 13. The version on the
chef-server-13 branch has been bumped to 13.3 to avoid conflicts with
the 13.2 tags that got created before the 14 version bump.

NOTE: We will need to do a review of which patches to pull into this
branch before release and decide how much we want to support people
who deployed from current "upgrading" to this release.

Signed-off-by: Steven Danna <steve@chef.io>