### PR TITLE
Fix link

### DIFF
--- a/docs-chef-io/content/server/install_server_pre.md
+++ b/docs-chef-io/content/server/install_server_pre.md
@@ -15,9 +15,8 @@ aliases = ["/install_server_pre.html", "/install_server_pre/"]
 +++
 
 The following is a detailed discussion of the prerequisites for every
-installation of the Chef Infra Server. See <span
-class="title-ref">Install Chef Infra Server
-\</install_server.html\></span> for installation instructions.
+installation of the Chef Infra Server. See [Install Chef Infra Server]({{< relref "install_server" >}})
+for installation instructions.
 
 ## Platforms
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

### Description

Fixes a link to install_server.

See here at the top of the page:
https://docs.chef.io/server/install_server_pre/
https://deploy-preview-2266--chef-server.netlify.app/server/install_server_pre/

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
