### PR TITLE
Update pedant test suite to run on Ruby 3

### DIFF
--- a/oc-chef-pedant/Gemfile.lock
+++ b/oc-chef-pedant/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/chef.git
-  revision: 392785b4bc21c22a1ccbc44e00fe3ef924166f18
+  revision: f7616ee0a63087ca92fdfa10c7c5e1689d2c6713
   branch: chef-15
   specs:
     chef (15.15.1)
@@ -49,6 +49,7 @@ PATH
   specs:
     oc-chef-pedant (2.2.0)
       activesupport (>= 4.2.7.1, < 7.0)
+      addressable
       erubis (~> 2.7)
       mixlib-authentication (> 1.4, < 4.0)
       mixlib-config (>= 2, < 4)
@@ -92,7 +93,7 @@ GEM
     ed25519 (1.2.4)
     erubi (1.10.0)
     erubis (2.7.0)
-    ffi (1.14.2)
+    ffi (1.15.0)
     ffi-libarchive (1.0.17)
       ffi (~> 1.0)
     ffi-yajl (2.3.4)
@@ -167,12 +168,12 @@ GEM
       tty-color (~> 0.5)
     plist (3.6.0)
     proxifier (1.0.3)
-    pry (0.14.0)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.8.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
+      pry (~> 0.13.0)
     pry-stack_explorer (0.6.1)
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
@@ -203,9 +204,9 @@ GEM
       rspec-core (>= 2, < 4, != 2.12.0)
     rubyntlm (0.6.3)
     rubyzip (2.3.0)
-    strings (0.2.0)
+    strings (0.2.1)
       strings-ansi (~> 0.2)
-      unicode-display_width (~> 1.5)
+      unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
     syslog-logger (1.6.8)
@@ -241,7 +242,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
     webrick (1.7.0)
@@ -279,4 +280,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/oc-chef-pedant/lib/pedant/rspec/search_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/search_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012-2016 Chef Software, Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@ require 'pedant/concern'
 require 'pedant/request'
 require 'pedant/utility'
 require 'rspec/core/shared_context'
-require 'uri'
+require 'addressable/uri'
 
 module Pedant
   module RSpec
@@ -781,7 +781,7 @@ module Pedant
       end
 
       def search_result(index, query)
-        search_url = api_url(URI::encode("/search/#{index}?q=#{query}"))
+        search_url = api_url(Addressable::URI.encode("/search/#{index}?q=#{query}"))
         get(search_url, admin_user)
       end
 

--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency('uuidtools', '~> 2.0')
   s.add_dependency('erubis', '~> 2.7')
   s.add_dependency('rspec-rerun', '~> 1.0')
+  s.add_dependency('addressable')
 end


### PR DESCRIPTION
URI::encode is gone forever, Addressable::URI.encode is a better
replacement.

This means we need to take an explicit dep on addressable, but
addressable was always in the bundle here anyway.

Since addressable itself is a dep nightmare and the API we're
using has been stable for at least 5 years, don't include any
pin here and let it float to avoid conflicts.

(this is necessary to unblock chef-zero + chef-client on ruby 3)
