### PR TITLE
Initial chef-server-ctl wordmark replacements #1949

### DIFF
--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -7,6 +7,8 @@ require 'veil'
 require 'chef_server_ctl/log'
 require 'chef_server_ctl/config'
 require "license_acceptance/acceptor"
+require "chef-config/dist"
+require "chef"
 
 module Omnibus
   # This implements callbacks for handling commands related to the
@@ -70,13 +72,13 @@ module Omnibus
           last = exec_list.shift
           connection.exec(last)
         end
-        puts "Chef Server databases and roles have been successsfully deleted from #{postgres['vip']}"
+        puts "#{Chef::Dist::SERVER_PRODUCT} databases and roles have been successfully deleted from #{postgres['vip']}"
       rescue StandardError => e
         exec_list.insert(0, last) unless last.nil?
         if exec_list.empty?
           path = nil
         else
-          path = Time.now.strftime('/root/%FT%R-chef-server-manual-postgresql-cleanup.sql')
+          path = Time.now.strftime("/root/%FT%R-#{ChefConfig::Dist::SHORT}-server-manual-postgresql-cleanup.sql")
           dump_exec_list_to_file(path, exec_list)
         end
         # Note - we're just showing the error and not exiting, so that
@@ -159,8 +161,8 @@ EOM
 
     def err_CLEANSE001_postgres_failed(postgres, path, last, message)
       msg = <<EOM
-CLEANSE001: While local cleanse of Chef Server succeeded, an error
-            occurred while deleting Chef Server data from the external
+CLEANSE001: While local cleanse of #{Chef::Dist::SERVER_PRODUCT} succeeded, an error
+            occurred while deleting #{Chef::Dist::SERVER_PRODUCT} data from the external
             PostgreSQL server at #{postgres['vip']}.
 
             The error reported was:
@@ -190,11 +192,11 @@ EOM
     end
     def warn_CLEANSE002_no_postgres_delete(sql_path, postgres)
       <<EOM
-CLEANSE002: Note that Chef Server data was not removed from your
+CLEANSE002: Note that #{Chef::Dist::SERVER_PRODUCT} data was not removed from your
             remote PostgreSQL server because you did not specify
             the '--with-external' option.
 
-            If you do wish to purge Chef Server data from PostgreSQL,
+            If you do wish to purge #{Chef::Dist::SERVER_PRODUCT} data from PostgreSQL,
             you can do by logging into PostgreSQL on
             #{postgres['vip']}:#{postgres['port']}
             and executing the appropriate SQL staements manually.
@@ -274,7 +276,7 @@ log_level = if ENV['CSC_LOG_LEVEL']
 
 ChefServerCtl::Log.level = log_level
 
-ctl = Omnibus::ChefServerCtl.new(cmd_name, true, "Chef Server")
+ctl = Omnibus::ChefServerCtl.new(cmd_name, true, "#{Chef::Dist::SERVER_PRODUCT}")
 
 #Initialize global configuration
 ChefServerCtl::Config.init(ctl)

--- a/src/chef-server-ctl/plugins/backup.rb
+++ b/src/chef-server-ctl/plugins/backup.rb
@@ -2,8 +2,9 @@ require 'chef_backup'
 require 'chef/mixin/deep_merge'
 require 'optparse'
 require 'ostruct'
+require "chef-config/dist"
 
-add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
+add_command_under_category 'backup', 'general', "Backup the #{Chef::Dist::SERVER_PRODUCT}", 2 do
   ensure_configured!
   ensure_rsync!
 
@@ -12,7 +13,7 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
   options.config_only = false
 
   OptionParser.new do |opts|
-    opts.banner = 'Usage: chef-server-ctl backup [options]'
+    opts.banner = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl backup [options]"
 
     opts.on('-y', '--yes', 'Agree to go offline during tar based backups') do
       options.agree_to_go_offline = true
@@ -48,7 +49,7 @@ add_command_under_category 'backup', 'general', 'Backup the Chef Server', 2 do
   exit(0)
 end
 
-add_command_under_category 'restore', 'general', 'Restore the Chef Server from backup', 2 do
+add_command_under_category 'restore', 'general', "Restore the #{Chef::Dist::SERVER_PRODUCT} from backup", 2 do
   ensure_rsync!
 
   options = OpenStruct.new
