### PR TITLE
add metadata to every page in docs.chef.io/server/

### DIFF
--- a/docs-chef-io/content/server/_index.md
+++ b/docs-chef-io/content/server/_index.md
@@ -1,10 +1,11 @@
 +++
 title = "Chef Infra Server Overview"
 draft = false
-
 gh_repo = "chef-server"
-
 aliases = ["/server_overview.html", "/server_components.html", "/server_overview/"]
+
+[cascade]
+  product = ["server"]
 
 [menu]
   [menu.server]


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

This adds product metadata to every page in docs.chef.io/server/

We can use the [cascade parameter](https://gohugo.io/content-management/front-matter#front-matter-cascade) key in `content/server/_index.md` to add a product value to every page docs.chef.io/server/ so we can facet search results by that product

### Issues Resolved

chef/chef-web-docs#2878

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
