### PR TITLE
Build and test on RHEL 8

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,8 +9,9 @@ fips-platforms:
 builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
-    - el-8-x86_64
     - amazon-2-x86_64
+  el-8-x86_64:
+    - el-8-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
This avoids el7 in the package name which is being flagged by
vulnerability scanners and calling issues for fedramp customers.

Signed-off-by: Tim Smith <tsmith@chef.io>