### PR TITLE
MTLS server issue: knife config need spaces

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/pivotal.rb.erb
@@ -16,9 +16,9 @@ no_proxy "<%= node['private_chef']['lb']['vip'] %>"
 client_key key.path
 
  <% if node['private_chef']['nginx']['ssl_client_ca'] -%>
-ssl_ca_file = "<%= node['private_chef']['nginx']['ssl_client_ca'] %>"
-ssl_client_cert = "<%= node['private_chef']['nginx']['pivotal_ssl_client_cert'] %>"
-ssl_client_key = "<%= node['private_chef']['nginx']['pivotal_ssl_client_key'] %>"
+ssl_ca_file "<%= node['private_chef']['nginx']['ssl_client_ca'] %>"
+ssl_client_cert "<%= node['private_chef']['nginx']['pivotal_ssl_client_cert'] %>"
+ssl_client_key "<%= node['private_chef']['nginx']['pivotal_ssl_client_key'] %>"
 ssl_verify_mode :verify_peer
 <% else -%>
 ssl_verify_mode :verify_none


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

On enabling mtls on the Chef Infra Server, the chef-server-ctl commands running knife on local host fail with a 400.
It is a config issue fixed by replacing equals with spaces.  

Manage, Automate and Infra views still need to be tested with these changes.
