### PR TITLE
Remove unused postgresql versions from the definition

### DIFF
--- a/omnibus/config/software/postgresql96.rb
+++ b/omnibus/config/software/postgresql96.rb
@@ -30,8 +30,6 @@ dependency "libossp-uuid"
 dependency "config_guess"
 
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
-version("9.6.10") { source sha256: "8615acc56646401f0ede97a767dfd27ce07a8ae9c952afdb57163b7234fe8426" }
-version("9.6.14") { source sha256: "3f08c265c9ae814f727461408ab24fdf3d954c4f7ae42d9c97b3c7e03fc31a22" }
 version("9.6.15") { source sha256: "3cd9fe9af247167f863030842c1a57f58bdf3e5d50a94997d34a802b6032170a" }
 
 relative_path "postgresql-#{version}"


### PR DESCRIPTION
These are pointless here

Signed-off-by: Tim Smith <tsmith@chef.io>