### PR TITLE
deprecation note added to the chef backend docs

### DIFF
--- a/docs-chef-io/content/server/backend_failure_recovery.md
+++ b/docs-chef-io/content/server/backend_failure_recovery.md
@@ -14,6 +14,10 @@ aliases = ["/backend_failure_recovery.html", "/backend_failure_recovery/"]
     weight = 20
 +++
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 This document contains the recommended actions for responding to
 failures in your Chef Backend cluster.
 

--- a/docs-chef-io/content/server/backend_failure_recovery.md
+++ b/docs-chef-io/content/server/backend_failure_recovery.md
@@ -14,9 +14,7 @@ aliases = ["/backend_failure_recovery.html", "/backend_failure_recovery/"]
     weight = 20
 +++
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 This document contains the recommended actions for responding to
 failures in your Chef Backend cluster.

--- a/docs-chef-io/content/server/config_rb_backend.md
+++ b/docs-chef-io/content/server/config_rb_backend.md
@@ -14,6 +14,10 @@ aliases = ["/config_rb_backend.html", "/config_rb_backend/"]
     weight = 30
 +++
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 ## chef-backend.rb Options
 
 {{% config_rb_backend_summary %}}

--- a/docs-chef-io/content/server/config_rb_backend.md
+++ b/docs-chef-io/content/server/config_rb_backend.md
@@ -14,9 +14,7 @@ aliases = ["/config_rb_backend.html", "/config_rb_backend/"]
     weight = 30
 +++
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 ## chef-backend.rb Options
 

--- a/docs-chef-io/content/server/ctl_chef_backend.md
+++ b/docs-chef-io/content/server/ctl_chef_backend.md
@@ -14,6 +14,10 @@ aliases = ["/ctl_chef_backend.html"]
     weight = 20
 +++
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 The Chef Infra Server backend HA cluster includes a command-line utility
 named chef-backend-ctl. This command-line tool is used to manage the
 Chef Infra Server backend HA cluster, start and stop individual

--- a/docs-chef-io/content/server/ctl_chef_backend.md
+++ b/docs-chef-io/content/server/ctl_chef_backend.md
@@ -14,9 +14,7 @@ aliases = ["/ctl_chef_backend.html"]
     weight = 20
 +++
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 The Chef Infra Server backend HA cluster includes a command-line utility
 named chef-backend-ctl. This command-line tool is used to manage the

--- a/docs-chef-io/content/server/install_server_ha.md
+++ b/docs-chef-io/content/server/install_server_ha.md
@@ -14,6 +14,10 @@ aliases = ["/install_server_ha.html"]
     weight = 20
 +++
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 This topic introduces the underlying concepts behind the architecture of
 the high availability Chef Infra Server cluster. The topic then
 describes the setup and installation process for a high availability

--- a/docs-chef-io/content/server/install_server_ha.md
+++ b/docs-chef-io/content/server/install_server_ha.md
@@ -14,9 +14,7 @@ aliases = ["/install_server_ha.html"]
     weight = 20
 +++
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 This topic introduces the underlying concepts behind the architecture of
 the high availability Chef Infra Server cluster. The topic then

--- a/docs-chef-io/content/server/install_server_tiered.md
+++ b/docs-chef-io/content/server/install_server_tiered.md
@@ -14,9 +14,7 @@ aliases = ["/install_server_tiered.html", "/install_server_tiered/"]
     weight = 50
 +++
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 This topic describes how to set up the Chef Infra Server with a single
 back end and multiple load-balanced frontend servers.

--- a/docs-chef-io/content/server/install_server_tiered.md
+++ b/docs-chef-io/content/server/install_server_tiered.md
@@ -14,6 +14,10 @@ aliases = ["/install_server_tiered.html", "/install_server_tiered/"]
     weight = 50
 +++
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 This topic describes how to set up the Chef Infra Server with a single
 back end and multiple load-balanced frontend servers.
 

--- a/docs-chef-io/content/server/server_backup_restore.md
+++ b/docs-chef-io/content/server/server_backup_restore.md
@@ -57,6 +57,10 @@ chef-server-ctl restore /path/to/tar/archive.tar.gz
 
 ## Backup and restore a Chef Backend install
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 In a disaster recovery scenario, the backup and restore processes allow
 you to restore a data backup into a newly built cluster. It is not
 intended for the recovery of an individual machine in the chef-backend

--- a/docs-chef-io/content/server/server_backup_restore.md
+++ b/docs-chef-io/content/server/server_backup_restore.md
@@ -57,9 +57,7 @@ chef-server-ctl restore /path/to/tar/archive.tar.gz
 
 ## Backup and restore a Chef Backend install
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 In a disaster recovery scenario, the backup and restore processes allow
 you to restore a data backup into a newly built cluster. It is not

--- a/docs-chef-io/content/server/upgrade_server_ha_v2.md
+++ b/docs-chef-io/content/server/upgrade_server_ha_v2.md
@@ -15,9 +15,7 @@ aliases = ["/upgrade_server_ha_v2.html", "/upgrade_server_ha_v2/"]
     weight = 70
 +++
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 This topic describes the process of upgrading a high availability Chef Infra Server cluster.
 

--- a/docs-chef-io/content/server/upgrade_server_ha_v2.md
+++ b/docs-chef-io/content/server/upgrade_server_ha_v2.md
@@ -15,6 +15,10 @@ aliases = ["/upgrade_server_ha_v2.html", "/upgrade_server_ha_v2/"]
     weight = 70
 +++
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 This topic describes the process of upgrading a high availability Chef Infra Server cluster.
 
 {{% server_upgrade_duration %}}

--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -128,9 +128,7 @@ If you are running a Chef Infra Server release prior to 12.3.0 please contact Ch
 
 ### Chef Backend Install
 
-{{< warning >}}
 {{% EOL_backend %}}
-{{< /warning >}}
 
 The Chef Infra Server can operate in a high availability configuration that provides automated load balancing and failover for stateful components in the system architecture.
 

--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -128,6 +128,10 @@ If you are running a Chef Infra Server release prior to 12.3.0 please contact Ch
 
 ### Chef Backend Install
 
+{{< warning >}}
+{{% EOL_backend %}}
+{{< /warning >}}
+
 The Chef Infra Server can operate in a high availability configuration that provides automated load balancing and failover for stateful components in the system architecture.
 
 To upgrade your Chef Backend installation, see [High Availability: Upgrade to Chef Backend 2]({{< relref "upgrade_server_ha_v2" >}}).


### PR DESCRIPTION
Signed-off-by: Dishank Tiwari <dtiwari@progress.com>

### Description

The origin of this PR : https://github.com/chef/chef-web-docs/issues/3063

The deprecation note has been added to the Chef Backend docs. The warning has already been added and merged to the chef-web-docs repo via https://github.com/chef/chef-web-docs/pull/3120 PR.
