### PR TITLE
mTLS: Fix missing line terminating semi-colons in the nginx config

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -20,8 +20,8 @@
 
       <% if node['private_chef']['nginx']['ssl_client_ca'] -%>
         ssl_verify_client on;
-        ssl_client_certificate <%= node['private_chef']['nginx']['ssl_client_ca'] %>
-        ssl_verify_depth <%= node['private_chef']['nginx']['ssl_verify_depth'] %>
+        ssl_client_certificate <%= node['private_chef']['nginx']['ssl_client_ca'] %>;
+        ssl_verify_depth <%= node['private_chef']['nginx']['ssl_verify_depth'] %>;
       <% end -%>
     <% end %>
 


### PR DESCRIPTION
in the nginx_chef_api_lb.conf.erb file on lines 23 and 24. 

Signed-off-by: John McCrae <john.mccrae@progress.com>