### PR TITLE
Filtering the webserver information in the nginx default error responses

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -26,6 +26,8 @@ http {
   # logged to the request log.
   log_not_found off;
 
+  error_page 301 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417
+      418 421 422 423 424 425 426 428 429 431 451 500 501 502 504 505 506 507 508 510 511 = @errorrespfilter;
   server_names_hash_bucket_size <%= @server_names_hash_bucket_size %>;
 
   sendfile <%= @sendfile %>;
@@ -148,6 +150,13 @@ http {
             more_clear_headers Server;
             access_log /var/log/opscode/nginx/rewrite-port-80.log;
             return 301 https://$host$request_uri;
+            location @errorrespfilter {
+              return 301 https://$host$request_uri;
+              header_filter_by_lua_block { ngx.header.content_length = nil }
+              body_filter_by_lua '
+              ngx.arg[1] = ngx.re.sub(ngx.arg[1],"openresty", "chef")
+              ';
+            }
           }
       <%- end -%>
     <%-  end %>

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -48,6 +48,8 @@
 
     error_page 404 =404 /404.html;
     error_page 503 =503 /503.json;
+    error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 
+      418 421 422 423 424 425 426 428 429 431 451 500 501 502 504 505 506 507 508 510 511 = @errorrespfilter;
 
     # Whitelist the docs necessary to serve up error pages and friendly
     # html to non-chef clients hitting this host.
@@ -208,5 +210,11 @@
       rewrite_by_lua_file '<%=@script_path%>/dispatch.lua';
       proxy_pass http://$upstream;
       proxy_redirect http://$upstream /;
+    }
+    location @errorrespfilter {
+      header_filter_by_lua_block { ngx.header.content_length = nil }
+      body_filter_by_lua '
+      ngx.arg[1] = ngx.re.sub(ngx.arg[1],"openresty", "chef")
+      ';
     }
   }


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

The internal server software used by the chef-server is revealed by the web server(nginx/openresty) in the default error reponses.

### Issues Resolved

https://app.zenhub.com/workspaces/chef-infra-server-team-5fc64867d45ca500173dbbc7/issues/chef/customer-bugs/373

**Solved -** 

- openresty version/openresty server info in all the success/opscode-erchef generated responses - Solved by 'server_tokens off;' nginx tag
- openresty verison info in all the default nginx error responses - Solved by 'server_tokens off;' nginx tag
- openresty server name in the default nginx error reponses - solved by the 'body_filter_by_lua' directive(PR #2539 ). 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
