### PR TITLE
Remove EOL RHEL 6 builds

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -6,8 +6,6 @@ test-path: omnibus/omnibus-test.sh
 fips-platforms:
   - el-*-x86_64
 builder-to-testers-map:
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64

--- a/CODE_REVIEW_CHECKLIST.md
+++ b/CODE_REVIEW_CHECKLIST.md
@@ -72,11 +72,10 @@ may have.
 - [ ] Will this change work on all of our supported platforms and
       browsers?
 
-      Supported platforms (architectures) are:
-      - el-5, el-6, el-7, sles-11, sles-12, ubuntu 12.04, ubuntu 14.04 (x86_64)
-      - el-7 (ppc64)
-      - el-7, ubuntu 14.04 (ppc64le)
-      - el-6, el-7, sles-11, sles-12 (s390x)
+      Supported platforms are:
+      - el-7, el-8, sles-12, sles-15 ubuntu 16.04, ubuntu 18.04, ubuntu 20.04
+      - el-7, el-8, ubuntu 16.04, ubuntu 18.04, ubuntu 20.04
+      - el-7, el-8, sles-12, sles-15
 
       Note: For outside contributors, it is impossible to verify that.
       A Chef employee with access to our internal CI infrastructure


### PR DESCRIPTION
### Description

This PR removes RHEL 6 from the Omnibus build/test configuration and updates the Code Review Checklist to reflect the current list of supported architectures.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Issues Resolved

#2193 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
