### PR TITLE
Remove support for Ubuntu 16.04 + add Ubuntu FIPS

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -5,6 +5,7 @@ install-dir: /opt/opscode
 test-path: omnibus/omnibus-test.sh
 fips-platforms:
   - el-*-x86_64
+  - ubuntu-*-x86_64
 builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
@@ -13,7 +14,6 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -58,9 +58,9 @@ Vagrant.configure("2") do |config|
   attributes = load_settings
 
   config.vm.network 'public_network' if USE_AZURE
-  # Use the official Ubuntu 16.04 box
+  # Use the official Ubuntu 18.04 box
   # Vagrant will auto resolve the url to download from Atlas
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
   config.ssh.forward_agent = true
 
   # This plugin allows for a much more efficient sync than the vanilla rsync-auto command


### PR DESCRIPTION
We can enable FIPS on Ubuntu easily so we might as well since we're
already constrained in OpenSSL with FIPS on RHEL.

Ubuntu 16.04 is EOL at the end of April so let's remove this.

Signed-off-by: Tim Smith <tsmith@chef.io>