### PR TITLE
Update Ruby to 2.7.4

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: b02a8c311c403c102a79ba1c1d8c0ce689d93373
+  revision: e9feb357a695b6d022e7da2bb535baf5d53e8e84
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 8b5010716d8363d1300d4e6031dcd89e28082841
+  revision: 5c1b453f577c54ab4b75c45e5949906bd916371a
   branch: master
   specs:
     omnibus (8.1.12)
@@ -33,8 +33,8 @@ GEM
     artifactory (3.0.15)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.473.0)
-    aws-sdk-core (3.115.0)
+    aws-partitions (1.475.0)
+    aws-sdk-core (3.116.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -46,7 +46,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.3)
+    aws-sigv4 (1.2.4)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt_pbkdf (1.1.0)
     berkshelf (7.2.2)
@@ -101,7 +101,7 @@ GEM
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
     chef-cleanroom (1.0.2)
-    chef-cli (5.1.0)
+    chef-cli (5.3.0)
       addressable (>= 2.3.5, < 2.8)
       chef (>= 15.0)
       cookbook-omnifetch (~> 0.5)
@@ -148,7 +148,7 @@ GEM
     ed25519 (1.2.4)
     erubi (1.10.0)
     erubis (2.7.0)
-    faraday (1.4.2)
+    faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -179,7 +179,7 @@ GEM
     highline (2.0.3)
     httpclient (2.8.3)
     iniparse (1.5.0)
-    inspec-core (4.37.30)
+    inspec-core (4.38.3)
       addressable (~> 2.4)
       chef-telemetry (~> 1.0, >= 1.0.8)
       faraday (>= 0.9.0, < 1.5)
@@ -305,7 +305,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     rubyntlm (0.6.3)
-    rubyzip (2.3.1)
+    rubyzip (2.3.2)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -406,4 +406,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   2.2.15
+   2.2.22

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -12,13 +12,9 @@ provisioner:
   product_name: chef
 
 platforms:
-  - name: ubuntu-16.04
-    run_list: apt::default
   - name: ubuntu-18.04
     run_list: apt::default
   - name: centos-7
-    run_list:  yum-centos::default
-  - name: centos-8
     run_list:  yum-centos::default
   - name: sles-12
     driver:

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -6,7 +6,7 @@ override :erlang, version: "22.2"
 override :'omnibus-ctl', version: "master"
 override :chef, version: "v16.13.16"
 override :ohai, version: "v16.13.0"
-override :ruby, version: "2.7.3"
+override :ruby, version: "2.7.4"
 override :perl, version: "5.18.1"
 
 override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently


### PR DESCRIPTION
There are multiple CVEs in Ruby 2.7.3 to update.

Signed-off-by: Tim Smith <tsmith@chef.io>