### PR TITLE
Fix a couple links to images in the docs

### DIFF
--- a/docs-chef-io/content/server/_index.md
+++ b/docs-chef-io/content/server/_index.md
@@ -33,7 +33,7 @@ additional information.
 The following diagram shows the various components that are part of a
 Chef Infra Server deployment and how they relate to one another.
 
-<img src="/images/server_components_14.svg" width="500" alt="Diagram of Chef Infra Server deployment" />
+<img src="/images/server/server_components_14.svg" width="500" alt="Diagram of Chef Infra Server deployment" />
 
 <table>
 <colgroup>
@@ -86,7 +86,7 @@ The following diagram highlights the specific changes that occur when
 cookbooks are stored at an external location, such as Amazon Simple
 Storage Service (S3).
 
-<img src="/images/server_components_s3_14.svg" width="500" alt="image" />
+<img src="/images/server/server_components_s3_14.svg" width="500" alt="image" />
 
 The following table describes the components that are different from the
 default configuration of the Chef Infra Server when cookbooks are stored
@@ -223,7 +223,7 @@ The following diagram highlights the specific changes that occur when
 PostgreSQL is configured and managed independently of the Chef Infra
 Server configuration.
 
-<img src="/images/server_components_postgresql_14.svg" width="500" alt="image" />
+<img src="/images/server/server_components_postgresql_14.svg" width="500" alt="image" />
 
 The following table describes the components in an external PostgreSQL
 configuration that are different from the default configuration of the

--- a/docs-chef-io/content/server/runbook.md
+++ b/docs-chef-io/content/server/runbook.md
@@ -21,7 +21,7 @@ aliases = ["/runbook/"]
 The following diagram shows the various components that are part of a
 Chef Infra Server deployment and how they relate to one another.
 
-<img src="/images/server_components_14.svg" width="500" alt="Diagram of Chef Infra Server deployment" />
+<img src="/images/server/server_components_14.svg" width="500" alt="Diagram of Chef Infra Server deployment" />
 
 <table style="width:99%;">
 <colgroup>


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This fixes image links that were pointing to the wrong file path.

### Issues Resolved

chef/chef-web-docs#2855

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
