### PR TITLE
oc-chef-pedant: remove wait_until_queues_are_empty

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/search_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/search_util.rb
@@ -231,20 +231,12 @@ module Pedant
             objects.each do |o|
               send(object_add_method_symbol, admin_requestor, o)
             end
-            if objects.length > 0
-              Pedant::Utility.wait_until_queues_are_empty(i = 10, safety_sleep: false, quiet: true)
-            end
           end
 
           after :each do
             objects.each do |o|
               send(object_delete_method_symbol, admin_requestor, o['name'])
             end
-            # Technically we should call this here as well, but if the
-            # next test is also a search, it is probably calling
-            # setup_multiple_objects which will wait in the before
-            # anyway.
-            # Pedant::Utility.wait_until_queues_are_empty(i = 10, safety_sleep: false)
           end
         end
 
@@ -926,11 +918,6 @@ module Pedant
       end
 
       it "works for all object types" do
-        # Wait for queues to have emptied: with_search_polling's
-        # `force_solr_commit` could happen without every object having made it
-        # to solr before.
-        Pedant::Utility.wait_until_queues_are_empty
-
         # Ensure that a search against each Chef object type is
         # successful BEFORE any reindexing operations.
         should_find("node", node_name)
@@ -951,9 +938,6 @@ module Pedant
 
         # Now, send everything to be re-indexed
         puts `#{executable} reindex #{reindex_args.join(" ")} #{Pedant::Config.reindex_endpoint}`
-
-        # wait for reindex to have finished
-        Pedant::Utility.wait_until_queues_are_empty
 
         # Verify that the reindexing worked by finding all the items
         # again.  Remember, there are implicit Solr commit calls being

--- a/oc-chef-pedant/lib/pedant/utility.rb
+++ b/oc-chef-pedant/lib/pedant/utility.rb
@@ -81,43 +81,5 @@ module Pedant
       end
       return nil # Cannot find the fixture. Raise an error?
     end
-
-    # queues are not readable (e.g. there's no rabbitmq) OR empty
-    def self.queues_empty?(opts = {quiet: true})
-      ENV['PATH'] = "/opt/opscode/embedded/bin:#{ENV['PATH']}"
-      output = `/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl list_queues -p /chef | awk '{sum += $2} END {print sum}'`
-      status = $?
-      unless opts[:quiet]
-        STDERR.puts "Command exitstatus: #{status.exitstatus}"
-        STDERR.puts "Command output: #{output}"
-      end
-
-      if !status.success?
-        puts "Command failed, assuming rabbitmq not in use and returning true" unless opts[:quiet]
-        true
-      else
-        output.to_i == 0
-      end
-    end
-
-    def self.wait_until_queues_are_empty(i = 10, opts = {safety_sleep: true,
-                                                         quiet: true})
-      return if i <= 0
-      if queues_empty?
-        puts "RabbitMQ queue is empty (or failed to call rabbitmqctl list_queues)" unless opts[:quiet]
-        if opts[:safety_sleep]
-          # Why? It may be that expander has pulled the item from the
-          # queue but hasn't posted it to Solr. This is a very small
-          # window so we skip it in some places to avoid sleeping too
-          # often.
-          puts "Waiting an additional second" unless opts[:quiet]
-          sleep 1
-        end
-      else
-        puts "Waiting for RabbitMQ queue to be empty (#{i} tries remaining)" unless opts[:quiet]
-        sleep 1
-        wait_until_queues_are_empty(i - 1)
-      end
-    end
   end
 end


### PR DESCRIPTION
We no longer install rabbitmq so we don't have rabbitmqctl and don't
need to wait for these queues to empty.

Signed-off-by: Steven Danna <steve@chef.io>