### PR TITLE
Add a note to help fix reindex errors seen in fips env when nginx['enable_non_ssl'] = false

### DIFF
--- a/docs-chef-io/content/server/ctl_chef_server.md
+++ b/docs-chef-io/content/server/ctl_chef_server.md
@@ -925,6 +925,10 @@ This subcommand has the following syntax:
 chef-server-ctl reindex
 ```
 
+{{< note >}}
+Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+{{< /note >}}
+
 **Options**
 
 This subcommand has the following options:

--- a/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
@@ -53,7 +53,13 @@ This configuration file has the following general settings:
 
 :   Set to `true` to run the server in FIPS compliance mode. Set to
     `false` to force the server to run without FIPS compliance mode.
-    Default value is whatever the kernel is configured to.
+    Default: The kernel configuration FIPS value.
+
+    {{< note >}}
+
+    Chef Infra Server versions earlier than 14.5 that are configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+
+    {{< /note >}}
 
 <div id="config_rb_server_insecure_addon_compat" markdown="1">
 
@@ -611,6 +617,12 @@ This configuration file has the following settings for `nginx`:
     `true`, load balancers on the front-end hardware are allowed to do
     SSL termination of the WebUI and API. Default value: `false`.
 
+    {{< note >}}
+
+    Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+
+    {{< /note >}}
+
 `nginx['enable_stub_status']`
 
 :   Enables the Nginx `stub_status` module. See
@@ -743,7 +755,7 @@ This configuration file has the following settings for `nginx`:
 `nginx['ssl_protocols']`
 
 :   The SSL protocol versions that are enabled. For enhanced security set
-    this value to `'TLSv1.2'`. TLS 1.2 is supported on Chef Infra Client 10.16.4 
+    this value to `'TLSv1.2'`. TLS 1.2 is supported on Chef Infra Client 10.16.4
     and later on Linux, Unix, and macOS, and on Chef Infra Client 12.8 and later on
     Windows. If it is necessary to support these older end-of-life
     Chef Infra Client releases, set this value to `'TLSv1.1 TLSv1.2'`.

--- a/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v13_2/config_rb_server_optional_settings.md
@@ -55,11 +55,11 @@ This configuration file has the following general settings:
     `false` to force the server to run without FIPS compliance mode.
     Default: The kernel configuration FIPS value.
 
-    {{< note >}}
+{{< note  spaces=4 >}}
 
-    Chef Infra Server versions earlier than 14.5 that are configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+Chef Infra Server versions earlier than 14.5 that are configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
 
-    {{< /note >}}
+{{< /note >}}
 
 <div id="config_rb_server_insecure_addon_compat" markdown="1">
 
@@ -617,11 +617,9 @@ This configuration file has the following settings for `nginx`:
     `true`, load balancers on the front-end hardware are allowed to do
     SSL termination of the WebUI and API. Default value: `false`.
 
-    {{< note >}}
-
-    Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
-
-    {{< /note >}}
+{{< note  spaces=4 >}}
+Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+{{< /note >}}
 
 `nginx['enable_stub_status']`
 

--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -53,10 +53,13 @@ This configuration file has the following general settings:
 
 :   Set to `true` to run the server in FIPS compliance mode. Set to
     `false` to force the server to run without FIPS compliance mode.
-    Default value is whatever the kernel is configured to.
-    NOTE: For `chef-server-ctl reindex <options>` to work in versions of Infra Server before 14.5,
-    when `nginx['enable_non_ssl'] = false` and `fips = true`
-    `export CSC_LB_URL=https://127.0.0.1`
+    Default: The value in the kernel configuration.
+
+    {{< note >}}
+
+    Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+
+    {{< /note >}}
 
 `insecure_addon_compat`
 
@@ -588,12 +591,14 @@ This configuration file has the following settings for `nginx`:
 
 `nginx['enable_non_ssl']`
 
