### PR TITLE
Skeshari/veil version fix

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -49,6 +49,9 @@ allowed_licenses:
   - Unlicense
   - WTFPL
   - Zlib
+  - GPL-2.0-or-later
+  - GPL-1.0-or-later
+  - Artistic-1.0-Perl
 
 fallbacks:
   # These erlang overrides are temporary. We may be able to remove some of them once chef/license_scout#194 is resolved
@@ -197,4 +200,7 @@ exceptions:
       reason: Exception made by Chef Legal
     - name: core/nss-myhostname
       reason: Exception made by Chef Legal
-
+    - name: core/binutils
+      reason: Exception made by Chef Legal
+    - name: core/perl
+      reason: Exception made by Chef Legal

--- a/omnibus/partybus/Gemfile.lock
+++ b/omnibus/partybus/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/chef/chef_secrets
-  revision: 58373899212a23e4f37070aaa6d3a751b1281492
+  revision: 2875f29d82c528edd89cb614955e214f3aa4be0c
   specs:
-    veil (0.3.0)
+    veil (0.3.3)
       bcrypt (~> 3.1)
       pbkdf2
 

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/chef/chef_secrets.git
-  revision: 58373899212a23e4f37070aaa6d3a751b1281492
+  revision: 2875f29d82c528edd89cb614955e214f3aa4be0c
   specs:
-    veil (0.3.0)
+    veil (0.3.3)
       bcrypt (~> 3.1)
       pbkdf2
 

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -11,9 +11,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/chef_secrets
-  revision: 58373899212a23e4f37070aaa6d3a751b1281492
+  revision: 2875f29d82c528edd89cb614955e214f3aa4be0c
   specs:
-    veil (0.3.0)
+    veil (0.3.3)
       bcrypt (~> 3.1)
       pbkdf2
 

--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/chef/chef_secrets
-  revision: e43f1136ea9811b4254774af2c4191d27cf964f8
+  revision: 2875f29d82c528edd89cb614955e214f3aa4be0c
   specs:
-    veil (0.3.0)
+    veil (0.3.3)
       bcrypt (~> 3.1)
       pbkdf2
 

--- a/src/opscode-expander/Gemfile.lock
+++ b/src/opscode-expander/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/chef/chef_secrets
-  revision: e43f1136ea9811b4254774af2c4191d27cf964f8
+  revision: 2875f29d82c528edd89cb614955e214f3aa4be0c
   specs:
-    veil (0.3.0)
+    veil (0.3.3)
       bcrypt (~> 3.1)
       pbkdf2
 


### PR DESCRIPTION
### Description

Added required veil-0.3.3 to Gemfile.lock and added licenses

### Issues Resolved

https://buildkite.com/chef/chef-chef-server-chef-server-13-omnibus-adhoc/builds/176#

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
