### PR TITLE
2020 EOLs

### DIFF
--- a/docs-chef-io/content/server/api_chef_server.md
+++ b/docs-chef-io/content/server/api_chef_server.md
@@ -1077,8 +1077,6 @@ As an example, to retrieve users whos `external_authentication_uid` is
 GET /users?external_authentication_uid=jane%40doe.com
 ```
 
-*New in Chef Server 12.7.*
-
 #### POST
 
 The `POST` method is used to create a user on the Chef Infra Server.

--- a/docs-chef-io/content/server/ctl_chef_server.md
+++ b/docs-chef-io/content/server/ctl_chef_server.md
@@ -413,8 +413,6 @@ It should be owned and readable only by `root`.
 The `set-secret` subcommand allows storing shared secrets and service
 credentials. Only secrets known to Chef Infra Server can be stored.
 
-*New in Chef Server 12.14*
-
 **Syntax**
 
 This subcommand has the following syntax:
@@ -461,8 +459,6 @@ This subcommand has the following options:
 The `remove-secret` subcommand allows removing a stored shared secret
 and service credential.
 
-*New in Chef Server 12.14*
-
 **Syntax**
 
 This subcommand has the following syntax:
@@ -482,8 +478,6 @@ chef-server-ctl remove-secret ldap bind_password
 The `show-secret` subcommand allows viewing a stored shared secret and
 service credential.
 
-*New in Chef Server 12.14*
-
 **Syntax**
 
 This subcommand has the following syntax:
@@ -496,8 +490,6 @@ chef-server-ctl show-secret GROUP NAME
 
 The `set-db-superuser-password` subcommand allows storing the database
 superuser password.
-
-*New in Chef Server 12.14*
 
 **Syntax**
 
@@ -514,8 +506,6 @@ the environment variable `DB_PASSWORD`.
 
 The `set-actions-password` subcommand allows storing the RabbitMQ
 Actions password.
-
-*New in Chef Server 12.14*
 
 **Syntax**
 
@@ -534,8 +524,6 @@ The `oc-id-show-app` subcommand allows for retrieving the client ID and
 client secret for applications known to **oc-id**. Note that with
 `insecure_addon_compat` [disabled](/runbook/server_security/#chef-infra-server-credentials-management),
 this data will no longer be written to `/etc/opscode/oc-id-applications/APP.json`.
-
-*New in Chef Server 12.14*
 
 **Syntax**
 
@@ -575,8 +563,6 @@ uploaded.
 
 {{< /note >}}
 
-*New in Chef Server 12.7*
-
 **Syntax**
 
 This subcommand has the following syntax:
@@ -602,8 +588,6 @@ number and creating a new hash value. You can choose whether to copy the
 updated secrets file to each node in the cluster and reconfiguring or by
 running this subcommand on all the nodes.
 
-*New in Chef Server 12.7*
-
 **Syntax**
 
 This subcommand has the following syntax:
@@ -619,8 +603,6 @@ all credentials for a given service by incrementing the value and
 creating a new hash value. You can choose whether to copy the updated
 secrets file to each node in the cluster and reconfiguring or by running
 this subcommand for that specific service on all the nodes.
-
-*New in Chef Server 12.7*
 
 **Syntax**
 
@@ -640,8 +622,6 @@ copy the secrets file to each Chef Infra Server and run
 `sudo chef-server-ctl reconfigure` on them to complete the rotation
 process.
 
-*New in Chef Server 12.7*
-
 **Syntax**
 
 This subcommand has the following syntax:
@@ -654,8 +634,6 @@ chef-server-ctl rotate-shared-secrets
 
 The `show-service-credentials` subcommand shows all of the service
 credentials for services running on the local Chef Infra Server.
-
-*New in Chef Server 12.7*
 
 **Syntax**
 
@@ -674,8 +652,6 @@ creation requests. For most users, the unused authorization objects do
 not substantially affect the performance of Chef Infra Server; however
 in certain situations it can be helpful to clean them up. This command
 is primarily intended for use by Chef support.
-
-New in Chef Server 12.16.9
 
 **Syntax**
 
@@ -1151,8 +1127,6 @@ This subcommand has the following options:
 
 :   Removes a user who is in one or more 'admin' groups unless that user
     is the only member of the 'admin' group(s).
-
-    New in Chef Server 12.9.
 
 ### user-edit
 

--- a/docs-chef-io/content/server/ctl_chef_server.md
+++ b/docs-chef-io/content/server/ctl_chef_server.md
@@ -104,7 +104,7 @@ chef-server-ctl help
 
 The `install` subcommand is used to install premium features of the Chef
 Infra Server: Chef management console and Chef Infra Client run
-reporting, high availability configurations, Chef Push Jobs, and Chef
+reporting, high availability configurations, and Chef
 Infra Server replication.
 
 {{< warning >}}

--- a/docs-chef-io/content/server/install_server_pre.md
+++ b/docs-chef-io/content/server/install_server_pre.md
@@ -480,13 +480,6 @@ local user and group accounts that will prevent these accounts from
 being created automatically during setup, you will need to create these
 accounts.
 
-{{< note >}}
-
-The Chef Push Jobs feature of the Chef Infra Server use the same user
-and group accounts as the Chef Infra Server.
-
-{{< /note >}}
-
 #### Group Accounts
 
 The following group accounts are required:

--- a/docs-chef-io/content/server/server_firewalls_and_ports.md
+++ b/docs-chef-io/content/server/server_firewalls_and_ports.md
@@ -123,7 +123,3 @@ Infra Server in a tiered configuration:
 ### Back End
 
 {{% server_firewalls_and_ports_tiered %}}
-
-## Chef Push Jobs
-
-{{% server_firewalls_and_ports_push_jobs %}}

--- a/docs-chef-io/content/server/server_security.md
+++ b/docs-chef-io/content/server/server_security.md
@@ -297,15 +297,13 @@ To regenerate SSL certificates:
 
 ## Chef Infra Server Credentials Management
 
-**New in Chef Server 12.14:** Chef Infra Server limits where it writes
-service passwords and keys to disk. In the default configuration,
-credentials are only written to files in `/etc/opscode`.
+Chef Infra Server limits where it writes service passwords and keys to disk.
+In the default configuration, credentials are only written to files in `/etc/opscode`.
 
 By default, Chef Infra Server still writes service credentials to
 multiple locations inside `/etc/opscode`. This is designed to maintain
-compatibility with add-ons. Chef Server 12.14 introduces the
-`insecure_addon_compat` configuration option in
-`/etc/opscode/chef-server.rb`, which allows you to further restrict
+compatibility with add-ons. The `insecure_addon_compat` configuration option in
+`/etc/opscode/chef-server.rb`, allows you to further restrict
 where credentials are written. `insecure_addon_compat` can be used if
 you are not using add-ons, or if you are using the latest add-on
 versions. Setting `insecure_addon_compat` to `false` writes credentials
@@ -321,8 +319,8 @@ including them in your configuration file.
 ### Add-on Compatibility
 
 The following table lists which add-on versions support the more
-restrictive `insecure_addon_compat false` setting. These version also
-now **require** Chef Server 12.14.0 or greater:
+restrictive `insecure_addon_compat false` setting.
+These version **require** Chef Server 12.14.0 or greater:
 
 <table>
 <colgroup>

--- a/docs-chef-io/content/server/server_security.md
+++ b/docs-chef-io/content/server/server_security.md
@@ -320,7 +320,7 @@ including them in your configuration file.
 
 The following table lists which add-on versions support the more
 restrictive `insecure_addon_compat false` setting.
-These version **require** Chef Server 12.14.0 or greater:
+These versions **require** Chef Server 12.14.0 or greater:
 
 <table>
 <colgroup>

--- a/docs-chef-io/content/server/server_security.md
+++ b/docs-chef-io/content/server/server_security.md
@@ -344,10 +344,6 @@ now **require** Chef Server 12.14.0 or greater:
 <td>Chef Manage</td>
 <td>2.5.0</td>
 </tr>
-<tr class="odd">
-<td>Push Jobs Server</td>
-<td>2.2.0</td>
-</tr>
 </tbody>
 </table>
 

--- a/docs-chef-io/content/server/server_users.md
+++ b/docs-chef-io/content/server/server_users.md
@@ -72,15 +72,6 @@ Server:
 
 ### org-user-add
 
-{{< warning >}}
-
-Early RC candidates for the Chef Server 12 release named this command
-`org-associate`. This is the same command, with the exception of the
-`--admin` flag, which is added to the command (along with the rename)
-for the upcoming final release of Chef Server 12.
-
-{{< /warning >}}
-
 {{% ctl_chef_server_org_user_add %}}
 
 **Syntax**

--- a/docs-chef-io/content/server/upgrade_server.md
+++ b/docs-chef-io/content/server/upgrade_server.md
@@ -227,7 +227,7 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
 
 ## Upgrading Add-ons
 
-Chef Infra Server 13 and 14 supports Chef Manage. This add-ons is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions). Chef Manage will reach EOL on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
+Chef Infra Server 13 and 14 support Chef Manage. This add-ons is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions). Chef Manage will reach EOL on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
 
 Chef Manage
 : Chef Manage is deprecated and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. Chef Manage is a management console for  data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface

--- a/docs-chef-io/content/server/upgrade_server.md
+++ b/docs-chef-io/content/server/upgrade_server.md
@@ -227,7 +227,7 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
 
 ## Upgrading Add-ons
 
-Chef Infra Server 13 and 14 support Chef Manage. This add-ons is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions). Chef Manage will reach EOL on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
+Chef Infra Server 13 and 14 support Chef Manage. This add-on is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions). Chef Manage will reach EOL on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
 
 Chef Manage
 : Chef Manage is deprecated and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. Chef Manage is a management console for  data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface

--- a/docs-chef-io/content/server/upgrade_server.md
+++ b/docs-chef-io/content/server/upgrade_server.md
@@ -227,13 +227,10 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
 
 ## Upgrading Add-ons
 
-Chef Infra Server 13 and 14 supports Chef Manage and Push Jobs. Both of these add-ons are [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions). Push Jobs will reach EOL on December 31, 2020 and Chef Manage will reach EOL on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
+Chef Infra Server 13 and 14 supports Chef Manage. This add-ons is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions). Chef Manage will reach EOL on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
 
 Chef Manage
 : Chef Manage is deprecated and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. Chef Manage is a management console for  data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface
-
-Push Jobs
-: Push Jobs deprecated and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2020. Chef Push Jobs is an extension of the Chef Infra Server that allows for running jobs against nodes independently of a Chef Infra Client run.
 
 ### Use Downloads
 

--- a/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
@@ -33,7 +33,7 @@ This configuration file has the following general settings:
 :   Default value:
 
     ```ruby
