### PR TITLE
Praj/add pipeline test for 12.17.15

### DIFF
--- a/.expeditor/integration_test.pipeline.yml
+++ b/.expeditor/integration_test.pipeline.yml
@@ -95,6 +95,22 @@ steps:
       executor:
         docker:
 
+  - label: ':terraform: standalone-upgrade-ipv4-ubuntu-20.04-from-12.17.15'
+    command: .expeditor/integration_test.pipeline.sh aws apply
+    artifact_paths:
+      - ./integration_test.log
+      - ./*capture_paths.tar.gz
+    env:
+      SCENARIO: omnibus-standalone-upgrade
+      PLATFORM: ubuntu-20.04
+      ENABLE_IPV6: false
+      INSTALL_VERSION: 12.17.15
+    expeditor:
+      accounts:
+        - aws/chef-cd
+      executor:
+        docker:
+
   - label: ':terraform: standalone-upgrade-ipv4-rhel-7'
     command: .expeditor/integration_test.pipeline.sh aws apply
     artifact_paths:

--- a/terraform/aws/modules/aws_instance/amis.tf
+++ b/terraform/aws/modules/aws_instance/amis.tf
@@ -130,6 +130,28 @@ data "aws_ami" "ubuntu_1804" {
   owners = ["099720109477"]
 }
 
+# identify ubuntu 20.04 ami
+data "aws_ami" "ubuntu_2004" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"]
+}
+
 # identify suse 12 ami
 # The byos ami does not allow any updates
 # Matching with the latest sp whichh is a pay as you go image.

--- a/terraform/aws/modules/aws_instance/locals.tf
+++ b/terraform/aws/modules/aws_instance/locals.tf
@@ -17,6 +17,7 @@ locals {
     "ubuntu-14.04" = data.aws_ami.ubuntu_1404.id
     "ubuntu-16.04" = data.aws_ami.ubuntu_1604.id
     "ubuntu-18.04" = data.aws_ami.ubuntu_1804.id
+    "ubuntu-20.04" = data.aws_ami.ubuntu_2004.id
     sles-12        = data.aws_ami.sles_12.id
   }
 }


### PR DESCRIPTION
- Add a permanent upgrade test from 12.17.15 -> UPGRADE_VERSION in the integration_test_pipeline
- Enable integration tests to run on ubuntu 20.04
