### PR TITLE
Add chef-server-ctl maintenance sub command for controlling chef server for maintenance activities

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -440,6 +440,12 @@ default['private_chef']['lb']['access_by_lua_file'] = false
 # Load balancer route configuration
 ###
 default['private_chef']['lb']['xdl_defaults']['503_mode'] = false
+default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = false
+default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = false
+default['private_chef']['lb']['xdl_defaults']['couchdb_acls'] = false
+default['private_chef']['lb']['xdl_defaults']['couchdb_association_requests'] = false
+default['private_chef']['lb']['xdl_defaults']['couchdb_organizations'] = false
+default['private_chef']['lb']['xdl_defaults']['couchdb_associations'] = false
 default['private_chef']['lb']['xmaint_allowed_ips_list'] = [ '127.0.0.1' ]
 
 ####

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -431,8 +431,8 @@ default['private_chef']['lb_internal']['account_port'] = 9685
 default['private_chef']['lb']['redis_connection_timeout'] = 1000
 default['private_chef']['lb']['redis_keepalive_timeout'] = 2000
 default['private_chef']['lb']['redis_connection_pool_size'] = 250
-default['private_chef']['lb']['maint_refresh_interval'] = 600
-default['private_chef']['lb']['ban_refresh_interval'] = 600
+default['private_chef']['lb']['maint_refresh_interval'] = 600 # the data from the redis to the shared memory in lua may take up to 600 sec
+default['private_chef']['lb']['ban_refresh_interval'] = 600 # not used
 default['private_chef']['lb']['chef_min_version'] = 10
 default['private_chef']['lb']['access_by_lua_file'] = false
 