-    %w{chef-manage opscode-push-jobs-server}
+    %w{chef-manage}
     ```
 
 `api_version`

--- a/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
@@ -818,6 +818,8 @@ This configuration file has the following settings for `nginx`:
     `nginx['worker_connections']` to determine the maximum number of
     allowed clients. Default value: `node['cpu']['total'].to_i`.
 
+`nginx['x_forwarded_proto']`
+
 :   The protocol used to connect to the server. Possible values: `http`
     and `https`. This is the protocol used to connect to the Chef Infra
     Server by a Chef Infra Client or a workstation. Default value:

--- a/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
@@ -122,17 +122,14 @@ This configuration file has the following settings for `bookshelf`:
 
 `bookshelf['access_key_id']`
 
-:   The access key identifier. This may point at an external storage
-    location, such as Amazon EC2. See [AWS external bookshelf
-    settings](/server/#aws-settings) for
-    more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Server 12.14, this is no longer the
-    preferred command.
+:   Deprecated.
+    Use `chef-server-ctl set-secret bookshelf access_key_id` from the [Secrets Management](/ctl_chef_server/#ctl-chef-server-secrets-management) commands.
 
-    Please use `chef-server-ctl set-secret bookshelf access_key_id` from
-    the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    commands.
+    The access key identifier.
+    This may point at an external storage location, such as Amazon EC2.
+    See [AWS external bookshelf settings](/server/#aws-settings) for
+    more information on configuring external bookshelf. Default value:
+    **generated**.
 
 `bookshelf['data_dir']`
 
@@ -153,8 +150,6 @@ This configuration file has the following settings for `bookshelf`:
 
 :   Use to configure request logging for the bookshelf service. Default
     value: `false`.
-
-    New in Chef Server 12.17.15.
 
 `bookshelf['external_url']`
 
@@ -189,17 +184,14 @@ This configuration file has the following settings for `bookshelf`:
 
 `bookshelf['secret_access_key']`
 
-:   The secret key. This may point at an external storage location, such
+:   Deprecated.
+    Use `chef-server-ctl set-secret bookshelf secret_access_key` from the [Secrets Management](/ctl_chef_server/#ctl-chef-server-secrets-management) commands.
+
+    The secret key. This may point at an external storage location, such
     as Amazon EC2. See [AWS external bookshelf
     settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Server 12.14, this is no longer the
-    preferred command.
-
-    Please use `chef-server-ctl set-secret bookshelf secret_access_key`
-    from the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    commands.
+    **generated**.
 
 `bookshelf['storage_type']`
 
@@ -323,16 +315,14 @@ This configuration file has the following settings for `data_collector`:
 
 `data_collector['token']`
 
-:   Legacy configuration for shared data collector security token. When
+:   Deprecated. Use `chef-server-ctl set-secret data_collector token` from
+    the [Secrets Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
+    commands.
+
+    Legacy configuration for shared data collector security token. When
     configured, the token will be passed as an HTTP header named
     `x-data-collector-token` which the server can choose to accept or
-    reject. As of Chef Server 12.14, this is no longer the preferred
-    command.
-
-    Please use `chef-server-ctl set-secret data_collector token` from
-    the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    commands.
+    reject.
 
 `data_collector['timeout']`
 
@@ -771,8 +761,6 @@ This configuration file has the following settings for `nginx`:
 :   Whether nginx should only respond to requests where the Host header
     matches one of the configured FQDNs. Default value: `false`.
 
-    New in Chef Server 12.17
-
 `nginx['stub_status']['allow_list']`
 
 :   The IP address on which accessing the `stub_status` endpoint is
@@ -812,14 +800,11 @@ This configuration file has the following settings for `nginx`:
     local IP addresses to the configured FQDNs. Useful in combination
     with `nginx['strict_host_header']`. Default value: `true`.
 
-    New in Chef Server 12.17
-
 `nginx['show_welcome_page']`
 
 :   Determines whether or not the default nginx welcome page is shown.
     Default value: `true`.
 
-    New in Chef Server 12.17.15.
 
 `nginx['worker_connections']`
 
@@ -832,8 +817,6 @@ This configuration file has the following settings for `nginx`:
 :   The number of allowed worker processes. Use with
     `nginx['worker_connections']` to determine the maximum number of
     allowed clients. Default value: `node['cpu']['total'].to_i`.
-
-`nginx['x_forwarded_proto']`
 
 :   The protocol used to connect to the server. Possible values: `http`
     and `https`. This is the protocol used to connect to the Chef Infra
@@ -868,8 +851,6 @@ This configuration file has the following settings for `oc_bifrost`:
 
 :   Use to configure request logging for the `oc_bifrost` service.
     Default value: `true`.
-
-    New in Chef Server 12.17.15.
 
 `oc_bifrost['extended_perf_log']`
 
@@ -1052,9 +1033,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['email_from_address']`
 