@@ -56,13 +57,13 @@ add_command_under_category 'restore', 'general', 'Restore the Chef Server from b
   options.restore_dir = nil
 
   OptionParser.new do |opts|
-    opts.banner = 'Usage: chef-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]'
+    opts.banner = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]"
 
     opts.on('-d', '--staging-dir [directory]', String, 'The path to an empty directory for use in restoration.  Ensure it has enough available space for all expanded data in the backup archive') do |staging_directory|
       options.restore_dir = File.expand_path(staging_directory)
     end
 
-    opts.on('-c', '--cleanse', 'Agree to cleansing all existing state during a restore.  THIS WILL COMPLETELY REMOVING EXISTING CHEF DATA') do
+    opts.on('-c', '--cleanse', "Agree to cleansing all existing state during a restore.  THIS WILL COMPLETELY REMOVING EXISTING #{Chef::Dist::SERVER_PRODUCT.upcase} DATA") do
       options.agree_to_cleanse = 'yes'
     end
 
@@ -82,7 +83,7 @@ add_command_under_category 'restore', 'general', 'Restore the Chef Server from b
 
   unless ARGV.length >= 2
     log('Invalid command', :error)
-    log('USAGE: chef-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]', :error)
+    log("USAGE: #{ChefConfig::Dist::SHORT}-server-ctl restore $PATH_TO_BACKUP_TARBALL [options]", :error)
     exit(1)
   end
 
@@ -109,7 +110,7 @@ end
 
 def ensure_configured!
   unless running_config
-    log('You must reconfigure the Chef Server before a backup can be performed', :error)
+    log("You must reconfigure the #{Chef::Dist::SERVER_PRODUCT} before a backup can be performed", :error)
     exit(1)
   end
 end

--- a/src/chef-server-ctl/plugins/check_config.rb
+++ b/src/chef-server-ctl/plugins/check_config.rb
@@ -1,4 +1,6 @@
-add_command_under_category "check-config", "general", "Load the chef-server configuration and run all preflight checks", 1 do
+require "chef-config/dist"
+
+add_command_under_category "check-config", "general", "Load the #{ChefConfig::Dist::SHORT}-server configuration and run all preflight checks", 1 do
   chef_args = "-l fatal"
   attributes_path = "#{base_path}/embedded/cookbooks/check-config.json"
   status = run_chef(attributes_path, chef_args)

--- a/src/chef-server-ctl/plugins/filtered-dump.rb
+++ b/src/chef-server-ctl/plugins/filtered-dump.rb
@@ -1,6 +1,7 @@
+require "chef"
+require "chef-config/dist"
 
-
-add_command_under_category "filtered-dump", "Debug Tools", "Generate a filtered dump of indexable Chef Objects for all organizations.  Top-level data is captured; only object name is captured from object json" do
+add_command_under_category "filtered-dump", "Debug Tools", "Generate a filtered dump of indexable #{Chef::Dist::SERVER_PRODUCT} Objects for all organizations.  Top-level data is captured; only object name is captured from object json" do
   require 'json'
   require 'zlib'
   require 'stringio'

--- a/src/chef-server-ctl/plugins/gather-logs.rb
+++ b/src/chef-server-ctl/plugins/gather-logs.rb
@@ -2,10 +2,12 @@
 #
 # All Rights Reserved
 #
+require "chef-config/dist"
+require "chef"
 
-add_command_under_category "gather-logs", "general", "Create a tarball of recent logs and system information for Chef Support", 2 do
+add_command_under_category "gather-logs", "general", "Create a tarball of recent logs and system information for #{Chef::Dist::SERVER_PRODUCT} Support", 2 do
   if Process.uid != 0
-    STDERR.puts "private-chef-ctl gather-logs should be run as root."
+    STDERR.puts "private-#{ChefConfig::Dist::SHORT}-ctl gather-logs should be run as root."
     exit 1
   end
   run_command("/opt/opscode/bin/gather-logs")

--- a/src/chef-server-ctl/plugins/key_control.rb
+++ b/src/chef-server-ctl/plugins/key_control.rb
@@ -18,6 +18,7 @@ require "openssl"
 require "optparse"
 require "ostruct"
 require "chef/key"
