### PR TITLE
ci: don't promote docker containers for now

### DIFF
--- a/.expeditor/promote_harts_and_containers.sh
+++ b/.expeditor/promote_harts_and_containers.sh
@@ -35,27 +35,29 @@ jq -r -c ".packages[]" manifest.json | while read service_ident; do
   else
     echo "Promoting ${service_ident} hart to the ${EXPEDITOR_CHANNEL} channel"
     hab pkg promote "${service_ident}" "${EXPEDITOR_CHANNEL}"
-
+    # The pipeline has been improved, breaking this. I'm told to fix
+    # it requires doing something different.
+    #
     # TODO: remove this if we begin creating a container for `chef/openresty-noroot`
-    if [ "$pkg_name" = "openresty-noroot" ];
-    then
-      echo "Skipping promotion of container for ${service_ident}"
-      continue
-    fi
-
-    echo "Promoting ${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release} container to ${EXPEDITOR_CHANNEL} tag"
-    docker pull "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}"
-    docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
-    docker push "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
-
-    if [ "${EXPEDITOR_CHANNEL}" = "stable" ];
-    then
-      docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:latest"
-      docker push "${pkg_origin}/${pkg_name}:latest"
-      docker rmi "${pkg_origin}/${pkg_name}:latest"
-    fi
-
-    docker rmi "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
+    # if [ "$pkg_name" = "openresty-noroot" ];
+    # then
+    #   echo "Skipping promotion of container for ${service_ident}"
+    #   continue
+    # fi
+    #
+    # echo "Promoting ${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release} container to ${EXPEDITOR_CHANNEL} tag"
+    # docker pull "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}"
+    # docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
+    # docker push "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
+    #
+    # if [ "${EXPEDITOR_CHANNEL}" = "stable" ];
+    # then
+    #   docker tag "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:latest"
+    #   docker push "${pkg_origin}/${pkg_name}:latest"
+    #   docker rmi "${pkg_origin}/${pkg_name}:latest"
+    # fi
+    #
+    # docker rmi "${pkg_origin}/${pkg_name}:${pkg_version}-${pkg_release}" "${pkg_origin}/${pkg_name}:${EXPEDITOR_CHANNEL}"
   fi
 done
 


### PR DESCRIPTION
I'm told we now need to do this with:

https://expeditor.chef.io/docs/reference/actions/#built_inpromote_docker_images

I need to figure out how that would work with our manifest and
such. Right now I would like to get a single merge to go through
without an error and then work from there.

Signed-off-by: Steven Danna <steve@chef.io>