### PR TITLE
Cleanup the docs / man pages from postgresql install

### DIFF
--- a/omnibus/config/software/postgresql96.rb
+++ b/omnibus/config/software/postgresql96.rb
@@ -55,5 +55,9 @@ build do
     Dir.glob("#{install_dir}/embedded/postgresql/#{short_version}/bin/*").sort.each do |bin|
       link bin, "#{install_dir}/embedded/bin/#{File.basename(bin)}"
     end
+
+    delete "#{install_dir}/embedded/postgresql/#{short_version}/share/doc"
+    delete "#{install_dir}/embedded/postgresql/#{short_version}/share/man"
+
   end
 end


### PR DESCRIPTION
This frees up a ton of space in the install for docs that won't actually
display

Signed-off-by: Tim Smith <tsmith@chef.io>