-:   New in Chef Server 12.12.
-
-    Outbound email address. Defaults to the `'from_email'` value.
+:  Outbound email address. Defaults to the `'from_email'` value.
 
 `oc_id['log_directory']`
 
@@ -1073,9 +1052,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['origin']`
 
-:   New in Chef Server 12.12.
-
-    The FQDN for the server that is sending outbound email. Defaults to
+:   The FQDN for the server that is sending outbound email. Defaults to
     the `'api_fqdn'` value, which is the FQDN for the Chef Infra Server.
 
 `oc_id['num_to_keep']`
@@ -1297,8 +1274,6 @@ This configuration file has the following settings for `opscode-erchef`:
 
 :   Use to configure request logging for the `opscode_erchef` service.
     Default value: `true`.
-
-    New in Chef Server 12.17.15.
 
 `opscode_erchef['ibrowse_max_pipeline_size']`
 
@@ -1576,9 +1551,7 @@ This configuration file has the following settings for `opscode-solr4`:
 
 `opscode_solr4['log_gc']`
 
-:   New in Chef Server 12.12.
-
-    Enable or disable GC logging. Default is `true`.
+:  Enable or disable GC logging. Default is `true`.
 
 `opscode_solr4['log_rotation']`
 

--- a/docs-chef-io/content/server/v13_2/reusable_text/config_rb_server_settings_ldap.md
+++ b/docs-chef-io/content/server/v13_2/reusable_text/config_rb_server_settings_ldap.md
@@ -73,16 +73,14 @@ This configuration file has the following settings for `ldap`:
 
 `ldap['bind_password']`
 
-:   Legacy configuration for the password of the binding user. The
+:   Deprecated. Use `chef-server-ctl set-secret ldap bind_password` from the
+    [Secrets Management](/ctl_chef_server.html#ctl-chef-server-secrets-management)
+    commands.
+
+    Legacy configuration for the password of the binding user. The
     password for the user specified by `ldap['bind_dn']`. Leave this
     value and `ldap['bind_dn']` unset if anonymous bind is sufficient.
-    Default value: `nil`. As of Chef Server 12.14, this is no longer the
-    preferred command.
-
-    Please use `chef-server-ctl set-secret ldap bind_password` from the
-    [Secrets
-    Management](/ctl_chef_server.html#ctl-chef-server-secrets-management)
-    commands.
+    Default value: `nil`.
 
     ```bash
     chef-server-ctl set-secret ldap bind_password

