### PR TITLE
add version annotations to integration_test pipeline

### DIFF
--- a/.expeditor/integration_test.pipeline.sh
+++ b/.expeditor/integration_test.pipeline.sh
@@ -245,6 +245,20 @@ apply () {
   TF_VAR_backend_version_url=$(for channel in unstable current stable; do mixlib-install download chef-backend --url -c $channel -a x86_64 -p "$(sed 's/rhel/el/' <<<"${TF_VAR_platform%-*}")" -l "${TF_VAR_platform##*-}" -v "$BACKEND_VERSION" 2>/dev/null && break; done | head -n 1)
   export TF_VAR_backend_version_url
 
+  # update buildkite annotations
+  if [[ "$(command -v buildkite-agent)" ]]; then
+    echo '--- :buildkite: Update Buildkite annotations to include test versions.'
+    buildkite-agent annotate --style 'info' <<EOF
+* *Chef Server (Install):*  **${INSTALL_VERSION}**
+
+* *Chef Server (Upgrade):*  **${UPGRADE_VERSION}**
+
+* *Chef Backend:*  **${BACKEND_VERSION}**
+
+* *Elastic Search:*  **${ELASTIC_VERSION}**
+EOF
+  fi
+
   echo -e "+++ :terraform: Execute \033[38;5;62m\033[1m${TF_VAR_scenario}\033[0m scenario"
 
   #capture output to /workdir/integration_test.log

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # Order is important. The last matching pattern has the most precedence.
 
 *                                @chef/chef-server-maintainers
-.expeditor/**                    @chef/jex-team
 README.md                        @chef/docs-team
 RELEASE_NOTES.md                 @chef/docs-team
 .github/ISSUE_TEMPLATE/**        @chef/docs-team


### PR DESCRIPTION
### Description

This PR adds a buildkite "info" annotation containing the versions being tested in each `integration_test` pipeline run.

A demonstration of the annotations can be found here:

https://buildkite.com/chef/chef-chef-server-master-integration-test/builds/310

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#2087

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
