### PR TITLE
The version of ruby on the builder was updated from 2.6.0 to 2.7.0.

### DIFF
--- a/src/oc-id/spec/support/monkeypatch.rb
+++ b/src/oc-id/spec/support/monkeypatch.rb
@@ -1,18 +1,24 @@
-# This patch is only required when using rails 4.2 with ruby 2.6
+# This patch is only required when using rails 4.2 with ruby 2.6 or greater
 #
-# https://github.com/rails/rails/issues/34790
+# https://github.com/rails/rails/issues/34790#issuecomment-681034561
 
-if RUBY_VERSION>='2.6.0'
-  if Rails.version < '5'
+# a workaround to avoid MonitorMixin double-initialize error
+# https://github.com/rails/rails/issues/34790#issuecomment-681034561
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
+  if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
     class ActionController::TestResponse < ActionDispatch::TestResponse
       def recycle!
-        # hack to avoid MonitorMixin double-initialize error:
-        @mon_mutex_owner_object_id = nil
-        @mon_mutex = nil
-        initialize
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+          @mon_data = nil
+          @mon_data_owner_object_id = nil
+        else
+          @mon_mutex = nil
+          @mon_mutex_owner_object_id = nil
+        end
+         initialize
       end
     end
   else
-    puts "Monkeypatch for ActionController::TestResponse no longer needed"
+    $stderr.puts "Monkeypatch for ActionController::TestResponse is no longer needed"
   end
 end


### PR DESCRIPTION
Updating the monkeypatch for this to later version.
Fixes #2215 
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

https://buildkite.com/chef/chef-chef-server-master-verify/builds/2932