### PR TITLE
Remove bundler/rubygems omnibus defs

### DIFF
--- a/omnibus/config/software/chef_backup-gem.rb
+++ b/omnibus/config/software/chef_backup-gem.rb
@@ -22,7 +22,6 @@ license "Apache-2.0"
 license_file "https://github.com/chef/chef_backup/blob/master/LICENSE"
 
 dependency 'ruby'
-dependency 'rubygems'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/fixie-gem.rb
+++ b/omnibus/config/software/fixie-gem.rb
@@ -23,8 +23,6 @@ license_file "https://github.com/chef/fixie/blob/master/LICENSE"
 source git: "https://github.com/chef/fixie.git"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/knife-opc-gem.rb
+++ b/omnibus/config/software/knife-opc-gem.rb
@@ -23,8 +23,6 @@ license_file "https://github.com/chef/knife-opc/blob/master/LICENSE"
 source git: "git://github.com/opscode/knife-opc.git"
 
 dependency "ruby"
-dependency "rubygems"
-dependency "bundler"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/knife-tidy-gem.rb
+++ b/omnibus/config/software/knife-tidy-gem.rb
@@ -24,7 +24,6 @@ license_file "https://github.com/chef/knife-tidy/blob/master/LICENSE"
 skip_transitive_dependency_licensing true
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/mixlib-install.rb
+++ b/omnibus/config/software/mixlib-install.rb
@@ -23,7 +23,6 @@ license_file "LICENSE"
 source git: "https://github.com/chef/mixlib-install.git"
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/oc-chef-pedant.rb
+++ b/omnibus/config/software/oc-chef-pedant.rb
@@ -21,7 +21,6 @@ license "Apache-2.0"
 license_file "LICENSE"
 
 dependency "ruby"
-dependency "bundler"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus/config/software/oc_erchef.rb
+++ b/omnibus/config/software/oc_erchef.rb
@@ -27,7 +27,6 @@ dependency "perl_pg_driver"
 
 # RUBY DEPSOLVER - REMOVE FOR ROLLBACK #
 dependency "ruby"
-dependency "bundler"
 # END RUBY DEPSOLVER #
 
 build do

--- a/omnibus/config/software/oc_id.rb
+++ b/omnibus/config/software/oc_id.rb
@@ -29,7 +29,6 @@ license_file "LICENSE"
 dependency "nokogiri"
 dependency "postgresql96" # for libpq
 dependency "ruby"
-dependency "bundler"
 
 relative_path "oc-id"
 

--- a/omnibus/config/software/partybus.rb
+++ b/omnibus/config/software/partybus.rb
@@ -20,7 +20,7 @@ source path: "#{Omnibus::Config.project_root}/#{name}"
 
 license :project_license
 
-dependency "bundler"
+dependency "ruby"
 dependency "postgresql96"
 
 build do

--- a/omnibus/config/software/rest-client-gem.rb
+++ b/omnibus/config/software/rest-client-gem.rb
@@ -23,7 +23,6 @@ license_file "https://github.com/rest-client/rest-client/blob/master/LICENSE"
 source git: "https://github.com/rest-client/rest-client.git"
 
 dependency "ruby"
-dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -3,8 +3,6 @@
 # the various usages are updated in lockstep
 #
 override :erlang, version: "22.2"
-override :rubygems, version: "3.0.3"
-override :bundler, version: "1.17.3"  # pin to avoid double bundle error
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v15.17.4"
 override :ohai, version: "v15.12.0"


### PR DESCRIPTION
Ruby includes built-in rubygems and bundler now so we're just installing
these over again. It makes the packages larger and makes it so we have
to keep the bundler release in the overrides file in sync with the
version that ruby ships in the ruby package.

Signed-off-by: Tim Smith <tsmith@chef.io>