### PR TITLE
Update tests to handle local omnibus packages from Buildkite artifacts api

### DIFF
--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -4,12 +4,17 @@ set -ueo pipefail
 channel="${CHANNEL:-unstable}"
 product="${PRODUCT:-chef-server}"
 version="${VERSION:-latest}"
+package_file=${PACKAGE_FILE:-""}
 
 export PATH="/opt/opscode/bin:/opt/opscode/embedded/bin:$PATH"
 export INSTALL_DIR="/opt/opscode"
 
 echo "--- Installing $channel $product $version"
-package_file="$(/opt/omnibus-toolchain/bin/install-omnibus-product -c "$channel" -P "$product" -v "$version" -i "$INSTALL_DIR" | tail -n 1)"
+if [[ -z $package_file ]]; then
+  package_file="$(.omnibus-buildkite-plugin/install-omnibus-product.sh -c "$channel" -P "$product" -v "$version" -i "$INSTALL_DIR"  | tail -1)"
+else
+  .omnibus-buildkite-plugin/install-omnibus-product.sh -f "$package_file" -P "$product" -v "$version" -i "$INSTALL_DIR"  &> /dev/null
+fi
 
 echo "--- Verifying omnibus package is signed"
 /opt/omnibus-toolchain/bin/check-omnibus-package-signed "$package_file"


### PR DESCRIPTION
### Description
Updated tests to support the use of skip-artifactory-platforms within the shim pipeline definition where packages will be downloaded directly from the buildkite artifacts api.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
