### PR TITLE
Fix RHEL8 FIPS enablement in integration test

### DIFF
--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -49,14 +49,14 @@ steps:
       executor:
        docker:
 
-  - label: ':terraform: fips-ipv4-rhel-8'
+  - label: ':terraform: fips-ipv4-rhel-7'
     command: .expeditor/integration_test.pipeline.sh aws apply
     artifact_paths:
       - ./integration_test.log
       - ./*capture_paths.tar.gz
     env:
       SCENARIO: omnibus-fips
-      PLATFORM: rhel-8
+      PLATFORM: rhel-7
       ENABLE_IPV6: false
     expeditor:
       accounts:

--- a/terraform/aws/scenarios/omnibus-fips/main.tf
+++ b/terraform/aws/scenarios/omnibus-fips/main.tf
@@ -32,7 +32,11 @@ resource "null_resource" "chef_server_fips" {
       "echo -e '\nBEGIN ENABLING FIPS MODE\n'",
       "sudo yum install -y dracut-fips dracut-fips-aesni",
       "sudo dracut -f",
-      "if [ -f /etc/default/grub ]; then sudo sed -i '/GRUB_CMDLINE_LINUX/{s/=\"/=\"fips=1 /;}' /etc/default/grub; sudo grub2-mkconfig -o /boot/grub2/grub.cfg; else sudo sed -i '/^\t.*kernel.*boot/{s/$/ fips=1/;}' /boot/grub/grub.conf; fi",
+      "case $(sed 's/.*release //;s/\\..*//;' /etc/redhat-release) in\n",
+      "8) sudo fips-mode-setup --enable ;;\n",
+      "7) sudo sed -i '/GRUB_CMDLINE_LINUX/{s/=\"/=\"fips=1 /;}' /etc/default/grub; sudo grub2-mkconfig -o /boot/grub2/grub.cfg ;;\n",
+      "6) sudo sed -i '/^\t.*kernel.*boot/{s/$/ fips=1/;}' /boot/grub/grub.conf ;;\n",
+      "esac",
       "echo -e '\nEND ENABLING FIPS MODE\n'",
     ]
   }


### PR DESCRIPTION
### Description

This PR fixes the core dump that was occurring in the `omnibus-fips` integration test scenario when run against RHEL8.

It also modifies the integration test pipeline to run `omnibus-fips` against RHEL7 due to an issue with Terraform not properly identifying the type of RSA key used to SSH onto the test instance.  In RHEL8, once FIPS mode is enabled, the machine will no longer allow the SHA1 based `ssh-rsa` algorithm access to the machine (see: https://bugs.centos.org/view.php?id=16720#c36524).

### Issues Resolved

#2069 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
