### PR TITLE
Invalid path in the Makefile for building Chef Server

### DIFF
--- a/omnibus/Makefile
+++ b/omnibus/Makefile
@@ -64,9 +64,9 @@ prune: prune_deb
 clear_pkg_cache: clear_pkg_cache_deb
 
 clear_pkg_cache_%:
-	cd .kitchen/kitchen-vagrant/kitchen-omnibus-default-$(DEV_PLATFORM) \
+	cd .kitchen/kitchen-vagrant/default-$(DEV_PLATFORM) \
 	&& vagrant ssh -c 'rm -v -f /var/cache/omnibus/pkg/*.$*'
-	cd .kitchen/kitchen-vagrant/kitchen-omnibus-default-$(DEV_PLATFORM) \
+	cd .kitchen/kitchen-vagrant/default-$(DEV_PLATFORM) \
 	&& vagrant ssh -c 'rm -v -f /var/cache/omnibus/pkg/*.$*.metadata.json'
 
 prune_%:


### PR DESCRIPTION
### Description

Invalid path in the Makefile for building Chef Server.

### Issues Resolved

Current paths are causing the builds to fail with the following error,

```
       Chef Client finished, 24/38 resources updated in 02 minutes 33 seconds
       Downloading files from <default-ubuntu-1804>
       Finished converging <default-ubuntu-1804> (2m46.58s).
-----> Test Kitchen is finished. (3m35.27s)
cd .kitchen/kitchen-vagrant/kitchen-omnibus-default-ubuntu-1804 \
	&& vagrant ssh -c 'rm -v -f /var/cache/omnibus/pkg/*.deb'
/bin/sh: line 0: cd: .kitchen/kitchen-vagrant/kitchen-omnibus-default-ubuntu-1804: No such file or directory
make: *** [clear_pkg_cache_deb] Error 1
```


### Check List

- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG