### PR TITLE
Update docs.chef.io and GitHub links to avoid redirects or 404s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2413,7 +2413,7 @@ https://raw.githubusercontent.com/antirez/redis/2.8/00-RELEASENOTES
 * Expose `db_timeout` for sqerl in Erchef, bifrost and mover as a parameter
   that can be set in the "/etc/opscode/chef-server.rb" file for convenience.
   By default there is a hard coded value of 5 seconds (5000ms) as per:
-  [sqerl\_client.erl](https://github.com/opscode/sqerl/blob/master/src/sqerl_client.erl#L134)
+  [sqerl\_client.erl](https://github.com/chef/sqerl/blob/master/src/sqerl_client.erl#L134)
 * Select appropriate default port for LDAP and LDAPS (when encryption is
   selected, as previously user had to manually add port to make it work).
 * Expose `proxy_connect_timeout` for Nginx when it connects to the backends,
@@ -2976,7 +2976,7 @@ https://raw.githubusercontent.com/antirez/redis/2.8/00-RELEASENOTES
 ## 11.1.0 (2014-02-06)
 
 ### omnibus-ruby 1.3.0
-* https://github.com/opscode/omnibus-ruby/blob/master/CHANGELOG.md#130-december-6-2013
+* https://github.com/chef/omnibus-ruby/blob/master/CHANGELOG.md#130-december-6-2013
 
 ### omnibus-software 3d9d097332199fdafc3237c0ec11fcd784c11b4d
 * [keepalived] update to 1.2.9 + patch for Centos 5.5

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository is the central repository for the Chef Server.
 
 If you want to file an issue about Chef Server or contribute a change, you're in the right place.
 
-If you need to file an issue against another Chef project, you can find a list of projects and where to file issues in the [community contributions section](https://docs.chef.io/community_contributions.html#issues-and-bug-reports) of the [Chef docs](https://docs.chef.io).
+If you need to file an issue against another Chef project, you can find a list of projects and where to file issues in the [community contributions section](https://docs.chef.io/community_contributions/#issues-and-bug-reports) of the [Chef docs](https://docs.chef.io).
 
 ## Getting Help
 

--- a/oc-chef-pedant/README.md
+++ b/oc-chef-pedant/README.md
@@ -75,7 +75,7 @@ There are some tests that only make sense to run in certain environments or that
 
 WARNING: Do not perform this testing on a production environment as it interacts with actual LDAP credentials.
 
-You will need LDAP running on your EC test server with a valid LDAP user. Follow the instructions here to get LDAP running with EC http://docs.chef.io/server_ldap.html.
+You will need LDAP running on your EC test server with a valid LDAP user. Follow the instructions here to get LDAP running with EC https://docs.chef.io/server_ldap/.
 
 Please update the entries in `pedant_config.rb`. Set `ldap_testing` to true,
 and fill in ldap({}) with your LDAP credentials a user on the test server you pointed EC at above.

--- a/oc-chef-pedant/spec/api/cookbook_artifacts/create_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbook_artifacts/create_spec.rb
@@ -303,7 +303,7 @@ describe "Cookbook Artifacts API endpoint", :cookbook_artifacts, :cookbook_artif
               'service[snuggle]'           => '0.0.1'  }
           ].each do |valid_provides|
 
-            # http://docs.chef.io/config_rb_metadata.html#provides
+            # https://docs.chef.io/config_rb_metadata/#provides
             context "with metadata.providing set to valid value #{valid_provides}" do
 
               let(:payload) { update_payload_metadata("providing", valid_provides) }

--- a/oc-chef-pedant/spec/api/cookbooks/create_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/create_spec.rb
@@ -179,7 +179,7 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_create do
           context "with metadata.providing" do
             after(:each) { delete_cookbook admin_user, cookbook_name, cookbook_version }
 
-            # http://docs.chef.io/config_rb_metadata.html#provides
+            # https://docs.chef.io/config_rb_metadata/#provides
             should_create_with_metadata 'providing', 'cats::sleep'
             should_create_with_metadata 'providing', 'here(:kitty, :time_to_eat)'
             should_create_with_metadata 'providing', 'service[snuggle]'

--- a/oc-chef-pedant/spec/api/cookbooks/update_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks/update_spec.rb
@@ -886,7 +886,7 @@ describe "Cookbooks API endpoint", :cookbooks, :cookbooks_update do
 
             after(:each) { delete_cookbook admin_user, cookbook_name, cookbook_version }
 
-            # http://docs.chef.io/config_rb_metadata.html#provides
+            # https://docs.chef.io/config_rb_metadata/#provides
             should_change_with_metadata 'providing', 'cats::sleep'
             should_change_with_metadata 'providing', 'here(:kitty, :time_to_eat)'
             should_change_with_metadata 'providing', 'service[snuggle]'

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -217,7 +217,7 @@ class PostgresqlPreflightValidator < PreflightValidator
       CSPG001: The value of postgresql['external'] must be set prior to the initial
                run of chef-server-ctl reconfigure and cannot be changed.
 
-               See https://docs.chef.io/error_messages.html#cspg001-changed-setting
+               See https://docs.chef.io/errors/#cspg001-changed-setting
                for more information on how you can transition an existing chef-server
                to a new instance configured for an external database and vice-versa.
     EOM
@@ -230,7 +230,7 @@ class PostgresqlPreflightValidator < PreflightValidator
                for external database support - please set it now and
                then re-run 'chef-server-ctl reconfigure'.
 
-               See https://docs.chef.io/server_components.html#postgresql-settings
+               See https://docs.chef.io/server/#postgresql-settings
                for more information.
     EOM
   end
@@ -242,7 +242,7 @@ class PostgresqlPreflightValidator < PreflightValidator
                for external database support - please run this now, then
                re-run 'chef-server-ctl reconfigure'.
 
-               See https://docs.chef.io/server_components.html#postgresql-settings
+               See https://docs.chef.io/server/#postgresql-settings
                for more information.
     EOM
   end
@@ -253,7 +253,7 @@ class PostgresqlPreflightValidator < PreflightValidator
                postgresql['vip'] to the host or IP of an external postgres database
                in chef-server.rb.
 
-               See https://docs.chef.io/server_components.html#postgresql-settings
+               See https://docs.chef.io/server/#postgresql-settings
                for more information.
     EOM
   end
@@ -265,7 +265,7 @@ class PostgresqlPreflightValidator < PreflightValidator
                you have configured postgresql['port'] if it's not the standard
                port 5432, then run 'chef-server-ctl reconfigure' again.
 
-               See https://docs.chef.io/error_messages.html#cspg010-cannot-connect
+               See https://docs.chef.io/errors/#cspg010-cannot-connect
                for more information about postgresql networking requirements.
     EOM
   end
@@ -278,7 +278,7 @@ CSPG011: I could not authenticate to #{cs_pg_attr['vip']} as
          chef-server.rb under "postgresql['db_superuser_password'] is correct
          for this user.
 
-         See https://docs.chef.io/error_messages.html#cspg011-cannot-authenticate
+         See https://docs.chef.io/errors/#cspg011-cannot-authenticate
          for more information.
 EOM
   end
@@ -292,7 +292,7 @@ CSPG012: There is a missing or incorrect pg_hba.conf entry for the
          allow the application accounts to connect from all Chef Server
          nodes.
 
-         See https://docs.chef.io/error_messages.html#cspg012-incorrect-rules
+         See https://docs.chef.io/errors/#cspg012-incorrect-rules
          for more information.
 EOM
   end
@@ -303,7 +303,7 @@ EOM
                superuser access to the to the database specified.  At minimum, this
                user must be granted CREATE DATABASE and CREATE ROLE privileges.
 
-               See https://docs.chef.io/error_messages.html#cspg013-incorrect-permissions
+               See https://docs.chef.io/errors/#cspg013-incorrect-permissions
                for more information.
     EOM
   end
@@ -313,7 +313,7 @@ EOM
       CSPG014: Chef Server currently requires PostgreSQL version #{REQUIRED_MAJOR}.#{REQUIRED_MINOR} or greater.
                The database you have provided is running version #{ver}.
 
-               See https://docs.chef.io/error_messages.html#cspg014-incorrect-version
+               See https://docs.chef.io/errors/#cspg014-incorrect-version
                for more information.
     EOM
   end
@@ -324,7 +324,7 @@ EOM
                template1 available.  Please create the template1 database before
                proceeding.
 
-               See https://docs.chef.io/error_messages.html#cspg015-missing-database
+               See https://docs.chef.io/errors/#cspg015-missing-database
                for more information.
     EOM
   end
@@ -334,7 +334,7 @@ EOM
       CSPG016: The Chef Server database named '#{dbname}' already exists on the
                PostgreSQL server. Please remove it before proceeding.
 
-               See https://docs.chef.io/error_messages.html#cspg016-database-exists
+               See https://docs.chef.io/errors/#cspg016-database-exists
                for more information.
     EOM
   end
@@ -347,7 +347,7 @@ EOM
                troubleshooting link below for information about configuring
                Chef Server to use an alternative user name.
 
-               See https://docs.chef.io/error_messages.html#cspg017-user-exists
+               See https://docs.chef.io/errors/#cspg017-user-exists
                for more information.
     EOM
   end

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
@@ -67,7 +67,7 @@ ruby_block 'migration-level file sanity check' do
     rescue Exception => e
       message = <<~EOF
         ERROR:
-        The /var/opt/opscode/upgrades/migration-level file is missing or corrupt!  Please read http://docs.chef.io/install_server_pre.html and correct this file before proceeding
+        The /var/opt/opscode/upgrades/migration-level file is missing or corrupt! Please read https://docs.chef.io/server/install_server_pre/ and correct this file before proceeding
 
         * If this is a new installation:
           run: "cd /opt/opscode/embedded/service/partybus ; /opt/opscode/embedded/bin/bundle exec bin/partybus init"

--- a/src/chef-mover/apps/chef_db/README.md
+++ b/src/chef-mover/apps/chef_db/README.md
@@ -1,46 +1,29 @@
-# Chef DB #
+# Chef DB
 
-This is the database layer for chef.
+This is the database layer for Chef Infra Server.
 
-Chef is a system integration framework written in erlang and ruby and designed to bring the benefits of configuration management to your entire infrastructure.
+Chef is a system integration framework written in Erlang and Ruby and designed to bring the benefits of configuration management to your entire infrastructure.
 
-The Chef Wiki is the definitive source of user documentation.
+The Chef Docs Site is the definitive source of user documentation.
 
-    http://wiki.chef.io/display/chef/Home
+    httpss://docs.chef.io
 
-This README focuses on developers who want to modify Chef source code.  For users who just want to run the latest and greatest Chef development version in their environment, see:
+This README focuses on developers who want to modify Chef source code.  For users who just want to run the latest and greatest Chef development version in their environment, see
+   [TODO: add URL when available for Erlang chef build process]
 
-   [TODO: add URL when available for erlang chef build process]
-
-# DEVELOPMENT:
-
-Before working on the code, if you plan to contribute your changes, you need to read the Opscode Contributing document.
-
-    http://wiki.chef.io/display/chef/How+to+Contribute
-
-You will also need to set up the repository with the appropriate branches. We document the process on the Chef Wiki.
-
-    http://wiki.chef.io/display/chef/Working+with+git
-
-Once your repository is set up, you can start working on the code.
-
-# LINKS:
+## Links
 
 Source:
 
-    https://github.com/opscode/chef_db
+    https://github.com/chef/chef-server
 
 Tickets/Issues:
 
-    http://tickets.chef.io/
+    https://github.com/chef/chef-server/issues
 
-Documentation:
+## License
 
-    http://wiki.chef.io/display/chef/Home/
-
-# LICENSE:
-
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright:: Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/chef-mover/apps/chef_index/README.md
+++ b/src/chef-mover/apps/chef_index/README.md
@@ -1,43 +1,30 @@
-# Chef Index #
+# Chef Index
 
-This is the search/indexing layer for chef.
+This is the search/indexing layer for Chef Infra Server.
 
-Chef is a system integration framework written in erlang and ruby and designed to bring the benefits of configuration management to your entire infrastructure.
+Chef Infra is a system integration framework written in Erlang and Ruby and designed to bring the benefits of configuration management to your entire infrastructure.
 
-The Chef Wiki is the definitive source of user documentation.
+The Chef Docs Site is the definitive source of user documentation.
 
-    https://docs.chef.io/
+    https://docs.chef.io
 
 This README focuses on developers who want to modify Chef source code.  For users who just want to run the latest and greatest Chef development version in their environment, see:
 
    [TODO: add URL when available for erlang chef build process]
 
-# DEVELOPMENT:
-
-Before working on the code, if you plan to contribute your changes, you need to read the Opscode Contributing document.
-You will also need to set up the repository with the appropriate branches. We document the process on the Chef Wiki.
-
-    https://github.com/chef/chef/blob/master/CONTRIBUTING.md
-
-Once your repository is set up, you can start working on the code.
-
-# LINKS:
+## Links
 
 Source:
 
-    https://github.com/opscode/chef_index
+    https://github.com/chef/chef-server
 
 Tickets/Issues:
 
-    http://tickets.chef.io/
+    https://github.com/chef/chef-server/issues
 
-Documentation:
+## License
 
-    https://docs.chef.io/
-
-# LICENSE:
-
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright:: Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/chef-mover/apps/chef_objects/README.md
+++ b/src/chef-mover/apps/chef_objects/README.md
@@ -1,46 +1,30 @@
-# Chef Objects #
+# Chef Objects
 
-This library defines the internal objects used by chef.
+This library defines the internal objects used by Chef Infra Server.
 
-Chef is a system integration framework written in erlang and ruby and designed to bring the benefits of configuration management to your entire infrastructure.
+Chef Infra is a system integration framework written in Erlang and Ruby and designed to bring the benefits of configuration management to your entire infrastructure.
 
-The Chef Wiki is the definitive source of user documentation.
+The Chef Docs Site is the definitive source of user documentation.
 
-    http://wiki.chef.io/display/chef/Home
+    https://docs.chef.io
 
 This README focuses on developers who want to modify Chef source code.  For users who just want to run the latest and greatest Chef development version in their environment, see:
 
    [TODO: add URL when available for erlang chef build process]
 
-# DEVELOPMENT:
-
-Before working on the code, if you plan to contribute your changes, you need to read the Opscode Contributing document.
-
-    http://wiki.chef.io/display/chef/How+to+Contribute
-
-You will also need to set up the repository with the appropriate branches. We document the process on the Chef Wiki.
-
-    http://wiki.chef.io/display/chef/Working+with+git
-
-Once your repository is set up, you can start working on the code.
-
-# LINKS:
+## Links
 
 Source:
 
-    https://github.com/opscode/chef_objects
+    https://github.com/chef/chef-server
 
 Tickets/Issues:
 
-    http://tickets.chef.io/
+    https://github.com/chef/chef-server/issues
 
-Documentation:
+## License
 
-    http://wiki.chef.io/display/chef/Home/
-
-# LICENSE:
-
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright:: Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/chef-mover/apps/oc_chef_authz/README.md
+++ b/src/chef-mover/apps/oc_chef_authz/README.md
@@ -1,67 +1,30 @@
-# Chef Authoriation #
+# Chef Authoriation
 
-This is the authorization layer for chef.
+This is the authorization layer for Chef Infra Server.
 
-Chef is a system integration framework written in erlang and ruby and designed to bring the benefits of configuration management to your entire infrastructure.
+Chef Infra is a system integration framework written in Erlang and Ruby and designed to bring the benefits of configuration management to your entire infrastructure.
 
-The Chef Wiki is the definitive source of user documentation.
+The Chef Docs Site is the definitive source of user documentation.
 
-    http://wiki.chef.io/display/chef/Home
+    https://docs.chef.io
 
 This README focuses on developers who want to modify Chef source code.  For users who just want to run the latest and greatest Chef development version in their environment, see:
 
    [TODO: add URL when available for erlang chef build process]
 
-## License
-
-All files in the repository are licensed under the Apache 2.0 license. If any
-file is missing the License header it should assume the following is attached;
-
-```
-Copyright 2014 Chef Software Inc
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-```
-
-# DEVELOPMENT:
-
-Before working on the code, if you plan to contribute your changes, you need to read the Opscode Contributing document.
-
-    http://wiki.chef.io/display/chef/How+to+Contribute
-
-You will also need to set up the repository with the appropriate branches. We document the process on the Chef Wiki.
-
-    http://wiki.chef.io/display/chef/Working+with+git
-
-Once your repository is set up, you can start working on the code.
-
-# LINKS:
+## Links
 
 Source:
 
-    https://github.com/opscode/chef_authz
+    https://github.com/chef/chef-server
 
 Tickets/Issues:
 
-    http://tickets.chef.io/
+    https://github.com/chef/chef-server/issues
 
-Documentation:
+## License
 
-    http://wiki.chef.io/display/chef/Home/
-
-# LICENSE:
-
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright:: Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -24,7 +24,7 @@ module ChefServerCtl
     DEFAULT_ERCHEF_REINDEX_SCRIPT = "/opt/opscode/embedded/service/opscode-erchef/bin/reindex-opc-organization".freeze
     DOC_PATENT_MSG = <<-DOC.freeze
 
-Documentation: https://docs.chef.io/server_overview/
+Documentation: https://docs.chef.io/server/
 Patents:       https://www.chef.io/patents
 
     DOC

--- a/src/nginx/habitat/plan.sh
+++ b/src/nginx/habitat/plan.sh
@@ -22,7 +22,7 @@ pkg_binds_optional=(
   [oc_id]="port"
 )
 pkg_description="NGINX configuration and content for Chef Server"
-pkg_upstream_url="https://docs.chef.io/server_components.html"
+pkg_upstream_url="https://docs.chef.io/server/"
 pkg_svc_run="openresty -c ${pkg_svc_config_path}/nginx.conf -p ${pkg_svc_var_path}"
 
 pkg_version() {

--- a/src/oc-id/CONTRIBUTING.md
+++ b/src/oc-id/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-Contributing to oc-id
-===========================
+# Contributing to oc-id
+
 Thanks for your interest in contributing to oc-id!
 
 The basic process:
-* Sign a Chef CLA (see below)
+
 * Create a git topic branch for your patch and push it to GitHub
 * Open a pull request
 
-The Apache License and Chef Contributor License Agreements
------------------------------------------------------------
+## The Apache License and Chef Contributor License Agreements
+
 Licensing is very important to open source projects, it helps ensure the software continues to be available under the terms that the author desired.
 Chef uses the Apache 2.0 license to strike a balance between open contribution and allowing you to use the software however you would like to.
 
@@ -23,27 +23,24 @@ It only takes a few minutes to complete a CLA, and you retain the copyright to y
 
 You can [become a contributor by signing the ICLA or by contributing on behalf of your company](http://supermarket.chef.io/become-a-contributor).
 
-For more information about licensing, copyright, and CLAs see Chef's [Community Contributions](http://docs.chef.io/community_contributions.html) page.
+For more information about licensing, copyright, and CLAs see Chef's [Community Contributions](https://docs.chef.io/community_contributions/) page.
 
-Working with the community
---------------------------
+## Working with the community
+
 These resources will help you learn more about Chef and connect to other members of the Chef community:
 
 * [chef](http://lists.chef.io/sympa/info/chef) and [chef-dev](http://lists.chef.io/sympa/info/chef-dev) mailing lists
-* #chef and #chef-hacking IRC channels on irc.freenode.net
-* [Chef docs](http://docs.chef.io)
+* [Chef docs](https://docs.chef.io)
 * Chef [product page](http://www.chef.io/chef)
 
+## Overview
 
-Overview
---------
 If you're experienced with the toolchain, here are the steps for submitting a patch to oc-id:
 
-1. [Fork the project](https://github.com/opscode/oc-id/fork) on GitHub
+1. [Fork the project](https://github.com/chef/chef-server/fork) on GitHub
 1. Create a feature branch:
 
         $ git checkout -b my_feature
 
 1. Make your changes, writing excellent commit messages and adding appropiate test coverage
-1. Open a [Pull Request](https://github.com/opscode/oc-id/pull) against the oc-id master branch on GitHub
-
+1. Open a [Pull Request](https://github.com/chef/chef-server/pull) against the chef-server master branch on GitHub

--- a/src/oc-id/MAINTAINERS.md
+++ b/src/oc-id/MAINTAINERS.md
@@ -7,7 +7,7 @@ your pull request. Additionally, you need to not receive a veto from a
 Lieutenant or the Project Lead.
 
 Check out
-[How Chef is Maintained](https://github.com/opscode/chef-rfc/blob/master/rfc030-maintenance-policy.md#how-the-project-is-maintained)
+[How Chef is Maintained](https://github.com/chef/chef-rfc/blob/master/rfc030-maintenance-policy.md#how-the-project-is-maintained)
 for details on the process, how to become a maintainer, lieutenant, or the
 project lead.
 

--- a/src/oc-id/README.md
+++ b/src/oc-id/README.md
@@ -27,7 +27,7 @@ To run this app you'll need:
 
 For instructions on configuring the Chef identity that is included with Chef
 server, see the
-[chef-server.rb Settings documentation](https://docs.chef.io/config_rb_server_optional_settings.html#oc-id).
+[chef-server.rb Settings documentation](https://docs.chef.io/server/config_rb_server_optional_settings/#oc-id-14).
 
 [RailsConfig](https://github.com/railsconfig/rails_config) is used for
 application configuration. The defaults are in config/settings.yml. You can
@@ -51,7 +51,7 @@ Applications that can be authorize against oc-id can be managed by
 administrators by going to /id/oauth/applications.
 
 The redirect URL is for applications using
-[omniauth-chef-oauth2](https://github.com/opscode/omniauth-chef-oauth2) is
+[omniauth-chef-oauth2](https://github.com/chef/omniauth-chef-oauth2) is
 usually something like `https://host:port/auth/chef_oauth2/callback`.
 
 ## Development
@@ -77,7 +77,7 @@ Historically we built assets in the omnibus pipeline, but that has
 proven difficult because nodejs no longer supports all of our
 platforms. Instead we are committing assets to git. This isn't ideal,
 as it makes it harder alter assets in the dev-vm; they are
-now synchronized from the host. 
+now synchronized from the host.
 
 You can locally compile assets with the command:
 

--- a/src/oc_bifrost/README.md
+++ b/src/oc_bifrost/README.md
@@ -32,7 +32,7 @@ after [Bifrost][], the burning rainbow bridge to Asgard in Norse mythology.
 [opscode-authz][] API server.
 
 [Bifrost]:http://en.wikipedia.org/wiki/Bifrost
-[opscode-authz]:https://github.com/opscode/opscode-authz
+[opscode-authz]:https://github.com/chef/opscode-authz
 
 TODO
 ====

--- a/src/oc_bifrost/doc/metrics.md
+++ b/src/oc_bifrost/doc/metrics.md
@@ -160,5 +160,5 @@ When the request is finished, several more metrics are generated.
   - `bifrost.application.byRequestType.$REQUEST_LABEL.$REQUEST_VERB.upstreamRequests.rdbms.bifrost_db.my_fun2`
   - `bifrost.application.byRequestType.$REQUEST_LABEL.$REQUEST_VERB.upstreamRequests.rdbms.bifrost_db.my_fun3`
 
-[estatsd]:https://github.com/opscode/estatsd
-[stats_hero]:https://github.com/opscode/stats_hero
+[estatsd]:https://github.com/chef/estatsd
+[stats_hero]:https://github.com/chef/stats_hero

--- a/src/oc_bifrost/schema/sqitch.plan
+++ b/src/oc_bifrost/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=bifrost
-%uri=https://github.com/opscode/oc_bifrost
+%uri=https://github.com/chef/oc_bifrost
 
 base 2013-06-24T11:10:23Z Christopher Maier <cm@opscode.com> # The initial base install of the bifrost schema
 forbid_group_cycles [base] 2013-06-24T13:04:05Z Christopher Maier <cm@opscode.com> # Add forbid_group_cycles function and accompanying trigger

--- a/src/oc_erchef/apps/chef_db/README.md
+++ b/src/oc_erchef/apps/chef_db/README.md
@@ -28,7 +28,7 @@ Once your repository is set up, you can start working on the code.
 
 Source:
 
-    https://github.com/opscode/chef_db
+    https://github.com/chef/chef_db
 
 Tickets/Issues:
 

--- a/src/oc_erchef/apps/chef_objects/README.md
+++ b/src/oc_erchef/apps/chef_objects/README.md
@@ -28,7 +28,7 @@ Once your repository is set up, you can start working on the code.
 
 Source:
 
-    https://github.com/opscode/chef_objects
+    https://github.com/chef/chef_objects
 
 Tickets/Issues:
 

--- a/src/oc_erchef/apps/oc_chef_authz/README.md
+++ b/src/oc_erchef/apps/oc_chef_authz/README.md
@@ -49,7 +49,7 @@ Once your repository is set up, you can start working on the code.
 
 Source:
 
-    https://github.com/opscode/chef_authz
+    https://github.com/chef/chef_authz
 
 Tickets/Issues:
 

--- a/src/oc_erchef/doc/API/acl.md
+++ b/src/oc_erchef/doc/API/acl.md
@@ -11,7 +11,7 @@ Authentication
 ----------
 
 This API uses the same authentication scheme as the rest of chef; see
-http://docs.chef.io/api_chef_server.html for a description.
+https://docs.chef.io/server/api_chef_server/ for a description.
 
 Tasks Remaining
 --------------
@@ -64,13 +64,13 @@ The two APIs available for these types
 Appended to the end of the appropriate path for the object type this returns the full ACL for an object.
 
 This is returned as a set of ACEs for each permission type (create,
-read, update, delete, grant, aka CRUDG). 
+read, update, delete, grant, aka CRUDG).
 { "create" : {"actors" : [ "user1" ...],
               "groups" : [ "group1" ... ] } ,
   "read" : ... ,
   "update" : ... ,
   "delete" : ... ,
-  "grant" : ... } 
+  "grant" : ... }
 
 The actors section contains both the _users_ and _clients_ by
 name. (NOTE: determine what happens when there is a user and client
@@ -96,11 +96,11 @@ It expects JSON of the form:
  "groups" : [ "group1" ... ] }
 
 The actors and groups are in the same format as returned in the GET
-above. 
+above.
 
 The authorization service manages the permissions for who can write an
 ACL; at this time we require 'grant' permission in the ACL to update
-it. 
+it.
 
 Implementation Notes
 ----------------
@@ -125,5 +125,3 @@ delivers most of the functionality early.
 The access policy (who can read/who can update) is determined in the
 bifrost\_wm\_acl\_action\_resource:auth_info function. Note that this
 resource also allows 'delete' which is not exposed to the end users.
-
-

--- a/src/oc_erchef/doc/API/containers.md
+++ b/src/oc_erchef/doc/API/containers.md
@@ -12,7 +12,7 @@ Authentication
 ----------
 
 These API use the same authentication scheme as the rest of chef; see
-http://docs.chef.io/api_chef_server.html for a description.
+https://docs.chef.io/server/api_chef_server/ for a description.
 
 Tasks Remaining
 ----------
@@ -36,14 +36,14 @@ an entity in authz; they are a way of providing a default set of permissions for
 object. Second, they serve as the source of the ACL used to authorize LIST and CREATE operations on
 objects.
 
-There's a container for every chef object type that has an ACL. At the present time these are: 
+There's a container for every chef object type that has an ACL. At the present time these are:
 'clients', 'containers, 'cookbooks',  'data', 'environments', 'groups', 'nodes', 'roles',
 'sandboxes'.
 These may be extended in the future. These are specific to an org, and each org as it's own
 copies. These are created when an org is created, and required for an org to function properly.
 
 There are also two global containers 'users' and 'organizations', used to regulate who can create
-and list these entities. 
+and list these entities.
 
 The actual container JSON object is very minimal:
 ```
@@ -126,7 +126,7 @@ TODO: Describe behavior when we fail validation for the structure.
 ##### Response
 
 The 'Location' header is set to `API_URL/organizations/ORGNAME/containers/NAME`, and the response
-body will be 
+body will be
 
 ```{ "uri" : "API_URL/organizations/ORGNAME/containers/NAME" }```
 
@@ -151,7 +151,7 @@ of authz acls, and most of the action will be done via the ACL resource.
 
 #### GET
 
-The GET method retrieves a container. It takes no parameters. 
+The GET method retrieves a container. It takes no parameters.
 
 Since the 'containerpath' field is in the process of being deprecated, it effectively returns no
 useful information beyond the name, which the requestor presumably already knows.
@@ -205,7 +205,7 @@ in model validation, and returns BadRequest. Containerpath can be updated and th
 perserved.
 
 In the opscode-account sql implementation, only containername can be changed; alterations to
-containerpath are ignored. 
+containerpath are ignored.
 TODO: test for SQL implmentations should verify we rename the object as opposed to creating a new
 one (probably with the same authz id).
 
@@ -260,4 +260,3 @@ s.match("/containers/", :method=>"get").to(:controller=>'containers', :action=>'
 s.match("/containers/:id", :id => /[\w\.-]+/, :method=>"get").to(:controller=>'containers', :action=>'show')
 s.match("/containers/:id", :id => /[\w\.-]+/, :method=>"put").to(:controller=>'containers', :action=>'update')
 s.match("/containers/:id", :id => /[\w\.-]+/, :method=>"delete").to(:controller=>'containers', :action=>'destroy')
-

--- a/src/oc_erchef/doc/API/groups.md
+++ b/src/oc_erchef/doc/API/groups.md
@@ -11,7 +11,7 @@ Authentication
 ----------
 
 This API uses the same authentication scheme as the rest of chef; see
-http://docs.chef.io/api_chef_server.html for a description.
+https://docs.chef.io/api_chef_server.html for a description.
 
 
 Tasks Remaining

--- a/src/oc_erchef/doc/oc_erchef-build-guide.org
+++ b/src/oc_erchef/doc/oc_erchef-build-guide.org
@@ -107,8 +107,8 @@ your build:
 2. Edit =config/software/oc_erchef.rb=. Change the version value to be
    the name of your oc_erchef feature branch. You might also need to
    update other components (e.g. oc-chef-pedant).
-3. If your changes require app config changes, edit the [[https://github.com/opscode/opscode-omnibus/blob/master/files/private-chef-cookbooks/private-chef/attributes/default.rb#L166][defaults]] and
-   [[https://github.com/opscode/opscode-omnibus/blob/master/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb][template]].
+3. If your changes require app config changes, edit the [[https://github.com/chef/opscode-omnibus/blob/master/files/private-chef-cookbooks/private-chef/attributes/default.rb#L166][defaults]] and
+   [[https://github.com/chef/opscode-omnibus/blob/master/files/private-chef-cookbooks/private-chef/templates/default/oc_erchef.config.erb][template]].
 4. Push your feature branch of opscode-omnibus
 
 * Trigger Build
@@ -120,7 +120,3 @@ prefix with origin. Example: =sf/a-feature=.
 The trigger should succeed quickly. You can click on a trigger job
 and in the left panel select "Downstream build view" to monitor
 progress.
-
-
-
-

--- a/src/oc_erchef/doc/openresty-deploy-plan.md
+++ b/src/oc_erchef/doc/openresty-deploy-plan.md
@@ -14,7 +14,7 @@ First, we'll "bake-test" an openresty load balancer to look for exceptional reso
 
 The OpenResty / Lua work has been combined into one pull request:
 
-* https://github.com/opscode/opscode-platform-cookbooks/pull/112
+* https://github.com/chef/opscode-platform-cookbooks/pull/112
 
 This will need to be merged before deploy. In order to simplify a potential rollback, prepend the first line of the merge commit with the following:
 

--- a/src/oc_erchef/raml-docs/README.md
+++ b/src/oc_erchef/raml-docs/README.md
@@ -6,7 +6,7 @@ RAML, see: [raml.org](http://raml.org)
 ## State of oc_erchef RAML Documentation
 
 Official and complete documentation of the Chef Server API is hosted at
-[docs.chef.io](http://docs.chef.io/api_chef_server.html). We find RAML
+[docs.chef.io](https://docs.chef.io/server/api_chef_server/). We find RAML
 useful during development of new features, but at this time have no
 plans to make these docs official or comprehensive.
 

--- a/src/oc_erchef/schema/README.md
+++ b/src/oc_erchef/schema/README.md
@@ -100,4 +100,4 @@ make
 
 The targets of the [Makefile](Makefile) actually call out to
 corresponding targets in the
-[Open Source Makefile](https://github.com/opscode/chef-server-schema/blob/master/Makefile).
+[Open Source Makefile](https://github.com/chef/chef-server-schema/blob/master/Makefile).

--- a/src/oc_erchef/schema/baseline/sqitch.plan
+++ b/src/oc_erchef/schema/baseline/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=oss_chef
-%uri=https://github.com/opscode/chef-server-schema
+%uri=https://github.com/chef/chef-server-schema
 
 osc_users 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # Open Source users table
 nodes 2013-09-04T14:07:22Z Christopher Maier <cm@opscode.com> # Nodes table

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0
 %project=enterprise_chef
-%uri=https://github.com/opscode/enterprise-chef-server-schema
+%uri=https://github.com/chef/enterprise-chef-server-schema
 
 drop_osc_users [oss_chef:osc_users] 2013-09-05T19:22:00Z Christopher Maier <cm@opscode.com> # Remove osc_users table
 users [drop_osc_users] 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # users table

--- a/src/oc_erchef/schema/t/monkey_patches.sql
+++ b/src/oc_erchef/schema/t/monkey_patches.sql
@@ -9,7 +9,7 @@
 -- have in place.
 --
 -- See
--- https://github.com/opscode/chef-sql-schema/commit/be4f85a1429e2b02aadea425e6e77fdcfe3d1c71
+-- https://github.com/chef/chef-sql-schema/commit/be4f85a1429e2b02aadea425e6e77fdcfe3d1c71
 -- for more details.
 CREATE OR REPLACE FUNCTION chef_pgtap.is_wide_uuid(p_table_name NAME, p_column_name NAME)
 RETURNS BOOLEAN


### PR DESCRIPTION
A lot of things have moved and not all these links work anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>