### PR TITLE
Harmonize Treatment of Host Header in Pedant

### DIFF
--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -137,11 +137,9 @@ module Pedant
       auth_headers = opts[:auth_headers] || requestor.signing_headers(method, url, payload)
 
       uri = URI.parse(url)
-      if (uri.scheme == 'http' && uri.port == 80) || (uri.scheme == 'https' && uri.port == 443)
-        host = uri.host
-      else
-        host = "#{uri.host}:#{uri.port}"
-      end
+
+      # for further details, see: get_host_port in oc-chef-pedant/lib/pedant/utility.rb
+      host = "#{uri.host}:#{uri.port}"
 
       final_headers = standard_headers.
         merge(auth_headers).

--- a/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/cookbook_util.rb
@@ -330,7 +330,7 @@ module Pedant
           http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
         end
 
-        response = http.get(uri.request_uri, {})
+        response = Pedant::Utility.get_host_port http, uri
 
         begin
           response.code.should eq expected_reponse_code.to_s

--- a/oc-chef-pedant/lib/pedant/utility.rb
+++ b/oc-chef-pedant/lib/pedant/utility.rb
@@ -81,5 +81,12 @@ module Pedant
       end
       return nil # Cannot find the fixture. Raise an error?
     end
+
+    # Chef::ServerAPI always sets the Host header to HOSTNAME:PORT.
+    # We do the same thing here since the Version 4 AWS Signature
+    # scheme uses the Host header as part of the canonically signed content.
+    def self.get_host_port http, uri
+        http.get uri.request_uri, {"Host" => "#{uri.hostname}:#{uri.port}"}
+    end
   end
 end

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/read_spec.rb
@@ -217,7 +217,7 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
             http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
           end
 
-          response = http.get(uri.request_uri, {})
+          response = Pedant::Utility.get_host_port http, uri
           response.body.should == recipe_content
         end
 

--- a/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/read_spec.rb
@@ -325,7 +325,7 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_read do
               http.ca_file     = Pedant::Config.ssl_ca_file     if Pedant::Config.ssl_ca_file
             end
 
-            response = http.get(uri.request_uri, {})
+            response = Pedant::Utility.get_host_port http, uri
             response.body.should == recipe_content
           end
 


### PR DESCRIPTION
Harmonize treatment of Host header in Pedant.

Chef::ServerAPI always sets the Host header to HOSTNAME:PORT.
We do the same here for consistency in order to avoid sigv4
signing issues.

verify:
https://buildkite.com/chef/chef-chef-server-master-verify/builds/2323#95b54d19-1e87-45a2-9092-3e69ceb99fb7

adhoc:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1605#5a0aca9e-5a4e-49df-a761-cf18f0a27042