### PR TITLE
Add mtls support for the pivotal user

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -517,6 +517,8 @@ default['private_chef']['nginx']['show_welcome_page'] = true
 
 # Set to a path to a CA certificate to enable mutual TLS checking of the client SSL/TLS certificate
 default['private_chef']['nginx']['ssl_client_ca'] = false
+default['private_chef']['nginx']['pivotal_ssl_client_cert'] = false
+default['private_chef']['nginx']['pivotal_ssl_client_key'] = false
 # default['private_chef']['nginx']['ssl_client_ca'] = "/etc/something/foo.ca.pem"
 default['private_chef']['nginx']['ssl_verify_depth'] = 2
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
@@ -14,7 +14,15 @@ chef_server_url "<%= @prefix %>://<%= @vip %>"
 chef_server_root "<%= @prefix %>://<%= @vip %>"
 no_proxy "<%= node['private_chef']['lb']['vip'] %>"
 client_key key.path
+
+ <% if node['private_chef']['nginx']['ssl_client_ca'] -%>
+ssl_ca_file = <%= node['private_chef']['nginx']['ssl_client_ca'] %>
+ssl_client_cert = <%= node['private_chef']['nginx']['pivotal_ssl_client_cert'] %>
+ssl_client_key = <%= node['private_chef']['nginx']['pivotal_ssl_client_key'] %>
+ssl_verify_mode :verify_peer
+<% else -%>
 ssl_verify_mode :verify_none
+<% end -%>
 
 at_exit do
   # By holding onto key to reference it in at_exit,


### PR DESCRIPTION
Co-authored-by: John McCrae <john.mccrae@progress.com>
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

chef-server-ctl commands use pivotal user under the hood to create user etc. This will allow the user to run chef-server-ctl commands when mtls is enabled.

TODO: Docs need to be updated.

The user will need to include the following in the /etc/opscode/chef-server.rb file:
```
nginx['pivotal_ssl_client_cert'] = "path to the user cert"
nginx['pivotal_ssl_client_key'] = "path to the user key"
``` 

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/2109