### PR TITLE
Update openresty to v1.19.3.2 in habitat builds

### DIFF
--- a/src/openresty-noroot/habitat/plan.sh
+++ b/src/openresty-noroot/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=openresty-noroot
 pkg_origin=chef
-pkg_version=1.13.6.2
+pkg_version=1.19.3.2
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_license=('BSD-2-Clause')
@@ -8,7 +8,7 @@ pkg_source=https://openresty.org/download/openresty-${pkg_version}.tar.gz
 pkg_dirname=openresty-${pkg_version}
 pkg_filename=openresty-${pkg_version}.tar.gz
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942
+pkg_shasum=ce40e764990fbbeb782e496eb63e214bf19b6f301a453d13f70c4f363d1e5bb9
 pkg_deps=(
   core/bzip2
   core/coreutils
@@ -35,8 +35,7 @@ pkg_exports=(
 )
 pkg_exposes=(port)
 
-# TODO: current version is 1.0.1, we should try updating
-lpeg_version="0.12"
+lpeg_version="1.0.1"
 lpeg_source="http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-${lpeg_version}.tar.gz"
 
 do_prepare() {


### PR DESCRIPTION
### Description

Update openresty (and lpeg) that gets packaged with hab to the same version as what gets built via omnibus.

### Issues Resolved

#1697 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
