### PR TITLE
Fix command name typo in clean-bifrost error output

### DIFF
--- a/src/chef-server-ctl/plugins/cleanup_bifrost.rb
+++ b/src/chef-server-ctl/plugins/cleanup_bifrost.rb
@@ -141,7 +141,7 @@ def safety_check(db)
                           WHERE tablename='cleanup_tracking_auth_actors'")
   if res.ntuples > 0
     puts "ERROR: cleanup_tracking_auth_actors already exists.  cleanup-bifrost may be running."
-    puts "ERROR: If you are sure cleanup-bifrost is not running, you can clean up the tracking tables with: chef-backend-ctl cleanup-bifrost --force-cleanup"
+    puts "ERROR: If you are sure cleanup-bifrost is not running, you can clean up the tracking tables with: chef-server-ctl cleanup-bifrost --force-cleanup"
     exit(1)
   end
 end


### PR DESCRIPTION
### Description

The error output says to run `chef-backend-ctl` but this command is part of `chef-server-ctl` and not `chef-backend-ctl`

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
