### PR TITLE
Rename aws to amazon in the gather-logs script

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -176,7 +176,7 @@ then
     known_platform="rhel"
 elif [[ -f "/etc/os-release" ]] && grep -q "Amazon Linux 2" /etc/os-release;
 then
-    known_platform="aws"
+    known_platform="amazon"
     cat "/etc/os-release" >> "$tmpdir/platform_version.txt"
     cat "/etc/system-release-cpe" >> "$tmpdir/platform_version.txt"
 else
@@ -331,7 +331,7 @@ then
 
     rpm -qa | $installed_packages_grep >> "$installed_packages_file"
 
-elif [[ $known_platform == 'aws' ]];
+elif [[ $known_platform == 'amazon' ]];
 then
 
     rpm -qa | $installed_packages_grep >> "$installed_packages_file"


### PR DESCRIPTION
This just prevents developer confusion. This is a check for Amazon Linux. Don't confuse that with systems running on AWS.

Signed-off-by: Tim Smith <tsmith@chef.io>