+require "chef-config/dist"
 
 # Due to how things are being exec'ed, the CWD will be all wrong,
 # so we want to use the full path when loaded from omnibus-ctl,
@@ -31,7 +32,7 @@ add_command_under_category "add-client-key", "key-rotation", "Create a new clien
   @options = OpenStruct.new
   @options.expiration_date = "infinity"
   @key = nil
-  @usage = "Usage: chef-server-ctl add-client-key ORGNAME CLIENTNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]."
+  @usage = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl add-client-key ORGNAME CLIENTNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]."
   @usage = @usage << @helper.add_key_usage
   @arg_list = ["-e", "--expiration-date", "-k", "--key-name", "-p", "--public-key-path"]
 
@@ -101,7 +102,7 @@ add_command_under_category "add-user-key", "key-rotation", "Create a new user ke
   @options = OpenStruct.new
   @options.expiration_date = "infinity"
   @key = nil
-  @usage = "Usage: chef-server-ctl add-user-key USERNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]"
+  @usage = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl add-user-key USERNAME [-p, --public-key-path, -e, --expiration-date DATE, -k, --key-name NAME]"
   @usage = @usage << @helper.add_key_usage
   @arg_list = ["-e", "--expiration-date", "-k", "--key-name", "-p", "--public-key-path"]
   opt_parser = OptionParser.new do |opts|
@@ -166,7 +167,7 @@ add_command_under_category "list-client-keys", "key-rotation", "List keys for a 
   @helper = ::ChefServerCtl::Helpers::KeyCtlHelper.new
   @options = OpenStruct.new
   @options.show_public_keys = false
-  @usage = "Usage: chef-server-ctl list-client-keys ORGNAME CLIENTNAME [-v, --verbose]"
+  @usage = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl list-client-keys ORGNAME CLIENTNAME [-v, --verbose]"
   @arg_list = ["-v", "--verbose"]
 
   opt_parser = OptionParser.new do |opts|
@@ -208,7 +209,7 @@ add_command_under_category "list-user-keys", "key-rotation", "List keys for a us
 
   @options = OpenStruct.new
   @options.show_public_keys = false
-  @usage = "Usage: chef-server-ctl list-user-keys USERNAME [-v, --verbose]"
+  @usage = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl list-user-keys USERNAME [-v, --verbose]"
   @arg_list = ["-v", "--verbose"]
 
   opt_parser = OptionParser.new do |opts|
@@ -246,7 +247,7 @@ add_command_under_category "delete-user-key", "key-rotation", "Delete a key", 2 
   cmd_args = ARGV[1..-1]
   @helper = ::ChefServerCtl::Helpers::KeyCtlHelper.new
   @options = OpenStruct.new
-  @usage = "Usage: chef-server-ctl delete-user-key USERNAME KEYNAME"
+  @usage = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl delete-user-key USERNAME KEYNAME"
 
   @helper.get_required_arg!(@options, cmd_args, @usage, :username, "USERNAME", 1)
   @helper.get_required_arg!(@options, cmd_args, @usage, :key_name, "KEYNAME", 2)
@@ -268,7 +269,7 @@ add_command_under_category "delete-client-key", "key-rotation", "Delete a key", 
   cmd_args = ARGV[1..-1]
   @helper = ::ChefServerCtl::Helpers::KeyCtlHelper.new
   @options = OpenStruct.new
-  @usage = "Usage: chef-server-ctl delete-client-key ORGNAME CLIENTNAME KEYNAME"
+  @usage = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl delete-client-key ORGNAME CLIENTNAME KEYNAME"
 
   @helper.get_required_arg!(@options, cmd_args, @usage, :orgname, "ORGNAME", 1)
   @helper.get_required_arg!(@options, cmd_args, @usage, :clientname, "CLIENTNAME", 2)

--- a/src/chef-server-ctl/plugins/password.rb
+++ b/src/chef-server-ctl/plugins/password.rb
@@ -6,6 +6,7 @@
 
 require 'highline/import'
 require 'shellwords'
+require "chef-config/dist"
 
 knife_config = ::ChefServerCtl::Config.knife_config_file
 knife_cmd    = "#{::ChefServerCtl::Config.knife_bin} opc user password"
