### PR TITLE
WIP: chef zero automatically requires latest client.

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -574,6 +574,7 @@ def set_chef_zero_provisioning(config, opts)
     chef.binary_path = opts[:chef_path] if opts.has_key?(:chef_path)
     opts[:recipes].each { |recipe| chef.add_recipe(recipe) }
     chef.json = opts[:json]
+    chef.install = false
   end
 end
 


### PR DESCRIPTION
202012.21.0 vagrant box vagrant vm currently does not have latest chef
       client 17 installed.

Tested that vagrant box comes up and we are able to run tests.

Not tested with different dev setups like external db
Not tested code hot loading.

Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Fixes Failure:
==> chef-server: Running provisioner: chef_zero...
    chef-server: Installing Chef (latest)...
Vagrant could not detect Chef on the guest! Even after Vagrant
attempted to install Chef, it could still not find Chef on the system.
Please make sure you are connected to the Internet and can access
Chef's package distribution servers. If you already have Chef
installed on this guest, you can disable the automatic Chef detection
by setting the 'install' option in the Chef configuration section of
your Vagrantfile:

    chef.install = false