### PR TITLE
adds configurable option to run nginx master process as non-root user

### DIFF
--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -724,7 +724,7 @@ This configuration file has the following settings for `nginx`:
     Starting with Chef Infra Server 14.3, this value defaults to `'TLSv1.2'` for
     enhanced security. Previous releases defaulted to `'TLSv1 TLSv1.1 TLSv1.2'`,
     which allowed for less secure SSL connections. TLS 1.2 is supported on
-    Chef Infra Client 10.16.4 and later on Linux, Unix, and macOS, and on Chef 
+    Chef Infra Client 10.16.4 and later on Linux, Unix, and macOS, and on Chef
     Infra Client 12.8 and later on Windows. If it is necessary to support these older end-of-life
     Chef Infra Client releases, set this value to `'TLSv1.1 TLSv1.2'`.
 
@@ -820,6 +820,14 @@ This configuration file has the following settings for `nginx`:
 :   Time duration in seconds till which the browser caches the `HSTS` information.
     Possible values: greater than or equal to `31536000` and less than or equal to `63072000`.
     Default value: `31536000` (1 year).
+
+`user['nginx_no_root']`
+
+:   Boolean, default `false`.  Specifies that `nginx` processes, including the `master` process, should not
+    run as the `root` user on a system and will instead run as `user['username']` (defaults to `opscode`).
+    **REQUIRES** that `nginx['ssl_port']` and `nginx['non_ssl_port']` options are configured to non-privileged
+    ports greater than `1024` or that the local system is otherwise allowed to bind to privileged ports
+    with the user `user['username']`.
 
 ### oc_bifrost
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -80,7 +80,7 @@ default['private_chef']['user']['username'] = 'opscode'
 default['private_chef']['user']['shell'] = '/usr/sbin/nologin'
 # The home directory for the chef services user
 default['private_chef']['user']['home'] = '/opt/opscode/embedded'
-# The home directory for the chef services user
+# Whether nginx should be configured to not use the root user
 default['private_chef']['user']['nginx_no_root'] = false
 
 ####

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -80,6 +80,8 @@ default['private_chef']['user']['username'] = 'opscode'
 default['private_chef']['user']['shell'] = '/usr/sbin/nologin'
 # The home directory for the chef services user
 default['private_chef']['user']['home'] = '/opt/opscode/embedded'
+# The home directory for the chef services user
+default['private_chef']['user']['nginx_no_root'] = false
 
 ####
 # Service data_dir, etc_dir, log_directory perms

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/fix_permissions.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/fix_permissions.rb
@@ -24,3 +24,14 @@ end
 execute "find #{GEM_PATH} -perm /u=r,g=r,o=r ! -perm /u=x -exec chmod 644 {} \\;" do
   user 'root'
 end
+
+[
+  '/opt/opscode/embedded/nginx',
+  "#{node['private_chef']['nginx']['dir']}",
+  "#{node['private_chef']['nginx']['log_directory']}",
+].each do |nginx_no_root_perms_fix_path|
+  execute "find #{nginx_no_root_perms_fix_path} -user 'root' -exec chown #{node['private_chef']['user']['username']} {} \\;" do
+    user 'root'
+    only_if { node['private_chef']['user']['nginx_no_root'] }
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/nginx.rb
@@ -109,8 +109,8 @@ end
 if node['private_chef']['required_recipe']['enable']
   remote_file ::File.join(nginx_html_dir, 'required_recipe') do
     source "file://#{node['private_chef']['required_recipe']['path']}"
-    owner 'root'
-    group 'root'
+    owner OmnibusHelper.new(node).ownership['owner']
+    group OmnibusHelper.new(node).ownership['group']
     mode '0644'
   end
 end
@@ -122,8 +122,8 @@ if node['private_chef']['nginx']['ssl_dhparam'].nil?
   openssl_dhparam ssl_dhparam do
     key_length node['private_chef']['nginx']['dhparam_key_length']
     generator node['private_chef']['nginx']['dhparam_generator_id']
-    owner 'root'
-    group 'root'
+    owner OmnibusHelper.new(node).ownership['owner']
+    group OmnibusHelper.new(node).ownership['group']
     mode '0600'
   end
 
@@ -134,8 +134,8 @@ end
 remote_directory nginx_html_dir do
   source 'html'
   files_backup false
-  files_owner 'root'
-  files_group 'root'
+  files_owner OmnibusHelper.new(node).ownership['owner']
+  files_group OmnibusHelper.new(node).ownership['group']
   files_mode '0644'
   owner OmnibusHelper.new(node).ownership['owner']
   group OmnibusHelper.new(node).ownership['group']
