### PR TITLE
Revert "Build and test on RHEL 8"

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,9 +9,8 @@ fips-platforms:
 builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
-    - amazon-2-x86_64
-  el-8-x86_64:
     - el-8-x86_64
+    - amazon-2-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
RHEL8 fails to compile our old perl release so we need to wait on the new Perl release before we can build on RHEL8.

See https://github.com/chef/chef-server/issues/2166 for the perl work.

This reverts commit abcf660f5239854af56e4dd67b7dbb20cd96c635.
Signed-off-by: Tim Smith <tsmith@chef.io>
