### PR TITLE
Fix Terraform lint errors

### DIFF
--- a/terraform/aws/Makefile
+++ b/terraform/aws/Makefile
@@ -238,7 +238,7 @@ list-active-workspaces:
 # returns anything in order to determine if lint fails
 lint:
 	@set -e; \
-	LINT_OUTPUT=$$(terraform fmt --diff --list --write=false ./); \
+	LINT_OUTPUT=$$(terraform fmt --recursive --diff --list --write=false ./); \
 	if test -n "$$LINT_OUTPUT"; then \
 		echo "$$LINT_OUTPUT"; \
 		exit 1; \

--- a/terraform/aws/common/versions.tf
+++ b/terraform/aws/common/versions.tf
@@ -10,13 +10,13 @@ provider "aws" {
 }
 
 provider "http" {
-	version = "~> 1.1"
+  version = "~> 1.1"
 }
 
 provider "null" {
-	version = "~> 2.1"
+  version = "~> 2.1"
 }
 
 provider "template" {
-	version = "~> 2.1"
+  version = "~> 2.1"
 }

--- a/terraform/aws/modules/aws_instance/locals.tf
+++ b/terraform/aws/modules/aws_instance/locals.tf
@@ -11,12 +11,12 @@ locals {
   ssh_username = replace(var.platform, "/ubuntu-.*/", "ubuntu") == "ubuntu" ? "ubuntu" : "ec2-user"
 
   ami_ids = {
-    rhel-6       = data.aws_ami.rhel_6.id
-    rhel-7       = data.aws_ami.rhel_7.id
-    rhel-8       = data.aws_ami.rhel_8.id
+    rhel-6         = data.aws_ami.rhel_6.id
+    rhel-7         = data.aws_ami.rhel_7.id
+    rhel-8         = data.aws_ami.rhel_8.id
     "ubuntu-14.04" = data.aws_ami.ubuntu_1404.id
     "ubuntu-16.04" = data.aws_ami.ubuntu_1604.id
     "ubuntu-18.04" = data.aws_ami.ubuntu_1804.id
-    sles-12      = data.aws_ami.sles_12.id
+    sles-12        = data.aws_ami.sles_12.id
   }
 }

--- a/terraform/aws/modules/aws_instance/main.tf
+++ b/terraform/aws/modules/aws_instance/main.tf
@@ -78,10 +78,10 @@ resource "aws_instance" "default" {
 }
 
 resource "local_file" "connection_info" {
-	# only output connection info if this instance has paths we want to capture
-	count = length(var.capture_paths) > 0 ? 1 : 0
+  # only output connection info if this instance has paths we want to capture
+  count = length(var.capture_paths) > 0 ? 1 : 0
 
-	# write a file containing ssh connection information on the first line with the remaining lines being the list of paths to capture
-  content = format("%s@%s\n%v\n", local.ssh_username, aws_instance.default.public_dns, var.capture_paths)
+  # write a file containing ssh connection information on the first line with the remaining lines being the list of paths to capture
+  content  = format("%s@%s\n%v\n", local.ssh_username, aws_instance.default.public_dns, var.capture_paths)
   filename = "/tmp/${var.build_prefix}${var.name}-connection_info.txt"
 }

--- a/terraform/aws/modules/aws_instance/variables.tf
+++ b/terraform/aws/modules/aws_instance/variables.tf
@@ -59,7 +59,7 @@ variable "name" {
 }
 
 variable "capture_paths" {
-	type    = list(string)
+  type        = list(string)
   description = "List of paths to be extracted from the instance when scenario completes."
-	default = []
+  default     = []
 }

--- a/terraform/aws/scenarios/omnibus-external-openldap/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-openldap/main.tf
@@ -40,7 +40,7 @@ data "template_file" "hosts_config" {
     # TODO(ssd) 2020-05-21: As far as I can tell, the erlang eldap
     # library has a bug in it that prevents us from connecting to IPv6
     # LDAP servers.
-    ldap_ip        = module.ldap.private_ipv4_address
+    ldap_ip = module.ldap.private_ipv4_address
   }
 }
 

