### PR TITLE
fix external elasticsearch scenario on upgrade

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/cleanup.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/cleanup.rb
@@ -61,3 +61,31 @@ directory '/opt/opscode/sv/opscode-expander-reindexer' do
   action :delete
   recursive true
 end
+
+
+component_runit_service 'opscode-expander' do
+  action :disable
+end
+
+directory '/opt/opscode/sv/opscode-expander' do
+  recursive true
+  action :delete
+end
+
+component_runit_service 'opscode-solr4' do
+  action :disable
+end
+
+directory '/opt/opscode/sv/opscode-solr4' do
+  recursive true
+  action :delete
+end
+
+component_runit_service 'rabbitmq' do
+  action :disable
+end
+
+directory '/opt/opscode/sv/rabbitmq' do
+  recursive true
+  action :delete
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
@@ -152,33 +152,6 @@ link '/opt/opscode/embedded/elasticsearch/config' do
   to elasticsearch_conf_dir
 end
 
-component_runit_service 'opscode-expander' do
-  action :disable
-end
-
-directory '/opt/opscode/sv/opscode-expander' do
-  recursive true
-  action :delete
-end
-
-component_runit_service 'opscode-solr4' do
-  action :disable
-end
-
-directory '/opt/opscode/sv/opscode-solr4' do
-  recursive true
-  action :delete
-end
-
-component_runit_service 'rabbitmq' do
-  action :disable
-end
-
-directory '/opt/opscode/sv/rabbitmq' do
-  recursive true
-  action :delete
-end
-
 # Define resource for elasticsearch component_runit_service
 component_runit_service 'elasticsearch'
 

--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -215,30 +215,37 @@ CLEANSE002: Note that Chef Server data was not removed from your
 EOM
     end
 
-    # External Solr/ElasticSearch Commands
-    def external_status_opscode_solr4(_detail_level)
-      solr = external_services['opscode-solr4']['external_url']
+    # External ElasticSearch Commands
+    def external_status_elasticsearch(_detail_level)
+      elasticsearch = external_services['elasticsearch']['external_url']
       begin
-        Chef::HTTP.new(solr).get(solr_status_url)
-        puts "run: opscode-solr4: connected OK to #{solr}"
+        Chef::HTTP.new(elasticsearch).get(elasticsearch_status_url)
+        puts "run: elasticsearch: connected OK to #{elasticsearch}"
       rescue StandardError => e
-        puts "down: opscode-solr4: failed to connect to #{solr}: #{e.message.split("\n")[0]}"
+        puts "down: elasticsearch: failed to connect to #{elasticsearch}: #{e.message.split("\n")[0]}"
       end
     end
 
-    def external_cleanse_opscode_solr4(perform_delete)
+    def external_cleanse_elasticsearch(perform_delete)
       log <<-EOM
-Cleansing data in a remote Sol4 instance is not currently supported.
+Cleansing data in a remote Elasticsearch instance is not currently supported.
 EOM
     end
 
-    def solr_status_url
+    def elasticsearch_status_url
       case running_service_config('opscode-erchef')['search_provider']
       when "elasticsearch"
         "/chef"
       else
         "/admin/ping?wt=json"
       end
+    end
+
+    # External Solr Status callback needs to be implemented.
+    # opscode-solr4['external'] is set to true un chef-server-running-json
+    # to support backward compatibility with reporting.
+    def external_status_opscode_solr4(_detail_level)
+      #opscode-solr4 status is seen as elasticsearch status"
     end
 
     # Override reconfigure to skip license checking


### PR DESCRIPTION
 [chef-server-ctl] Implement callback for external elasticsearch service
                                  External service shows up as elasticsearch in chef-server-running.json
                                  We maintain the hash for opscode-solr4 to support backcompat with reporting.

 [omnibus] Cleanup all of the deprecated services in the cleanup recipe.
                    The solr, rabbit and opscode-expander recipes were being removed in
                    the elasticsearch recipe. This recipe does not get run in the
                    external-elasticsearch scenario.
                  The cleanup recipe is run on all scenarios and is the right place for
                  well.. cleanup.

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/1695