### PR TITLE
Add build_prefix to azure postgresql

### DIFF
--- a/terraform/azure/scenarios/omnibus-external-postgresql/main.tf
+++ b/terraform/azure/scenarios/omnibus-external-postgresql/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_postgresql_server" "default" {
   resource_group_name = module.chef_server.resource_group_name
   location            = module.chef_server.location
 
-  name                         = "${var.scenario}-${replace(var.platform, ".", "")}-${var.arm_contact}"
+  name                         = "${var.build_prefix}-${var.scenario}-${replace(var.platform, ".", "")}-${var.arm_contact}"
   administrator_login          = "bofh"
   administrator_login_password = "i1uvd3v0ps!"
   version                      = "9.6"


### PR DESCRIPTION
### Description

For some reason Azure's Resource Group serves as a unique namespace for all resources *except* the PostgreSQL DBaaS instance.  This caused failures when multiple integration test pipelines were run concurrently due to naming collisions on the PostgreSQL instances.

This PR adds the `build_prefix` to the PostgreSQL instance name which prevents the naming collisions.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>


### Issues Resolved
#2083


### Check List

- [ ] New functionality includes tests
- [X] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