--- a/terraform/aws/scenarios/omnibus-external-postgresql/main.tf
+++ b/terraform/aws/scenarios/omnibus-external-postgresql/main.tf
@@ -46,7 +46,7 @@ data "template_file" "chef_server_rb" {
   template = file("${path.module}/templates/chef-server.rb.tpl")
 
   vars = {
-    enable_ipv6 = var.enable_ipv6
+    enable_ipv6   = var.enable_ipv6
     postgresql_ip = var.enable_ipv6 == "true" ? module.postgresql.public_ipv6_address : module.postgresql.private_ipv4_address
   }
 }

--- a/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
+++ b/terraform/aws/scenarios/omnibus-tiered-upgrade/main.tf
@@ -51,7 +51,7 @@ data "template_file" "chef_server_config" {
   vars = {
     enable_ipv6         = var.enable_ipv6
     back_end_ip         = var.enable_ipv6 == "true" ? module.back_end.public_ipv6_address : module.back_end.private_ipv4_address
-    front_end_ip = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
+    front_end_ip        = var.enable_ipv6 == "true" ? module.front_end.public_ipv6_address : module.front_end.private_ipv4_address
     back_end_node_fqdn  = module.back_end.private_ipv4_dns
     front_end_node_fqdn = module.front_end.private_ipv4_dns
     cidr                = var.enable_ipv6 == "true" ? 64 : 32
@@ -241,7 +241,7 @@ resource "null_resource" "back_end_upgrade" {
     ]
   }
 
- # copy configuration to front-end
+  # copy configuration to front-end
   provisioner "remote-exec" {
     inline = [
       "set -evx",
@@ -285,7 +285,7 @@ resource "null_resource" "front_end_upgrade" {
   }
 }
 
-resource "null_resource" "chef_server_test"{
+resource "null_resource" "chef_server_test" {
   depends_on = [null_resource.front_end_upgrade]
 
   connection {

--- a/terraform/azure/Makefile
+++ b/terraform/azure/Makefile
@@ -211,7 +211,7 @@ list-active-workspaces:
 # returns anything in order to determine if lint fails
 lint:
 	@set -e; \
-	LINT_OUTPUT=$$(terraform fmt --diff --list --write=false ./); \
+	LINT_OUTPUT=$$(terraform fmt --recursive --diff --list --write=false ./); \
 	if test -n "$$LINT_OUTPUT"; then \
 		echo "$$LINT_OUTPUT"; \
 		exit 1; \

--- a/terraform/azure/common/versions.tf
+++ b/terraform/azure/common/versions.tf
@@ -11,13 +11,13 @@ provider "azurerm" {
 }
 
 provider "http" {
-	version = "~> 1.1"
+  version = "~> 1.1"
 }
 
 provider "null" {
-	version = "~> 2.1"
+  version = "~> 2.1"
 }
 
 provider "template" {
-	version = "~> 2.1"
+  version = "~> 2.1"
 }

--- a/terraform/azure/modules/arm_instance/main.tf
+++ b/terraform/azure/modules/arm_instance/main.tf
@@ -53,8 +53,8 @@ resource "azurerm_public_ip" "default" {
 }
 
 resource "azurerm_network_interface" "default" {
-  resource_group_name       = data.azurerm_resource_group.chef_resource_group.name
-  location                  = data.azurerm_resource_group.chef_resource_group.location
+  resource_group_name = data.azurerm_resource_group.chef_resource_group.name
+  location            = data.azurerm_resource_group.chef_resource_group.location
 
   name = "${var.name}-${local.arm_resource_group_name}"
 
@@ -116,9 +116,9 @@ resource "azurerm_virtual_machine" "default" {
 
 # obtain the ip address after the public ip has been assigned to the virtual machine
 data "azurerm_public_ip" "default" {
-	depends_on = [azurerm_virtual_machine.default]
+  depends_on = [azurerm_virtual_machine.default]
 
   resource_group_name = data.azurerm_resource_group.chef_resource_group.name
 
-  name                = "${var.name}-${local.arm_resource_group_name}"
+  name = "${var.name}-${local.arm_resource_group_name}"
 }


### PR DESCRIPTION
### Description
The Terraform lint check has been silently failing since moving from Terraform version 11 to 12 since the newer version does not recurse directory structures by default anymore.

In fixing the lint check, several errors were uncovered and corrected in the second commit.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