@@ -14,7 +15,7 @@ add_command_under_category "password", "organization-and-user-management", "Set 
   # changed arg to turn on ldap to --enable-external-auth since that makes more sense to new users, but left in
   # --disable for older users.
   unless ARGV.length == 2 || (ARGV.length == 3 && (ARGV[2] == "--disable" || ARGV[2] == "--enable-external-auth"))
-    STDERR.puts "Usage: private-chef-ctl password <username> [--enable-external-auth]"
+    STDERR.puts "Usage: private-#{ChefConfig::Dist::SHORT}-ctl password <username> [--enable-external-auth]"
     exit 1
   end
 
@@ -31,7 +32,7 @@ add_command_under_category "password", "organization-and-user-management", "Set 
       exit 1
     end
     if password == '' && ldap_authentication_enabled?
-      example_cmd = "'chef-server-ctl password #{username} --enable-external-auth'"
+      example_cmd = "'#{ChefConfig::Dist::SHORT}-server-ctl password #{username} --enable-external-auth'"
       STDERR.puts "You entered a blank password. If you were trying to enable ldap try #{example_cmd}?"
       exit 1
     end

--- a/src/chef-server-ctl/plugins/rebuild_migration_state.rb
+++ b/src/chef-server-ctl/plugins/rebuild_migration_state.rb
@@ -1,10 +1,12 @@
+require "chef-config/dist"
+
 add_command_under_category "rebuild-migration-state", "general", "Attempt to rebuild the migration-state file before upgrade.", 2 do
   require 'optparse'
   rebuild_args = ARGV[1..-1]
   options = {}
 
   OptionParser.new do |opts|
-    opts.banner = "chef-server-ctl rebuild-migration-state [options]"
+    opts.banner = "#{ChefConfig::Dist::SHORT}-server-ctl rebuild-migration-state [options]"
     opts.on("--force", "Overwrite existing migration state.") do |b|
       options[:force] = true
     end

--- a/src/chef-server-ctl/plugins/reindex.rb
+++ b/src/chef-server-ctl/plugins/reindex.rb
@@ -18,6 +18,8 @@ require 'optparse'
 require 'chef/config'
 require 'chef/org'
 require 'redis'
+require "chef-config/dist"
+require "chef"
 
 def all_orgs
   Chef::Config.from_file(::ChefServerCtl::Config.knife_config_file)
@@ -66,12 +68,12 @@ def redis
 end
 
 def disable_api
-  puts "- Disabling the Chef API."
+  puts "- Disabling the #{Chef::Dist::SERVER_PRODUCT} API."
   redis.hset("dl_default", "503_mode", true)
 end
 
 def enable_api
-  puts "- Re-enabling the Chef API"
+  puts "- Re-enabling the #{Chef::Dist::SERVER_PRODUCT} API"
   redis.hdel("dl_default", "503_mode")
 end
 

--- a/src/chef-server-ctl/plugins/rotate_credentials.rb
+++ b/src/chef-server-ctl/plugins/rotate_credentials.rb
@@ -2,17 +2,19 @@ require "veil"
 require "time"
 require "optparse"
 require "highline"
+require "chef-config/dist"
+require "chef"
 
 # rotate-credentials will generate new credential values for all credentials for
 # a given service by incrementing the value and creating a new hash value.
 # Because the shared secrets are known on all nodes in the cluster the user can
 # choose between copying the secrets file to each node in the cluster and
 # reconfiguring or by running this command on all nodes.
-add_command_under_category "rotate-credentials", "Secrets Management", "Rotate Chef Server credentials for a given service", 2 do
+add_command_under_category "rotate-credentials", "Secrets Management", "Rotate #{Chef::Dist::SERVER_PRODUCT} credentials for a given service", 2 do
   ensure_configured!
 
   OptionParser.new do |opts|
-    opts.banner = "Usage: chef-server-ctl rotate-credentials $service_name"
+    opts.banner = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl rotate-credentials $service_name"
 
     opts.on("-h", "--help", "Show this message") do
       puts opts
@@ -47,7 +49,7 @@ add_command_under_category "rotate-credentials", "Secrets Management", "Rotate C
     if status.success?
       remove_backup_file(backup_file)
       log("#{service}'s credentials have been rotated!", :notice)
-      log("Run 'chef-server-ctl rotate-credentials #{service}' on each Chef Server", :notice)
+      log("Run '#{ChefConfig::Dist::SHORT}-server-ctl rotate-credentials #{service}' on each #{Chef::Dist::SERVER_PRODUCT}", :notice)
       exit(0)
     else
       log("Credential rotation failed", :error)
