### PR TITLE
Standardize usage of webmachine dependency

### DIFF
--- a/src/chef-mover/_checkouts/oc_erchef/rebar.config
+++ b/src/chef-mover/_checkouts/oc_erchef/rebar.config
@@ -115,8 +115,8 @@
   {git,"git://github.com/opscode/stats_hero.git",
        "0811d3045874f6c16b76c04ac9358322e029c4b7"}},
  {webmachine,".*",
-  {git,"git://github.com/basho/webmachine",
-       "8525948570419ba3e330ee14cb28fdf2de788506"}},
+  {git,"git://github.com/chef/webmachine",
+       "1389b01a9fbc25d36aad8956e08d2d0db242625f"}},
  {uuid,".*",
   {git,"git://github.com/okeuday/uuid.git",
         "f7c141c8359cd690faba0d2684b449a07db8e915"}}]}.

--- a/src/chef-mover/rebar.lock
+++ b/src/chef-mover/rebar.lock
@@ -176,7 +176,7 @@
   2},
  {<<"webmachine">>,
   {git,"git://github.com/chef/webmachine",
-       {ref,"6f1819d6c035b6c1aa05002a81d1d6d17f232c99"}},
+       {ref,"1389b01a9fbc25d36aad8956e08d2d0db242625f"}},
   1}]}.
 [
 {pkg_hash,[

--- a/src/oc_erchef/apps/data_collector/rebar.config
+++ b/src/oc_erchef/apps/data_collector/rebar.config
@@ -7,7 +7,7 @@
     %% lager has to come first since we use its parse transform
     {lager, ".*",
         {git, "git://github.com/erlang-lager/lager.git",                {branch, "master"}}},
-    {opscoderl_httpc, ".*",                            
+    {opscoderl_httpc, ".*",
         {git, "git://github.com/chef/opscoderl_httpc.git",              {branch, "master"}}},
     {pooler, ".*",
         {git, "git://github.com/seth/pooler.git",                       {branch, "master"}}}


### PR DESCRIPTION
These are the dependencies changes for the sigv4 work.  Assumes merged erlang22 and license scout + erlcloud dep PRs.

This PR is part of a broader effort to replace AWS sigv2 with sigv4, encompassing modifications to oc_erchef, bookshelf, mini_s3, erlcloud, pedant clients, and other systems. In brief, the erlcloud library was wired-in to oc-erchef and bookshelf via mini_s3. oc-erchef was modified to generate sigv4 requests. bookshelf was modified to accept sigv4 requests. A host of issues were solved pertaining to host headers and ports, expiration windows, ipv6, etc. Finally, new unit tests exercising various aspects of newly-added functionality were added.

verify:
https://buildkite.com/chef/chef-chef-server-master-verify/builds/2321#497a69af-b34a-4499-993d-8de819cdd079

adhoc:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1604#8099f688-112c-49de-b1ae-b364e2bf3bef