### PR TITLE
Added disk space warning if not enough for ES reindex

### DIFF
--- a/src/chef-server-ctl/lib/chef_server_ctl/helpers/du.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/helpers/du.rb
@@ -1,0 +1,22 @@
+require 'mixlib/shellout'
+module Du
+  # Calculate the disk space used by the given path. Requires that
+  # `du` is in our PATH.
+  #
+  # @param path [String] Path to a directory on disk
+  # @return [Integer] KB used by directory on disk
+  #
+  def self.du(path)
+    command = Mixlib::ShellOut.new("du -sk #{path}")
+    command.run_command
+    if command.status.success?
+      command.stdout.split("\t").first.to_i
+    else
+      puts "du -sk #{path} failed with exit status: #{command.exitstatus}"
+      puts "du stderr: #{command.stderr}"
+      raise 'DuFailedException', command.stderr
+    end
+  rescue Errno::ENOENT
+    raise 'DuFailedException', command.stderr
+  end
+end

--- a/src/chef-server-ctl/lib/chef_server_ctl/helpers/statfs.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/helpers/statfs.rb
@@ -1,0 +1,79 @@
+require 'ffi'
+
+class Statfs
+  #
+  # Statfs provides a simple interface to the statvfs system call.
+  # Since the statvfs struct varies a bit across platforms, this
+  # likely only works on Linux and OSX at the moment.
+  #
+  extend FFI::Library
+  ffi_lib FFI::Library::LIBC
+
+  attach_function(:statvfs, %i(string pointer), :int)
+  attach_function(:strerror, [:int], :string)
+
+  FSBLKCNT_T = if RbConfig::CONFIG['host_os'] =~ /darwin|osx|mach/i
+                 :uint
+               else
+                 :ulong
+               end
+
+  # See http://man7.org/linux/man-pages/man2/statvfs.2.html
+  class Statvfs < FFI::Struct
+    spec = [
+            :f_bsize,   :ulong,      # Filesystem block size
+            :f_frsize,  :ulong,      # Fragement size
+            :f_blocks,  FSBLKCNT_T,  # Size of fs in f_frsize units
+            :f_bfree,   FSBLKCNT_T,  # Number of free blocks
+            :f_bavail,  FSBLKCNT_T,  # Number of free blocks for unpriviledged users
+            :f_files,   FSBLKCNT_T,  # Number of inodes
+            :f_ffree,   FSBLKCNT_T,  # Number of free inodes
+            :f_favail,  FSBLKCNT_T,  # Number of free inodes for unprivilged users
+            :f_fsid,    :ulong,      # Filesystem ID
+            :f_flag,    :ulong,      # Mount Flags
+            :f_namemax, :ulong       # Max filename length
+           ]
+
+    # Linux has this at the end of the struct and if we don't include
+    # it we end up getting a memory corruption error when th object
+    # gets GCd.
+    if RbConfig::CONFIG['host_os'] =~ /linux/i
+      spec << :f_spare
+      spec << [:int, 6]
+    end
+
+    layout(*spec)
+  end
+
+  def initialize(path)
+    @statvfs = stat(path)
+  end
+
+  #
+  # @returns [Integer] Free inodes on the given filesystem
+  #
+  def free_inodes
+    @statvfs[:f_favail]
+  end
+
+  #
+  # @returns [Integer] Free space in KB on the given filesystem
+  #
+  def free_space
+    # Since we are running as root we could report f_bfree but will
+    # stick with f_bavail since it will typically be more
+    # conservative.
+    (@statvfs[:f_frsize] * @statvfs[:f_bavail]) / 1024
+  end
+
+  private
+
+  def stat(path)
+    statvfs = Statvfs.new
+    if statvfs(path, statvfs.to_ptr) != 0
+      raise 'StatvfsFailedException', command.stderr
+    end
+
+    statvfs
+  end
+end


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Raise disk space warning if disk space is not enough for ES reindexing

### Issues Resolved

Added function to verify disk space in the preflight checks

https://app.zenhub.com/workspaces/chef-infra-server-team-5fc64867d45ca500173dbbc7/issues/chef/chef-server/2197

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
