### PR TITLE
Added Amazon Linux 2 support

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,6 +9,7 @@ builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
+    - amazon-2-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

We have Amazon Linux 2 builders/testers in Buildkite now and we should produce packages for Amazon Linux 2. Without a doubt folks are using the current EL7 packages on Amazon right now. We should just make it more official so it's clear that works.

### Issues Resolved

Added 'amazon-2-x86_64' support in expeditor.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
