### PR TITLE
Removed Login shell for opscode chef service

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -77,7 +77,7 @@ default['private_chef']['addons']['ubuntu_distribution'] =
 # The username for the chef services user
 default['private_chef']['user']['username'] = 'opscode'
 # The shell for the chef services user
-default['private_chef']['user']['shell'] = '/bin/sh'
+default['private_chef']['user']['shell'] = '/usr/sbin/nologin'
 # The home directory for the chef services user
 default['private_chef']['user']['home'] = '/opt/opscode/embedded'
 


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Remove interactive login shells for two chef-server services (opscode andopscode-pgsql) if they are not required.

### Issues Resolved

https://app.zenhub.com/workspaces/chef-infra-server-team-5fc64867d45ca500173dbbc7/issues/chef/chef-server/2150

After my analysis, opscode doesn't need interactive login shell but opscode-pgsql needs it in postgresql DB operations.'chef-server-ctl psql App' internally using opscode-pgsql interactive shell for DB operations.So We are going to remove the interactive shell access for opscode only as opscode-pgsql needs more investigation.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
