### PR TITLE
Add retries to the elasticsearch/redis service starts to resolve restore issues

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/elasticsearch.rb
@@ -158,8 +158,13 @@ link '/opt/opscode/embedded/elasticsearch/config' do
   to elasticsearch_conf_dir
 end
 
+# While Restoring the chef server backup, enable is always successful 
+# but start is not which is the root cause of restore issue.
+# So added retries for making sure the elasticsearch runit service is running
 component_runit_service 'elasticsearch' do
   action [:enable, :start]
+  retries 10
+  retry_delay 1
 end
 
 include_recipe 'private-chef::elasticsearch_index'

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/redis_lb.rb
@@ -82,6 +82,8 @@ component_runit_service 'redis_lb'
 # Restart the redis_lb runit service.
 runit_service 'redis_lb' do
   action :restart
+  retries 10
+  retry_delay 1
   only_if { is_data_master? }
 end
 


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

after applying backup few services are not getting started(runsv)

### Issues Resolved

There is some action issue in ES recipe which are enable & start. It was intentionally added for elasticsearch_index.rb recipe.
Verifying the impact after removing start from elasticsearch.rb recipe. There are still some more errors while restarting redis_lb & nginx.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
