### PR TITLE
Add Content-Security-Policy and X-Frame-Options headers to our static content

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -52,13 +52,21 @@
     # Whitelist the docs necessary to serve up error pages and friendly
     # html to non-chef clients hitting this host.
     location ~ "^/[0-9]{3,3}\.(json|html)|favicon.ico|index.html$" {
+      add_header Content-Security-Policy "default-src 'self';";
+      add_header X-Frame-Options DENY;
     }
     location "/css/" {
+      add_header Content-Security-Policy "default-src 'self';";
+      add_header X-Frame-Options DENY;
     }
     location "/images/" {
+      add_header Content-Security-Policy "default-src 'self';";
+      add_header X-Frame-Options DENY;
     }
 
     location /version {
+      add_header Content-Security-Policy "default-src 'self';";
+      add_header X-Frame-Options DENY;
       types { }
       default_type text/plain;
       alias /opt/opscode/version-manifest.txt;

--- a/src/nginx/habitat/config/chef_http_lb_common
+++ b/src/nginx/habitat/config/chef_http_lb_common
@@ -48,7 +48,7 @@
     error_page 404 =404 /404.html;
     error_page 503 =503 /503.json;
 
-    # Whitelist the docs necessary to serve up error pages and friendly
+    # Allow the docs necessary to serve up error pages and friendly
     # html to non-chef clients hitting this host.
     location ~ "^/[0-9]{3,3}\.(json|html)|favicon.ico|index.html$" {
     }


### PR DESCRIPTION
This came up in a security audit. The user browseable page that just points user to use knife or access our API does not set Content-Security-Policy and doesn't set `X-Frame-Options DENY` if manage is installed. This static content should be pretty locked down. I've tested this on an installation and it doesn't impact the page loading, but improved our scan scores.

Signed-off-by: Tim Smith <tsmith@chef.io>