### PR TITLE
ci: guard on BUILDKITE rather than EXPEDITOR env var

### DIFF
--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-if [[ "${EXPEDITOR:-false}" == "true" ]]; then
+if [[ "${BUILDKITE:-false}" == "true" ]]; then
   # TODO(ssd) 2019-12-13: packages.microsoft.com periodically fails with
   # an error such as:
   #

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -30,7 +30,6 @@ steps:
     executor:
       docker:
         environment:
-          - EXPEDITOR=true
           - OCTOKIT_ACCESS_TOKEN
 
 #########################################################################


### PR DESCRIPTION
Signed-off-by: Steven Danna <steve@chef.io>