@@ -64,14 +66,14 @@ end
 # the shared secrets are known on all nodes in the cluster the user can choose
 # between copying the secrets file to each node in the cluster and reconfiguring
 # or by running this command on all nodes.
-add_command_under_category "rotate-all-credentials", "Secrets Management", "Rotate all Chef Server service credentials", 2 do
+add_command_under_category "rotate-all-credentials", "Secrets Management", "Rotate all #{Chef::Dist::SERVER_PRODUCT} service credentials", 2 do
   ensure_configured!
 
   # Rotate and save the credentials
   begin
     backup_file = backup_secrets_file
 
-    log("Rotating all Chef Server service credentials...", :notice)
+    log("Rotating all #{Chef::Dist::SERVER_PRODUCT} service credentials...", :notice)
     credentials.rotate_credentials
     credentials.save
   rescue => e
@@ -87,7 +89,7 @@ add_command_under_category "rotate-all-credentials", "Secrets Management", "Rota
     if status.success?
       remove_backup_file(backup_file)
       log("All credentials have been rotated!", :notice)
-      log("Run 'chef-server-ctl rotate-all-credentials' on each Chef Server", :notice)
+      log("Run '#{ChefConfig::Dist::SHORT}-server-ctl rotate-all-credentials' on each #{Chef::Dist::SERVER_PRODUCT}", :notice)
       exit(0)
     else
       log("Credential rotation failed", :error)
@@ -103,7 +105,7 @@ end
 # new service credentials for all services. It will then do a chef run to apply
 # the new credentials. As the shared secret and salt is securely and randomly
 # generated the user must copy the secrets file to all nodes in the cluster.
-add_command_under_category "rotate-shared-secrets", "Secrets Management", "Rotate the Chef Server shared secrets and all service credentials", 2 do
+add_command_under_category "rotate-shared-secrets", "Secrets Management", "Rotate the #{Chef::Dist::SERVER_PRODUCT} shared secrets and all service credentials", 2 do
   ensure_configured!
 
   backup_file = backup_secrets_file
@@ -127,7 +129,7 @@ add_command_under_category "rotate-shared-secrets", "Secrets Management", "Rotat
     if status.success?
       remove_backup_file(backup_file)
       log("The shared secrets and all service credentials have been rotated!", :notice)
-      log("Please copy #{secrets_file_path} to each Chef Server and run 'chef-server-ctl reconfigure'", :notice)
+      log("Please copy #{secrets_file_path} to each #{Chef::Dist::SERVER_PRODUCT} and run '#{ChefConfig::Dist::SHORT}-server-ctl reconfigure'", :notice)
       exit(0)
     else
       log("Shared credential rotation failed", :error)
@@ -156,25 +158,25 @@ end
 # credentials the chef-client reconfigure run will re-enable/link the services,
 # restart the Chef Server and remove the sentinel file that enables the
 # pre-hook.
-add_command_under_category "require-credential-rotation", "Secrets Management", "Disable the Chef Server and require credential rotation", 2 do
+add_command_under_category "require-credential-rotation", "Secrets Management", "Disable the #{Chef::Dist::SERVER_PRODUCT} and require credential rotation", 2 do
   @agree_to_disable = false
   @ui = HighLine.new
 
   OptionParser.new do |opts|
-    opts.banner = "Usage: chef-server-ctl require-credential-rotation [--yes]"
+    opts.banner = "Usage: #{ChefConfig::Dist::SHORT}-server-ctl require-credential-rotation [--yes]"
 
     opts.on("-h", "--help", "Show this message") do
       puts opts
       exit
     end
 
-    opts.on("-y", "--yes", "Agree to disable the Chef Server and require credential rotation") do
+    opts.on("-y", "--yes", "Agree to disable the #{Chef::Dist::SERVER_PRODUCT} and require credential rotation") do
       @agree_to_disable = true
     end
   end.parse!(ARGV)
 
   # Agree to disable and require rotation
