### PR TITLE
Allow preventing user's from changing their e-mail with new `allow_email_update_only_from_manage` config

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -238,6 +238,7 @@ default['private_chef']['opscode-erchef']['sql_ro_user'] = 'opscode_chef_ro'
 # See default['private_chef']['postgresql']['db_connection_superuser'] for information
 default['private_chef']['opscode-erchef']['sql_connection_user'] = nil
 default['private_chef']['opscode-erchef']['enable_request_logging'] = true
+default['private_chef']['opscode-erchef']['allow_email_update_only_from_manage'] = false
 
 #
 # Reindex configurables

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb
@@ -140,7 +140,8 @@
         ]},
         {base_resource_url, <%= @helper.erl_atom_or_string(node['private_chef']['opscode-erchef']['base_resource_url']) %>},
         {strict_search_result_acls, <%= @strict_search_result_acls %>},
-        {include_version_in_status, <%= node['private_chef']['opscode-erchef']['include_version_in_status'] %>}
+        {include_version_in_status, <%= node['private_chef']['opscode-erchef']['include_version_in_status'] %>},
+        {allow_email_update_only_from_manage, <%= node['private_chef']['opscode-erchef']['allow_email_update_only_from_manage'] %>}
     ]},
 
     {chef_authn, [

--- a/scripts/bk_tests/chef_zero-Gemfile
+++ b/scripts/bk_tests/chef_zero-Gemfile
@@ -8,7 +8,7 @@ gem 'pry-stack_explorer'
 gem 'rake'
 
 # For "rake chef_zero_spec"
-gem 'chef-zero', github: 'chef/chef-zero', tag: 'v15.0.5'
+gem 'chef-zero', github: 'chef/chef-zero', tag: 'v15.0.6'
 
 # If you want to load debugging tools into the bundle exec sandbox,
 # # add these additional dependencies into Gemfile.local

--- a/src/oc_erchef/apps/chef_objects/src/chef_user.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_user.erl
@@ -316,7 +316,16 @@ common_user_validation(EJ, User, Operation) ->
     end,
     % Ensure the user can't set this - we make use of it in some cases by setting it internally
     EJ1 = ej:delete({<<"id">>}, EJ),
-    {ok, EJ1}.
+    % Setting the email to lower case for uniqueness,
+    % test@chef.io and TEST@chef.io are considered to be the same email addresses in user creation
+    EJ2 =
+    case ej:get({<<"email">>}, EJ1) of
+        undefined ->
+            EJ1;
+        Email ->
+            ej:set({<<"email">>}, EJ1, string:lowercase(Email))
+    end,
+    {ok, EJ2}.
 
 external_auth_uid(EJson, #chef_user{external_authentication_uid = ExtAuthUid}) ->
     case ej:get({<<"external_authentication_uid">>}, EJson) of

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
@@ -224,6 +224,242 @@ verify_request_signature_test_() ->
        end}
      ]}.
 
+verify_email_updates_test_() ->
+        {foreach,
+     fun() ->
+             meck:new(oc_chef_wm_named_user, [non_strict])
+     end,
+     fun(_) ->
+             meck:unload(oc_chef_wm_named_user)
+     end,
+     [
+      {"No email change in the user update request from web/chef-manage",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = false, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from web/chef-manage",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = false, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+       {"No email change in the user update request from command line/Knife",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = false, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from command line/Knife",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = false, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+       {"No email change in the user update request from web/chef-manage when allow_email_update_only_from_manage is true",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = true, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from web/chef-manage when allow_email_update_only_from_manage is true",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = true, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+       {"No email change in the user update request from command line/Knife when allow_email_update_only_from_manage is true",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = true, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              halt
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from command line/Knife when allow_email_update_only_from_manage is true",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = true, 
+               ApiVersion = 0,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              halt
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+       %% For API version V1
+       {"No email change in the user update request from web/chef-manage API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = false, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_base, update_from_json}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from web/chef-manage API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = false, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_base, update_from_json}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+       {"No email change in the user update request from command line/Knife API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = false, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_base, update_from_json}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from command line/Knife API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = false, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_base, update_from_json}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+       {"No email change in the user update request from web/chef-manage when allow_email_update_only_from_manage is true API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = true, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_base, update_from_json}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from web/chef-manage when allow_email_update_only_from_manage is true API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "web",
+               EmailUpdateConfig = true, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              {ok, oc_chef_wm_base, update_from_json}
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+       {"No email change in the user update request from command line/Knife when allow_email_update_only_from_manage is true API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = true, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              halt
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end},
+      {"Email change in the user update request from command line/Knife when allow_email_update_only_from_manage is true API v1",
+       fun() ->
+               OrigEmail = <<"user@example.com">>,
+               NewEmail = <<"user2@example.com">>,
+               RequestOrigin = "knife",
+               EmailUpdateConfig = true, 
+               ApiVersion = 1,
+               meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
+                                                              halt
+                                                      end),
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+                       RequestOrigin, EmailUpdateConfig, ApiVersion),
+               ?assert(meck:validate(oc_chef_wm_named_user))
+       end}
+     ]}.
+
 make_req_data() ->
     #wm_reqdata{}.
 


### PR DESCRIPTION
### Description

- Due to being an API we probably will limit permissions on the API to systems that perform email verification themselves.
- Chef-server can distinguish between the requests originating from the webui and client.
The requests from the webui will have header x-ops-request-source set.
If this is not set it implies that the request is originating from the the client / knife. If such a request has altered the email address in the json field. Send error to the effect: Use chef-manage to change user email
- Email for user creation should be case insensitive.For example 'test@chef.io' and 'TEST@chef.io' are considered to be the same email addresses in user creation and should 409 conflict.

### Issues Resolved

There are two approches for fixing the point 3-issue.
- Sql changes for UNIQUE email address. Cons:  Migration must be done for installation
- Code change in oc_erchef befor storing it to DB. Cons: It does not clean current discrepancies.

https://app.zenhub.com/workspaces/chef-infra-server-team-5fc64867d45ca500173dbbc7/issues/chef/customer-bugs/338
### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
