### PR TITLE
Expand data gather-logs collects + better align with automate

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -29,7 +29,7 @@ then
 
     if [[ ! -e "/opt/$path/bin/$ctl_cmd" ]];
     then
-        echo "ERROR: Chef Server may not be installed."
+        echo "ERROR: Chef Infra Server may not be installed."
         exit 1
     fi
 elif [[ $type == 'OSC' ]];
@@ -187,17 +187,27 @@ umask > "$tmpdir/umask.txt"
 
 uptime > "$tmpdir/uptime.txt"
 
-cp "/proc/cpuinfo" "$tmpdir/cpuinfo.txt"
+mkdir -p "$tmpdir/proc/sys/crypto/"
 
-cp "/proc/meminfo" "$tmpdir/meminfo.txt"
+cp "/proc/cpuinfo" "$tmpdir/proc/cpuinfo"
 
-free -m > "$tmpdir/free-m.txt"
+cp "/proc/meminfo" "$tmpdir/proc/meminfo"
+
+cp "/proc/version" "$tmpdir/proc/version"
+
+cp "/proc/sys/crypto/fips_enabled" "$tmpdir/proc/sys/crypto/fips_enabled"
+
+free -m > "$tmpdir/free_m.txt"
 
 ps fauxww > "$tmpdir/ps_fauxww.txt"
 
-df -h >  "$tmpdir/df_h.txt"
+df -h > "$tmpdir/df_h.txt"
 
-df -i >  "$tmpdir/df_i.txt"
+df -i > "$tmpdir/df_i.txt"
+
+df -k > "$tmpdir/df_k.txt"
+
+/opt/opscode/bin/ohai > "$tmpdir/ohai.txt"
 
 if [[ -e /opt/opscode-manage/bin/opscode-manage-ctl ]];
 then


### PR DESCRIPTION
Ideally we should gather the same-ish system data for automate and chef server so that one day we can process these gather logs and get some value from them

- stick proc files in /proc to match Automate
- Gather fips status to match Automate
- Gather /proc/version to match Automate
- Rename free-m.txt to free_m.txt to match our standard pattern and align with Automate
- Gather df -k to align with automate
- Gather the output of Ohai which has a bunch of troubleshooting data.

Signed-off-by: Tim Smith <tsmith@chef.io>