### PR TITLE
Improve the Discourse release announcement script

### DIFF
--- a/.expeditor/announce-release.sh
+++ b/.expeditor/announce-release.sh
@@ -5,14 +5,15 @@ set -exou pipefail
 # Download the release-notes for our specific build
 curl -o release-notes.md "https://packages.chef.io/release-notes/${EXPEDITOR_PRODUCT_KEY}/${EXPEDITOR_VERSION}.md"
 
-topic_title="Chef Server $EXPEDITOR_VERSION Released!"
+topic_title="Chef Infra Server $EXPEDITOR_VERSION Released!"
 topic_body=$(cat <<EOH
-We are delighted to announce the availability of version $EXPEDITOR_VERSION of Chef Server.
+We are delighted to announce the availability of version $EXPEDITOR_VERSION of Chef Infra Server.
 $(cat release-notes.md)
+
 ---
 ## Get the Build
 
-You can download binaries directly from [downloads.chef.io](https://downloads.chef.io/$EXPEDITOR_PRODUCT_KEY/$EXPEDITOR_VERSION).
+You can download binaries directly from [downloads.chef.io](https://downloads.chef.io/tools/infra-server/stable?v=$EXPEDITOR_VERSION).
 EOH
 )
 


### PR DESCRIPTION
Chef Server -> Chef Infra Server
Fix the downloads link to be the new URL format
Add an empty line at the end of the release notes to prevent making the
last paragraph header level

Signed-off-by: Tim Smith <tsmith@chef.io>