### PR TITLE
cookbooks: set explicit TMPDIR for elasticsearch

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-elasticsearch-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-elasticsearch-run.erb
@@ -5,9 +5,13 @@ ulimit -n 65536
 
 export ES_HOME=<%= node['private_chef']['elasticsearch']['dir'] %>            #/var/opt/opscode/elasticsearch
 export ES_DATA=<%= node['private_chef']['elasticsearch']['dir'] %>/data       #/var/opt/opscode/elasticsearch/data
+
 export JAVA_HOME=/opt/opscode/embedded/open-jre/
 export ES_PATH_CONF=<%= node['private_chef']['elasticsearch']['dir'] %>/config
 export PATH=<%= node['private_chef']['install_path'] %>/embedded/bin:$JAVA_HOME/bin:$ES_HOME:$PATH #/opt/opscode/embedded/bin
+
+export TMPDIR=<%= node['private_chef']['elasticsearch']['temp_directory'] %>
+export ES_TMPDIR=<%= node['private_chef']['elasticsearch']['temp_directory'] %>
 
 cd $ES_HOME
 exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> <%= node['private_chef']['install_path'] %>/embedded/elasticsearch/bin/elasticsearch


### PR DESCRIPTION
Elasticsearch requires a temporary directory on which it can create
executable files to support the execution of native code via JNA.

Many of our customers have /tmp mounted noexec by default causing
problems.

This configures elasticsearch to use a custom tmp directory.

Similar changes have previously been made in chef-backend and Chef Automate

Signed-off-by: Steven Danna <steve@chef.io>