### PR TITLE
Zei/add pedant for status endpoint/2214

### DIFF
--- a/oc-chef-pedant/lib/pedant/command_line.rb
+++ b/oc-chef-pedant/lib/pedant/command_line.rb
@@ -153,7 +153,7 @@ module Pedant
                 principals acl containers groups association omnibus organizations
                 usags controls keys cookbook-artifacts license headers server-api-version
                 policies pedantic self-test api-v0 api-v1 object-identifiers oc_id
-                multiuser universe chef-zero-quirks user-keys client-keys required-recipe)
+                multiuser universe chef-zero-quirks user-keys client-keys required-recipe, status)
       export_options(opts, tags)
     end
 

--- a/oc-chef-pedant/spec/api/status_spec.rb
+++ b/oc-chef-pedant/spec/api/status_spec.rb
@@ -1,0 +1,17 @@
+
+describe "Testing Status API with config", :config do
+  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
+  context "Status API", :status, :smoke do
+    it "GET /_status should respond with valid health data" do
+      r = get("#{platform.server}/_status", superuser)
+      r.should look_like(status_for_json: 200)
+      data = JSON.parse(r)
+      data.has_key?("server_version").to_s.should eql config['opscode-erchef']['include_version_in_status'].to_s
+      data.has_key?("status").should eql true
+      data.has_key?("upstreams").should eql true
+      data.has_key?("keygen").should eql true
+      data.has_key?("indexing").should eql true
+      data["status"].should eql 'pong'
+    end
+  end
+end

--- a/scripts/bk_tests/chef_zero-Gemfile
+++ b/scripts/bk_tests/chef_zero-Gemfile
@@ -8,7 +8,7 @@ gem 'pry-stack_explorer'
 gem 'rake'
 
 # For "rake chef_zero_spec"
-gem 'chef-zero', github: 'chef/chef-zero'
+gem 'chef-zero', github: 'chef/chef-zero', tag: 'v15.0.5'
 
 # If you want to load debugging tools into the bundle exec sandbox,
 # # add these additional dependencies into Gemfile.local


### PR DESCRIPTION
### Description

Adding the pedant tests for the`/_status` endpoint

### Issues Resolved

Adds more test coverage for the issue #2214 

### Check List

- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin.
