### PR TITLE
Add Erlcloud Dep and Requisite License Scout Fixes

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -75,6 +75,9 @@ fallbacks:
     - name: epgsql
       license_id: BSD-3-Clause
       license_content: https://github.com/chef/epgsql-1/blob/master/LICENSE
+    - name: erlcloud
+      license_id: BSD-2-Clause
+      license_content: https://github.com/chef/erlcloud/blob/master/COPYRIGHT
     - name: erlsom
       license_id: LGPL-3.0
       license_content: https://github.com/willemdj/erlsom/blob/master/COPYING
@@ -87,6 +90,9 @@ fallbacks:
     - name: jiffy
       license_id: MIT
       license_content: https://github.com/davisp/jiffy/blob/master/LICENSE
+    - name: lhttpc
+      license_id: BSD-3-Clause
+      license_content: https://github.com/erlcloud/lhttpc/blob/master/LICENCE
     - name: mochiweb
       license_id: MIT
       license_content: https://github.com/mochi/mochiweb/blob/master/LICENSE

--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -18,6 +18,8 @@
         {git, "git://github.com/markan/envy.git",                     {branch, "master"}}},
     {eper, ".*",
         {git, "git://github.com/massemanet/eper.git",                 {branch, "master"}}},
+    {erlcloud, ".*",
+        {git, "git://github.com/chef/erlcloud.git",                   {branch, "lbaker/presigned"}}},
     {erlsom, ".*",
         {git, "git://github.com/chef/erlsom.git",                     {branch, "integer_long_string_probs2"}}},
     {erlware_commons, ".*",

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -28,6 +28,8 @@
         {git, "git://github.com/markan/envy.git",                     {branch, "master"}}},
     {eper, ".*",
         {git, "git://github.com/massemanet/eper.git",                 {branch, "master"}}},
+    {erlcloud, ".*",
+        {git, "git://github.com/chef/erlcloud.git",                   {branch, "lbaker/presigned"}}},
     {erlware_commons, ".*",
         {git, "https://github.com/chef/erlware_commons.git",          {branch, "lbaker/fix_for_ftmap"}}},
     {folsom, ".*",


### PR DESCRIPTION
Add the erlcloud dep and requisite license scout fixes for the upcoming sigv4 changes.

This PR is part of a broader effort to replace AWS sigv2 with sigv4, encompassing modifications to oc_erchef, bookshelf, mini_s3, erlcloud, pedant clients, and other systems. In brief, the erlcloud library was wired-in to oc-erchef and bookshelf via mini_s3. oc-erchef was modified to generate sigv4 requests. bookshelf was modified to accept sigv4 requests. A host of issues were solved pertaining to host headers and ports, expiration windows, ipv6, etc. Finally, new unit tests exercising various aspects of newly-added functionality were added.

verify:
https://buildkite.com/chef/chef-chef-server-master-verify/builds/2353

adhoc:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1623#17ddc153-de88-40e5-80a5-4b6fdb43b46b

integration_test:
https://buildkite.com/chef/chef-chef-server-master-integration-test/builds/332#bd52a321-f88b-45d1-99f8-e39a52991527