### PR TITLE
Pinning chef-server-ctl to 15.16.2 of chef-utils. 

### DIFF
--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'chef', "= 15.16.2"
+gem 'chef-utils', "= 15.16.2" # mixlib-shellout currently floats on anything < 16.7.23
 gem "chef_backup"
 gem "omnibus-ctl"
 gem "veil", git: "https://github.com/chef/chef_secrets.git"

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -289,6 +289,7 @@ DEPENDENCIES
   bundler
   chef (= 15.16.2)
   chef-server-ctl!
+  chef-utils (= 15.16.2)
   chef_backup
   chefstyle
   omnibus-ctl

--- a/src/chef-server-ctl/chef-server-ctl.gemspec
+++ b/src/chef-server-ctl/chef-server-ctl.gemspec
@@ -48,10 +48,11 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "appbundler"
 
+  spec.add_runtime_dependency "chef"
+
   spec.add_development_dependency "chefstyle"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-
 
 end


### PR DESCRIPTION
This is necessary since mixlib-shellout floats on any version < 16.7.23

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/2343