### PR TITLE
Exclude the habitat directory in the brakeman scans

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Scan
       continue-on-error: true
       run: |
-        brakeman -f sarif -o output.sarif.json src/oc-id
+        brakeman -f sarif -o output.sarif.json src/oc-id --skip-files habitat/
 
     # Upload the SARIF file generated in the previous step
     - name: Upload SARIF


### PR DESCRIPTION
This dir has files that can't be parsed correctly and don't matter to
rails static analysis.

Signed-off-by: Tim Smith <tsmith@chef.io>