### PR TITLE
Update the omnibus cookbook lock to the latest

### DIFF
--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -1,10 +1,6 @@
 source 'https://supermarket.chef.io'
 
-# The apt cookbook is required to bring the apt cache up-to-date on Ubuntu
-# systems, since the cache can become stale on older boxes.
-cookbook 'apt'
-
-cookbook 'omnibus'
+cookbook 'omnibus', '~> 6.0'
 cookbook 'yum-centos'
 cookbook 'zip'
 

--- a/omnibus/Berksfile.lock
+++ b/omnibus/Berksfile.lock
@@ -1,14 +1,15 @@
 DEPENDENCIES
-  apt
-  omnibus
+  omnibus (~> 6.0)
   yum-centos
   zip
 
 GRAPH
-  apt (7.4.0)
+  ark (6.0.2)
+    seven_zip (>= 3.1)
   chef-ingredient (3.3.0)
   chef-sugar (5.1.12)
-  git (10.1.0)
+  git (11.0.0)
+    ark (>= 0.0.0)
   homebrew (5.2.1)
   omnibus (6.0.0)
     chef-ingredient (>= 0.21.4)

--- a/omnibus/Berksfile.lock
+++ b/omnibus/Berksfile.lock
@@ -2,22 +2,15 @@ DEPENDENCIES
   apt
   omnibus
   yum-centos
-  yum-epel
   zip
 
 GRAPH
-  apt (7.2.0)
-  build-essential (8.2.1)
-    mingw (>= 1.1)
-    seven_zip (>= 0.0.0)
-  chef-ingredient (3.1.2)
-  chef-sugar (5.1.8)
-  git (10.0.0)
-  homebrew (5.0.8)
-  mingw (2.1.0)
-    seven_zip (>= 0.0.0)
-  omnibus (5.7.2)
-    build-essential (>= 6.0.0)
+  apt (7.4.0)
+  chef-ingredient (3.3.0)
+  chef-sugar (5.1.12)
+  git (10.1.0)
+  homebrew (5.2.1)
+  omnibus (6.0.0)
     chef-ingredient (>= 0.21.4)
     chef-sugar (>= 3.2.0)
     git (>= 0.0.0)
@@ -25,12 +18,8 @@ GRAPH
     remote_install (>= 0.0.0)
     seven_zip (>= 0.0.0)
     wix (>= 0.0.0)
-  remote_install (2.0.0)
-  seven_zip (3.1.2)
-    windows (>= 0.0.0)
-  windows (6.0.1)
-  wix (5.0.0)
-    windows (>= 2.0)
-  yum-centos (3.2.0)
-  yum-epel (3.3.0)
+  remote_install (2.1.3)
+  seven_zip (4.2.1)
+  wix (6.0.1)
+  yum-centos (5.1.1)
   zip (1.1.0)

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -13,7 +13,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-18.04
-    run_list: apt::default
+    lifecycle:
+      pre_converge:
+      - remote: apt update
   - name: centos-7
     run_list:  yum-centos::default
   - name: sles-12


### PR DESCRIPTION
This gets us Chef Infra Client 16+ support in the dev environment

Signed-off-by: Tim Smith <tsmith@chef.io>