### PR TITLE
Interpolate Port for oc-id Endpoint URL

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -38,7 +38,7 @@ end
 
 app_settings = {
   'chef' => {
-    'endpoint' => "https://#{node['private_chef']['lb_internal']['vip']}",
+    'endpoint' => "https://#{node['private_chef']['lb_internal']['vip']}:#{node['private_chef']['nginx']['ssl_port']}",
     'superuser' => 'pivotal',
     #
     # Why is this verify_none?


### PR DESCRIPTION
# Description

This allows you to run NginX on a non-standard port, e.g. 8443 or 444.

Sample error output when running on non-standard port:
```
2020-09-17_20:22:03.03296 I, [2020-09-17T20:22:03.032872 #3209]  INFO -- : Started POST "/id/auth/chef/callback" for 127.0.0.1 at 2020-09-17 20:22:03 +0000
2020-09-17_20:22:03.03373 I, [2020-09-17T20:22:03.033667 #3209]  INFO -- : (chef) Callback phase initiated.
2020-09-17_20:22:04.97915 [2020-09-17T20:22:04+00:00] ERROR: Error connecting to https://127.0.0.1/authenticate_user, retry 1/5
2020-09-17_20:22:10.00031 [2020-09-17T20:22:10+00:00] ERROR: Error connecting to https://127.0.0.1/authenticate_user, retry 2/5
2020-09-17_20:22:15.02000 [2020-09-17T20:22:15+00:00] ERROR: Error connecting to https://127.0.0.1/authenticate_user, retry 3/5
2020-09-17_20:22:20.03982 [2020-09-17T20:22:20+00:00] ERROR: Error connecting to https://127.0.0.1/authenticate_user, retry 4/5
2020-09-17_20:22:25.06056 [2020-09-17T20:22:25+00:00] ERROR: Error connecting to https://127.0.0.1/authenticate_user, retry 5/5
2020-09-17_20:22:30.08855 F, [2020-09-17T20:22:30.088465 #3209] FATAL -- :
2020-09-17_20:22:30.08858 Errno::ECONNRESET (Error connecting to https://127.0.0.1/authenticate_user - Connection reset by peer - SSL_connect):
```

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
