### PR TITLE
More cleanup of the configuration cookbook

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/.rubocop.yml
+++ b/omnibus/files/private-chef-cookbooks/private-chef/.rubocop.yml
@@ -1,6 +1,2 @@
 AllCops:
   TargetRubyVersion: 2.7
-
-# We need to turn this on, but it's going to require testing
-Chef/Deprecations/ResourceWithoutUnifiedTrue:
-  Enabled: false

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bifrost_database.rb
@@ -23,12 +23,12 @@ postgres_attrs = node['private_chef']['postgresql']
 
 # create users
 
-private_chef_pg_user bifrost_attrs['sql_user'] do
+pg_user bifrost_attrs['sql_user'] do
   password PrivateChef.credentials.get('oc_bifrost', 'sql_password')
   superuser false
 end
 
-private_chef_pg_user bifrost_attrs['sql_ro_user'] do
+pg_user bifrost_attrs['sql_ro_user'] do
   password PrivateChef.credentials.get('oc_bifrost', 'sql_ro_password')
   superuser false
 end
@@ -40,13 +40,13 @@ private_chef_pg_database 'bifrost' do
   notifies :deploy, 'private_chef_pg_sqitch[/opt/opscode/embedded/service/oc_bifrost/db]', :immediately
 end
 
-private_chef_pg_user_table_access bifrost_attrs['sql_user'] do
+pg_user_table_access bifrost_attrs['sql_user'] do
   database 'bifrost'
   schema 'public'
   access_profile :write
 end
 
-private_chef_pg_user_table_access bifrost_attrs['sql_ro_user'] do
+pg_user_table_access bifrost_attrs['sql_ro_user'] do
   database 'bifrost'
   schema 'public'
   access_profile :read

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/bookshelf_database.rb
@@ -18,12 +18,12 @@ bookshelf_attrs = node['private_chef']['bookshelf']
 postgres_attrs = node['private_chef']['postgresql']
 
 # create users
-private_chef_pg_user bookshelf_attrs['sql_user'] do
+pg_user bookshelf_attrs['sql_user'] do
   password PrivateChef.credentials.get('bookshelf', 'sql_password')
   superuser false
 end
 
-private_chef_pg_user bookshelf_attrs['sql_ro_user'] do
+pg_user bookshelf_attrs['sql_ro_user'] do
   password PrivateChef.credentials.get('bookshelf', 'sql_ro_password')
   superuser false
 end
@@ -35,13 +35,13 @@ private_chef_pg_database 'bookshelf' do
   notifies :deploy, 'private_chef_pg_sqitch[/opt/opscode/embedded/service/bookshelf/schema]', :immediately
 end
 
-private_chef_pg_user_table_access bookshelf_attrs['sql_user'] do
+pg_user_table_access bookshelf_attrs['sql_user'] do
   database 'bookshelf'
   schema 'public'
   access_profile :write
 end
 
-private_chef_pg_user_table_access bookshelf_attrs['sql_ro_user'] do
+pg_user_table_access bookshelf_attrs['sql_ro_user'] do
   database 'bookshelf'
   schema 'public'
   access_profile :read

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/erchef_database.rb
@@ -16,12 +16,12 @@
 postgres = node['private_chef']['postgresql']
 erchef = node['private_chef']['opscode-erchef']
 
-private_chef_pg_user erchef['sql_user'] do
+pg_user erchef['sql_user'] do
   password PrivateChef.credentials.get('opscode_erchef', 'sql_password')
   superuser false
 end
 
-private_chef_pg_user erchef['sql_ro_user'] do
+pg_user erchef['sql_ro_user'] do
   password PrivateChef.credentials.get('opscode_erchef', 'sql_ro_password')
   superuser false
 end
@@ -65,14 +65,14 @@ private_chef_pg_sqitch '/opt/opscode/embedded/service/opscode-erchef/schema' do
   action :nothing
 end
 
-private_chef_pg_user_table_access erchef['sql_user'] do
+pg_user_table_access erchef['sql_user'] do
   database 'opscode_chef'
   schema 'public'
   access_profile :write
   only_if { is_data_master? }
 end
 
