### PR TITLE
cookbooks: remove reference to ElasticsearchPreflightValidator

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_checks.rb
@@ -145,9 +145,6 @@ class PreflightChecks
     end
     AuthPreflightValidator.new(node).run!
     IndexingPreflightValidator.new(node).run!
-    if PrivateChef['elasticsearch']['enable']
-      ElasticsearchPreflightValidator.new(node).run!
-    end
     SslPreflightValidator.new(node).run!
     BookshelfPreflightValidator.new(node).run!
     RequiredRecipePreflightValidator.new(node).run!


### PR DESCRIPTION
This class is no more.

Signed-off-by: Steven Danna <steve@chef.io>
