### PR TITLE
Update Elasticsearch to 7.9.1

### DIFF
--- a/oc-chef-pedant/lib/pedant/rspec/search_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/search_util.rb
@@ -718,7 +718,9 @@ module Pedant
       end
 
       def get_response_count(r)
-        if r["response"].nil?
+        if (r["response"].nil?) and (r["hits"]["total"].is_a? Hash)
+          r["hits"]["total"]["value"]
+        elsif r["response"].nil?
           r["hits"]["total"]
         else
           r["response"]["numFound"]

--- a/omnibus/config/software/elasticsearch.rb
+++ b/omnibus/config/software/elasticsearch.rb
@@ -30,6 +30,11 @@ version "6.8.12" do
          sha512: "9f6179ee49baa48b49c5328b88ddf2f0ef868f49c1f04d77975622120749725c48ac09cd565c05f6033eb227eaff905aff9f881a85efcf2fa75cc586cb8c45cb"
 end
 
+version "7.9.1" do
+  source url: "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{version}-linux-x86_64.tar.gz",
+         sha512: "e24aab0fbeb0b53cc386bb0ca1fc84c457851c5d80d147324bf97ff42f063332a93dec3c693550662393a72c7a0522a100181dd9a7d50b3e487a0f2a2a9bbcc0"
+end
+
 target_path = "#{install_dir}/embedded/elasticsearch"
 
 build do
@@ -38,7 +43,9 @@ build do
   delete "#{project_dir}/lib/sigar/*sparc*"
   delete "#{project_dir}/lib/sigar/*freebsd*"
   delete "#{project_dir}/config"
+  delete "#{project_dir}/jdk"
   delete "#{project_dir}/modules/x-pack-ml"
+  delete "#{project_dir}/modules/ingest-geoip"
   mkdir  "#{project_dir}/plugins"
   # by default RPMs will not include empty directories in the final package
   # ES will fail to start if this dir is not present.

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -173,6 +173,7 @@ elasticsearch['enable_gc_log'] = false
 elasticsearch['initial_cluster_join_timeout'] = 90
 elasticsearch['shard_count'] = 5
 elasticsearch['replica_count'] = 1
+#elasticsearch['es_version'] = '6.8.12'
 
 # each item in this list will be placed as-is into java_opts config file.
 # entries are set in chef-server.rb as

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
@@ -2,7 +2,6 @@
 # All Rights Reserved
 
 MAX_MAP_COUNT = 262_144
-
 cluster_name = if node['previous_run'] && node['previous_run']['elasticsearch'] && node['previous_run']['elasticsearch']['cluster_name']
                  node['previous_run']['elasticsearch']['cluster_name']
                else
@@ -115,8 +114,15 @@ heap_size = if node['private_chef']['opscode-solr4'] &&
             end
 
 jvm_config_file = File.join(elasticsearch_conf_dir, 'jvm.options')
+
+jvm_source = if node['private_chef']['elasticsearch']['es_version'].to_f > 7.0 
+              'elasticsearch_jvm_es7.opts.erb'
+            else
+              'elasticsearch_jvm.opts.erb'
+            end
+
 template jvm_config_file do
-  source 'elasticsearch_jvm.opts.erb'
+  source jvm_source
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
   mode '0644'

--- a/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/spec/libraries/helper_spec.rb
@@ -190,6 +190,28 @@ describe OmnibusHelper do
       end
     end
 
+    context 'when elastic search is version 6' do
+      let(:elastic_version) { '6.8.12' }
+
+      it 'should return 6' do
+        helper = described_class.new(node)
+        expect(Chef::HTTP).to receive(:new).with(external_url).and_return(client)
+        expect(client).to receive(:get).with('').and_return(response)
+        expect(helper.elastic_search_major_version).to eq(6)
+      end
+    end
+
+    context 'when elastic search is version 7' do
+      let(:elastic_version) { '7.9.1' }
+
+      it 'should return 7' do
+        helper = described_class.new(node)
+        expect(Chef::HTTP).to receive(:new).with(external_url).and_return(client)
+        expect(client).to receive(:get).with('').and_return(response)
+        expect(helper.elastic_search_major_version).to eq(7)
+      end
+    end
+
     context 'when elastic search is version unsupported' do
       let(:elastic_version) { '200.50.35' }
 
@@ -197,7 +219,7 @@ describe OmnibusHelper do
         helper = described_class.new(node)
         expect(Chef::HTTP).to receive(:new).with(external_url).and_return(client)
         expect(client).to receive(:get).with('').and_return(response)
-        expect { helper.elastic_search_major_version }.to raise_error(/Unsupported elasticsearch version/)
+        expect { helper.elastic_search_major_version }.to raise_error(/Unsupported Elasticsearch version/)
       end
     end
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch.yml.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch.yml.erb
@@ -19,6 +19,17 @@ network.host: "<%= @listen %>"
 http.port: <%= @port %>
 
 <%
+  # ES7 mandatory configuration.These settings are applicable only for the users using standalone or tiered configurations. 
+  # For BYOD(external elasticsearch) none of the omnibus configs are applicable.
+  # Note: we have not enabled bootstrap checks, so failing bootstrap checks will appear as warnings in the es logs.
+  if node['private_chef']['elasticsearch']['es_version'].to_f > 7.0
+%>
+discovery.type: single-node
+<%
+  end
+%>
+
+<%
   # ES uses secomp in production mode. This is not supported in RHEL <  7
   # Reference:
   # https://www.elastic.co/guide/en/elasticsearch/reference/master/_system_call_filter_check.html
@@ -32,3 +43,5 @@ bootstrap.system_call_filter: false
     end
   end
 %>
+
+

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch_jvm_es7.opts.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/elasticsearch_jvm_es7.opts.erb
@@ -1,0 +1,63 @@
+## JVM Configuration
+
+<% # Wants: log_dir, enable_gc_log, heap_size, new_size, jvm_opts, tmp_dir %>
+
+<% @jvm_opts.each do |opt| %>
+<%=opt%>
+<% end %>
+# Do not override xmx/xms/newsize in
+# jvm_options - instead set the attributes in chef-server.rb
+-Xmx<%=@heap_size%>m
+-Xms<%=@heap_size%>m
+-XX:NewSize=<%= @new_size %>M
+
+# These are defaulted based on what 7.9 ships with.
+# https://github.com/elastic/elasticsearch/blob/7.9/distribution/src/config/jvm.options
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## JVM temporary directory
+-Djava.io.tmpdir=<%= @tmp_dir %>
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=<%= @tmp_dir %>
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=<%= @tmp_dir %>
+
+## GC logging
+<% if @enable_gc_log %>
+  ## JDK 8 GC logging
+  8:-XX:+PrintGCDetails
+  8:-XX:+PrintGCDateStamps
+  8:-XX:+PrintTenuringDistribution
+  8:-XX:+PrintGCApplicationStoppedTime
+  8:-Xloggc:${loggc}
+  8:-XX:+UseGCLogFileRotation
+  8:-XX:NumberOfGCLogFiles=32
+  8:-XX:GCLogFileSize=64m
+
+  
+  # JDK 9+ GC logging
+  9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+<% end %>


### PR DESCRIPTION
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/2017

NOTE: eabee67f3b2ebeaee00cbeb07e073633660c4a88 currently removes compatibility with the older versions.
We need to support older versions as well.