### PR TITLE
erchef: new ibrowse to address spurious 500s

### DIFF
--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -37,7 +37,7 @@
     {folsom_graphite, ".*",
         {git, "git://github.com/chef/folsom_graphite.git",            {branch, "master"}}},
     {ibrowse, ".*",
-        {git, "git://github.com/chef/ibrowse.git",                    {branch, "ma/revert_ipv6"}}},
+        {git, "git://github.com/chef/ibrowse.git",                    {branch, "chef-server"}}},
      %% latest version of jiffy i could find that doesn't
      %% break oc_erchef_unit and oc_bifrost on master verify
      %% pipeline.  could also try the two commits directly

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -68,7 +68,7 @@
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"ibrowse">>,
   {git,"git://github.com/chef/ibrowse.git",
-       {ref,"7b2b0bfd5e15e57706beb2ef0360cdc7f24b37c5"}},
+       {ref,"1df08a6aca30614f69126451957af6a3d0aeb7b2"}},
   0},
  {<<"jiffy">>,
   {git,"git://github.com/davisp/jiffy.git",


### PR DESCRIPTION
This pulls in a new ibrowse branch that has
chef/ibrowse@1df08a6aca30614f69126451957af6a3d0aeb7b2

The new commit avoids extra calls to ssl:send() with empty request
bodies.  We think that these extra ssl:send calls were causing
spurious 500s.

Based on some debugging of the problem, we noted that:

- mini_s3 uses HTTP/1.0 when making HEAD requests. Code comments
  indicates this is to avoid a bug in ibrowse related to chunked
  encoding,

- ibrowse always attempts to send a body, even when that body is
  empty, and

- erchef is configured to talk to bookshelf via nginx.

Given this and some other debugging, we believe the following is
happening occasionally:

- ibrowse sends the start of the head request, including the headers.
  nginx gets this, sees content-length is zero so it can process the
  request without reading the non-existent body.

- nginx gets the response and returns it, and closes the
  connection. The connection is closed because mini_s3 used HTTP/1.0
  which doesn't support keepalive connections.

- ibrowse tries to call ssl:send(Sock, []) to send the empty body but
  gets {error, closed}.

- ibrowse returns an error for what would have been a successful
  request.

Avoiding the empty `ssl:send` resolves the issue in our reproduction
case.

We may also update mini_s3 to avoid using HTTP/1.0, since the
consensus of previous maintainers is that the bug it is working around
is likely no longer an issue. However, changing the HTTP version will
also change how the ibrowse pool behaves and thus we want to do that
as a separate change.

Signed-off-by: Steven Danna <steve@chef.io>