### PR TITLE
Prevent chef.io/progress.com emails from using ZenDesk SSO

### DIFF
--- a/src/oc-id/app/controllers/zendesks_controller.rb
+++ b/src/oc-id/app/controllers/zendesks_controller.rb
@@ -6,7 +6,11 @@ class ZendesksController < ApplicationController
 
   def show
     if signed_in?
-      redirect_to zendesk_sso_url(current_user, params[:return_to])
+      if (current_user.email =~ /@chef.io$/i || current_user.email =~ /@progress.com$/i)
+        render json: {message: "This account is not permitted for ZenDesk SSO"}, status: :forbidden
+      else
+        redirect_to zendesk_sso_url(current_user, params[:return_to])
+      end
       return
     end
 

--- a/src/oc-id/spec/controllers/zendesks_controller_spec.rb
+++ b/src/oc-id/spec/controllers/zendesks_controller_spec.rb
@@ -29,15 +29,40 @@ describe ZendesksController do
       end
 
       context 'when signed in' do
+        let(:testuser) do
+          User.new({
+            :username => 'jimmy',
+            :email => 'jim.kirk@federation-captains.org',
+          })
+        end
         before :each do
           allow(controller).to receive(:signed_in?).and_return(true)
-          allow(controller).to receive(:current_user).and_return('testuser')
+          allow(controller).to receive(:current_user).and_return(testuser)
           allow(controller).to receive(:zendesk_sso_url).and_return('http://test')
         end
 
         it 'redirects to the zendesk SSO URL' do
-          expect(controller).to receive(:zendesk_sso_url).with('testuser', 'testreturnto')
+          expect(controller).to receive(:zendesk_sso_url).with(testuser, 'testreturnto')
           get 'show', return_to: 'testreturnto'
+        end
+      end
+
+      context 'when signed in' do
+        let(:chefuser) do
+          User.new({
+            :username => 'jammy',
+            :email => 'jam.kirk@chef.io',
+          })
+        end
+        before :each do
+          allow(controller).to receive(:signed_in?).and_return(true)
+          allow(controller).to receive(:current_user).and_return(chefuser)
+        end
+
+        it 'renders json and a 403' do
+          get 'show'
+          expect(response.body).to eq("{\"message\":\"This account is not permitted for ZenDesk SSO\"}")
+          expect(response.status).to eq 403
         end
       end
     end


### PR DESCRIPTION
As a temporary workaround, accounts with chef.io and progress.com email addresses
cannot use the ZenDesk SSO logins. This does not prevent ZenDesk Agent
logins, which are separate. This only prevents logins using your Hosted
Chef/manage.chef.io/id.chef.io credentials.
