### PR TITLE
zei/Configurable status endpoint

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -347,6 +347,7 @@ default['private_chef']['opscode-erchef']['ssl_session_caching']['enabled'] = fa
 # the /_status endpoint.
 
 default['private_chef']['opscode-erchef']['health_ping_timeout'] = 400
+default['private_chef']['opscode-erchef']['include_version_in_status'] = false
 
 # Stats endpoint
 default['private_chef']['opscode-erchef']['stats_auth_enable'] = true

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -139,7 +139,8 @@
             chef_<%= node['private_chef']['opscode-erchef']['search_provider'] %>
         ]},
         {base_resource_url, <%= @helper.erl_atom_or_string(node['private_chef']['opscode-erchef']['base_resource_url']) %>},
-        {strict_search_result_acls, <%= @strict_search_result_acls %>}
+        {strict_search_result_acls, <%= @strict_search_result_acls %>},
+        {include_version_in_status, <%= node['private_chef']['opscode-erchef']['include_version_in_status'] %>}
     ]},
 
     {chef_authn, [


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

Whether the status endpoint should include the chef server version or not can be configured from `chef-server.rb`. Setting the key `include_version_in_status` in `chef-server.rb` to true, will enable the `server_version` in the status endpoint response. By default this value is false.

### Issues Resolved

Resolves isses #2214

### Check List

- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin.
