### PR TITLE
Fix typo in error handler name

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_indexing_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_indexing_validator.rb
@@ -94,7 +94,7 @@ class IndexingPreflightValidator < PreflightValidator
   # disabled.
   def verify_es_disabled_if_user_set_external_solr
     if external? && elasticsearch_enabled?
-      fail_with err_INDEX005_should_dsiable_es
+      fail_with err_INDEX005_should_disable_es
     end
   end
 


### PR DESCRIPTION
Obvious fix.

### Description

Fixes a typo in the name of the error handler for an invalid elasticsearch configuration.

Somehow I misconfigured something, and ended up with this error when provisioning a new server.
```
  ================================================================================
  Recipe Compile Error in /var/opt/opscode/local-mode-cache/cookbooks/private-chef/recipes/default.rb
  ================================================================================

  NameError
  ---------
  undefined local variable or method `err_INDEX005_should_dsiable_es' for #<IndexingPreflightValidator:0x00000000049949c8>
  Did you mean?  err_INDEX005_should_disable_es

  Cookbook Trace:
  ---------------
    /var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_indexing_validator.rb:97:in `verify_es_disabled_if_user_set_external_solr'
    /var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_indexing_validator.rb:41:in `run!'
    /var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_checks.rb:147:in `run!'
    /var/opt/opscode/local-mode-cache/cookbooks/private-chef/recipes/config.rb:99:in `from_file'
    /var/opt/opscode/local-mode-cache/cookbooks/private-chef/recipes/default.rb:49:in `from_file'

  Relevant File Content:
  ----------------------
  /var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_indexing_validator.rb:

   90:    end
   91:
   92:    # If an external search provider was explicitly enabled by the user,
   93:    # then we expect that both internal search services should be
   94:    # disabled.
   95:    def verify_es_disabled_if_user_set_external_solr
   96:      if external? && elasticsearch_enabled?
   97>>       fail_with err_INDEX005_should_dsiable_es
   98:      end
   99:    end
  100:
  101:    def external?
  102:      cs_elasticsearch_attr['external'] || cs_solr_attr['external']
  103:    end
  104:
  105:    def elasticsearch_enabled?
  106:      return false if PrivateChef['use_chef_backend']
```


### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
