### PR TITLE
Update pg gem to 1.2.3

### DIFF
--- a/dev-docs/FrequentTasks.md
+++ b/dev-docs/FrequentTasks.md
@@ -135,6 +135,34 @@ directory.
 11) If other gems need updating, go back to step 6, otherwise you are
 done.
 
+### Steps to Update the PG Gem in chef-server
+
+1) `cd` to the directory containing the .gemspec in chef-server-ctl for PG gem update.
+
+2) Rename or otherwise backup and delete the Gemfile.lock.
+
+3) Edit the .gemspec file to update the PG gem(s).
+
+4) chef-server-ctl depends on PG gem and chef_fixie which also depends on the PG gem.
+
+5) Make sure to update chef_fixie gem in the rubygem.org with same PG gem version otherwise chef-server-ctl fails with dependency conflict error.
+
+5) After publishing the `chef_fixie`, The chef-server gemspec changes can be tested in dev vm
+
+6) `ssh` into a dev vm.  Do `sudo -i` or otherwise login as root.
+
+6) `cd` to the directory containing the edited .gemspec
+file, using /host as the root directory, e.g. /host/src/chef-server-ctl.
+
+7) generate .gem file
+```
+/opt/opscode/embedded/bin/gem build *.gemspec
+```
+8) install .gem file
+```
+/opt/opscode/embedded/bin/gem install *.gem
+```
+
 ## Updating Chef Client
 
 - Ensure that the versions in the following locations are consistent.

--- a/omnibus/config/software/server-complete.rb
+++ b/omnibus/config/software/server-complete.rb
@@ -32,7 +32,6 @@ dependency "openssl-fips-config" if fips_mode?
 dependency "postgresql96"
 dependency "redis" # dynamic routing controls
 dependency "haproxy"
-dependency "pg-gem" # used by private-chef-ctl reconfigure
 dependency "elasticsearch" # used by search
 
 # moved earlier because it is external to this repo and pinned, so should change infrequently

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/ec_postgres.rb
@@ -56,7 +56,7 @@ class EcPostgres
     require 'pg'
     postgres = node['private_chef']['postgresql']
     as_user(postgres['username']) do
-      connection = ::PGconn.open('dbname' => database, :port => postgres['port'])
+      connection = ::PG::Connection.open('dbname' => database, :port => postgres['port'])
       begin
         yield connection
       ensure

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user.rb
@@ -69,7 +69,7 @@ action_class do
       pg_shadow_info = connection.exec('select passwd from pg_shadow where usename = $1', [ new_resource.username ])
       if pg_shadow_info.ntuples > 0
         pg_shadow_info = pg_shadow_info[0]
-        if new_resource.password && pg_shadow_info['passwd'] != ::PGconn.encrypt_password(new_resource.password, new_resource.username)
+        if new_resource.password && pg_shadow_info['passwd'] != ::PG::Connection.encrypt_password(new_resource.password, new_resource.username)
           changes << '  Update password'
           sql << " ENCRYPTED PASSWORD '#{connection.escape(new_resource.password)}'"
         end

--- a/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
+++ b/omnibus/files/private-chef-upgrades/001/020_multi_key_schema_migration.rb
@@ -12,7 +12,7 @@ define_upgrade do
     running_config = JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
     pc = running_config['private_chef']
     keyname = pc['opscode-erchef'].has_key?('sql_user') ? 'opscode-erchef' : 'postgresql'
-    connection = ::PGconn.open('user' => pc[keyname]['sql_user'],
+    connection = ::PG::Connection.open('user' => pc[keyname]['sql_user'],
                                'host' => pc['postgresql']['vip'],
                                'password' => Partybus.config.secrets.get('opscode_erchef', 'sql_password'),
                                'port' => pc['postgresql']['port'],

--- a/omnibus/partybus/lib/partybus/migration_api/v1.rb
+++ b/omnibus/partybus/lib/partybus/migration_api/v1.rb
@@ -93,7 +93,7 @@ module Partybus
       def pg_conn_for(service, opts = {})
         require 'pg'
         options = default_opts_for_service(service).merge(opts)
-        ::PGconn.open({'user' => options[:username],
+        ::PG::Connection.open({'user' => options[:username],
                       'password' => options[:password],
                       'dbname' => options[:database],
                       'host' => Partybus.config.postgres['vip'],

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       mixlib-install
       mixlib-log
       omnibus-ctl
-      pg (~> 0.17, >= 0.17.1)
+      pg (~> 1.2, >= 1.2.3)
       pry
       rb-readline
       redis
@@ -106,10 +106,10 @@ GEM
     chef_backup (0.1.1)
       highline (~> 1.6, >= 1.6.9)
       mixlib-shellout (>= 2.0, < 4.0)
-    chef_fixie (0.5.1)
-      chef (>= 15.2)
+    chef_fixie (1.0.2)
+      chef (>= 16)
       ffi-yajl (>= 1.2.0)
-      pg (~> 0.17, >= 0.17.1)
+      pg (~> 1.2, >= 1.2.3)
       pry (~> 0.13)
       sequel (~> 4.11)
       uuidtools (~> 2.1, >= 2.1.3)
@@ -203,7 +203,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0225)
+    mime-types-data (3.2021.0704)
     minitar (0.9)
     mixlib-archive (1.1.7)
       mixlib-log
@@ -258,7 +258,7 @@ GEM
     pastel (0.8.0)
       tty-color (~> 0.5)
     pbkdf2 (0.1.0)
-    pg (0.21.0)
+    pg (1.2.3)
     plist (3.6.0)
     proxifier (1.0.3)
     pry (0.14.1)

--- a/src/chef-server-ctl/chef-server-ctl.gemspec
+++ b/src/chef-server-ctl/chef-server-ctl.gemspec
@@ -27,8 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "pry"
   spec.add_runtime_dependency "rb-readline"
 
-  # investigate what it would take to upgrade this...
-  spec.add_runtime_dependency "pg", "~> 0.17", ">= 0.17.1"
+  spec.add_runtime_dependency "pg", '~> 1.2', '>= 1.2.3'
 
   spec.add_runtime_dependency "redis"
   # TODO
@@ -52,7 +51,7 @@ Gem::Specification.new do |spec|
   # tools we bundle in the chef-server install and include here so we can have a single Gemfile.lock
   # for the overall chef-server "app"
   spec.add_runtime_dependency "knife-ec-backup"
-  spec.add_runtime_dependency "chef_fixie"
+  spec.add_runtime_dependency "chef_fixie" 
 
   # Used to resolve download urls
   spec.add_runtime_dependency "mixlib-install"


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Update to the latest pg gem in our tooling

### Issues Resolved
Updated the pg gem to 1.2.3

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
