### PR TITLE
Document update for new allow_email_update_only_from_manage config

### DIFF
--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -1198,6 +1198,15 @@ This configuration file has the following settings for
 
 This configuration file has the following settings for `opscode-erchef`:
 
+`opscode_erchef["allow_email_update_only_from_manage"]`
+
+:   Set to `true`, users can only update their email from the Chef management console.
+    Set to `false`, users can update their email using knife and the Chef management console.
+
+    Default value : `false`.
+
+    **New in Chef Infra Server 14.5**
+
 `opscode_erchef['auth_skew']`
 
 :   Default value: `900`.


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Documentation update for new allow_email_update_only_from_manage config

### Issues Resolved
#2545 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