-private_chef_pg_user_table_access erchef['sql_ro_user'] do
+pg_user_table_access erchef['sql_ro_user'] do
   database 'opscode_chef'
   schema 'public'
   access_profile :read

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id_database.rb
@@ -19,11 +19,11 @@
 id_attrs = node['private_chef']['oc_id']
 
 # create users
-private_chef_pg_user id_attrs['sql_user'] do
+pg_user id_attrs['sql_user'] do
   password PrivateChef.credentials.get('oc_id', 'sql_password')
 end
 
-private_chef_pg_user id_attrs['sql_ro_user'] do
+pg_user id_attrs['sql_ro_user'] do
   password PrivateChef.credentials.get('oc_id', 'sql_ro_password')
 end
 
@@ -31,7 +31,7 @@ private_chef_pg_database 'oc_id' do
   owner id_attrs['sql_user']
 end
 
-private_chef_pg_user_table_access id_attrs['sql_ro_user'] do
+pg_user_table_access id_attrs['sql_ro_user'] do
   database 'oc_id'
   schema 'public'
   access_profile :read

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/postgresql.rb
@@ -62,7 +62,7 @@ directory postgresql_dir do
 end
 
 # Upgrade the cluster if you gotta
-private_chef_pg_upgrade 'upgrade_if_necessary'
+pg_upgrade 'upgrade_if_necessary'
 
 component_runit_service 'postgresql' do
   control ['t']
@@ -120,7 +120,7 @@ if is_data_master?
   end
 
   # Update the postgresql superuser  with a password for tcp-based access.
-  private_chef_pg_user node['private_chef']['postgresql']['db_superuser'] do
+  pg_user node['private_chef']['postgresql']['db_superuser'] do
     password PrivateChef.credentials.get('postgresql', 'db_superuser_password')
     # This initial password set must be done over local socket:
     local_connection true

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/elasticsearch_index.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/elasticsearch_index.rb
@@ -16,7 +16,6 @@
 #
 
 provides :elasticsearch_index
-resource_name :elasticsearch_index
 
 property :index_name, String, name_property: true
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/elasticsearch_index.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/elasticsearch_index.rb
@@ -18,7 +18,7 @@
 provides :elasticsearch_index
 resource_name :elasticsearch_index
 
-property :index_name, name_property: true
+property :index_name, String, name_property: true
 
 property :server_url, kind_of: String
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/oc_id_application.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/oc_id_application.rb
@@ -18,9 +18,9 @@
 provides :oc_id_application
 resource_name :oc_id_application
 
-property :write_to_disk, kind_of: [TrueClass, FalseClass], default: false
+property :write_to_disk, [true, false], default: false
 
-property :redirect_uri, kind_of: String, required: true
+property :redirect_uri, String, required: true
 
 action :create do
   converge_by "create oc-id application '#{new_resource.name}'" do

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/oc_id_application.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/oc_id_application.rb
@@ -16,7 +16,6 @@
 #
 
 provides :oc_id_application
-resource_name :oc_id_application
 
 property :write_to_disk, [true, false], default: false
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/package_cleaner.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/package_cleaner.rb
@@ -22,56 +22,36 @@
 
 # Completely clean up after a given service / package
 
-property :package,
-  kind_of: String,
-  name_property: true
+property :package, String, name_property: true
 
 # Directories that should be recursively removed
-property :directories,
-  kind_of: Array,
-  default: []
+property :directories, Array, default: []
 
 # Files that should be removed
-property :files,
-  kind_of: Array,
-  default: []
+property :files, Array, default: []
 
 # Links that should be unlinked
-property :links,
-  kind_of: Array,
-  default: []
+property :links, Array, default: []
 
 # Users created for this service that should be removed
-property :users,
-  kind_of: Array,
-  default: []
+property :users, Array, default: []
 
 # Groups created for this service that should be removed
-property :groups,
-  kind_of: Array,
-  default: []
+property :groups, Array, default: []
 
 # Some packages to be removed are also governed by runit services.  In
 # that case, we'll need to remove the control files, links, etc, for
 # those services
-property :is_service,
-  kind_of: [TrueClass, FalseClass],
-  default: true
+property :is_service, [true, false], default: true
 
 # Directory where runit service folders are dropped off.