-  msg = "Are you sure you want to disable the Chef Server and require credential rotation?" \
+  msg = "Are you sure you want to disable the #{Chef::Dist::SERVER_PRODUCT} and require credential rotation?" \
           "\n Type 'yes' to confirm: "
   exit(1) unless @agree_to_disable || @ui.ask("<%= color(%Q(#{msg}), :yellow) %>") =~ /yes/i
 
@@ -190,8 +192,8 @@ add_command_under_category "require-credential-rotation", "Secrets Management", 
   FileUtils.mkdir_p(data_path) unless File.directory?(data_path)
   FileUtils.touch(credential_rotation_required_file)
 
-  log("The Chef Server has been disabled until credentials have been rotated. "\
-      "Run 'sudo chef-server-ctl rotate-shared-secrets' to rotate them.")
+  log("The #{Chef::Dist::SERVER_PRODUCT} has been disabled until credentials have been rotated. "\
+      "Run 'sudo #{ChefConfig::Dist::SHORT}-server-ctl rotate-shared-secrets' to rotate them.")
 
   exit(0)
 end
@@ -206,8 +208,8 @@ add_global_pre_hook "require_credential_rotation" do
   # TODO RETHINK AS PART OF GEM CONVERSION
   return if ARGV == %w{omnibus-ctl opscode rotate-shared-secrets}
 
-  raise("You must rotate the Chef Server credentials to enable the Chef Server. "\
-        "Please run 'sudo chef-server-ctl rotate-shared-secrets'")
+  raise("You must rotate the #{Chef::Dist::SERVER_PRODUCT} credentials to enable the #{Chef::Dist::SERVER_PRODUCT}. "\
+        "Please run 'sudo #{ChefConfig::Dist::SHORT}-server-ctl rotate-shared-secrets'")
 end
 
 def backup_secrets_file(backup_file = nil)
@@ -224,7 +226,7 @@ def restore_secrets_file(backup_file)
 end
 
 def secrets_file_path
-  "/etc/opscode/private-chef-secrets.json"
+  "/etc/opscode/private-#{ChefConfig::Dist::SHORT}-secrets.json"
 end
 
 def remove_backup_file(backup_file)
@@ -238,7 +240,7 @@ end
 
 def ensure_configured!
   unless running_config
-    log("You must reconfigure the Chef Server before a backup can be performed", :error)
+    log("You must reconfigure the #{Chef::Dist::SERVER_PRODUCT} before a backup can be performed", :error)
     exit(1)
   end
 end

--- a/src/chef-server-ctl/plugins/server_admins.rb
+++ b/src/chef-server-ctl/plugins/server_admins.rb
@@ -17,6 +17,7 @@
 require 'restclient'
 require 'json'
 require 'pg'
+require "chef"
 
 PLACEHOLDER_GLOBAL_ORG_ID = "00000000000000000000000000000000"
 
@@ -48,7 +49,7 @@ add_command_under_category "grant-server-admin-permissions", "server-admins", "G
   }.merge(::ChefServerCtl::Config.ssl_params)
   RestClient::Request.execute(req_params)
 
-  puts "User #{username} was added to server-admins. This user can now list, read, create, and delete users (even for orgs they are not members of) for this Chef Server."
+  puts "User #{username} was added to server-admins. This user can now list, read, create, and delete users (even for orgs they are not members of) for this #{Chef::Dist::SERVER_PRODUCT}."
 end
 
 add_command_under_category "remove-server-admin-permissions", "server-admins", "Remove all special permission granted to a user from being a server-admin.", 2 do
@@ -103,7 +104,7 @@ add_command_under_category "remove-server-admin-permissions", "server-admins", "
   req_params[:url] = "#{::ChefServerCtl::Config.bifrost_url}/groups/#{server_admins_authz_id}/actors/#{user_authz_id}"
   RestClient::Request.execute(req_params)
 
-  puts "User #{username} was removed from server-admins. This user can no longer list, read, create, and delete users for this Chef Server except for where they have default permissions (such as within an org)."
+  puts "User #{username} was removed from server-admins. This user can no longer list, read, create, and delete users for this #{Chef::Dist::SERVER_PRODUCT} except for where they have default permissions (such as within an org)."
 
 end
 
@@ -151,7 +152,7 @@ def get_server_admins_authz_id(db)
   server_admins_erchef_group = db.exec_params("SELECT authz_id FROM groups WHERE name='server-admins' AND org_id='#{PLACEHOLDER_GLOBAL_ORG_ID}'")
 
   if server_admins_erchef_group.ntuples == 0
