### PR TITLE
Add erlcloud library to rebar.lock files

### DIFF
--- a/src/bookshelf/rebar.lock
+++ b/src/bookshelf/rebar.lock
@@ -1,5 +1,6 @@
 {"1.1.0",
-[{<<"cf">>,
+[{<<"base16">>,{pkg,<<"base16">>,<<"1.0.0">>},1},
+ {<<"cf">>,
   {git,"git://github.com/project-fifo/cf.git",
        {ref,"2bcf00402db9ca5a4790de7f82c8139baaf8856c"}},
   0},
@@ -7,6 +8,7 @@
   {git,"git://github.com/chef/chef_secrets.git",
        {ref,"58373899212a23e4f37070aaa6d3a751b1281492"}},
   0},
+ {<<"eini">>,{pkg,<<"eini">>,<<"1.2.6">>},1},
  {<<"ej">>,
   {git,"https://github.com/seth/ej.git",
        {ref,"40821f7ab3d8746e8573e8542ad452d2b346ed7f"}},
@@ -23,6 +25,10 @@
   {git,"git://github.com/chef/epgsql-1.git",
        {ref,"34b4182f0e21f9189ddd7b2e290f01a9e7d93bf1"}},
   1},
+ {<<"erlcloud">>,
+  {git,"git://github.com/chef/erlcloud.git",
+       {ref,"f6f8d10c7efd7dbb97f3fa3e243bf9db2064b677"}},
+  0},
  {<<"erlsom">>,
   {git,"git://github.com/chef/erlsom.git",
        {ref,"131e660ee39254a58b75075e07dfd742f445bfce"}},
@@ -44,10 +50,12 @@
   {git,"https://github.com/davisp/jiffy.git",
        {ref,"ee8b48cb448a999e1fddbb5e2e32e7dfe33acf5c"}},
   1},
+ {<<"jsx">>,{pkg,<<"jsx">>,<<"2.9.0">>},1},
  {<<"lager">>,
   {git,"git://github.com/erlang-lager/lager.git",
        {ref,"f26a8ea0f4c2ed6506a54e0b9890edd8148b9500"}},
   0},
+ {<<"lhttpc">>,{pkg,<<"lhttpc">>,<<"1.6.2">>},1},
  {<<"meck">>,
   {git,"git://github.com/eproxus/meck.git",
        {ref,"9753464ac1ebc0fc1a6777322bc871eaed82be35"}},
@@ -91,6 +99,10 @@
   1}]}.
 [
 {pkg_hash,[
+ {<<"base16">>, <<"283644E2B21BD5915ACB7178BED7851FB07C6E5749B8FAD68A53C501092176D9">>},
+ {<<"eini">>, <<"DFFA48476FD89FB6E41CEEA0ADFA1BC6E7862CCD6584417442F8BB37E5D34715">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"jsx">>, <<"D2F6E5F069C00266CAD52FB15D87C428579EA4D7D73A33669E12679E203329DD">>},
+ {<<"lhttpc">>, <<"044F16F0018C7AA7E945E9E9406C7F6035E0B8BC08BF77B00C78CE260E1071E3">>},
  {<<"recon">>, <<"2F7FCBEC2C35034BADE2F9717F77059DC54EB4E929A3049CA7BA6775C0BD66CD">>}]}
 ].

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -1,5 +1,6 @@
 {"1.1.0",
-[{<<"bcrypt">>,
+[{<<"base16">>,{pkg,<<"base16">>,<<"1.0.0">>},1},
+ {<<"bcrypt">>,
   {git,"git://github.com/abhay/erlang-bcrypt.git",
        {ref,"f6ff677ac73872a3ce477fda5ab4143cfc3a5f91"}},
   0},
@@ -31,6 +32,7 @@
   {git,"git://github.com/chef/efast_xs.git",
        {ref,"c2a6b925ed94ab8a28ff49375782834033919190"}},
   0},
+ {<<"eini">>,{pkg,<<"eini">>,<<"1.2.6">>},1},
  {<<"ej">>,
   {git,"git://github.com/chef/ej.git",
        {ref,"85bbf475ec533447d244be50f7f450f41cbc1adf"}},
@@ -47,6 +49,10 @@
   {git,"git://github.com/chef/epgsql-1.git",
        {ref,"34b4182f0e21f9189ddd7b2e290f01a9e7d93bf1"}},
   1},
+ {<<"erlcloud">>,
+  {git,"git://github.com/chef/erlcloud.git",
+       {ref,"f6f8d10c7efd7dbb97f3fa3e243bf9db2064b677"}},
+  0},
  {<<"erlware_commons">>,
   {git,"git://github.com/chef/erlware_commons.git",
        {ref,"20c611d8c457edfc84a915cf1026f22980a83e00"}},
@@ -68,10 +74,12 @@
   {git,"git://github.com/davisp/jiffy.git",
        {ref,"051a74338c089c39f09532188bc82cf1adedbdc8"}},
   0},
+ {<<"jsx">>,{pkg,<<"jsx">>,<<"2.9.0">>},1},
  {<<"lager">>,
   {git,"git://github.com/erlang-lager/lager.git",
        {ref,"f26a8ea0f4c2ed6506a54e0b9890edd8148b9500"}},
   0},
+ {<<"lhttpc">>,{pkg,<<"lhttpc">>,<<"1.6.2">>},1},
  {<<"meck">>,
   {git,"git://github.com/eproxus/meck.git",
        {ref,"558e925b48ce257b12e381080c851dc49c87d7bb"}},
@@ -143,6 +151,10 @@
   1}]}.
 [
 {pkg_hash,[
+ {<<"base16">>, <<"283644E2B21BD5915ACB7178BED7851FB07C6E5749B8FAD68A53C501092176D9">>},
+ {<<"eini">>, <<"DFFA48476FD89FB6E41CEEA0ADFA1BC6E7862CCD6584417442F8BB37E5D34715">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"jsx">>, <<"D2F6E5F069C00266CAD52FB15D87C428579EA4D7D73A33669E12679E203329DD">>},
+ {<<"lhttpc">>, <<"044F16F0018C7AA7E945E9E9406C7F6035E0B8BC08BF77B00C78CE260E1071E3">>},
  {<<"recon">>, <<"2F7FCBEC2C35034BADE2F9717F77059DC54EB4E929A3049CA7BA6775C0BD66CD">>}]}
 ].


### PR DESCRIPTION
Add the erlcloud dependency to rebar.lock files in preparation for upcoming sigv4 changes.

This PR is part of a broader effort to replace AWS sigv2 with sigv4, encompassing modifications to oc_erchef, bookshelf, mini_s3, erlcloud, pedant clients, and other systems. In brief, the erlcloud library was wired-in to oc-erchef and bookshelf via mini_s3. oc-erchef was modified to generate sigv4 requests. bookshelf was modified to accept sigv4 requests. A host of issues were solved pertaining to host headers and ports, expiration windows, ipv6, etc. Finally, new unit tests exercising various aspects of newly-added functionality were added.

verify and adhoc:
https://buildkite.com/chef/chef-chef-server-master-verify/builds/2429
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1665#8eeed3df-bcc7-44e7-9683-e12ca44e970b