### PR TITLE
Disable nginx server tokens everywhere

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -12,6 +12,7 @@ events {
 }
 
 http {
+  server_tokens off;
 
 <% if node['private_chef']['nginx']['log_x_forwarded_for'] -%>
   log_format opscode ' $http_x_forwarded_for- $remote_user [$<%= @helper.time_format %>]  '
@@ -115,7 +116,6 @@ http {
       <%- if @non_ssl_port %>
     server {
       listen <%= @non_ssl_port %> default_server;
-      server_tokens off;
       server_name _;
       return 404;
     }
@@ -123,7 +123,6 @@ http {
 
     server {
       listen <%= @ssl_port %> ssl;
-      server_tokens off;
 
       ssl_certificate <%= @ssl_certificate %>;
       ssl_certificate_key <%= @ssl_certificate_key %>;


### PR DESCRIPTION
Avoid exposing information on our openresty version regardless of where
the query is being made

Signed-off-by: Tim Smith <tsmith@chef.io>

See: https://getchef.zendesk.com/agent/tickets/27777

### Test Results

Vanilla chef-server
```
root@api:~# curl http://api
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>openresty/1.19.3.1</center>
</body>
</html>
```

This branch
```
root@api:~# curl http://api
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>openresty</center>
</body>
</html>
```

### Pipelines

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/2596#3431fca1-2a62-4d9f-9c11-ec5e3a98b2d4
https://buildkite.com/chef/chef-umbrella-master-chef-server/builds/430#33b4be36-cf8d-4c9d-83c5-ab47b5064179

NOTE:  There's a failure on the azure umbrella scenario.  Not sure yet whether it's caused by anything in this branch.