### PR TITLE
Add an omnibus definition to cleanup leftover ruby files in the install

### DIFF
--- a/omnibus/config/software/more-ruby-cleanup-server.rb
+++ b/omnibus/config/software/more-ruby-cleanup-server.rb
@@ -1,0 +1,35 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "more-ruby-cleanup-server"
+
+skip_transitive_dependency_licensing true
+license :project_license
+
+source path: "#{project.files_path}/#{name}"
+
+dependency "ruby"
+
+build do
+  block "Delete bundler git cache, docs, and build info" do
+    gemdir = File.expand_path("#{install_dir}/embedded/service/gem/ruby/*/")
+
+    remove_directory "#{gemdir}/cache"
+    remove_directory "#{gemdir}/doc"
+    remove_directory "#{gemdir}/build_info"
+  end
+end

--- a/omnibus/config/software/server-complete.rb
+++ b/omnibus/config/software/server-complete.rb
@@ -67,3 +67,6 @@ dependency "oc_erchef"
 dependency "oc-chef-pedant"
 dependency "private-chef-upgrades"
 dependency "private-chef-cookbooks"
+
+# ruby cleanup that's specific to how oc-id is installed in server
+dependency "more-ruby-cleanup-server"


### PR DESCRIPTION
This is 99% the same as what we're already doing in the ruby-cleanup
definition, but the paths are specific to where we install for oc-id

Signed-off-by: Tim Smith <tsmith@chef.io>