-    msg = "The server-admins global group was not found. Please finish upgrading your Chef Server by following the documentation before using Server Admins related commands."
+    msg = "The server-admins global group was not found. Please finish upgrading your #{Chef::Dist::SERVER_PRODUCT} by following the documentation before using Server Admins related commands."
     STDERR.puts msg
     raise SystemExit.new(1, msg)
   end

--- a/src/chef-server-ctl/plugins/version.rb
+++ b/src/chef-server-ctl/plugins/version.rb
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 require 'json'
+require "chef"
 
-add_command_under_category "version", "general", "Display current version of Chef Server.", 2 do
+add_command_under_category "version", "general", "Display current version of #{Chef::Dist::SERVER_PRODUCT}.", 2 do
 
   begin
     # detect if running as a habitat service

--- a/src/chef-server-ctl/plugins/wrap-knife-opc.rb
+++ b/src/chef-server-ctl/plugins/wrap-knife-opc.rb
@@ -14,23 +14,25 @@
 # limitations under the License.
 
 require 'shellwords'
+require "chef-config/dist"
+require "chef"
 
 knife_config = ::ChefServerCtl::Config.knife_config_file
 knife_cmd    = ::ChefServerCtl::Config.knife_bin
 cmd_args     = ARGV[1..-1]
 
 cmds = {
-  "org-create"      => ["create", "org", "Create an organization in the chef server."],
-  "org-delete"      => ["delete", "org", "Delete an organization in the chef server."],
-  "org-list"        => ["list", "org", "List all organizations in the chef server."],
-  "org-show"        => ["show", "org", "Show an organization in the chef server."],
+  "org-create"      => ["create", "org", "Create an organization in the #{Chef::Dist::SERVER_PRODUCT}."],
+  "org-delete"      => ["delete", "org", "Delete an organization in the #{Chef::Dist::SERVER_PRODUCT}."],
+  "org-list"        => ["list", "org", "List all organizations in the #{Chef::Dist::SERVER_PRODUCT}."],
+  "org-show"        => ["show", "org", "Show an organization in the #{Chef::Dist::SERVER_PRODUCT}."],
   "org-user-add"    => ["add", "org user", "Associate a user with an organization."],
   "org-user-remove" => ["remove", "org user", "Dissociate a user with an organization."],
-  "user-create"     => ["create", "user", "Create a user in the chef server."],
-  "user-delete"     => ["delete", "user", "Delete a user in the chef server."],
-  "user-edit"       => ["edit", "user", "Edit a user in the chef server."],
-  "user-list"       => ["list", "user", "List all users in the chef server."],
-  "user-show"       => ["show", "user", "Show a user in the chef server."],
+  "user-create"     => ["create", "user", "Create a user in the #{Chef::Dist::SERVER_PRODUCT}."],
+  "user-delete"     => ["delete", "user", "Delete a user in the #{Chef::Dist::SERVER_PRODUCT}."],
+  "user-edit"       => ["edit", "user", "Edit a user in the #{Chef::Dist::SERVER_PRODUCT}."],
+  "user-list"       => ["list", "user", "List all users in the #{Chef::Dist::SERVER_PRODUCT}."],
+  "user-show"       => ["show", "user", "Show a user in the #{Chef::Dist::SERVER_PRODUCT}."],
 }
 
 cmds.each do |cmd, args|


### PR DESCRIPTION
### Description

This is an initial pass of replacements for issue #1949: Make Chef Server distributable under a configurable name - wordmarks in outputs.

This pas focuses on `chef-server-ctl` and replaces:

 * `chef` with `#{ChefConfig::Dist::SHORT}`
 * `Chef Server` with `#{Chef::Dist::SERVER_PRODUCT}`

Multiple passes will likely be required; this is a small chunk meant to be easy to review and test.

This PR replaces [1976](https://github.com/chef/chef-server/pull/1976) because that PR was far too aggressive and broke smoke tests (and, all of Chef Server, apparently...)

Further PRs will follow to apply wordmarks in other areas of Chef Server, like the recipes and Erlang code

Signed-off-by: Josh Gitlin <jgitlin@pinnacle21.com>

### Issues Resolved

#1949 

### Check List

- N/A New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
