### PR TITLE
cookbooks: remove deprecrated_solr_indexing

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -136,10 +136,9 @@ default['private_chef']['jetty']['log_directory'] = '/var/opt/opscode/opscode-so
 ####
 # Chef Solr 4
 ####
-# default['private_chef']['opscode-solr4']['enable'] defined in recipes/config.rb
-# Set this to point at a solr/cloudsearch installation
+default['private_chef']['opscode-solr4']['enable'] = false
+# Set this to point at a solr/elasticsearch installation
 # not controlled by chef-server
-#
 default['private_chef']['opscode-solr4']['external'] = false
 default['private_chef']['opscode-solr4']['external_url'] = nil
 default['private_chef']['opscode-solr4']['dir'] = '/var/opt/opscode/opscode-solr4'
@@ -176,7 +175,7 @@ default['private_chef']['opscode-solr4']['elasticsearch_replica_count'] = 1
 ####
 # Chef Expander
 ####
-# default['private_chef']['opscode-expander']['enable'] defined in recipes/config.rb
+default['private_chef']['opscode-expander']['enable'] = false
 default['private_chef']['opscode-expander']['dir'] = '/var/opt/opscode/opscode-expander'
 default['private_chef']['opscode-expander']['log_directory'] = '/var/log/opscode/opscode-expander'
 default['private_chef']['opscode-expander']['log_rotation']['file_maxbytes'] = 104857600
@@ -192,12 +191,12 @@ default['private_chef']['opscode-expander']['retry_wait'] = 1
 var_base = '/var/opt/opscode'
 log_base = '/var/log/opscode'
 
-# default['private_chef']['elasticsearch']['enable'] defined in recipes/config.rb
 elasticsearch = default['private_chef']['elasticsearch']
 
 # These attributes cannot be overridden in chef-server.rb
 # elasticsearch['tunable_blacklist'] = %w{dir data_dir try_start}
 # elasticsearch['try_start'] = true
+elasticsearch['enable'] = true
 elasticsearch['dir'] = "#{var_base}/elasticsearch"
 elasticsearch['data_dir'] = "#{var_base}/elasticsearch/data"
 elasticsearch['plugins_directory'] = "#{var_base}/elasticsearch/plugins"
@@ -351,8 +350,8 @@ default['private_chef']['opscode-erchef']['depsolver_timeout'] = 5000
 default['private_chef']['opscode-erchef']['ibrowse_max_sessions'] = 256
 default['private_chef']['opscode-erchef']['ibrowse_max_pipeline_size'] = 1
 # general search settings used to set up chef_index
-# default['private_chef']['opscode-erchef']['search_provider'] defined in recipes/config.rb
-# default['private_chef']['opscode-erchef']['search_queue_mode'] defined in recipes/config.rb
+default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch'
+default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch'
 default['private_chef']['opscode-erchef']['search_batch_max_size'] = '5000000'
 default['private_chef']['opscode-erchef']['search_batch_max_wait'] = '10'
 # solr_service configuration for erchef. These are used to configure an opscoderl_httpc pool

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/helper.rb
@@ -209,8 +209,6 @@ class OmnibusHelper
   def solr_url
     if node['private_chef']['opscode-solr4']['external']
       node['private_chef']['opscode-solr4']['external_url']
-    elsif node['private_chef']['deprecated_solr_indexing']
-      "http://#{vip_for_uri('opscode-solr4')}:#{node['private_chef']['opscode-solr4']['port']}/solr"
     else
       "http://#{vip_for_uri('elasticsearch')}:#{node['private_chef']['elasticsearch']['port']}"
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -145,6 +145,7 @@ class PreflightChecks
     end
     AuthPreflightValidator.new(node).run!
     SolrPreflightValidator.new(node).run!