--- a/docs-chef-io/content/server/v13_2/reusable_text/server_tuning_postgresql.md
+++ b/docs-chef-io/content/server/v13_2/reusable_text/server_tuning_postgresql.md
@@ -12,7 +12,6 @@ The following setting is often modified from the default as part of the tuning e
     -   Each front end machine always runs the **oc_bifrost** and
         **opscode-erchef** services.
     -   The Reporting add-on adds the **reporting** service.
-    -   The Chef Push Jobs service adds the **push_jobs** service.
 
     Each of these services requires 25 connections, above the default
     value.

--- a/docs-chef-io/content/server/v14_0/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14_0/config_rb_server_optional_settings.md
@@ -33,7 +33,7 @@ This configuration file has the following general settings:
 :   Default value:
 
     ```ruby
-    %w{chef-manage opscode-push-jobs-server}
+    %w{chef-manage}
     ```
 
 `api_version`

--- a/docs-chef-io/content/server/v14_0/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14_0/config_rb_server_optional_settings.md
@@ -122,17 +122,13 @@ This configuration file has the following settings for `bookshelf`:
 
 `bookshelf['access_key_id']`
 
-:   The access key identifier. This may point at an external storage
-    location, such as Amazon EC2. See [AWS external bookshelf
-    settings](/server/#aws-settings) for
-    more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Infra Server 12.14, this is no longer the
-    preferred command.
-
-    Please use `chef-server-ctl set-secret bookshelf access_key_id` from
-    the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
+:   Deprecated. Use `chef-server-ctl set-secret bookshelf access_key_id` from
+    the [Secrets Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
     commands.
+
+    The access key identifier. This may point at an external storage
+    location, such as Amazon EC2. See [AWS external bookshelf
+    settings](/server/#aws-settings) for more information on configuring external bookshelf. Default value: **generated**.
 
 `bookshelf['data_dir']`
 
@@ -153,8 +149,6 @@ This configuration file has the following settings for `bookshelf`:
 
 :   Use to configure request logging for the bookshelf service. Default
     value: `false`.
-
-    New in Chef Server 12.17.15.
 
 `bookshelf['external_url']`
 
@@ -189,17 +183,15 @@ This configuration file has the following settings for `bookshelf`:
 
 `bookshelf['secret_access_key']`
 
-:   The secret key. This may point at an external storage location, such
+:   Deprecated. Use `chef-server-ctl set-secret bookshelf secret_access_key`
+    from the [Secrets Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
+    commands.
+
+    The secret key. This may point at an external storage location, such
     as Amazon EC2. See [AWS external bookshelf
     settings](/server/#aws-settings) for
     more information on configuring external bookshelf. Default value:
-    **generated**. As of Chef Infra Server 12.14, this is no longer the
-    preferred command.
-
-    Please use `chef-server-ctl set-secret bookshelf secret_access_key`
-    from the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    commands.
+    **generated**.
 
 `bookshelf['storage_type']`
 
@@ -323,16 +315,14 @@ This configuration file has the following settings for `data_collector`:
 
 `data_collector['token']`
 
-:   Legacy configuration for shared data collector security token. When
+:   Deprecated. Use `chef-server-ctl set-secret data_collector token` from
+    the [Secrets Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
+    commands.
+
+    Legacy configuration for shared data collector security token. When
     configured, the token will be passed as an HTTP header named
     `x-data-collector-token` which the server can choose to accept or
-    reject. As of Chef Infra Server 12.14, this is no longer the preferred
-    command.
-
-    Please use `chef-server-ctl set-secret data_collector token` from
-    the [Secrets
-    Management](/ctl_chef_server/#ctl-chef-server-secrets-management)
-    commands.
+    reject.
 
 `data_collector['timeout']`
 
@@ -753,8 +743,6 @@ This configuration file has the following settings for `nginx`:
 :   Whether nginx should only respond to requests where the Host header
     matches one of the configured FQDNs. Default value: `false`.
 
-    New in Chef Server 12.17
-
 `nginx['stub_status']['allow_list']`
 
 :   The IP address on which accessing the `stub_status` endpoint is
@@ -794,14 +782,10 @@ This configuration file has the following settings for `nginx`:
     local IP addresses to the configured FQDNs. Useful in combination
     with `nginx['strict_host_header']`. Default value: `true`.
 
-    New in Chef Server 12.17
-
 `nginx['show_welcome_page']`
 
 :   Determines whether or not the default nginx welcome page is shown.
     Default value: `true`.
-
-    New in Chef Server 12.17.15.
 
 `nginx['worker_connections']`
 
@@ -850,8 +834,6 @@ This configuration file has the following settings for `oc_bifrost`:
 
 :   Use to configure request logging for the `oc_bifrost` service.
     Default value: `true`.
-
-    New in Chef Server 12.17.15.
 
 `oc_bifrost['extended_perf_log']`
 
@@ -1034,9 +1016,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['email_from_address']`
 
-:   New in Chef Infra Server 12.12.
-
-    Outbound email address. Defaults to the `'from_email'` value.
+:   Outbound email address. Defaults to the `'from_email'` value.
 
 `oc_id['log_directory']`
 
@@ -1055,9 +1035,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['origin']`
 
-:   New in Chef Infra Server 12.12.
-
-    The FQDN for the server that is sending outbound email. Defaults to
+:   The FQDN for the server that is sending outbound email. Defaults to
     the `'api_fqdn'` value, which is the FQDN for the Chef Infra Server.
 
 `oc_id['num_to_keep']`
@@ -1279,8 +1257,6 @@ This configuration file has the following settings for `opscode-erchef`:
 
 :   Use to configure request logging for the `opscode_erchef` service.
     Default value: `true`.
-
-    New in Chef Server 12.17.15.
 
 `opscode_erchef['ibrowse_max_pipeline_size']`
 

--- a/docs-chef-io/content/server/v14_0/reusable_text/config_rb_server_settings_ldap.md
+++ b/docs-chef-io/content/server/v14_0/reusable_text/config_rb_server_settings_ldap.md
@@ -73,16 +73,14 @@ This configuration file has the following settings for `ldap`:
 
 `ldap['bind_password']`
 
-:   Legacy configuration for the password of the binding user. The
+:   Deprecated. Use `chef-server-ctl set-secret ldap bind_password` from the
+    [Secrets Management](/ctl_chef_server.html#ctl-chef-server-secrets-management)
+    commands.
+
+    Legacy configuration for the password of the binding user. The
     password for the user specified by `ldap['bind_dn']`. Leave this
     value and `ldap['bind_dn']` unset if anonymous bind is sufficient.
-    Default value: `nil`. As of Chef Server 12.14, this is no longer the
-    preferred command.
-
-    Please use `chef-server-ctl set-secret ldap bind_password` from the
-    [Secrets
-    Management](/ctl_chef_server.html#ctl-chef-server-secrets-management)
-    commands.
+    Default value: `nil`.
 
     ```bash
     chef-server-ctl set-secret ldap bind_password

--- a/docs-chef-io/content/server/v14_0/reusable_text/server_tuning_postgresql.md
+++ b/docs-chef-io/content/server/v14_0/reusable_text/server_tuning_postgresql.md
@@ -12,7 +12,6 @@ The following setting is often modified from the default as part of the tuning e
     -   Each front end machine always runs the **oc_bifrost** and
         **opscode-erchef** services.
     -   The Reporting add-on adds the **reporting** service.
-    -   The Chef Push Jobs service adds the **push_jobs** service.
 
     Each of these services requires 25 connections, above the default
     value.


### PR DESCRIPTION
### Description

This PR removes documentation for Chef Server 12.x and Push Jobs, which reach EOL on 12/31/2020

### Issues Resolved

Part of https://github.com/chef/chef-web-docs/issues/2807
Derivative of: https://github.com/chef/chef-web-docs/pull/2811

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
