### PR TITLE
WIP: Update to use Perl 5.30.0

### DIFF
--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -153,6 +153,10 @@ fallbacks:
     - name: core/bundler
       license_id: MIT
       license_content: https://raw.githubusercontent.com/bundler/bundler/master/LICENSE.md
+  perl_cpanm:
+    - name: sqitch
+      license_id: MIT
+      license_content: https://raw.githubusercontent.com/sqitchers/sqitch/develop/LICENSE.md
 
 exceptions:
   erlang:
@@ -214,4 +218,3 @@ exceptions:
       reason: Exception made by Chef Legal
     - name: core/nss-myhostname
       reason: Exception made by Chef Legal
-

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -7,7 +7,7 @@ override :'omnibus-ctl', version: "main"
 override :chef, version: "v16.17.4"
 override :ohai, version: "v16.17.0"
 override :ruby, version: "2.7.5"
-override :perl, version: "5.18.1"
+override :perl, version: "5.30.0"
 override :redis, version: "5.0.14"
 
 override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -8,6 +8,7 @@ override :chef, version: "v16.17.4"
 override :ohai, version: "v16.17.0"
 override :ruby, version: "2.7.5"
 override :perl, version: "5.30.0"
+override :sqitch, version: "0.9999"
 override :redis, version: "5.0.14"
 
 override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently


### PR DESCRIPTION
### Description

This PR adds omnibus overides to upgrade the version of Perl to `5.30.0` and sqitch to a compatible version (`0.9999`).

Signed-off-by: Christopher A. Snapp <chris.snapp@progress.com>

### Issues Resolved

#2166 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
