### PR TITLE
Removed publicly exposed bifrost port

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -424,7 +424,6 @@ default['private_chef']['lb_internal']['enable'] = true
 default['private_chef']['lb_internal']['vip'] = '127.0.0.1'
 default['private_chef']['lb_internal']['chef_port'] = 9680
 default['private_chef']['lb_internal']['account_port'] = 9685
-default['private_chef']['lb_internal']['oc_bifrost_port'] = 9683
 default['private_chef']['lb']['redis_connection_timeout'] = 1000
 default['private_chef']['lb']['redis_keepalive_timeout'] = 2000
 default['private_chef']['lb']['redis_connection_pool_size'] = 250

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -191,31 +191,6 @@ http {
     }
   }
 
-  # internal service access for oc_bifrost
-  server {
-    <%= @helper.listen_port(node['private_chef']['lb_internal']['oc_bifrost_port']) %>
-    server_name <%= @helper.server_name %>;
-    more_clear_headers Server;
-
-    client_max_body_size <%= @client_max_body_size %>;
-    proxy_set_header        Host            $host;
-    proxy_set_header        X-Real-IP       $remote_addr;
-    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto http;
-    proxy_set_header        X-Forwarded-Host $http_host;
-    proxy_pass_request_headers on;
-
-    proxy_connect_timeout   90;
-    proxy_send_timeout      90;
-    proxy_read_timeout      90;
-
-    access_log /var/log/opscode/nginx/internal-authz.access.log opscode;
-    error_log  /var/log/opscode/nginx/internal-authz.error.log<%= node['private_chef']['lb']['debug'] ? " debug" : "" %>;
-
-    location / {
-      proxy_pass http://oc_bifrost;
-    }
-  }
   <%- end -%>
 
   include <%= node['private_chef']['nginx']['dir'] %>/etc/nginx.d/*.conf;


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Chef Server currently exposes bifrost via reverse proxy from nginx on port 9683.Determine if publicly exposed bifrost port is still used.

### Issues Resolved

Removed the publicly exposed bifrost from nginx configuration as we are not using it anymore

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