@@ -440,12 +440,15 @@ default['private_chef']['lb']['access_by_lua_file'] = false
 # Load balancer route configuration
 ###
 default['private_chef']['lb']['xdl_defaults']['503_mode'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_acls'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_association_requests'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_organizations'] = false
-default['private_chef']['lb']['xdl_defaults']['couchdb_associations'] = false
+default['private_chef']['lb']['xmaint_allowed_ips_list'] = [ '127.0.0.1' ]
+# as we have moved away from couchdb, should we remove the following? for every API request there will be loaded from redis to nginx
+# default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = false
+# default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = false
+# default['private_chef']['lb']['xdl_defaults']['couchdb_acls'] = false
+# default['private_chef']['lb']['xdl_defaults']['couchdb_association_requests'] = false
+# default['private_chef']['lb']['xdl_defaults']['couchdb_organizations'] = false
+# only the below value is used for resolving whether to use 'opscode_erchef' or 'opscode_account'. The code can be removed as we moved away from 'opscode_account'
+# default['private_chef']['lb']['xdl_defaults']['couchdb_associations'] = false
 
 ####
 # Nginx

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -431,7 +431,7 @@ default['private_chef']['lb_internal']['account_port'] = 9685
 default['private_chef']['lb']['redis_connection_timeout'] = 1000
 default['private_chef']['lb']['redis_keepalive_timeout'] = 2000
 default['private_chef']['lb']['redis_connection_pool_size'] = 250
-default['private_chef']['lb']['maint_refresh_interval'] = 600 # the data from the redis to the shared memory in lua may take up to 600 sec
+default['private_chef']['lb']['maint_refresh_interval'] = 600 # the data from redis to the shared memory in lua may take up to 600 sec
 default['private_chef']['lb']['ban_refresh_interval'] = 600 # not used
 default['private_chef']['lb']['chef_min_version'] = 10
 default['private_chef']['lb']['access_by_lua_file'] = false
@@ -441,14 +441,6 @@ default['private_chef']['lb']['access_by_lua_file'] = false
 ###
 default['private_chef']['lb']['xdl_defaults']['503_mode'] = false
 default['private_chef']['lb']['xmaint_allowed_ips_list'] = [ '127.0.0.1' ]
-# as we have moved away from couchdb, should we remove the following? for every API request there will be loaded from redis to nginx
-# default['private_chef']['lb']['xdl_defaults']['couchdb_containers'] = false
-# default['private_chef']['lb']['xdl_defaults']['couchdb_groups'] = false
-# default['private_chef']['lb']['xdl_defaults']['couchdb_acls'] = false
-# default['private_chef']['lb']['xdl_defaults']['couchdb_association_requests'] = false
-# default['private_chef']['lb']['xdl_defaults']['couchdb_organizations'] = false
-# only the below value is used for resolving whether to use 'opscode_erchef' or 'opscode_account'. The code can be removed as we moved away from 'opscode_account'
-# default['private_chef']['lb']['xdl_defaults']['couchdb_associations'] = false
 
 ####
 # Nginx

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
@@ -122,10 +122,10 @@ end
 -- Examines the shared_dict provided and determine if it needs updating
 -- based on expiry time.  If so, it clears all entries and refreshes
 -- the dict data from redis
-local function refresh_expiring_set(shared_dict, name, interval)
+local function refresh_expiring_set(shared_dict, redis_set_name, interval)
   local updated_at = shared_dict:get("updated_at");
   if updated_at == nil or (ngx.now() - updated_at) >= interval then
-    ok, updated_data = redis_fetch_set(name)
+    ok, updated_data = redis_fetch_set(redis_set_name)
     if ok then
        shared_dict:flush_all();
        for index, key in ipairs(updated_data) do
@@ -157,13 +157,20 @@ function config.is_route_darklaunched(route_id)
   return maint:get("dl_" .. route_id)
 end
 
--- return true if the given address is maintenance mode
--- whitelist
-function config.is_addr_whitelisted(component, remote_addr)
+-- return true if ip needs to be allowed in maintenance mode
+-- gets the data by redis call
+function config.is_addr_allowed_in_maint_mode(remote_addr)
+  ok, allowed_ips_list = redis_fetch_set("xmaint_allowed_ips_list")
+--  for k, v in pairs(allowed_ips_list) do ngx.log(ngx.ERR, "inside maint_whitelisted with : ", v) end
+  if ok then
+    for k, v in pairs(allowed_ips_list) do
+      if v == remote_addr then return true end
+    end
+  end
   return false
 end
 
-
+-- need to change by using 'banned_ips' shared dict or calling the redis directly
 function config.is_addr_banned(remote_addr)
   return false
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/config.lua.erb
@@ -161,7 +161,7 @@ end
 -- gets the data by redis call
 function config.is_addr_allowed_in_maint_mode(remote_addr)
   ok, allowed_ips_list = redis_fetch_set("xmaint_allowed_ips_list")
---  for k, v in pairs(allowed_ips_list) do ngx.log(ngx.ERR, "inside maint_whitelisted with : ", v) end
+--  for k, v in pairs(allowed_ips_list) do ngx.log(ngx.ERR, "inside maint_allowlisted with : ", v) end
   if ok then
     for k, v in pairs(allowed_ips_list) do
       if v == remote_addr then return true end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
@@ -64,6 +64,11 @@ if mode == "api" then
 end
 
 
+-- This check is of not much value as the list of ip not to be allowed
+-- is more than the list of ips to be allowed in maintenance mode
+-- if we should remove this call, then we need to handle the ngx.shared.maint_data
+-- refresh logic correctly, currently as far as I know we are not setting the
+-- 'maint_data' set in redis
 -- global maint mode && address NOT excluded? no can do, muchacho
 if config.is_in_maint_mode_for_addr(remote_addr) then
   ngx.exit(ngx.HTTP_SERVICE_UNAVAILABLE)
@@ -78,6 +83,9 @@ local route = routes.resolve_uri(mode, uri)
 if not route.route_id then
   ngx.exit(ngx.HTTP_NOT_FOUND)
 end
+
+-- adding the flag to ignore 503 route level check
+route.maint_ip_allowed = config.is_addr_allowed_in_maint_mode(remote_addr)
 
 -- Load restrictions and darklaunch constraints for this org.
 -- note that org name may not be valid - we'll use an appropriate default if it's not,

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/dispatch.lua.erb
@@ -84,7 +84,7 @@ if not route.route_id then
   ngx.exit(ngx.HTTP_NOT_FOUND)
 end
 
--- adding the flag to ignore 503 route level check
+-- add the flag to ignore 503 route level check
 route.maint_ip_allowed = config.is_addr_allowed_in_maint_mode(remote_addr)
 
 -- Load restrictions and darklaunch constraints for this org.

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/resolver.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/resolver.lua.erb
@@ -43,10 +43,8 @@ upstream_resolver.tarpitify = function(route_id, org_config, internal)
 end
 
 upstream_resolver.acct_erchef_fun = function(route)
-  if route.org_config["couchdb_" .. route.endpoint] == 0 then
-    return "erchef"
-  end
-  return "acct"
+--  returns "erchef" as we moved away from 'opscode_account'
+  return "erchef"
 end
 
 -- If this is an internal non API vhost , the caller must also ensure that route.internal == true

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/route_checks.lua.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/scripts/route_checks.lua.erb
@@ -33,8 +33,9 @@ response[503] = {}
 -- are handled here.
 --
 response[503].default = function(route)
-  if route.org_config["503_mode"] == 1 or
-     config.is_route_in_maint_mode(route.route_id) then
+--  ngx.log(ngx.ERR, "allowlist check is ", (not route.maint_ip_allowed))
+  if (not route.maint_ip_allowed) and
+     (route.org_config["503_mode"] == 1 or config.is_route_in_maint_mode(route.route_id)) then
      return true
    end
   return false

--- a/src/chef-server-ctl/plugins/maintenance.rb
+++ b/src/chef-server-ctl/plugins/maintenance.rb
@@ -1,0 +1,60 @@
+
+require 'redis'
+
+def redis
+  @redis ||= begin
+               vip = running_config["private_chef"]["redis_lb"]["vip"]
+               port = running_config["private_chef"]["redis_lb"]["port"]
+               password = credentials.get('redis_lb', 'password')
+               Redis.new(port: port, ip: vip, password: password)
+             end
+end
+
+def enable_maintenance
+  puts "- Enabling maintenance mode"
+  redis.hset("dl_default", "503_mode", true)
+end
+
+def disable_maintenance
+  puts "- Disabling maintenance mode"
+  redis.hdel("dl_default", "503_mode")
+end
+
+# def add_ip_to_whitelist(ip)
+#   puts "- Adding ", ip, " to whitelist."
+#   redis.sadd(ip) #something like this
+# end
+#
+# def remove_ip_from_whitelist(ip)
+#   puts "- Removing ", ip, " from whitelist."
+#   redis.spop(ip) #something like this
+# end
+
+add_command_under_category "maintenance", "general", "Handel the server properly while maintenance", 2 do
+  args = ARGV[1..-1] # Chop off first 1 args, keep the rest... that is, everything after "chef-server-ctl maintenance"
+  options = {}
+
+  if args[0] == 'on'
+    enable_maintenance
+    args = args[1..-1]
+  elsif args[0] == 'off'
+    disable_maintenance
+    args = args[1..-1]
+  elsif args.length == 0
+    $stderr.puts "Please specify the action 'on' or 'off' or pass the maintenance options"
+    exit 1
+  end
+
+  OptionParser.new do |opts|
+
+    # even if you enable in the redis you have to refresh the shared_dict of nginx lua or reduce the maint_refresh_interval
+    opts.on("-a", "--add-ip", "Add an IP to whitelist") do |a|
+      options[:add_ip] = a
+    end
+
+    opts.on("-r", "--remove-ip", "Remove an IP from the whitelist") do |a|
+      options[:remove_ip] = a
+    end
+  end.parse!(args)
+
+end

--- a/src/chef-server-ctl/plugins/maintenance.rb
+++ b/src/chef-server-ctl/plugins/maintenance.rb
@@ -1,5 +1,6 @@
 
-require 'redis'
+require "redis"
+require "resolv"
 
 def redis
   @redis ||= begin
@@ -20,41 +21,77 @@ def disable_maintenance
   redis.hdel("dl_default", "503_mode")
 end
 
-# def add_ip_to_whitelist(ip)
-#   puts "- Adding ", ip, " to whitelist."
-#   redis.sadd(ip) #something like this
-# end
-#
-# def remove_ip_from_whitelist(ip)
-#   puts "- Removing ", ip, " from whitelist."
-#   redis.spop(ip) #something like this
-# end
+def list_allowed_ips()
+  ips = redis.smembers("xmaint_allowed_ips_list")
+  if ips.length == 0
+    puts "- allowed IP list is empty."
+  else
+    puts "- The following IPs are allowed in the maintenance mode \n", ips
+  end
+end
+
+def add_ip_to_allowed_list(ip)
+  validate_ip(ip)
+  puts "- Adding #{ip} to allowed list."
+  redis.sadd("xmaint_allowed_ips_list", ip)
+end
+
+def remove_ip_from_allowed_list(ip)
+  validate_ip(ip)
+  puts "- Removing #{ip} from allowed list."
+  redis.srem("xmaint_allowed_ips_list", ip)
+end
+
+def validate_ip(ip)
+  isIPv4 = ip =~ Resolv::IPv4::Regex ? true : false
+  isIPv6 = ip =~ Resolv::IPv6::Regex ? true : false
+  unless isIPv4 or isIPv6
+    $stderr.puts "The IP address is invalid, please enter valid IP address"
+    exit 1
+  end
+end
+
 
 add_command_under_category "maintenance", "general", "Handel the server properly while maintenance", 2 do
   args = ARGV[1..-1] # Chop off first 1 args, keep the rest... that is, everything after "chef-server-ctl maintenance"
   options = {}
 
-  if args[0] == 'on'
-    enable_maintenance
-    args = args[1..-1]
-  elsif args[0] == 'off'
-    disable_maintenance
-    args = args[1..-1]
-  elsif args.length == 0
-    $stderr.puts "Please specify the action 'on' or 'off' or pass the maintenance options"
-    exit 1
+  case args[0]
+    when 'on'
+      enable_maintenance
+      args = args[1..-1]
+    when 'off'
+      disable_maintenance
+      args = args[1..-1]
+    else
+      if args.length == 0
+        $stderr.puts "Please specify the action 'on' or 'off' or pass the maintenance options"
+        exit 1
+      end
   end
 
   OptionParser.new do |opts|
 
-    # even if you enable in the redis you have to refresh the shared_dict of nginx lua or reduce the maint_refresh_interval
-    opts.on("-a", "--add-ip", "Add an IP to whitelist") do |a|
+    opts.on("-l", "--list-ips", "List the allowed IPs list") do
+      options[:list_ip] = true
+    end
+
+    opts.on("-a", "--add-ip [String]", "Add an IP to allowed list") do |a|
       options[:add_ip] = a
     end
 
-    opts.on("-r", "--remove-ip", "Remove an IP from the whitelist") do |a|
+    opts.on("-r", "--remove-ip [String]", "Remove an IP from the allowed list") do |a|
       options[:remove_ip] = a
     end
+
+    opts.on("-h", "--help", "Print this help message") do
+      puts opts
+      exit 1
+    end
   end.parse!(args)
+
+  list_allowed_ips() if options[:list_ip]
+  add_ip_to_allowed_list(options[:add_ip]) if options[:add_ip]
+  remove_ip_from_allowed_list(options[:remove_ip]) if options[:remove_ip]
 
 end

--- a/src/chef-server-ctl/plugins/maintenance.rb
+++ b/src/chef-server-ctl/plugins/maintenance.rb
@@ -1,97 +1,104 @@
 
-require "redis"
-require "resolv"
+require 'redis'
+require 'resolv'
 
 def redis
   @redis ||= begin
-               vip = running_config["private_chef"]["redis_lb"]["vip"]
-               port = running_config["private_chef"]["redis_lb"]["port"]
+               vip = running_config['private_chef']['redis_lb']['vip']
+               port = running_config['private_chef']['redis_lb']['port']
                password = credentials.get('redis_lb', 'password')
                Redis.new(port: port, ip: vip, password: password)
              end
 end
 
 def enable_maintenance
-  puts "- Enabling maintenance mode"
-  redis.hset("dl_default", "503_mode", true)
+  puts '- Enabling maintenance mode'
+  redis.hset('dl_default', '503_mode', true)
 end
 
 def disable_maintenance
-  puts "- Disabling maintenance mode"
-  redis.hdel("dl_default", "503_mode")
+  puts '- Disabling maintenance mode'
+  redis.hdel('dl_default', '503_mode')
 end
 
 def list_allowed_ips()
-  ips = redis.smembers("xmaint_allowed_ips_list")
+  ips = redis.smembers('xmaint_allowed_ips_list')
   if ips.length == 0
-    puts "- allowed IP list is empty."
+    puts '- allowed IP list is empty.'
   else
-    puts "- The following IPs are allowed in the maintenance mode \n", ips
+    puts '- The following IPs are allowed in maintenance mode', ips
   end
 end
 
 def add_ip_to_allowed_list(ip)
   validate_ip(ip)
   puts "- Adding #{ip} to allowed list."
-  redis.sadd("xmaint_allowed_ips_list", ip)
+  redis.sadd('xmaint_allowed_ips_list', ip)
 end
 
 def remove_ip_from_allowed_list(ip)
   validate_ip(ip)
   puts "- Removing #{ip} from allowed list."
-  redis.srem("xmaint_allowed_ips_list", ip)
+  redis.srem('xmaint_allowed_ips_list', ip)
 end
 
 def validate_ip(ip)
   isIPv4 = ip =~ Resolv::IPv4::Regex ? true : false
   isIPv6 = ip =~ Resolv::IPv6::Regex ? true : false
   unless isIPv4 or isIPv6
-    $stderr.puts "The IP address is invalid, please enter valid IP address"
+    $stderr.puts 'The IP address is invalid, please enter valid IP address'
     exit 1
   end
 end
 
 
-add_command_under_category "maintenance", "general", "Handel the server properly while maintenance", 2 do
-  args = ARGV[1..-1] # Chop off first 1 args, keep the rest... that is, everything after "chef-server-ctl maintenance"
+add_command_under_category 'maintenance', 'general', 'Handel the server properly while maintenance', 2 do
+  args = ARGV[1..-1] # Chop off first 1 args, keep the rest... that is, everything after 'chef-server-ctl maintenance'
   options = {}
+
+  if args.length == 0
+    $stderr.puts 'Please specify the action \'on\' or \'off\' or pass the options \'-h\' for help'
+    exit 1
+  end
 
   case args[0]
     when 'on'
-      enable_maintenance
-      args = args[1..-1]
+      args = ['--on']
     when 'off'
-      disable_maintenance
-      args = args[1..-1]
-    else
-      if args.length == 0
-        $stderr.puts "Please specify the action 'on' or 'off' or pass the maintenance options"
-        exit 1
-      end
+      args = ['--off']      
   end
 
   OptionParser.new do |opts|
 
-    opts.on("-l", "--list-ips", "List the allowed IPs list") do
-      options[:list_ip] = true
+    opts.on('--on', 'Enable maintenance mode') do
+      enable_maintenance()
     end
 
-    opts.on("-a", "--add-ip [String]", "Add an IP to allowed list") do |a|
-      options[:add_ip] = a
+    opts.on('--off', 'Disable maintenance mode') do
+      disable_maintenance()
     end
 
-    opts.on("-r", "--remove-ip [String]", "Remove an IP from the allowed list") do |a|
-      options[:remove_ip] = a
+    opts.on('-l', '--list-ips', 'List the allowed IPs list') do
+      list_allowed_ips()
     end
 
-    opts.on("-h", "--help", "Print this help message") do
+    opts.on('-a', '--add-ip [String]', 'Add an IP to allowed list') do |ip|
+      add_ip_to_allowed_list(ip)
+    end
+
+    opts.on('-r', '--remove-ip [String]', 'Remove an IP from the allowed list') do |ip|
+      remove_ip_from_allowed_list(ip)
+    end
+
+    opts.on('-h', '--help', 'Print this help message') do
       puts opts
       exit 1
     end
   end.parse!(args)
 
-  list_allowed_ips() if options[:list_ip]
-  add_ip_to_allowed_list(options[:add_ip]) if options[:add_ip]
-  remove_ip_from_allowed_list(options[:remove_ip]) if options[:remove_ip]
+  if args.length > 0
+    $stderr.puts 'Please specify the action \'on\' or \'off\' or pass the options \'-h\' for help'
+    exit 1
+  end
 
 end

--- a/src/chef-server-ctl/spec/maintenance_spec.rb
+++ b/src/chef-server-ctl/spec/maintenance_spec.rb
@@ -1,0 +1,52 @@
+
+require 'omnibus_ctl_helper'
+
+module Omnibus
+  class Ctl
+    def credentials
+      # This is defined in chef-server-ctl, but chef-server-ctl isn't
+      # actually loaded as part of these tests and attempting to load
+      # it would require some code changes since it expects to be able
+      # to run the command specified in ARGV.
+    end
+  end
+end
+
+
+describe "chef-server-ctl maintenance" do
+
+  let(:command)   { "maintenance" }
+  let(:running_config) { { 'private_chef' => { 'redis_lb' => { 'vip' => '127.0.0.1', 'port' => '16379' } } } }
+  let(:veil_creds) do
+    double("ChefSecretsFile", save: true)
+  end
+
+  before do
+    @helper = OmnibusCtlHelper.new(["./plugins/maintenance.rb"])
+    allow(@helper.ctl).to receive(:running_config).and_return(running_config)
+    allow(@helper.ctl).to receive(:credentials).and_return(veil_creds)
+    allow(veil_creds).to receive(:save)
+  end
+
+  context "when an invalid argument is passed" do
+    it "should return a proper error" do
+      expect { @helper.run_test_omnibus_command(command, []) }
+        .to raise_error(SystemExit) { |e| expect(e.status).to eq(1) }
+    end
+  end
+
+#   need to install redis in the test environment
+#   context "Mode on" do
+#     it "should turn on the maintenance mode" do
+#       expect { @helper.run_test_omnibus_command(command, ["on"]) }
+#         .to output(/name: default\nexpired: false/).to_stdout
+#     end
+#   end
+#
+#   context "Mode off" do
+#     it "should turn off the maintenance mode" do
+#       expect { @helper.run_test_omnibus_command(command, ["off"]) }
+#         .to output(/name: default\nexpired: false/).to_stdout
+#     end
+#   end
+end

--- a/src/chef-server-ctl/spec/maintenance_spec.rb
+++ b/src/chef-server-ctl/spec/maintenance_spec.rb
@@ -35,18 +35,4 @@ describe "chef-server-ctl maintenance" do
     end
   end
 
-#   need to install redis in the test environment
-#   context "Mode on" do
-#     it "should turn on the maintenance mode" do
-#       expect { @helper.run_test_omnibus_command(command, ["on"]) }
-#         .to output(/name: default\nexpired: false/).to_stdout
-#     end
-#   end
-#
-#   context "Mode off" do
-#     it "should turn off the maintenance mode" do
-#       expect { @helper.run_test_omnibus_command(command, ["off"]) }
-#         .to output(/name: default\nexpired: false/).to_stdout
-#     end
-#   end
 end


### PR DESCRIPTION
### Description

adding `chef-server-ctl maintenance` sub command for controlling chef server for maintenance activities.
As part of this the following features are added
1. `chef-server-ctl maintenance on/off` will turn on or off the maintenance mode. In this mode the APIs will not work.
2. `-a [ip address]` and `-r [ip address]` will add and remove the ip address from the allow list. The APIs hit from the allow listed ips will not be blocked during maintenance mode.
3. By default `127.0.0.1` ip is allow listed

### Issues Resolved

resolves #2089 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
