### PR TITLE
cookbooks: ensure ES is started

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
@@ -152,7 +152,8 @@ link '/opt/opscode/embedded/elasticsearch/config' do
   to elasticsearch_conf_dir
 end
 
-# Define resource for elasticsearch component_runit_service
-component_runit_service 'elasticsearch'
+component_runit_service 'elasticsearch' do
+  action [:enable, :start]
+end
 
 include_recipe 'private-chef::elasticsearch_index'


### PR DESCRIPTION
The elasticsearch_index recipe requires that elasticsearch is
started. The component_runit_service will start the service for new
installs and part of its enable action, but for subsequent runs it
won't.

Signed-off-by: Steven Danna <steve@chef.io>