### PR TITLE
Rename the upgrade_server page to upgrades

### DIFF
--- a/docs-chef-io/content/server/install_server_ha.md
+++ b/docs-chef-io/content/server/install_server_ha.md
@@ -352,13 +352,13 @@ To restore a backup to this system, follow the [chef-server-ctl]({{< relref "ser
 ### Upgrading Chef Infra Server on the Frontend Machines
 
 1.  On one frontend server, follow the [standalone upgrade
-    process]({{< relref "upgrade_server/#standalone" >}}).
+    process]({{< relref "upgrades/#standalone" >}}).
 2.  Copy `/var/opt/opscode/upgrades/migration-level` from the first
     upgraded frontend to `/var/opt/opscode/upgrades/migration-level` on
     each of the remaining frontends.
 3.  Once the updated file has been copied to each of the remaining
     frontends, perform the [standalone upgrade
-    process]({{< relref "upgrade_server/#standalone" >}}) on each of the frontend
+    process]({{< relref "upgrades/#standalone" >}}) on each of the frontend
     servers.
 
 ### Configuring Frontend and Backend Members on Different Networks

--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -4,7 +4,7 @@ draft = false
 
 gh_repo = "chef-server"
 
-aliases = ["/upgrade_server.html", "/upgrade_server/"]
+aliases = ["/upgrade_server.html", "/upgrade_server/", "/upgrades/"]
 
 [menu]
   [menu.server]
@@ -58,7 +58,7 @@ For more information on password generation, including a list of supported add-o
 
 ### Upgrading to 12.3.0
 
-If you are running a Chef Infra Server relese prior to 12.3.0 please contact Chef Support for additional guidance on upgrading your Chef Infra Server installation.
+If you are running a Chef Infra Server release prior to 12.3.0 please contact Chef Support for additional guidance on upgrading your Chef Infra Server installation.
 
 ## Chef Infra Server 14 Upgrade Process
 
@@ -227,7 +227,7 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
 
 ### Upgrading Manage Add-On
 
-Chef Manage is a management console for  data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface.
+Chef Manage is a management console for data bags, attributes, run-lists, roles, environments, and cookbooks from a web user interface.
 
 Chef Infra Server 13 and 14 support the Chef Manage add-on. This add-on is [deprecated](https://docs.chef.io/versions/#deprecated-products-and-versions) and will reach [EOL](https://docs.chef.io/versions/#deprecated-products-and-versions) on December 31, 2021. After upgrading Chef Infra Server, reinstall the add-on and then reconfigure Chef Infra Server and the add-on.
 

--- a/omnibus/package-scripts/chef-server/postinst
+++ b/omnibus/package-scripts/chef-server/postinst
@@ -51,7 +51,7 @@ if [ -e /etc/opscode/chef-server-running.json ]; then
   echo "this command)"
   echo
   echo "For detailed upgrade instructions please see:"
-  echo "https://docs.chef.io/upgrade_server.html"
+  echo "https://docs.chef.io/server/upgrades/"
 fi
 
 exit 0

--- a/omnibus/package-scripts/chef-server/preinst
+++ b/omnibus/package-scripts/chef-server/preinst
@@ -31,7 +31,7 @@ warn_about_search_reindex() {
         echo ""
         echo "We recommend taking a full backup before proceeding."
         echo ""
-        echo "See https://docs.chef.io/upgrade_server/ for additional information on backups and upgrading."
+        echo "See https://docs.chef.io/server/upgrades/ for additional information on backups and upgrading."
         echo ""
         echo "############################ NOTICE ##################################"
     fi


### PR DESCRIPTION
docs.chef.io/server/upgrades makes a lot more sense. We don't need server in the doc names anymore since it's in the URL path

Signed-off-by: Tim Smith <tsmith@chef.io>