### PR TITLE
Thread version in from the sup init state to avoid being called for every request

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -841,7 +841,8 @@ init_base_state(ResourceMod, InitParams) ->
                 metrics_config = ?gv(metrics_config, InitParams),
 
                 resource_args = ?gv(resource_args, InitParams),
-                resource_mod = ResourceMod}.
+                resource_mod = ResourceMod,
+                version = ?gv(version, InitParams)}.
 
 validate_request(_Verb, Req, State) ->
     {Req, State}.

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
@@ -11,9 +11,12 @@
 -export([start_link/0]).
 
 %% supervisor callbacks
--export([init/1]).
+-export([init/1,
+         default_resource_init/0]).
 
 -include("oc_chef_wm.hrl").
+-define(VERSION_PATH, '/opt/opscode/version-manifest.txt').
+
 
 %% @spec start_link() -> ServerRet
 %% @doc API for starting the supervisor.
@@ -158,7 +161,7 @@ default_resource_init() ->
 
                 %% This is set if default_orgname mode is enabled
                 {default_orgname, oc_chef_wm_routes:default_orgname()},
-
+                {version, get_version()},
                 %% metrics and stats_hero config. We organize these into a proplist which
                 %% will end up in the base_state record rather than having a key for each of
                 %% these in base state.
@@ -177,3 +180,14 @@ default_resource_init() ->
         _ ->
             Defaults
     end.
+
+get_version() ->
+    {ok, Device} = file:open(?VERSION_PATH, [read]),
+    %% Assuming that the first line of the file will have the version.
+    Version =
+        case file:read_line(Device) of
+            {ok, Data} -> list_to_binary(lists:subtract(Data,"chef-server \n"));
+            _ -> <<"error">>
+        end,
+    file:close(Device),
+    Version.

--- a/src/oc_erchef/include/oc_chef_wm.hrl
+++ b/src/oc_erchef/include/oc_chef_wm.hrl
@@ -196,11 +196,16 @@
 
           % Multiple resources may create a key at time of object creation.  Expose it
           % in base_state so that it's available for common handling.
-          key_context :: #key_context{} | undefined
+          key_context :: #key_context{} | undefined,
+          version :: atom()
 
          }).
 
 -type chef_wm_create_update_response() :: {true | {halt, 403 | 500 | 409}, wm_req(), #base_state{}}.
+
+-record(status_state, {
+          chef_infra_server_version :: binary() 
+         }).
 
 -record(client_state, {
           client_data,

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -139,7 +139,7 @@
   0},
  {<<"sync">>,
   {git,"git://github.com/rustyio/sync.git",
-       {ref,"9106be75883d7646dae72d4ac80c6ea88464a5ca"}},
+       {ref,"7c9367e73b7dbb01a788f8d0120d747330112f6f"}},
   0},
  {<<"uuid">>,
   {git,"git://github.com/okeuday/uuid.git",


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

root@api:~# curl -k  https://192.168.33.100/_status
{"status":"pong","upstreams":{"chef_elasticsearch":"pong","chef_sql":"pong","oc_chef_authz":"pong"},"keygen":{"keys":10,"max":10,"max_workers":2,"cur_max_workers":2,"inflight":0,"avail_workers":2,"start_size":0},"indexing":{"mode":"batch"},"version":"14.0.67+20201111171939"}
