### PR TITLE
Add retries to the nginx service starts to resolve restore issues

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -243,7 +243,13 @@ cookbook_file File.join(nginx_addon_dir, 'README.md') do
 end
 
 # Set up runit service for nginx component
-component_runit_service 'nginx'
+# While Restoring the chef server backup, start is not always successful.
+# So added retries for making sure the nginx runit service is running
+component_runit_service 'nginx' do
+  action [:enable, :start]
+  retries 10
+  retry_delay 1
+end
 
 # log rotation
 template '/etc/opscode/logrotate.d/nginx' do


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

after applying backup nginx service is not getting started(runsv)

### Issues Resolved

This is resolved by adding retry mechanism.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
