### PR TITLE
Update FrequentTasks.md

### DIFF
--- a/dev-docs/FrequentTasks.md
+++ b/dev-docs/FrequentTasks.md
@@ -208,3 +208,25 @@ chef-server/src/bookshelf/rebar.lock
 chef-server/src/oc_erchef/rebar.lock
 chef-server/src/oc_bifrost/rebar.lock
 ```
+
+## Buildkite Artifacts (omnibus/adhoc)
+
+Build artifacts are no longer automatically published to artifactory, in order to speed up pipeline runs in cases where artifacts aren't needed.  To publish an artifact in Artifactory's unstable channel, you must first set the Buildkite environment variable `PUBLISH_TO_ARTIFACTORY=true`. (**Buildkite web UI > New Build > Options** opens the Environment Variables settings).
+
+It may be possible to have the artifacts for the nightlies published to artifactory by adding an environment variable to .expeditor/config.yml (untested):
+
+```
+diff --git a/.expeditor/config.yml b/.expeditor/config.yml
+index 36962f703..ac772214e 100644
+--- a/.expeditor/config.yml
++++ b/.expeditor/config.yml
+@@ -43,6 +43,7 @@ pipelines:
+  - omnibus/adhoc:
+       definition: .expeditor/release.omnibus.yml
+       env:
+         - ADHOC: true
++        - PUBLISH_TO_ARTIFACTORY: true
+   - post-promote:
+       description: "Generate and upload release manifest"
+       definition: .expeditor/post-promote.pipeline.yml
+```


### PR DESCRIPTION
## Buildkite Artifacts (omnibus/adhoc)

If you want an artifact to appear in Artifactory's unstable channel, you must now set `PUBLISH_TO_ARTIFACTORY=true` in the Environment Variables section of the Buildkite web GUI.  Select New Build, then select Options in the popup to open the Environment Variables section.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
