### PR TITLE
zei/major versions constraint/1576

### DIFF
--- a/src/chef-mover/apps/chef_objects/test/chef_cookbook_version_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_cookbook_version_tests.erl
@@ -229,7 +229,9 @@ version_to_binary_test() ->
     ?assertEqual(<<"0.0.1">>, chef_cookbook_version:version_to_binary({0,0,1})).
 
 parse_version_test_() ->
-    GoodVersions = [{<<"1.2">>, {1, 2, 0}},
+    GoodVersions = [
+                    {<<"1">>, {1, 0, 0}},
+                    {<<"1.2">>, {1, 2, 0}},
                     {<<"1.2.3">>, {1, 2, 3}},
                     {<<"1.2.", ?MAX_GOOD_VERSION>>, {1,2, ?MAX_GOOD_VERSION_INT}},
                     {<<"1.", ?MAX_GOOD_VERSION>>, {1, ?MAX_GOOD_VERSION_INT, 0}},
@@ -242,9 +244,7 @@ parse_version_test_() ->
 
 parse_version_badversion_test_() ->
     BadVersions = [
-                   <<"0">>,
-                   <<"1">>,
-                   <<?MAX_GOOD_VERSION>>,
+                   <<?BAD_POSITIVE_VERSION>>,
                    <<"">>,
                    <<"A">>,
                    <<"1.2.a">>,

--- a/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
@@ -406,6 +406,8 @@ parse_version(Version) when is_binary(Version) ->
     end.
 
 
+normalize_version([X]) ->
+    [X, 0, 0];
 normalize_version([X, Y]) ->
     [X, Y, 0];
 normalize_version([_, _, _] = V) ->

--- a/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
@@ -237,7 +237,9 @@ version_to_binary_test() ->
     ?assertEqual(<<"0.0.1">>, chef_cookbook_version:version_to_binary({0,0,1})).
 
 parse_version_test_() ->
-    GoodVersions = [{<<"1.2">>, {1, 2, 0}},
+    GoodVersions = [
+                    {<<"1">>, {1, 0, 0}},
+                    {<<"1.2">>, {1, 2, 0}},
                     {<<"1.2.3">>, {1, 2, 3}},
                     {<<"1.2.", ?MAX_GOOD_VERSION>>, {1,2, ?MAX_GOOD_VERSION_INT}},
                     {<<"1.", ?MAX_GOOD_VERSION>>, {1, ?MAX_GOOD_VERSION_INT, 0}},
@@ -250,9 +252,7 @@ parse_version_test_() ->
 
 parse_version_badversion_test_() ->
     BadVersions = [
-                   <<"0">>,
-                   <<"1">>,
-                   <<?MAX_GOOD_VERSION>>,
+                   <<?BAD_POSITIVE_VERSION>>,
                    <<"">>,
                    <<"A">>,
                    <<"1.2.a">>,


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

Fixing the validation for version given in the `metadata.rb` while uploading the cookbook.

### Issues Resolved

resolves #1576

### Check List

- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