@@ -169,8 +169,8 @@ lbconf = node['private_chef']['lb'].to_hash.merge(nginx_vars).merge(
 ].each do |script|
   template File.join(nginx_scripts_dir, script) do
     source "nginx/scripts/#{script}.erb"
-    owner 'root'
-    group 'root'
+    owner OmnibusHelper.new(node).ownership['owner']
+    group OmnibusHelper.new(node).ownership['group']
     mode '0644'
     variables lbconf
     # Note that due to JIT compile of lua resources, any
@@ -206,8 +206,8 @@ end
 
   template lb_config do
     source 'nginx/nginx_chef_api_lb.conf.erb'
-    owner 'root'
-    group 'root'
+    owner OmnibusHelper.new(node).ownership['owner']
+    group OmnibusHelper.new(node).ownership['group']
     mode '0644'
     variables(lbconf.merge(
       server_proto: server_proto,
@@ -227,8 +227,8 @@ nginx_config = File.join(nginx_etc_dir, 'nginx.conf')
 
 template nginx_config do
   source 'nginx/nginx.conf.erb'
-  owner 'root'
-  group 'root'
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
   mode '0644'
   variables(lbconf.merge(chef_lb_configs).merge(temp_dir: nginx_tempfile_dir))
   notifies :restart, 'component_runit_service[nginx]'
@@ -237,8 +237,8 @@ end
 # Write out README.md for addons dir
 cookbook_file File.join(nginx_addon_dir, 'README.md') do
   source 'nginx/nginx-addons.README.md'
-  owner 'root'
-  group 'root'
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
   mode '0644'
 end
 
@@ -254,8 +254,8 @@ end
 # log rotation
 template '/etc/opscode/logrotate.d/nginx' do
   source 'logrotate.erb'
-  owner 'root'
-  group 'root'
+  owner OmnibusHelper.new(node).ownership['owner']
+  group OmnibusHelper.new(node).ownership['group']
   mode '0644'
   variables(node['private_chef']['nginx'].to_hash.merge(
     'postrotate' => "/opt/opscode/embedded/sbin/nginx -c #{nginx_config} -s reopen",

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/nginx/nginx.conf.erb
@@ -1,4 +1,6 @@
+<% unless node['private_chef']['user']['nginx_no_root'] %>
 user <%= node['private_chef']['user']['username'] %> <%= node['private_chef']['user']['username']%>;
+<% end %>
 worker_processes <%= @worker_processes %>;
 error_log /var/log/opscode/nginx/error.log<%= node['private_chef']['lb']['debug'] ? " debug" : "" %>;
 # Enviroment variables that we wish to access while running must be declared here,

--- a/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-nginx-run.erb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/templates/default/sv-nginx-run.erb
@@ -1,5 +1,10 @@
 #!/bin/sh
 exec 2>&1
 exec /opt/opscode/embedded/bin/veil-env-helper -o DATA_COLLECTOR_TOKEN=data_collector.token -s REDIS_PASSWORD=redis_lb.password -- \
-  chpst -P env TZ=UTC <%= "OPENSSL_CONF=/opt/opscode/embedded/ssl/openssl.fips.cnf" if node['private_chef']['fips_enabled'] %> \
+  chpst \
+  <% if node['private_chef']['user']['nginx_no_root'] %>
+  -U <%= node['private_chef']['user']['username'] %> \
+  -u <%= node['private_chef']['user']['username'] %> \
+  <% end %>
+  -P env TZ=UTC <%= "OPENSSL_CONF=/opt/opscode/embedded/ssl/openssl.fips.cnf" if node['private_chef']['fips_enabled'] %> \
   /opt/opscode/embedded/sbin/nginx -c <%= File.join(node['private_chef']['nginx']['dir'], "etc", "nginx.conf") %>


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

### Description

Adds a boolean configurable option to the `chef-server.rb` file of `user['nginx_no_root']`.  This setting will update the `runsv` process that launches `nginx` to not use the `root` user on a system, even for the `master` nginx process.

* Adds attribute `default['private_chef']['user']['nginx_no_root'] = false` 
* Updates docs page for optional `chef-server.rb` settings with details of the function and considerations
* Updates the `fix_permissions` recipe to include `nginx`-related directories if `['nginx_no_root']` is enabled.
* Updates the `nginx` recipe configuration to use proper permissions for resources rather than hard-coded to `root:root`
* Updates the `nginx.conf` template to _not_ specify a `user` if `['nginx_no_root']` is enabled as this will generate an error when launching `nginx` daemon if this is populated and the `master` process is already set to the `worker` user.

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
