### PR TITLE
Increase the pipeline timeout to 30.

### DIFF
--- a/.expeditor/post-promote.pipeline.yml
+++ b/.expeditor/post-promote.pipeline.yml
@@ -3,7 +3,7 @@ steps:
       - .expeditor/upload_files.sh
     label: "Manifest Upload"
     concurrency: 1
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     concurrency_group: chef-server-master/deploy/$CHANNEL
     expeditor:
       secrets:


### PR DESCRIPTION
Updating the default timeout for 10 to 20 gets us further along in the
process. But sill fails, so bumping it to 30.

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Should resolve timeout failure seen at: https://buildkite.com/chef/chef-chef-server-master-post-promote/builds/76#_