### PR TITLE
join-cluster needs an absolute path to the secrets

### DIFF
--- a/docs-chef-io/content/server/ctl_chef_backend.md
+++ b/docs-chef-io/content/server/ctl_chef_backend.md
@@ -551,8 +551,8 @@ This subcommand has the following options:
 
 `-s PATH`, `--secrets-file-path PATH`
 
-:   The path to the location of the `secrets.json` file on the
-    bootstrapping node. Default value: `/etc/chef-backend/secrets.json`.
+:   The ABSOLUTE path to the location of the `secrets.json` file on the
+    bootstrapping node. The path should begin with a "/". Default value: `/etc/chef-backend/secrets.json`.
 
 `-y`, `--yes`
 


### PR DESCRIPTION

Signed-off-by: Sean Horn <sean_horn@chef.io>

### Description

The join-cluster code requires an absolute path be given to the chef-backend-secrets.json file, wherever it is on the filesystem on the joining node.
The given command should have that full path, like this, even when the secrets file is in the CWD: `chef-backend-ctl join-cluster LEADER_IP -s /my/path/is/here/chef-backend-secrets.json`

If this is not done, the `copy_secrets` method fails like this

```
/tmp/chef-backend-join-cluster-stacktrace.log
Exception of type ArgumentError occurred at 2021-03-10 20:42:50 +0000

/opt/chef-backend/embedded/lib/ruby/2.4.0/fileutils.rb:1460:in `block in fu_each_src_dest'
/opt/chef-backend/embedded/lib/ruby/2.4.0/fileutils.rb:1477:in `fu_each_src_dest0'
/opt/chef-backend/embedded/lib/ruby/2.4.0/fileutils.rb:1459:in `fu_each_src_dest'
/opt/chef-backend/embedded/lib/ruby/2.4.0/fileutils.rb:356:in `cp'
/opt/chef-backend/embedded/lib/ruby/gems/2.4.0/gems/libcb-0.1.0/lib/libcb/command/join-cluster.rb:275:in `copy_secrets'
/opt/chef-backend/embedded/lib/ruby/gems/2.4.0/gems/libcb-0.1.0/lib/libcb/command/join-cluster.rb:107:in `block in run'
```


### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
