### PR TITLE
Update gems to point to chef-15

### DIFF
--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'chef', git: 'https://github.com/chef/chef.git', branch: 'chef-15'
 gem "chef_backup"
 gem "omnibus-ctl", git: "https://github.com/chef/omnibus-ctl.git", tag: "v0.6.0"
 gem "veil", git: "https://github.com/chef/chef_secrets.git"

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -1,57 +1,14 @@
 GIT
-  remote: https://github.com/chef/chef_secrets.git
-  revision: 2875f29d82c528edd89cb614955e214f3aa4be0c
+  remote: https://github.com/chef/chef.git
+  revision: 7e11b5b2a25f4518ed0139caa92f2677c74ad0e3
+  branch: chef-15
   specs:
-    veil (0.3.3)
-      bcrypt (~> 3.1)
-      pbkdf2
-
-GIT
-  remote: https://github.com/chef/omnibus-ctl.git
-  revision: c82dbb47b73860799866f6eaf69590775b8bf7a8
-  tag: v0.6.0
-  specs:
-    omnibus-ctl (0.6.0)
-
-PATH
-  remote: .
-  specs:
-    chef-server-ctl (1.1.0)
-      appbundler
-      chef (~> 15.12.22)
-      chef_backup
-      ffi-yajl (>= 1.2.0)
-      highline (~> 1.6, >= 1.6.9)
-      knife-opc
-      license-acceptance
-      mixlib-log
-      omnibus-ctl
-      pg (~> 0.17, >= 0.17.1)
-      pry
-      rb-readline
-      redis
-      rest-client
-      uuidtools (~> 2.1, >= 2.1.3)
-      veil
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    appbundler (0.13.2)
-      mixlib-cli (>= 1.4, < 3.0)
-      mixlib-shellout (>= 2.0, < 4.0)
-    ast (2.4.1)
-    bcrypt (3.1.15)
-    bcrypt_pbkdf (1.0.1)
-    builder (3.2.4)
-    chef (15.12.22)
+    chef (15.15.1)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.12.22)
-      chef-utils (= 15.12.22)
+      chef-config (= 15.15.1)
+      chef-utils (= 15.15.1)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -78,39 +35,88 @@ GEM
       train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef-config (15.12.22)
+    chef-config (15.15.1)
       addressable
-      chef-utils (= 15.12.22)
+      chef-utils (= 15.15.1)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
-    chef-utils (15.12.22)
-    chef-zero (15.0.2)
+    chef-utils (15.15.1)
+
+GIT
+  remote: https://github.com/chef/chef_secrets.git
+  revision: 2875f29d82c528edd89cb614955e214f3aa4be0c
+  specs:
+    veil (0.3.3)
+      bcrypt (~> 3.1)
+      pbkdf2
+
+GIT
+  remote: https://github.com/chef/omnibus-ctl.git
+  revision: c82dbb47b73860799866f6eaf69590775b8bf7a8
+  tag: v0.6.0
+  specs:
+    omnibus-ctl (0.6.0)
+
+PATH
+  remote: .
+  specs:
+    chef-server-ctl (1.1.0)
+      appbundler
+      chef_backup
+      ffi-yajl (>= 1.2.0)
+      highline (~> 1.6, >= 1.6.9)
+      knife-opc
+      license-acceptance
+      mixlib-log
+      omnibus-ctl
+      pg (~> 0.17, >= 0.17.1)
+      pry
+      rb-readline
+      redis
+      rest-client
+      uuidtools (~> 2.1, >= 2.1.3)
+      veil
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    appbundler (0.13.2)
+      mixlib-cli (>= 1.4, < 3.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+    ast (2.4.2)
+    bcrypt (3.1.16)
+    bcrypt_pbkdf (1.1.0)
+    builder (3.2.4)
+    chef-zero (15.0.4)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 5.0)
       mixlib-log (>= 2.0, < 4.0)
       rack (~> 2.0, >= 2.0.6)
       uuidtools (~> 2.1)
+      webrick
     chef_backup (0.1.0)
       highline (~> 1.6, >= 1.6.9)
       mixlib-shellout (>= 2.0, < 4.0)
-    chefstyle (1.2.1)
-      rubocop (= 0.89.1)
+    chefstyle (1.6.2)
+      rubocop (= 1.9.1)
     coderay (1.1.3)
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     ed25519 (1.2.4)
-    erubi (1.9.0)
+    erubi (1.10.0)
     erubis (2.7.0)
-    ffi (1.13.1)
+    ffi (1.14.2)
     ffi-libarchive (1.0.4)
       ffi (~> 1.0)
     ffi-yajl (2.3.4)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
-    gssapi (1.3.0)
+    gssapi (1.3.1)
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
@@ -122,8 +128,8 @@ GEM
     httpclient (2.8.3)
     iniparse (1.5.0)
     ipaddress (0.8.3)