-:   Allow port 80 redirects to port 443. When this value is set to
-    `true`, load balancers on the front-end hardware are allowed to do
-    SSL termination of the WebUI and API. Default value: `false`.
-    NOTE: For `chef-server-ctl reindex <options>` to work in versions of Infra Server before 14.5,
-    when `nginx['enable_non_ssl'] = false` and `fips = true`
-    `export CSC_LB_URL=https://127.0.0.1`
+:   Allow port 80 redirects to port 443. Set to
+    `true`, to enable SSL termination by the front-end hardware load balancers for WebUI and API endpoints. Default value: `false`.
+
+    {{< note >}}
+
+    Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+
+    {{< /note >}}
 
 `nginx['enable_stub_status']`
 
@@ -730,7 +735,7 @@ This configuration file has the following settings for `nginx`:
     Starting with Chef Infra Server 14.3, this value defaults to `'TLSv1.2'` for
     enhanced security. Previous releases defaulted to `'TLSv1 TLSv1.1 TLSv1.2'`,
     which allowed for less secure SSL connections. TLS 1.2 is supported on
-    Chef Infra Client 10.16.4 and later on Linux, Unix, and macOS, and on Chef 
+    Chef Infra Client 10.16.4 and later on Linux, Unix, and macOS, and on Chef
     Infra Client 12.8 and later on Windows. If it is necessary to support these older end-of-life
     Chef Infra Client releases, set this value to `'TLSv1.1 TLSv1.2'`.
 

--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -54,6 +54,9 @@ This configuration file has the following general settings:
 :   Set to `true` to run the server in FIPS compliance mode. Set to
     `false` to force the server to run without FIPS compliance mode.
     Default value is whatever the kernel is configured to.
+    NOTE: For `chef-server-ctl reindex <options>` to work in versions of Infra Server before 14.5,
+    when `nginx['enable_non_ssl'] = false` and `fips = true`
+    `export CSC_LB_URL=https://127.0.0.1`
 
 `insecure_addon_compat`
 
@@ -588,6 +591,9 @@ This configuration file has the following settings for `nginx`:
 :   Allow port 80 redirects to port 443. When this value is set to
     `true`, load balancers on the front-end hardware are allowed to do
     SSL termination of the WebUI and API. Default value: `false`.
+    NOTE: For `chef-server-ctl reindex <options>` to work in versions of Infra Server before 14.5,
+    when `nginx['enable_non_ssl'] = false` and `fips = true`
+    `export CSC_LB_URL=https://127.0.0.1`
 
 `nginx['enable_stub_status']`
 

--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -55,11 +55,9 @@ This configuration file has the following general settings:
     `false` to force the server to run without FIPS compliance mode.
     Default: The value in the kernel configuration.
 
-    {{< note >}}
-
-    Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
-
-    {{< /note >}}
+{{< note  spaces=4 >}}
+Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+{{< /note >}}
 
 `insecure_addon_compat`
 
@@ -594,11 +592,9 @@ This configuration file has the following settings for `nginx`:
 :   Allow port 80 redirects to port 443. Set to
     `true`, to enable SSL termination by the front-end hardware load balancers for WebUI and API endpoints. Default value: `false`.
 
-    {{< note >}}
-
-    Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
-
-    {{< /note >}}
+{{< note  spaces=4 >}}
+Chef Infra Server versions earlier than 14.5 configured with `nginx['enable_non_ssl'] = false` and `fips = true` require `export CSC_LB_URL=https://127.0.0.1` to run the command `chef-server-ctl reindex <options>`
+{{< /note >}}
 
 `nginx['enable_stub_status']`
 


### PR DESCRIPTION
point customers to export CSC_LB_URL=https://127.0.0.1 on versions prior to 14.5 of Chef Infra server when fips is enabled and nginx['enable_non_ssl'] = false

Signed-off-by: Prajakta Purohit <prajakta@chef.io>
