### PR TITLE
Update dev provision-elasticsearch.sh to support version 7

### DIFF
--- a/.expeditor/README.md
+++ b/.expeditor/README.md
@@ -32,7 +32,7 @@ Environment variables are used to control how the scenarios are executed and all
 |-----------------------------|-----------------------------------------------------------------------------------------------|--------------------------------------------|
 | `INSTALL_VERSION` | The version number of the artifact you want to install first. | e.g. 12.19.31 |
 | `UPGRADE_VERSION` | The version number of the artifact you want to upgrade to. | e.g. 13.1.58+20200303212531 |
-| `ELASTIC_VERSION` | Version of Elasticsearch to install. | 2 or 5 with 6 being the default |
+| `ELASTIC_VERSION` | Version of Elasticsearch to install. | 2, 5, 6, or 7 with 6 being the default |
 | `ENABLE_SMOKE_TEST` | Enable Chef Infra Server smoke test. | true (default) |
 | `ENABLE_PEDANT_TEST` | Enable full Chef Infra Server pedant test. | true (default) |
 | `ENABLE_PSQL_TEST` | Enable testing of Chef Infra Server PostgreSQL database. | true (default) |

--- a/dev/scripts/provision-elasticsearch.sh
+++ b/dev/scripts/provision-elasticsearch.sh
@@ -5,6 +5,8 @@ if [ "${ELASTIC_VERSION}" = "2" ]; then
   echo "deb https://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
 elif [ "${ELASTIC_VERSION}" = "5" ]; then
   echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
+elif [ "${ELASTIC_VERSION}" = "7" ]; then
+  echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-7.x.list
 else
   echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
 fi


### PR DESCRIPTION
### Description

The https://github.com/chef/umbrella project uses https://github.com/chef/chef-server/dev/scripts/provision-elasticsearch.sh to handle the elasticsearch install.

This PR simply adds version 7.x support to the `provision-elasticsearch.sh` script

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>


### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
