### PR TITLE
Tag the index deletion search specs

### DIFF
--- a/oc-chef-pedant/spec/api/search/search_spec.rb
+++ b/oc-chef-pedant/spec/api/search/search_spec.rb
@@ -579,7 +579,7 @@ describe 'Search API endpoint', :search do
 
 
 
-  describe "Index Deletion" do
+  describe "Index Deletion", :search_index_deletion do
     context "Roles" do
       it_should_behave_like "Deletes from Solr Index" do
         let(:index_name) { "role" }


### PR DESCRIPTION
Currently the search tests fails if data exists in the system.

The pedant tests are currently written to support both solr and elasticsearch.

The return value in elasticsearch includes all the rows if none match based on the filter query applied.
But this return response does not match the test expectations that expected nothing to match. Causing the search tests to fail if data exists in the system.

Creating this flag to be able to currently skip the failing tests on the integrations_tests with data.

https://github.com/chef/chef-server/issues/2123


Signed-off-by: Prajakta Purohit <prajakta@chef.io>

