### PR TITLE
Remove old ACC only label from expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -53,21 +53,18 @@ merge_actions:
       ignore_labels:
         - "Expeditor: Skip Version Bump"
         - "Expeditor: Skip All"
-        - "Expeditor: ACC Only"
         - "Aspect: Documentation"
   - built_in:update_changelog:
       post_commit: false
       ignore_labels:
         - "Expeditor: Skip Changelog"
         - "Expeditor: Skip All"
-        - "Expeditor: ACC Only"
         - "Aspect: Documentation"
   - trigger_pipeline:omnibus/release:
       post_commit: true
       ignore_labels:
         - "Expeditor: Skip Omnibus"
         - "Expeditor: Skip All"
-        - "Expeditor: ACC Only"
         - "Aspect: Documentation"
       only_if: built_in:bump_version
   - trigger_pipeline:habitat/build:
@@ -75,7 +72,6 @@ merge_actions:
       ignore_labels:
         - "Expeditor: Skip Habitat"
         - "Expeditor: Skip All"
-        - "Expeditor: ACC Only"
         - "Aspect: Documentation"
       only_if: built_in:bump_version
 


### PR DESCRIPTION
Remove the label for the old ACC env

Signed-off-by: Tim Smith <tsmith@chef.io>