### PR TITLE
Add a configuration option to set the max-age of HSTS

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -489,6 +489,7 @@ default['private_chef']['nginx']['ssl_company_name'] = 'YouCorp'
 default['private_chef']['nginx']['ssl_organizational_unit_name'] = 'Operations'
 default['private_chef']['nginx']['ssl_key_length'] = 2048
 default['private_chef']['nginx']['ssl_duration'] = 3650
+default['private_chef']['nginx']['sts_max_age'] = 31536000
 default['private_chef']['nginx']['dhparam_key_length'] = 2048
 default['private_chef']['nginx']['dhparam_generator_id'] = 2
 default['private_chef']['nginx']['worker_processes'] = node['cpu']['total'].to_i

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/nginx_erb.rb
@@ -1,3 +1,5 @@
+require_relative './warnings.rb'
+
 class NginxErb
   attr_reader :node
 
@@ -116,4 +118,18 @@ class NginxErb
     end
   end
 
+
+  def get_max_age_for_hsts
+    max_age = node['private_chef']['nginx']['sts_max_age']
+    unless( max_age.is_a? Numeric and max_age >= 31536000 and max_age <= 63072000)
+        ChefServer::Warnings.warn <<~EOF
+          The HSTS max_age parameter should be a Numeric value in seconds
+          greater than or equal to 1 year (31536000) and less than or equal to 2 years (63072000)
+          setting the max-age to 31536000
+          EOF
+        31536000
+    else
+        max_age
+    end
+  end
 end

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -42,7 +42,7 @@
       add_header X-Content-Type-Options nosniff;
       add_header X-XSS-Protection 1;
       <% if @server_proto == 'https' %>
-      add_header Strict-Transport-Security max-age=<%= node['private_chef']['nginx']['sts_max_age'] %>;
+      add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
       <% end %>
     <% end %>
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -42,7 +42,7 @@
       add_header X-Content-Type-Options nosniff;
       add_header X-XSS-Protection 1;
       <% if @server_proto == 'https' %>
-      add_header Strict-Transport-Security max-age=31536000;
+      add_header Strict-Transport-Security max-age=<%= node['private_chef']['nginx']['sts_max_age'] %>;
       <% end %>
     <% end %>
 


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

max-age is the time period in which the HSTS information will be cached.

### Issues Resolved

resolves #857 

### Check List

- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
