### PR TITLE
Zei/Add configurable timestamp for access.log

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -451,6 +451,7 @@ default['private_chef']['nginx']['log_directory'] = '/var/log/opscode/nginx'
 default['private_chef']['nginx']['log_rotation']['file_maxbytes'] = 104857600
 default['private_chef']['nginx']['log_rotation']['num_to_keep'] = 10
 default['private_chef']['nginx']['log_x_forwarded_for'] = false
+default['private_chef']['nginx']['time_format'] = 'time_iso8601'
 default['private_chef']['nginx']['ssl_port'] = 443
 default['private_chef']['nginx']['enable_non_ssl'] = false
 default['private_chef']['nginx']['non_ssl_port'] = 80

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
@@ -106,4 +106,14 @@ class NginxErb
       '/var/log/opscode/nginx/access.log'
     end
   end
+
+  def time_format
+    time_format = node['private_chef']['nginx']['time_format']
+    unless( time_format == 'time_iso8601' or time_format == 'time_local')
+        'time_iso8601'
+    else
+        time_format
+    end
+  end
+
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -12,10 +12,11 @@ events {
 }
 
 http {
+
 <% if node['private_chef']['nginx']['log_x_forwarded_for'] -%>
-  log_format opscode '$http_x_forwarded_for - $remote_user [$time_iso8601]  '
+  log_format opscode ' $http_x_forwarded_for- $remote_user [$<%= @helper.time_format %>]  '
 <% else -%>
-  log_format opscode '$remote_addr - $remote_user [$time_iso8601]  '
+  log_format opscode '$remote_addr - $remote_user [$<%= @helper.time_format %>]  '
 <% end -%>
                     '"$request" $status "$request_time" $body_bytes_sent '
                     '"$http_referer" "$http_user_agent" "$upstream_addr" "$upstream_status" "$upstream_response_time" "$http_x_chef_version" "$http_x_ops_sign" "$http_x_ops_userid" "$http_x_ops_timestamp" "$http_x_ops_content_hash" $request_length "$http_x_remote_request_id"';


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

The timestamp for access.log will not be hard coded but should be configurable from `chef-serv er.rb`

### Issues Resolved

Resolves isses #2156

### Check List

- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
