### PR TITLE
Remove EOL RHEL 6

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -6,8 +6,6 @@ test-path: omnibus/omnibus-test.sh
 fips-platforms:
   - el-*-x86_64
 builder-to-testers-map:
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64


### PR DESCRIPTION
RHEL 6 went EOL at the end of Nov. Per our platform support policy we
will no longer produce builds for RHEL 6.

Signed-off-by: Tim Smith <tsmith@chef.io>