### PR TITLE
Set the default FIPS lb url to https to resolve failures during upgrades

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc-chef-pedant.rb
@@ -46,7 +46,12 @@ end
 # at least one shared protocol version. Leaving failure unhandled here,
 # since it means that a pedant run is not possible.
 ssl_version = allowed_versions.first.gsub('.', '_').to_sym
-reindex_endpoint = node['private_chef']['fips_enabled'] ? 'http://127.0.0.1' : 'https://127.0.0.1'
+
+# In the older version of FIPS, TLS directives were not supported and hence it had to be connected to http
+# currently FIPS supports https. 
+# If enable_non_ssl is set to false in nginx, the reindexing fails when it tries to make a http connection
+# https://github.com/chef/chef-server/blob/fd06de39ffcc65e06f03c99a2301f295ad43e526/src/chef-server-ctl/lib/chef_server_ctl/config.rb#L23
+reindex_endpoint = node['private_chef']['nginx']['enable_non_ssl'] ? 'http://127.0.0.1' : 'https://127.0.0.1'
 
 template pedant_config do
   owner 'root'

--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -20,7 +20,7 @@ module ChefServerCtl
     DEFAULT_KNIFE_CONFIG_FILE = "/etc/opscode/pivotal.rb".freeze
     DEFAULT_KNIFE_BIN = "/opt/opscode/embedded/bin/knife".freeze
     DEFAULT_LB_URL = "https://127.0.0.1".freeze
-    DEFAULT_FIPS_LB_URL = "http://127.0.0.1".freeze
+    DEFAULT_FIPS_LB_URL = "https://127.0.0.1".freeze
     DEFAULT_ERCHEF_REINDEX_SCRIPT = "/opt/opscode/embedded/service/opscode-erchef/bin/reindex-opc-organization".freeze
     DOC_PATENT_MSG = <<-DOC.freeze
 


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description
This issue occurs if FIPS is enabled on a system and http is disabled in loadbalancer.
in /opt/opscode/chef-server.rb
nginx['enable_non_ssl'] = false

Bug:
By default the lb url is set to http since tls directives were not available to use with older versions of erlang.
https://github.com/chef/chef-server/blob/master/src/chef-server-ctl/lib/chef_server_ctl/config.rb#L23

But the newer versions support https. It might be worth changing this default value to be https.

Test:
DEFAULT_FIPS_LB_URL = "http://127.0.0.1"
nginx['enable_non_ssl'] = true -> reindex pass
nginx['enable_non_ssl'] = true -> pedant pass
nginx['enable_non_ssl'] = false -> reindex fail
nginx['enable_non_ssl'] = false -> pedant fail

DEFAULT_FIPS_LB_URL = "https://127.0.0.1"
nginx['enable_non_ssl'] = true -> reindex pass
nginx['enable_non_ssl'] = true -> pedant pass
nginx['enable_non_ssl'] = false -> reindex pass
nginx['enable_non_ssl'] = false -> pedant pass

Docs:
https://docs.chef.io/server/config_rb_server_optional_settings/ - fips setting and nginx['enable_non_ssl'] settings are good place to include note to add env var for lb.

### Issues Resolved

https://github.com/chef/chef-server/issues/2389

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