-property :service_root,
-  kind_of: String,
-  default: '/opt/opscode/sv'
+property :service_root, String, default: '/opt/opscode/sv'
 
 # Directory where *links* to the runit service folders are dropped off
-property :service_link_root,
-  kind_of: String,
-  default: '/opt/opscode/service'
+property :service_link_root, String, default: '/opt/opscode/service'
 
 # Directory where links to the sv binary are dropped off
-property :service_init_link_root,
-  kind_of: String,
-  default: '/opt/opscode/init'
+property :service_init_link_root, String, default: '/opt/opscode/init'
 
 action :clean do
   remove_service if new_resource.is_service

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_cluster.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_cluster.rb
@@ -14,9 +14,7 @@
 # limitations under the License.
 #
 
-property :data_dir,
-  kind_of: String,
-  name_property: true
+property :data_dir, String, name_property: true
 
 # NOTE: Uses the value of node['private_chef']['postgresql']['username'] as
 # the user to run the initdb command.  This user will also be the

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_database.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_database.rb
@@ -13,21 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-property :database,
-  kind_of: String,
-  name_property: true
+property :database, String, name_property: true
 
-property :owner,
-  kind_of: String,
-  required: false
+property :owner, String, required: false
 
-property :template,
-  kind_of: String,
-  default: 'template0'
+property :template, String, default: 'template0'
 
-property :encoding,
-  kind_of: String,
-  default: 'UTF-8'
+property :encoding, String, default: 'UTF-8'
 
 # NOTE: Uses the value of node['private_chef']['postgresql']['username'] as
 # the user to run the database-creation psql command

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_sqitch.rb
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 
-property :database,       kind_of: String, required: true
-property :username,       kind_of: String
-property :password,       kind_of: String, required: false, default: ''
-property :target_version, kind_of: String
-property :hostname,       kind_of: String, required: true
-property :port,           kind_of: Integer, required: true
-property :sslmode,        kind_of: String, required: false, default: 'disable'
+property :database,       String, required: true
+property :username,       String
+property :password,       String, required: false, default: ''
+property :target_version, String
+property :hostname,       String, required: true
+property :port,           Integer, required: true
+property :sslmode,        String, required: false, default: 'disable'
 
 action :deploy do
   target = new_resource.target_version ? "--to-target #{new_resource.target_version}" : ''

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_upgrade.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_upgrade.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-# That's right folks, there are no attributes.
+# That's right folks, there are no properties.
 
 # NOTE: Uses the value of certain node attributes in the course of execution.
 #
@@ -60,6 +60,8 @@
 # creation and updating are separate steps (and we could conceivably
 # fail between them), we're going to drop off a sentinel file that we
 # can check to see if we've been migrated.
+
+provides :pg_upgrade
 
 action :upgrade do
   if upgrade_required?

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+provides :pg_user
+
 property :username,
   kind_of: String,
   name_property: true

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user_table_access.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user_table_access.rb
@@ -26,9 +26,7 @@ property :schema,
   kind_of: String,
   required: true
 
-property :access_profile,
-  equal_to: %i(write read),
-  required: true
+property :access_profile, Symbol, equal_to: %i(write read), required: true
 
 # NOTE: Uses the value of node['private_chef']['postgresql']['db_connection_superuser'] and ['db_superuser_password]
 # to make the connection to the postgres server.

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user_table_access.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user_table_access.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+provides :pg_user_table_access
 
 property :username, String, name_property: true
 

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user_table_access.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_user_table_access.rb
@@ -14,17 +14,12 @@
 # limitations under the License.
 #
 
-property :username,
-  kind_of: String,
-  name_property: true
 
-property :database,
-  kind_of: String,
-  required: true
+property :username, String, name_property: true
 
-property :schema,
-  kind_of: String,
-  required: true
+property :database, String, required: true
+
+property :schema, String, required: true
 
 property :access_profile, Symbol, equal_to: %i(write read), required: true
 


### PR DESCRIPTION
- Remove redundant `resource_name` calls
- Remove the `private_chef_FOO` resource naming
- Give all properties allowed types
- Stop using `kind_of` on the property types
- use true/false not TrueClass/FalseClass