+    IndexingPreflightValidator.new(node).run!
     if PrivateChef['elasticsearch']['enable']
       ElasticsearchPreflightValidator.new(node).run!
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_indexing_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_indexing_validator.rb
@@ -1,0 +1,72 @@
+#
+# Copyright:: 2020 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative './preflight_checks.rb'
+
+class IndexingPreflightValidator < PreflightValidator
+  # The cs_*attr variables hold the user-defined configuration
+  attr_reader :cs_erchef_attr
+
+  # The node_*attr variables hold the default configuration
+  attr_reader :node_erchef_attr
+
+  def initialize(node)
+    super
+
+    @cs_erchef_attr = PrivateChef['opscode_erchef']
+    @node_erchef_attr = node['private_chef']['opscode-erchef']
+  end
+
+  def run!
+    verify_consistent_reindex_sleep_times
+    verify_no_deprecated_indexing_options
+  end
+
+  def verify_consistent_reindex_sleep_times
+    final_min = cs_erchef_attr['reindex_sleep_min_ms'] || node_erchef_attr['reindex_sleep_min_ms']
+    final_max = cs_erchef_attr['reindex_sleep_max_ms'] || node_erchef_attr['reindex_sleep_max_ms']
+    if final_min > final_max
+      fail_with err_INDEX001_failed_validation(final_min, final_max)
+    end
+  end
+
+  def verify_no_deprecated_indexing_options
+    fail_with err_INDEX002_failed_validation if PrivateChef['deprecated_solr_indexing']
+  end
+
+  def err_INDEX001_failed_validation(final_min, final_max)
+    <<~EOM
+
+      INDEX001: opscode_erchef['reindex_sleep_min_ms'] (#{final_min}) is greater than
+                opscode_erchef['reindex_sleep_max_ms'] (#{final_max})
+
+                The maximum sleep time should be greater or equal to the minimum sleep
+                time.
+    EOM
+  end
+
+  def err_INDEX002_failed_validation
+    <<~EOM
+      INDEX001: You have configured
+
+                  deprecated_solr_indexing true
+
+               The Solr 4-based indexing pipeline is no longer supported.
+
+               Please contact Chef Support for help moving to the
+               Elasticsearch indexing pipeline.
+    EOM
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/private_chef.rb
@@ -117,11 +117,10 @@ module PrivateChef
   registered_extensions Mash.new
   ha Mash.new # For all other HA settings
   drbd Mash.new # For DRBD specific settings
+  deprecated_solr_indexing false
   # - end legacy config mashed -
 
   insecure_addon_compat true
-
-  deprecated_solr_indexing false
 
   class << self
     def from_file(filename)
@@ -270,7 +269,6 @@ module PrivateChef
       set_target_array_if_not_nil(results['private_chef'], 'folsom_graphite', PrivateChef['folsom_graphite'])
       set_target_array_if_not_nil(results['private_chef'], 'profiles', PrivateChef['profiles'])
       set_target_array_if_not_nil(results['private_chef'], 'insecure_addon_compat', PrivateChef['insecure_addon_compat'])
-      set_target_array_if_not_nil(results['private_chef'], 'deprecated_solr_indexing', PrivateChef['deprecated_solr_indexing'])
       results
     end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -81,38 +81,12 @@ else
     PrivateChef.from_file(chef_server_path)
   end
 
-  # Add support for the external search case
   if PrivateChef['opscode_solr4']['external']
-    # If the user has enabled external solr4 we keep these defaults
-    # more or less the same as they were before the change-over to
-    # Elasticsearch.
-    node.default['private_chef']['opscode-expander']['enable'] = true
-    node.default['private_chef']['opscode-solr4']['enable'] = false
-    node.default['private_chef']['elasticsearch']['enable'] = false
-
+    # TODO(ssd) 2020-09-11: We don't think anyone was actually using
+    # external solr and thus this conditional is probably unnecessary.
     node.default['private_chef']['opscode-erchef']['search_provider'] = 'solr'
-    node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch'
-  elsif PrivateChef['deprecated_solr_indexing']
-    # If the user has explicitly enabled the depcrecated solr mode, we
-    # start all services required to run the RabbitMQ -> Expander ->
-    # Solr indexing pipeline.
-    #
-    # This is the same as the block above, but we want to be explicit
-    # about it as the situation is very confusing.
-    node.default['private_chef']['opscode-solr4']['enable'] = true
-    node.default['private_chef']['opscode-expander']['enable'] = true
-    node.default['private_chef']['elasticsearch']['enable'] = false
-
-    node.default['private_chef']['opscode-erchef']['search_provider'] = 'solr'
-    node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch'
   else
-    # Our new default of Elasticsearch indexing
-    node.default['private_chef']['opscode-solr4']['enable'] = false
-    node.default['private_chef']['opscode-expander']['enable'] = false
-    node.default['private_chef']['elasticsearch']['enable'] = true
-
     node.default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch'
-    node.default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch'
   end
 
   # Bail out if something is wrong in our configuration.

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/config.rb
@@ -82,6 +82,7 @@ else
   end
 
   if PrivateChef['opscode_solr4']['external']
+    node.default['private_chef']['elasticsearch']['enable'] = false
     # TODO(ssd) 2020-09-11: We don't think anyone was actually using
     # external solr and thus this conditional is probably unnecessary.
     node.default['private_chef']['opscode-erchef']['search_provider'] = 'solr'

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_indexing_validator_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/preflight_indexing_validator_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: 2017-2018 Chef Software, Inc.
+# Copyright:: 2020 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require_relative '../../libraries/preflight_solr_validator.rb'
+require_relative '../../libraries/preflight_indexing_validator.rb'
 require_relative '../../libraries/private_chef.rb'
 require_relative '../../libraries/helper.rb'
 
-describe SolrPreflightValidator do
-  let(:solr_preflight) do
-    s = SolrPreflightValidator.new('private_chef' => {
+describe IndexingPreflightValidator do
+  let(:indexing_preflight) do
+    s = IndexingPreflightValidator.new('private_chef' => {
       'opscode-erchef' => {
         'reindex_sleep_min_ms' => 500,
         'reindex_sleep_max_ms' => 2000,
@@ -31,10 +31,6 @@ describe SolrPreflightValidator do
 
   before(:each) do
     allow(PrivateChef).to receive(:[]).with('postgresql').and_return({})
-    allow(PrivateChef).to receive(:[]).with('rabbitmq').and_return({})
-    allow(PrivateChef).to receive(:[]).with('opscode_solr4').and_return({})
-    allow(PrivateChef).to receive(:[]).with('elasticsearch').and_return({})
-    allow(PrivateChef).to receive(:[]).with('opscode_expander').and_return({})
   end
 
   context 'when min and max sleep time has been given in the config' do
@@ -50,7 +46,7 @@ describe SolrPreflightValidator do
       let(:max_sleep_time) { 2 }
 
       it 'raises an error' do
-        expect(solr_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
+        expect(indexing_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
       end
     end
   end
@@ -66,7 +62,7 @@ describe SolrPreflightValidator do
       let(:min_sleep_time) { 2001 }
 
       it 'raises an error' do
-        expect(solr_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
+        expect(indexing_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
       end
     end
   end
@@ -82,7 +78,7 @@ describe SolrPreflightValidator do
       let(:max_sleep_time) { 499 }
 
       it 'raises an error' do
-        expect(solr_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
+        expect(indexing_preflight.verify_consistent_reindex_sleep_times).to eq(:i_failed)
       end
     end
   end


### PR DESCRIPTION
In f47434bf6046d9c1bb02e62d2a5251f2752ee48b we added
deprecated_solr_indexing. This option is no longer supported. While
this didn't ship in a stable release, it did ship in a development
release that at least a few customers have used and thus we are
keeping a validation check to fail if it is present.

As part of this change I've added a new IndexingPreflightValidator
where we can move values from the old SolrPreflightValidator.

Signed-off-by: Steven Danna <steve@chef.io>