-    json (2.3.1)
-    knife-opc (0.4.6)
+    json (2.5.1)
+    knife-opc (0.4.7)
     libyajl2 (1.2.0)
     license-acceptance (1.0.19)
       pastel (~> 0.7)
@@ -137,7 +143,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types-data (3.2020.1104)
     mixlib-archive (1.0.7)
       mixlib-log
     mixlib-authentication (3.0.7)
@@ -145,7 +151,7 @@ GEM
     mixlib-config (3.0.9)
       tomlrb
     mixlib-log (3.0.9)
-    mixlib-shellout (3.1.4)
+    mixlib-shellout (3.2.2)
       chef-utils
     multi_json (1.15.0)
     net-scp (3.0.0)
@@ -172,58 +178,58 @@ GEM
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    parallel (1.19.2)
-    parser (2.7.1.4)
+    parallel (1.20.1)
+    parser (3.0.0.0)
       ast (~> 2.4.1)
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
     pbkdf2 (0.1.0)
     pg (0.21.0)
-    plist (3.5.0)
+    plist (3.6.0)
     proxifier (1.0.3)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rack (2.2.3)
     rainbow (3.0.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rb-readline (0.5.5)
-    redis (4.2.1)
-    regexp_parser (1.7.1)
+    redis (4.2.5)
+    regexp_parser (2.0.3)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
-    rubocop (0.89.1)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.9.1)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.3.0, < 1.0)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.3.0)
-      parser (>= 2.7.1.4)
-    ruby-progressbar (1.10.1)
-    rubyntlm (0.6.2)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.11.0)
+    rubyntlm (0.6.3)
     rubyzip (2.3.0)
     strings (0.2.0)
       strings-ansi (~> 0.2)
@@ -235,26 +241,27 @@ GEM
     toml (0.2.0)
       parslet (~> 1.8.0)
     tomlrb (1.3.0)
-    train-core (3.3.16)
+    train-core (3.4.9)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 4.0)
       net-ssh (>= 2.9, < 7.0)
-    train-winrm (0.2.6)
-      winrm (~> 2.0)
+    train-winrm (0.2.12)
+      winrm (>= 2.3.6, < 3.0)
+      winrm-elevated (~> 1.2.2)
       winrm-fs (~> 1.0)
-    tty-box (0.6.0)
+    tty-box (0.7.0)
       pastel (~> 0.8)
       strings (~> 0.2.0)
       tty-cursor (~> 0.7)
-    tty-color (0.5.2)
+    tty-color (0.6.0)
     tty-cursor (0.7.1)
-    tty-prompt (0.22.0)
+    tty-prompt (0.23.0)
       pastel (~> 0.8)
       tty-reader (~> 0.8)
-    tty-reader (0.8.0)
+    tty-reader (0.9.0)
       tty-cursor (~> 0.7)
       tty-screen (~> 0.8)
       wisper (~> 2.0)
@@ -265,7 +272,8 @@ GEM
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
-    winrm (2.3.4)
+    webrick (1.7.0)
+    winrm (2.3.6)
       builder (>= 2.1.2)
       erubi (~> 1.8)
       gssapi (~> 1.2)
@@ -273,8 +281,12 @@ GEM
       httpclient (~> 2.2, >= 2.2.0.2)
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
-      rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-fs (1.3.4)
+      rubyntlm (~> 0.6.0, >= 0.6.3)
+    winrm-elevated (1.2.3)
+      erubi (~> 1.8)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
+    winrm-fs (1.3.5)
       erubi (~> 1.8)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 2.0)
@@ -287,6 +299,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  chef!
   chef-server-ctl!
   chef_backup
   chefstyle

--- a/src/chef-server-ctl/chef-server-ctl.gemspec
+++ b/src/chef-server-ctl/chef-server-ctl.gemspec
@@ -46,8 +46,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "omnibus-ctl" # Gemfile has us getting latest from git
   spec.add_runtime_dependency "license-acceptance"
 
-  spec.add_runtime_dependency "chef", "~> 15.12.22"
-
   spec.add_runtime_dependency "appbundler"
 
   spec.add_development_dependency "chefstyle"


### PR DESCRIPTION
Signed-off-by: Lincoln Baker <lbaker@chef.io>

### Description

Update gems to point to chef-15

### Issues Resolved

https://github.com/chef/chef-server/issues/2229

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
https://buildkite.com/chef/chef-chef-server-master-verify/builds/3008#0f0dda2a-e63c-4de0-abd4-654256bb0bfb
https://buildkite.com/chef/chef-chef-server-master-verify/builds/3006#3a0e15ca-de03-4522-a8e7-d38a6ec67e5b
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
