### PR TITLE
Add lsblk output to gather logs to check for non-SSD drives

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -77,6 +77,9 @@ PATH=/opt/$path/embedded/bin:$PATH
 
 mkdir -p "$tmpdir"
 
+# grab information on all the drive / mountpoints including if they are SSD or not
+`lsblk -o name,mountpoint,size,type,rota --json` > "$tmpdir/lsblk.txt"
+
 for i in /opt/{chef,$path}*/version-manifest.txt \
               /opt/$path/pc-version.txt \
               /etc/$path/$config_name \


### PR DESCRIPTION
This came up in an escalation today. Large installs need to not be on
spinning rust and we can provide this output to support so they can add
it to their parsing tool.

Signed-off-by: Tim Smith <tsmith@chef.io>