### PR TITLE
Make sure ctl and pedant have licenses in the gemspec

### DIFF
--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'oc-chef-pedant'
   s.version       = '2.2.0'
-  s.date          = '2015-04-17'
   s.summary       = "Chef Infra Server API Testing Framework"
   s.authors       = ["Chef Software Engineering"]
   s.email         = 'dev@chef.io'

--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -2,9 +2,10 @@ Gem::Specification.new do |s|
   s.name          = 'oc-chef-pedant'
   s.version       = '2.2.0'
   s.date          = '2015-04-17'
-  s.summary       = "Enterprise Chef API Testing Framework"
+  s.summary       = "Chef Infra Server API Testing Framework"
   s.authors       = ["Chef Software Engineering"]
   s.email         = 'dev@chef.io'
+  s.license       = 'Apache-2.0'
   s.require_paths = ['lib', 'spec']
   s.files         = Dir['lib/**/*.rb'] + Dir['spec/**/*_spec.rb']
   s.homepage      = 'https://chef.io'

--- a/src/chef-server-ctl/chef-server-ctl.gemspec
+++ b/src/chef-server-ctl/chef-server-ctl.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.version       = ChefServerCtl::VERSION
   spec.authors       = ["Mark Anderson"]
   spec.email         = ["mark@chef.io"]
-  spec.description   = %q{Commands to control Chef Server}
+  spec.description   = "Commands to control Chef Infra Server"
   spec.summary       = spec.description
-  spec.licenses      = "Apache-2.0"
+  spec.license       = "Apache-2.0"
 
   spec.files         = %w{LICENSE README.md} + Dir.glob("{bin,doc,helpers,lib,plugins,spec}/**/*")
   spec.bindir        = "bin"


### PR DESCRIPTION
Use the standard license config here and also cleanup descriptions a bit.

Signed-off-by: Tim Smith <tsmith@chef.io>