### PR TITLE
Display patent information for every chef-server-ctl command

### DIFF
--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -13,6 +13,12 @@ module Omnibus
   # external services supported by Chef Server. As additional services
   # are external-enabled, controls/configuration will need to be added here.
   class ChefServerCtl < Omnibus::Ctl
+
+    def help(*args)
+      puts ::ChefServerCtl::Config::DOC_PATENT_MSG
+      super
+    end
+
     def db_data
       d = [%w{oc_bifrost bifrost},
            %w{opscode-erchef opscode_chef},
@@ -237,6 +243,8 @@ EOM
 
     # Override reconfigure to skip license checking
     def reconfigure(*args)
+
+      puts ::ChefServerCtl::Config::DOC_PATENT_MSG
 
       LicenseAcceptance::Acceptor.check_and_persist!("infra-server", ChefServerCtl::VERSION.to_s)
 

--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -23,6 +23,12 @@ module ChefServerCtl
     DEFAULT_FIPS_LB_URL = "http://127.0.0.1".freeze
     DEFAULT_RABBITMQCTL_BIN = "/opt/opscode/embedded/service/rabbitmq/sbin/rabbitmqctl".freeze
     DEFAULT_ERCHEF_REINDEX_SCRIPT = "/opt/opscode/embedded/service/opscode-erchef/bin/reindex-opc-organization".freeze
+    DOC_PATENT_MSG = <<-DOC.freeze
+
+Documentation: https://docs.chef.io/server_overview/
+Patents:       https://www.chef.io/patents
+
+    DOC
 
     def self.init(ctl)
       @@ctl = ctl

--- a/src/chef-server-ctl/plugins/version.rb
+++ b/src/chef-server-ctl/plugins/version.rb
@@ -24,6 +24,7 @@ add_command_under_category "version", "general", "Display current version of Che
     # isn't appropriate in all cases.  One option would be to ask the
     # LB for our version, but then the version command won't work when
     # we are offline.
+
     if File.exist?('/hab/svc/chef-server-ctl/PID')
       ident_file = File.read('../IDENT')
       version = "chef-server #{ident_file.split('/')[2]}"


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description
```
root@ip-10-0-25-194:~# chef-server-ctl version

Documentation: https://docs.chef.io/server_overview/
Patents: https://www.chef.io/patents

14.0.32+20200907092532
```

```
root@ip-10-0-25-194:~# chef-server-ctl help

Documentation: https://docs.chef.io/server_overview/
Patents:         https://www.chef.io/patents

chef-server-ctl: command (subcommand)
General Commands:
  backup
    Backup the Chef Server
```

```
root@ip-10-0-25-194:~# chef-server-ctl reconfigure

Documentation: https://docs.chef.io/server_overview/
Patents: https://www.chef.io/patents

Starting Chef Infra Client, version 15.12.22
```
