### PR TITLE
Replace Opscode copyrights

### DIFF
--- a/dev/cookbooks/dev/files/default/b2f
+++ b/dev/cookbooks/dev/files/default/b2f
@@ -4,7 +4,7 @@
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/oc-chef-pedant/lib/pedant.rb
+++ b/oc-chef-pedant/lib/pedant.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/chef_utility.rb
+++ b/oc-chef-pedant/lib/pedant/chef_utility.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/command_line.rb
+++ b/oc-chef-pedant/lib/pedant/command_line.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/concern.rb
+++ b/oc-chef-pedant/lib/pedant/concern.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/core_ext/hash.rb
+++ b/oc-chef-pedant/lib/pedant/core_ext/hash.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/gem.rb
+++ b/oc-chef-pedant/lib/pedant/gem.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/json.rb
+++ b/oc-chef-pedant/lib/pedant/json.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/platform.rb
+++ b/oc-chef-pedant/lib/pedant/platform.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/request.rb
+++ b/oc-chef-pedant/lib/pedant/request.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/requestor.rb
+++ b/oc-chef-pedant/lib/pedant/requestor.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/auth_headers_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/auth_headers_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/chef_data.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/chef_data.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2013 Opscode, Inc.
+# Copyright: Copyright (c) 2013 Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/client_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/client_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/common.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/common.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/common_responses.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/common_responses.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/data_bag_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/data_bag_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/environment_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/environment_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/http_status_codes.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/http_status_codes.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/internal_api.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/internal_api.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/keys_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/keys_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/knife_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/knife_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/matchers.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/matchers.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/node_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/node_util.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/role_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/role_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/user_util.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/user_util.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/rspec/validations.rb
+++ b/oc-chef-pedant/lib/pedant/rspec/validations.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/sandbox.rb
+++ b/oc-chef-pedant/lib/pedant/sandbox.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/ui.rb
+++ b/oc-chef-pedant/lib/pedant/ui.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/lib/pedant/utility.rb
+++ b/oc-chef-pedant/lib/pedant/utility.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/auth_spec.rb
+++ b/oc-chef-pedant/spec/api/auth_spec.rb
@@ -3,7 +3,7 @@
 # ex: ts=4 sw=4 et
 #
 # Author:: Douglas Triggs (<cm@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 require 'pedant/rspec/common'

--- a/oc-chef-pedant/spec/api/clients/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/clients/complete_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/controls_spec.rb
+++ b/oc-chef-pedant/spec/api/controls_spec.rb
@@ -3,7 +3,7 @@
 # ex => ts=4 sw=4 et
 #
 # Author => : Prajakta Purohit (<prajakta@chef.io>)
-# Copyright => : Copyright (c) 2014 Opscode, Inc.
+# Copyright => : Copyright (c) 2014 Chef Software, Inc.
 #
 
 require 'pedant/rspec/common'

--- a/oc-chef-pedant/spec/api/cookbooks_spec.rb
+++ b/oc-chef-pedant/spec/api/cookbooks_spec.rb
@@ -4,7 +4,7 @@
 # Author:: James Casey (<james@chef.io>)
 # Author:: Douglas Triggs (<doug@chef.io>)
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 require 'pp'

--- a/oc-chef-pedant/spec/api/data_bag/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/data_bag/complete_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/depsolver_spec.rb
+++ b/oc-chef-pedant/spec/api/depsolver_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/cookbooks_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/cookbooks_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/create_oss_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/create_oss_spec.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/create_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/create_spec.rb
@@ -4,7 +4,7 @@
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Douglas Triggs (<doug@chef.io>)
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 require 'pedant/rspec/auth_headers_util'

--- a/oc-chef-pedant/spec/api/environments/delete_oss_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/delete_oss_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/delete_spec.rb
@@ -4,7 +4,7 @@
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Douglas Triggs (<doug@chef.io>)
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 require 'pedant/rspec/auth_headers_util'

--- a/oc-chef-pedant/spec/api/environments/read_oss_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/read_oss_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/read_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/read_spec.rb
@@ -4,7 +4,7 @@
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Douglas Triggs (<doug@chef.io>)
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 require 'pedant/rspec/auth_headers_util'

--- a/oc-chef-pedant/spec/api/environments/recipes_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/recipes_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/roles_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/roles_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/single_cookbook_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/single_cookbook_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/update_oss_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/update_oss_spec.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/environments/update_spec.rb
+++ b/oc-chef-pedant/spec/api/environments/update_spec.rb
@@ -4,7 +4,7 @@
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Douglas Triggs (<doug@chef.io>)
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 require 'pedant/rspec/auth_headers_util'

--- a/oc-chef-pedant/spec/api/environments_spec.rb
+++ b/oc-chef-pedant/spec/api/environments_spec.rb
@@ -4,7 +4,7 @@
 # Author:: John Keiser (<jkeiser@chef.io>)
 # Author:: Douglas Triggs (<doug@chef.io>)
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 require 'pedant/rspec/auth_headers_util'

--- a/oc-chef-pedant/spec/api/knife/cookbook/download_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/cookbook/download_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/cookbook/upload_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/cookbook/upload_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/data_bag/create_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/data_bag/create_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/data_bag/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/data_bag/delete_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/data_bag/from_file_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/data_bag/from_file_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/data_bag/list_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/data_bag/list_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/data_bag/show_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/data_bag/show_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/nodes/bulk_delete_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/nodes/bulk_delete_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/nodes/create_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/nodes/create_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/nodes/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/nodes/delete_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/nodes/from_file_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/nodes/from_file_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/nodes/list_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/nodes/list_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/nodes/run_list_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/nodes/run_list_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/nodes/show_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/nodes/show_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/roles/bulk_delete_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/roles/bulk_delete_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/roles/create_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/roles/create_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/roles/delete_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/roles/delete_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/roles/from_file_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/roles/from_file_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/roles/list_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/roles/list_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/knife/roles/show_spec.rb
+++ b/oc-chef-pedant/spec/api/knife/roles/show_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/nodes/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/nodes/complete_endpoint_spec.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/nodes_spec.rb
+++ b/oc-chef-pedant/spec/api/nodes_spec.rb
@@ -4,7 +4,7 @@
 #
 # Author:: Mark Anderson (<mark@chef.io>)
 # Author:: Christopher Maier (<cm@chef.io>)
-# Copyright:: Copyright (c) 2011 Opscode, Inc.
+# Copyright:: Copyright (c) 2011 Chef Software, Inc.
 #
 
 # Considering nodes endpoint to only be implemented in Erlang, since

--- a/oc-chef-pedant/spec/api/object_identifier_spec.rb
+++ b/oc-chef-pedant/spec/api/object_identifier_spec.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/organization_spec.rb
+++ b/oc-chef-pedant/spec/api/organization_spec.rb
@@ -2,7 +2,7 @@
 #
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2013 Chef Software, Inc.
 
 require 'pedant/rspec/common'
 require 'json'

--- a/oc-chef-pedant/spec/api/pedant_spec.rb
+++ b/oc-chef-pedant/spec/api/pedant_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/policies/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/policies/complete_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/principal_spec.rb
+++ b/oc-chef-pedant/spec/api/principal_spec.rb
@@ -3,7 +3,7 @@
 # ex: ts=4 sw=4 et
 #
 # Author:: Douglas Triggs (<doug@chef.io>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 
 describe "Principals API Endpoint", :principals do

--- a/oc-chef-pedant/spec/api/roles/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/roles/complete_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/api/sandboxes/complete_endpoint_spec.rb
+++ b/oc-chef-pedant/spec/api/sandboxes/complete_endpoint_spec.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/oc-chef-pedant/spec/org_creation/validate_acls_spec.rb
+++ b/oc-chef-pedant/spec/org_creation/validate_acls_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2013 Chef Software, Inc.
 
 
 describe "Org Creation", :org_creation do

--- a/oc-chef-pedant/spec/org_creation/validate_containers_spec.rb
+++ b/oc-chef-pedant/spec/org_creation/validate_containers_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2013 Chef Software, Inc.
 
 
 describe "Org Creation", :org_creation do

--- a/oc-chef-pedant/spec/org_creation/validate_groups_spec.rb
+++ b/oc-chef-pedant/spec/org_creation/validate_groups_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Author:: Ho-Sheng Hsiao (<hosh@chef.io>)
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2013 Chef Software, Inc.
 
 
 describe "Org Creation", :org_creation do

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/oc_id.rb
@@ -1,6 +1,6 @@
 #
 # Author:: James Casey <james@chef.io>
-# Copyright:: Copyright (c) 2014-2015 Chef Software, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-chef-mover.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/opscode-chef-mover.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Marc Paradise <marc@chef.io>
-# Copyright:: 2013-2018 Chef Software, Inc.
+# Copyright:: Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/post_11_upgrade_cleanup.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/post_11_upgrade_cleanup.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Christopher Maier (<cm@chef.io>)
-# Copyright:: 2013-2018 Chef Software, Inc.
+# Copyright:: Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/sysctl-updates.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/sysctl-updates.rb
@@ -1,6 +1,6 @@
 
 # Author:: Marc Paradise (<marc@chef.io>)
-# Copyright:: 2013-2018 Chef Software, Inc.
+# Copyright:: Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/bookshelf/src/amazon_s3.hrl
+++ b/src/bookshelf/src/amazon_s3.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_app.erl
+++ b/src/bookshelf/src/bksw_app.erl
@@ -1,4 +1,4 @@
-%% @copyright 2019 Opscode, Inc. All Rights Reserved
+%% @copyright 2019 Chef Software, Inc. All Rights Reserved
 %% @author Tim Dysinger <dysinger@chef.io>
 %%
 %% Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/bookshelf/src/bksw_conf.erl
+++ b/src/bookshelf/src/bksw_conf.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Eric B Merritt <ericbmerritt@gmail.com>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_format.erl
+++ b/src/bookshelf/src/bksw_format.erl
@@ -1,4 +1,4 @@
-%% @copyright 2012 Opscode, Inc. All Rights Reserved
+%% @copyright Chef Software, Inc. All Rights Reserved
 %% @author Tim Dysinger <dysinger@chef.io>
 %%
 %% Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/bookshelf/src/bksw_io.erl
+++ b/src/bookshelf/src/bksw_io.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_io_names.erl
+++ b/src/bookshelf/src/bksw_io_names.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_req.erl
+++ b/src/bookshelf/src/bksw_req.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tim Dysinger <dysinger@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_sec.erl
+++ b/src/bookshelf/src/bksw_sec.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Eric B Merritt <ericbmerritt@gmail.com>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_util.erl
+++ b/src/bookshelf/src/bksw_util.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Eric B Merritt <ericbmerritt@gmail.com>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_webmachine_sup.erl
+++ b/src/bookshelf/src/bksw_webmachine_sup.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tim Dysinger <dysinger@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_wm_base.erl
+++ b/src/bookshelf/src/bksw_wm_base.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_wm_bucket.erl
+++ b/src/bookshelf/src/bksw_wm_bucket.erl
@@ -1,4 +1,4 @@
-%% @copyright 2012-2013 Opscode, Inc. All Rights Reserved
+%% @copyright Chef Software, Inc. All Rights Reserved
 %% @author Tim Dysinger <dysinger@chef.io>
 %%
 %% Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/bookshelf/src/bksw_wm_index.erl
+++ b/src/bookshelf/src/bksw_wm_index.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Eric B Merritt <ericbmerritt@gmail.com>
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -53,4 +53,3 @@ to_xml(Rq, Ctx) ->
     Term = bksw_xml:list_buckets(Buckets),
     Body = bksw_xml:write(Term),
     {Body, Rq, Ctx}.
-

--- a/src/bookshelf/src/bksw_wm_object.erl
+++ b/src/bookshelf/src/bksw_wm_object.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tim Dysinger <dysinger@chef.io>
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_wm_sql_bucket.erl
+++ b/src/bookshelf/src/bksw_wm_sql_bucket.erl
@@ -1,4 +1,4 @@
-%% @copyright 2012-2013 Opscode, Inc. All Rights Reserved
+%% @copyright Chef Software, Inc. All Rights Reserved
 %% @author Tim Dysinger <dysinger@chef.io>
 %%
 %% Licensed to the Apache Software Foundation (ASF) under one or more

--- a/src/bookshelf/src/bksw_wm_sql_index.erl
+++ b/src/bookshelf/src/bksw_wm_sql_index.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Eric B Merritt <ericbmerritt@gmail.com>
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_wm_sql_object.erl
+++ b/src/bookshelf/src/bksw_wm_sql_object.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Mark Anderson <mark@chef.io>
 %% @author Tim Dysinger <dysinger@chef.io>
-%% Copyright 2012-2015 Opscode, Inc. All Rights Reserved.
+%% Copyright 2012-2015 Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bksw_xml.erl
+++ b/src/bookshelf/src/bksw_xml.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tim Dysinger <dysinger@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/bookshelf.app.src
+++ b/src/bookshelf/src/bookshelf.app.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang; -*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/bookshelf/src/internal.hrl
+++ b/src/bookshelf/src/internal.hrl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tim Dysinger <dysinger@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/_checkouts/oc_erchef/include/chef_db.hrl
+++ b/src/chef-mover/_checkouts/oc_erchef/include/chef_db.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/_checkouts/oc_erchef/include/chef_index.hrl
+++ b/src/chef-mover/_checkouts/oc_erchef/include/chef_index.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/_checkouts/oc_erchef/include/chef_regex.hrl
+++ b/src/chef-mover/_checkouts/oc_erchef/include/chef_regex.hrl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -39,4 +39,3 @@
 -type re_msg() :: <<_:64,_:_*8>>.
 
 -type regex_pattern() :: [1..255,...].
-

--- a/src/chef-mover/_checkouts/oc_erchef/include/chef_solr.hrl
+++ b/src/chef-mover/_checkouts/oc_erchef/include/chef_solr.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/_checkouts/oc_erchef/include/chef_types.hrl
+++ b/src/chef-mover/_checkouts/oc_erchef/include/chef_types.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2019 Opscode, Inc. All Rights Reserved.
+%% Copyright 2019 Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/_checkouts/oc_erchef/include/oc_chef_authz.hrl
+++ b/src/chef-mover/_checkouts/oc_erchef/include/oc_chef_authz.hrl
@@ -8,7 +8,7 @@
 %%
 %% This module is an Erlang port of the mixlib-authorization Ruby gem.
 %%
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -51,4 +51,3 @@
           'path',           % 'path' of container (not used? Orig part of inheritance mech?; safe to delete? Yea!)
           'last_updated_by' % authz guid of last actor to update object
          }).
-

--- a/src/chef-mover/_checkouts/oc_erchef/include/oc_chef_types.hrl
+++ b/src/chef-mover/_checkouts/oc_erchef/include/oc_chef_types.hrl
@@ -1,8 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
-%% Copyright 2014 Chef, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -record(oc_chef_container, {
           id,

--- a/src/chef-mover/apps/chef_db/priv/README.md
+++ b/src/chef-mover/apps/chef_db/priv/README.md
@@ -28,7 +28,7 @@ Note that depending on settings the database and or username are subject to be d
 
 # LICENSE
 
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/chef-mover/apps/chef_db/priv/pgsql_schema.sql
+++ b/src/chef-mover/apps/chef_db/priv/pgsql_schema.sql
@@ -1,4 +1,4 @@
--- Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+-- Copyright Chef Software, Inc. All Rights Reserved.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 --
@@ -37,7 +37,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: checksums; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: checksums; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE checksums (
@@ -47,7 +47,7 @@ CREATE TABLE checksums (
 
 
 --
--- Name: clients; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: clients; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE clients (
@@ -66,7 +66,7 @@ CREATE TABLE clients (
 
 
 --
--- Name: cookbook_version_checksums; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbook_version_checksums; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE cookbook_version_checksums (
@@ -77,7 +77,7 @@ CREATE TABLE cookbook_version_checksums (
 
 
 --
--- Name: cookbook_versions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbook_versions; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE cookbook_versions (
@@ -104,7 +104,7 @@ ALTER TABLE ONLY cookbook_versions ALTER COLUMN serialized_object SET STORAGE EX
 CREATE INDEX cookbook_version_checksums_by_id ON cookbook_version_checksums(cookbook_version_id);
 
 --
--- Name: cookbooks; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbooks; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE cookbooks (
@@ -151,7 +151,7 @@ ALTER SEQUENCE cookbooks_id_seq OWNED BY cookbooks.id;
 
 
 --
--- Name: data_bag_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: data_bag_items; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE data_bag_items (
@@ -168,7 +168,7 @@ ALTER TABLE ONLY data_bag_items ALTER COLUMN serialized_object SET STORAGE EXTER
 
 
 --
--- Name: data_bags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: data_bags; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE data_bags (
@@ -183,7 +183,7 @@ CREATE TABLE data_bags (
 
 
 --
--- Name: environments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: environments; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE environments (
@@ -208,7 +208,7 @@ CREATE VIEW joined_cookbook_version AS
 
 
 --
--- Name: nodes; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: nodes; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE nodes (
@@ -226,7 +226,7 @@ ALTER TABLE ONLY nodes ALTER COLUMN serialized_object SET STORAGE EXTERNAL;
 
 
 --
--- Name: roles; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: roles; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE roles (
@@ -243,7 +243,7 @@ ALTER TABLE ONLY roles ALTER COLUMN serialized_object SET STORAGE EXTERNAL;
 
 
 --
--- Name: sandboxed_checksums; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: sandboxed_checksums; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE sandboxed_checksums (
@@ -255,7 +255,7 @@ CREATE TABLE sandboxed_checksums (
 
 
 --
--- Name: schema_info; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_info; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE schema_info (
@@ -264,7 +264,7 @@ CREATE TABLE schema_info (
 
 
 --
--- Name: osc_users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: osc_users; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE osc_users (
@@ -293,7 +293,7 @@ ALTER TABLE cookbooks ALTER COLUMN id SET DEFAULT nextval('cookbooks_id_seq'::re
 
 
 --
--- Name: checksums_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: checksums_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY checksums
@@ -301,7 +301,7 @@ ALTER TABLE ONLY checksums
 
 
 --
--- Name: clients_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: clients_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY clients
@@ -309,7 +309,7 @@ ALTER TABLE ONLY clients
 
 
 --
--- Name: clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY clients
@@ -317,7 +317,7 @@ ALTER TABLE ONLY clients
 
 
 --
--- Name: cookbook_versions_cookbook_id_major_minor_patch_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbook_versions_cookbook_id_major_minor_patch_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY cookbook_versions
@@ -325,7 +325,7 @@ ALTER TABLE ONLY cookbook_versions
 
 
 --
--- Name: cookbook_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbook_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY cookbook_versions
@@ -333,7 +333,7 @@ ALTER TABLE ONLY cookbook_versions
 
 
 --
--- Name: cookbooks_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbooks_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY cookbooks
@@ -341,7 +341,7 @@ ALTER TABLE ONLY cookbooks
 
 
 --
--- Name: cookbooks_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbooks_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY cookbooks
@@ -349,7 +349,7 @@ ALTER TABLE ONLY cookbooks
 
 
 --
--- Name: cookbooks_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbooks_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY cookbooks
@@ -357,7 +357,7 @@ ALTER TABLE ONLY cookbooks
 
 
 --
--- Name: data_bag_items_org_id_data_bag_name_item_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: data_bag_items_org_id_data_bag_name_item_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY data_bag_items
@@ -365,7 +365,7 @@ ALTER TABLE ONLY data_bag_items
 
 
 --
--- Name: data_bag_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: data_bag_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY data_bag_items
@@ -373,7 +373,7 @@ ALTER TABLE ONLY data_bag_items
 
 
 --
--- Name: data_bags_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: data_bags_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY data_bags
@@ -381,7 +381,7 @@ ALTER TABLE ONLY data_bags
 
 
 --
--- Name: data_bags_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: data_bags_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY data_bags
@@ -389,7 +389,7 @@ ALTER TABLE ONLY data_bags
 
 
 --
--- Name: data_bags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: data_bags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY data_bags
@@ -397,7 +397,7 @@ ALTER TABLE ONLY data_bags
 
 
 --
--- Name: environments_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: environments_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY environments
@@ -405,7 +405,7 @@ ALTER TABLE ONLY environments
 
 
 --
--- Name: environments_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: environments_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY environments
@@ -413,7 +413,7 @@ ALTER TABLE ONLY environments
 
 
 --
--- Name: environments_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: environments_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY environments
@@ -421,7 +421,7 @@ ALTER TABLE ONLY environments
 
 
 --
--- Name: nodes_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: nodes_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY nodes
@@ -429,7 +429,7 @@ ALTER TABLE ONLY nodes
 
 
 --
--- Name: nodes_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: nodes_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY nodes
@@ -437,7 +437,7 @@ ALTER TABLE ONLY nodes
 
 
 --
--- Name: nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY nodes
@@ -445,7 +445,7 @@ ALTER TABLE ONLY nodes
 
 
 --
--- Name: org_id_name_unique; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: org_id_name_unique; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY clients
@@ -453,7 +453,7 @@ ALTER TABLE ONLY clients
 
 
 --
--- Name: roles_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: roles_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY roles
@@ -461,7 +461,7 @@ ALTER TABLE ONLY roles
 
 
 --
--- Name: roles_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: roles_org_id_name_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY roles
@@ -469,7 +469,7 @@ ALTER TABLE ONLY roles
 
 
 --
--- Name: roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY roles
@@ -477,7 +477,7 @@ ALTER TABLE ONLY roles
 
 
 --
--- Name: sandboxed_checksums_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: sandboxed_checksums_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY sandboxed_checksums
@@ -485,7 +485,7 @@ ALTER TABLE ONLY sandboxed_checksums
 
 
 --
--- Name: osc_users_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: osc_users_authz_id_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY osc_users
@@ -493,7 +493,7 @@ ALTER TABLE ONLY osc_users
 
 
 --
--- Name: osc_users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: osc_users_email_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY osc_users
@@ -501,7 +501,7 @@ ALTER TABLE ONLY osc_users
 
 
 --
--- Name: osc_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: osc_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY osc_users
@@ -509,7 +509,7 @@ ALTER TABLE ONLY osc_users
 
 
 --
--- Name: osc_users_username_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: osc_users_username_key; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY osc_users
@@ -517,14 +517,14 @@ ALTER TABLE ONLY osc_users
 
 
 --
--- Name: cookbooks_org_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: cookbooks_org_id_index; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX cookbooks_org_id_index ON cookbooks USING btree (org_id);
 
 
 --
--- Name: nodes_org_id_environment_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: nodes_org_id_environment_index; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX nodes_org_id_environment_index ON nodes USING btree (org_id, environment);
@@ -565,4 +565,3 @@ ALTER TABLE ONLY data_bag_items
 --
 -- PostgreSQL database dump complete
 --
-

--- a/src/chef-mover/apps/chef_db/priv/pgsql_statements.config
+++ b/src/chef-mover/apps/chef_db/priv/pgsql_statements.config
@@ -1,5 +1,5 @@
 %% -*- mode:erlang, erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/src/chef_cache.erl
+++ b/src/chef-mover/apps/chef_db/src/chef_cache.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Kevin Smith <kevin@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/src/chef_db.app.src
+++ b/src/chef-mover/apps/chef_db/src/chef_db.app.src
@@ -1,5 +1,5 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/src/chef_db.erl
+++ b/src/chef-mover/apps/chef_db/src/chef_db.erl
@@ -6,7 +6,7 @@
 %% @author Christopher Maier <cm@chef.io>
 %% @author Mark Mzyk <mmzyk@chef.io>
 %% @author Seth Chisamore <schisamo@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/src/chef_db_darklaunch.erl
+++ b/src/chef-mover/apps/chef_db/src/chef_db_darklaunch.erl
@@ -1,5 +1,5 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -33,7 +33,3 @@ is_enabled(_, _) ->
 is_enabled(Feature, Darklaunch) ->
     ?CHEF_DB_DARKLAUNCH:is_enabled(Feature, Darklaunch).
 -endif.
-
-
-
-

--- a/src/chef-mover/apps/chef_db/src/chef_otto.erl
+++ b/src/chef-mover/apps/chef_db/src/chef_otto.erl
@@ -3,9 +3,9 @@
 %% @author Seth Falcon <seth@chef.io>
 %% @author Mark Anderson <mark@chef.io>
 %% @author Christopher Maier <cm@chef.io>
-%% @copyright 2011-2012 Opscode Inc.
+%% @copyright Chef Software, Inc.
 %% @end
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/src/chef_otto.hrl
+++ b/src/chef-mover/apps/chef_db/src/chef_otto.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/src/chefp.erl
+++ b/src/chef-mover/apps/chef_db/src/chefp.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/test/chef_db_test_utils.erl
+++ b/src/chef-mover/apps/chef_db/test/chef_db_test_utils.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Mark Anderson <mark@chef.io>
 %% @version 0.0.1
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/test/chef_db_tests.erl
+++ b/src/chef-mover/apps/chef_db/test/chef_db_tests.erl
@@ -1,5 +1,5 @@
 %% B
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/test/chef_otto_tests.erl
+++ b/src/chef-mover/apps/chef_db/test/chef_otto_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_db/test/chef_sql_tests.erl
+++ b/src/chef-mover/apps/chef_db/test/chef_sql_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -49,4 +49,3 @@ flatten_record_test_() ->
         end
       }
     ].
-

--- a/src/chef-mover/apps/chef_db/test/chefp_tests.erl
+++ b/src/chef-mover/apps/chef_db/test/chefp_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/src/chef_index.app.src
+++ b/src/chef-mover/apps/chef_index/src/chef_index.app.src
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/src/chef_index_queue.erl
+++ b/src/chef-mover/apps/chef_index/src/chef_index_queue.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/src/chef_index_sup.erl
+++ b/src/chef-mover/apps/chef_index/src/chef_index_sup.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author Kevin Smith <kevin@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -86,4 +86,3 @@ bunnyc_spec(VHost, Host, Port, User, Password, ExchangeName) ->
 server_for_vhost(VHost) ->
     Bin = erlang:iolist_to_binary([<<"chef_index_queue">>, VHost]),
     erlang:binary_to_atom(Bin, utf8).
-    

--- a/src/chef-mover/apps/chef_index/src/chef_lucene.erl
+++ b/src/chef-mover/apps/chef_index/src/chef_lucene.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/src/chef_solr.erl
+++ b/src/chef-mover/apps/chef_index/src/chef_solr.erl
@@ -4,7 +4,7 @@
 %% @doc Helper module for calling various Chef REST endpoints
 %% @end
 %%
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/src/lucene.erl
+++ b/src/chef-mover/apps/chef_index/src/lucene.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/src/lucene_sexp.erl
+++ b/src/chef-mover/apps/chef_index/src/lucene_sexp.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -87,4 +87,3 @@ parse_param(P) ->
         catch error:badarg ->
             erlang:list_to_integer(Str)
     end.
-

--- a/src/chef-mover/apps/chef_index/src/lucene_txfm.erl
+++ b/src/chef-mover/apps/chef_index/src/lucene_txfm.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -69,7 +69,7 @@ transform('field_range', Node, _Index) ->
         [FieldName, <<":">>, [<<"{">>, <<"*">>, <<" TO ">>, E, <<"}">>]] ->
             ?i2b([<<"content:{">>, FieldName, <<"__=__">>, <<" TO ">>,
                   FieldName, <<"__=__">>, E, <<"}">>]);
-        
+
         [FieldName, <<":">>, [<<"[">>, S, <<" TO ">>, E, <<"]">>]] ->
             ?i2b([<<"content:[">>, FieldName, <<"__=__">>, S, <<" TO ">>,
                   FieldName, <<"__=__">>, E, <<"]">>]);

--- a/src/chef-mover/apps/chef_index/test/chef_index_queue_tests.erl
+++ b/src/chef-mover/apps/chef_index/test/chef_index_queue_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/test/chef_index_sup_tests.erl
+++ b/src/chef-mover/apps/chef_index/test/chef_index_sup_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/test/chef_solr_tests.erl
+++ b/src/chef-mover/apps/chef_index/test/chef_solr_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/test/lucene_sexp_tests.erl
+++ b/src/chef-mover/apps/chef_index/test/lucene_sexp_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_index/test/lucene_txfm_tests.erl
+++ b/src/chef-mover/apps/chef_index/test/lucene_txfm_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_cert_http.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_cert_http.erl
@@ -3,7 +3,7 @@
 %% @author James Casey <james@chef.io>
 %% @doc interface to the certificate generation service
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -40,7 +40,7 @@ gen_cert(Guid, RequestId) ->
     FullHeaders = [{?X_OPS_REQUEST_ID, binary_to_list(RequestId)},
                    {"Accept", "application/json"}
                   ],
-    
+
     Url = envy:get(chef_objects, certificate_root_url, string),
     Body = body_for_post(Guid),
     case ibrowse:send_req(Url, FullHeaders, post, Body) of
@@ -82,5 +82,3 @@ check_http_response(Code, Headers, Body) ->
         "5" ++ _Digits ->
             throw({error, {server_error, {Code, Headers, Body}}})
     end.
-
-

--- a/src/chef-mover/apps/chef_objects/src/chef_client.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_client.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Douglas Triggs <doug@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -450,5 +450,3 @@ value_or_undefined(Key, Data) ->
 -spec(list(#chef_client{}, chef_object:select_callback()) -> chef_object:select_return()).
 list(#chef_client{org_id = OrgId}, CallbackFun) ->
     CallbackFun({list_query(), [OrgId], [name]}).
-
-

--- a/src/chef-mover/apps/chef_objects/src/chef_config.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_config.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_cookbook_version.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_cookbook_version.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author James Casey <james@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_data_bag.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_data_bag.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -179,4 +179,3 @@ validate_data_bag(DataBag) ->
 -spec(list(#chef_data_bag{}, chef_object:select_callback()) -> chef_object:select_return()).
 list(#chef_data_bag{org_id = OrgId}, CallbackFun) ->
     CallbackFun({list_query(), [OrgId], [name]}).
-

--- a/src/chef-mover/apps/chef_objects/src/chef_data_bag_item.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_data_bag_item.erl
@@ -3,7 +3,7 @@
 %% @author Seth Falcon <seth@chef.io>
 %% @author Christopher Maier <cm@chef.io>
 %% @author Mark Anderson <mark@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -241,4 +241,3 @@ is_wrapped_item(Ejson) ->
 -spec(list(#chef_data_bag_item{}, chef_object:select_callback()) -> chef_object:select_return()).
 list(#chef_data_bag_item{org_id = OrgId, data_bag_name = DataBagName}, CallBackFun) ->
     CallBackFun({list_query(), [OrgId, DataBagName], [item_name]}).
-

--- a/src/chef-mover/apps/chef_objects/src/chef_db_compression.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_db_compression.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Kevin Smith <kevin@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_deep_merge.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_deep_merge.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Dan Deleo <dan@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -77,4 +77,3 @@ merge(_Mergee, Other) ->
 %% happen.
 merge_dict(_Key, Mergee, Other) ->
   merge(Mergee, Other).
-

--- a/src/chef-mover/apps/chef_objects/src/chef_depsolver.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_depsolver.erl
@@ -4,7 +4,7 @@
 %%
 %% Regex from chef_json_validator.erl
 %% @author Marc Paradise <marc@chef.io>
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_depsolver_worker.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_depsolver_worker.erl
@@ -3,7 +3,7 @@
 %%%-------------------------------------------------------------------
 %%% @author Stephen Delano <stephen@chef.io>
 %%% @doc Worker module for chef_depsolver resource
-%%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%% Copyright Chef Software, Inc. All Rights Reserved.
 %%%
 %%% This file is provided to you under the Apache License,
 %%% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_environment.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_environment.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author John Keiser <jkeiser@chef.io>
 %% @author Doug Triggs <doug@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_json.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_json.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Doug Triggs <doug@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_json_validator.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_json_validator.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_metrics.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_metrics.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_node.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_node.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_object.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_object.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_object_base.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_object_base.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_objects.app.src
+++ b/src/chef-mover/apps/chef_objects/src/chef_objects.app.src
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_parallel.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_parallel.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_regex.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_regex.erl
@@ -6,7 +6,7 @@
 %%
 %% Regex used in erchef
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -134,5 +134,3 @@ regex_for(user_name) ->
                             <<"Malformed user name. Must only contain a-z, 0-9, _, or -">>);
 regex_for(non_blank_string) ->
    generate_regex_msg_tuple(?ANCHOR_REGEX(?NON_BLANK_REGEX), <<"Field must have a non-empty string value">>).
-
-

--- a/src/chef-mover/apps/chef_objects/src/chef_role.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_role.erl
@@ -1,8 +1,8 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% @copyright 2012 Opscode, Inc.
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% @copyright Chef Software, Inc.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -271,4 +271,3 @@ record_fields() ->
 
 list(#chef_role{org_id = OrgId}, CallbackFun) ->
     CallbackFun({list_query(), [OrgId], [name]}).
-

--- a/src/chef-mover/apps/chef_objects/src/chef_s3.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_s3.erl
@@ -6,7 +6,7 @@
 %% @author Ho-Sheng Hsiao <hosh@chef.io>
 %% @doc chef_s3 - Manage S3 activities for erchef
 %%
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -175,4 +175,3 @@ s3_external_url(VHostUrl) ->
         BadUrl ->
             {invalid_s3_url, BadUrl}
     end.
-

--- a/src/chef-mover/apps/chef_objects/src/chef_s3_ops.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_s3_ops.erl
@@ -3,7 +3,7 @@
 %% @author Kevin Smith <kevin@chef.io>
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Chisamore <schisamo@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/src/chef_sandbox.erl
+++ b/src/chef-mover/apps/chef_objects/src/chef_sandbox.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -179,4 +179,3 @@ proplist_to_checksum(Proplist) ->
          true -> true;
          false -> false
      end}.
-

--- a/src/chef-mover/apps/chef_objects/test/chef_cert_http_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_cert_http_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_client_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_client_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_config_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_config_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Chisamore <schisamo@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -57,8 +57,8 @@ config_option_test_() ->
 					     chef_config:config_option(TestApplication, TestOption, Type))
 			end
 		end}
-       end} || {Description, Value, Type, ErrorState} <- 
-		   [{"Positive integer: " ++ Label, V, pos_integer, E } || 
+       end} || {Description, Value, Type, ErrorState} <-
+		   [{"Positive integer: " ++ Label, V, pos_integer, E } ||
 		       {Label, V, E} <- [{"Succeeds with positive integer", 5, no_error},
 					 {"Fails with 0", 0, error},
 					 {"Fails with negative integer", -5, error},
@@ -68,4 +68,3 @@ config_option_test_() ->
 					 {"Fails with a binary", <<"This is also bad">>, error},
 					 {"Fails when undefined", undefined, always_error}]
 		   ]]}.
-	      

--- a/src/chef-mover/apps/chef_objects/test/chef_cookbook_version_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_cookbook_version_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_db_compression_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_db_compression_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_deep_merge_test.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_deep_merge_test.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -65,4 +65,3 @@ compat_test_() ->
     end
 
   }.
-

--- a/src/chef-mover/apps/chef_objects/test/chef_environment_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_environment_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_json_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_json_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_json_validator_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_json_validator_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_metrics_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_metrics_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_node_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_node_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_object_base_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_object_base_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -218,4 +218,3 @@ set_key_pair_test_() ->
              end
              || Type <- [key, cert] ],
     lists:flatten(Tests).
-

--- a/src/chef-mover/apps/chef_objects/test/chef_objects_test_utils.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_objects_test_utils.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Mark Anderson <mark@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_password_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_password_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -208,4 +208,3 @@ do_ec_migration(SHA, Salt) ->
     {ok, BcryptSalt} = bcrypt:gen_salt(),
     {ok, HashedPass} = bcrypt:hashpw(SHA, BcryptSalt),
     {list_to_binary(HashedPass), Salt, ?MIGRATION_HASH_TYPE}.
-

--- a/src/chef-mover/apps/chef_objects/test/chef_regex_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_regex_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_role_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_role_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_s3_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_s3_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Chisamore <schisamo@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_sandbox_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_sandbox_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -138,4 +138,3 @@ sandbox_rows() ->
     {<<"checksum">>, <<"dddddddddddddddddddddddddddddddd">>},
     {<<"uploaded">>, true}]
   ].
-

--- a/src/chef-mover/apps/chef_objects/test/chef_test_utility.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_test_utility.erl
@@ -4,7 +4,7 @@
 %%
 %% @doc Broadly useful EUnit testing utilities.
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/chef_objects/test/chef_user_tests.erl
+++ b/src/chef-mover/apps/chef_objects/test/chef_user_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/README.md
+++ b/src/chef-mover/apps/depsolver/README.md
@@ -72,7 +72,7 @@ License and Authors
 * Author:: Eric Merritt (<ericbmerritt@gmail.com>)
 * Author:: James Casey (<james@chef.io>)
 
-Copyright 2012 Opscode, Inc. All Rights Reserved.
+Copyright Chef Software, Inc. All Rights Reserved.
 
 This file is provided to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/priv/log_test.rb
+++ b/src/chef-mover/apps/depsolver/priv/log_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# Copyright 2012 Opscode, Inc. All Rights Reserved.
+# Copyright Chef Software, Inc. All Rights Reserved.
 #
 # This file is provided to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/src/depsolver.app.src
+++ b/src/chef-mover/apps/depsolver/src/depsolver.app.src
@@ -3,7 +3,7 @@
 %%
 %% @author Eric Merritt <ericbmerritt@gmail.com>
 %%
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/src/depsolver.erl
+++ b/src/chef-mover/apps/depsolver/src/depsolver.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 80 -*-
 %% ex: ts=4 sw=4 et
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/src/depsolver_app.erl
+++ b/src/chef-mover/apps/depsolver/src/depsolver_app.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 80 -*-
 %% ex: ts=4 sx=4 et
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/src/depsolver_culprit.erl
+++ b/src/chef-mover/apps/depsolver/src/depsolver_culprit.erl
@@ -3,7 +3,7 @@
 %%
 %% @author Eric Merritt <ericbmerritt@gmail.com>
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/src/depsolver_event_logger.erl
+++ b/src/chef-mover/apps/depsolver/src/depsolver_event_logger.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 80 -*-
 %% ex: ts=4 sx=4 et
 %%
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -27,7 +27,7 @@
 %% Config = [{root_dir, "/tmp/depsolver"}, {max_files, 200}].
 %% depsolver_event_logger:add_handler(Config).
 %% '''
-%% 
+%%
 %% The above will enable the solution event logging. You will find
 %% directories `ok', `error', `timeout', and `unreachable' under the
 %% specified `root_dir'. Each directory will contain no more than
@@ -63,14 +63,14 @@
 %% gen_event callbacks
 -export([
          code_change/3,
-         handle_call/2, 
+         handle_call/2,
          handle_event/2,
          handle_info/2,
          init/1,
          terminate/2
         ]).
 
--define(SERVER, ?MODULE). 
+-define(SERVER, ?MODULE).
 
 -define(DIRS, ["ok", "timeout", "unreachable", "error"]).
 -define(DEFAULT_MAX_FILES, 200).
@@ -175,7 +175,7 @@ get_count({error, resolution_timeout}, #state{timeout_count = Count}) ->
 get_count(_, #state{error_count = Count}) ->
     Count.
 
-result_label({ok, _}) ->    
+result_label({ok, _}) ->
     "ok";
 result_label({error, {unreachable_package, _}}) ->
     "unreachable";

--- a/src/chef-mover/apps/depsolver/src/depsolver_sup.erl
+++ b/src/chef-mover/apps/depsolver/src/depsolver_sup.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 80 -*-
 %% ex: ts=4 sx=4 et
 %%
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/src/depsolver_worker.erl
+++ b/src/chef-mover/apps/depsolver/src/depsolver_worker.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 80 -*-
 %% ex: ts=4 sx=4 et
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -38,7 +38,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--define(SERVER, ?MODULE). 
+-define(SERVER, ?MODULE).
 
 -record(state, {}).
 

--- a/src/chef-mover/apps/depsolver/src/depsolver_worker_sup.erl
+++ b/src/chef-mover/apps/depsolver/src/depsolver_worker_sup.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 80 -*-
 %% ex: ts=4 sx=4 et
 %%
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/depsolver/test/depsolver_tester.erl
+++ b/src/chef-mover/apps/depsolver/test/depsolver_tester.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sx=4 et
 %%-------------------------------------------------------------------
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -53,7 +53,7 @@ all_test_() ->
         application:start(depsolver)
     end,
     fun(_) -> application:stop(depsolver) end,
-    [ 
+    [
       {?MODULE, data1},
       {?MODULE, data2},
       {?MODULE, data3},

--- a/src/chef-mover/apps/depsolver/test/depsolver_tests.erl
+++ b/src/chef-mover/apps/depsolver/test/depsolver_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %%
 %%-------------------------------------------------------------------
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz.app.src
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz.app.src
@@ -1,4 +1,4 @@
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz_cleanup.erl
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz_cleanup.erl
@@ -10,7 +10,7 @@
 %%% @end
 %%% Created :  6 Nov 2013 by Oliver Ferrigni <>
 %%%-------------------------------------------------------------------
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz_db.hrl
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz_db.hrl
@@ -3,7 +3,7 @@
 %% @author Seth Falcon <seth@chef.io>
 %%
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz_http.erl
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_authz_http.erl
@@ -3,7 +3,7 @@
 %% @author Kevin Smith <kevin@chef.io>
 %% @doc oc_chef_authz's interface to the authz server
 %%
-%% Copyright 2011-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_container.erl
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_container.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_container).
 

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_group.erl
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_group.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_group).
 

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_org_user_association.erl
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_org_user_association.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tyler Cloke <tyler@chef.io>
-%% Copyright 2014 Opscode, Inc. All Rights Reserved.
+%% Copyright 2014 Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_org_user_association).
 
@@ -159,4 +159,3 @@ type_name(#oc_chef_org_user_association{}) ->
 
 delete(#oc_chef_org_user_association{org_id = OrgId, user_id = UserId}, CallbackFun) ->
     CallbackFun({delete_query(), [OrgId, UserId]}).
-

--- a/src/chef-mover/apps/oc_chef_authz/src/oc_chef_organization.erl
+++ b/src/chef-mover/apps/oc_chef_authz/src/oc_chef_organization.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Tyler Cloke <tyler@chef.io>
 %% @author Mark Anderson <mark@chef.io>
-%% Copyright 2014 Opscode, Inc. All Rights Reserved.
+%% Copyright 2014 Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_organization).
 

--- a/src/chef-mover/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
+++ b/src/chef-mover/apps/oc_chef_authz/test/oc_chef_authz_tests.erl
@@ -4,7 +4,7 @@
 %%
 %% This module is an Erlang port of the mixlib-authorization Ruby gem.
 %%
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_authz/test/oc_chef_group_tests.erl
+++ b/src/chef-mover/apps/oc_chef_authz/test/oc_chef_group_tests.erl
@@ -1,7 +1,7 @@
 %% @author Ho-Sheng Hsiao <hosh@chef.io>
 %% @doc group operations
 %%
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -97,4 +97,3 @@ handle_error_test_() ->
             end
         }
     ].
-

--- a/src/chef-mover/apps/oc_chef_authz/test/test_utils.erl
+++ b/src/chef-mover/apps/oc_chef_authz/test/test_utils.erl
@@ -3,7 +3,7 @@
 %% @author Mark Anderson <mark@chef.io>
 %% @version 0.0.1
 %% @end
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_wm/itest/db_helper.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/db_helper.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(db_helper).
 

--- a/src/chef-mover/apps/oc_chef_wm/itest/mocks/chef_authn.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/mocks/chef_authn.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(chef_authn).
 

--- a/src/chef-mover/apps/oc_chef_wm/itest/mocks/chef_otto.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/mocks/chef_otto.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(chef_otto).
 

--- a/src/chef-mover/apps/oc_chef_wm/itest/mocks/darklaunch_app.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/mocks/darklaunch_app.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(darklaunch_app).
 

--- a/src/chef-mover/apps/oc_chef_wm/itest/mocks/oc_chef_authz.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/mocks/oc_chef_authz.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_authz).
 

--- a/src/chef-mover/apps/oc_chef_wm/itest/mocks/oc_chef_authz_app.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/mocks/oc_chef_authz_app.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_authz_app).
 

--- a/src/chef-mover/apps/oc_chef_wm/itest/oc_chef_wm_containers_SUITE.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/oc_chef_wm_containers_SUITE.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_containers_SUITE).
 

--- a/src/chef-mover/apps/oc_chef_wm/itest/setup_helper.erl
+++ b/src/chef-mover/apps/oc_chef_wm/itest/setup_helper.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(setup_helper).
 
@@ -57,7 +57,7 @@ start_server(Config) ->
     application:set_env(oc_chef_authz, couchdb_port, 6984),
     application:set_env(chef_db, couchdb_host, "localhost"),
     application:set_env(chef_db, couchdb_port, 6984),
-    
+
     application:set_env(lager, error_logger_redirect, false),
 
     application:set_env(stats_hero, udp_socket_pool_size, 200),

--- a/src/chef-mover/apps/oc_chef_wm/priv/dispatch-chef-wm.conf
+++ b/src/chef-mover/apps/oc_chef_wm/priv/dispatch-chef-wm.conf
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 %% ex: ft=erlang ts=4 sw=4
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_wm/priv/mysql_statements.config
+++ b/src/chef-mover/apps/oc_chef_wm/priv/mysql_statements.config
@@ -1,5 +1,5 @@
 %% -*- mode:erlang; erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_wm/priv/mysql_statements_opc.config
+++ b/src/chef-mover/apps/oc_chef_wm/priv/mysql_statements_opc.config
@@ -1,5 +1,5 @@
 %% -*- mode:erlang, erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_wm/priv/pgsql_statements_opc.config
+++ b/src/chef-mover/apps/oc_chef_wm/priv/pgsql_statements_opc.config
@@ -1,5 +1,5 @@
 %% -*- mode:erlang, erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -70,4 +70,3 @@
          updated_at = $13"
   "  WHERE id = $14">>
 }.
-

--- a/src/chef-mover/apps/oc_chef_wm/src/chef_wm_enforce.erl
+++ b/src/chef-mover/apps/oc_chef_wm/src/chef_wm_enforce.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_wm/src/oc_chef_action.erl
+++ b/src/chef-mover/apps/oc_chef_wm/src/oc_chef_action.erl
@@ -3,7 +3,7 @@
 %%
 %% @author James Casey <james@chef.io>
 %%
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -339,4 +339,3 @@ req_header(Name, Req) ->
         Header ->
             iolist_to_binary(Header)
     end.
-

--- a/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
+++ b/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_containers).
 

--- a/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
+++ b/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_groups).
 

--- a/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
+++ b/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_named_container).
 

--- a/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
+++ b/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_named_group).
 

--- a/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
+++ b/src/chef-mover/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_organizations).
 

--- a/src/chef-mover/apps/oc_chef_wm/test/chef_wm_status_tests.erl
+++ b/src/chef-mover/apps/oc_chef_wm/test/chef_wm_status_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -127,5 +127,3 @@ a2b(A) ->
 
 a2s(A) ->
     atom_to_list(A).
-
-

--- a/src/chef-mover/apps/oc_chef_wm/test/chef_wm_util_tests.erl
+++ b/src/chef-mover/apps/oc_chef_wm/test/chef_wm_util_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_wm/test/oc_chef_action_tests.erl
+++ b/src/chef-mover/apps/oc_chef_wm/test/oc_chef_action_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2013-2014 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
+++ b/src/chef-mover/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/scripts/check_logs.rb
+++ b/src/chef-mover/scripts/check_logs.rb
@@ -3,7 +3,7 @@
 # @author Mark Anderson <mark@chef.io>
 # @author Marc Paradise <marc@chef.io>
 #
-# Copyright 2013 Opscode Inc
+# Copyright Chef Software, Inc.
 # All Rights Reserved
 #
 # This script will serve two purposes:
@@ -13,7 +13,7 @@
 #    that will not be captured as failing conditions at time of the migration.
 # 2) output a condensed, more easily readable log file containing details of issues that it
 #    does discover. This (plus the associated console/error logs) should be provided to
-#    Opscode Support in the event of failed migration(s).
+#    Chef Support in the event of failed migration(s).
 #
 # Exit code:
 #
@@ -493,5 +493,3 @@ else
     exit 0
   end
 end
-
-

--- a/src/chef-mover/src/mover.hrl
+++ b/src/chef-mover/src/mover.hrl
@@ -14,7 +14,7 @@
 %% License for the specific language governing permissions and limitations under
 %% the License.
 %%-------------------------------------------------------------------
-%% @copyright (C) 2013, Opscode Inc.
+%% @copyright (C) Chef Software, Inc..
 %%
 
 -define(PHASE_1_MIGRATION_COMPONENTS,

--- a/src/chef-mover/src/mover_app.erl
+++ b/src/chef-mover/src/mover_app.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Kevin Smith <kevin@chef.io>
-%% @copyright 2019 Opscode, Inc.
+%% @copyright 2019 Chef Software, Inc.
 -module(mover_app).
 
 -behaviour(application).

--- a/src/chef-mover/src/mover_manager.erl
+++ b/src/chef-mover/src/mover_manager.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Marc A. Paradise <marc@chef.io>
-%% @copyright 2013 Opscode, Inc.
+%% @copyright 2013 Chef Software, Inc.
 %%
 %% @doc
 %%

--- a/src/chef-mover/src/mover_org_darklaunch.erl
+++ b/src/chef-mover/src/mover_org_darklaunch.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Marc Paradise <marc@chef.io>
-%% @copyright 2013 Opscode, Inc.
+%% @copyright 2013 Chef Software, Inc.
 %%
 
 %% Placeholder module for darklaunch redis functions.
@@ -97,4 +97,3 @@ send_eredis_q(false, Command) ->
         {error, Error} ->
             {error, Error}
     end.
-

--- a/src/chef-mover/src/mover_org_migrator.erl
+++ b/src/chef-mover/src/mover_org_migrator.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Marc Paradise <marc@chef.io>
-%% @copyright 2013 Opscode, Inc.
+%% @copyright 2013 Chef Software, Inc.
 %%
 %% @doc a gen_fsm that migrates a single org from end to end.
 %%
@@ -142,4 +142,3 @@ migration_successful(CallbackMod, OrgName) ->
 
 migration_failed(CallbackMod, OrgName, StateName) ->
     mover_util:call_if_exported(CallbackMod, migration_failed, [OrgName,StateName, CallbackMod:migration_type()], fun moser_state_tracker:migration_failed/3).
-

--- a/src/chef-mover/src/mover_org_migrator_sup.erl
+++ b/src/chef-mover/src/mover_org_migrator_sup.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Marc Paradise <marc@chef.io>
-%% @copyright 2011-2012 Opscode, Inc.
+%% @copyright Chef Software, Inc.
 
 % @doc a supervisor for mover_org_migrator
 
@@ -25,4 +25,3 @@ init([]) ->
 
 start_worker(CallbackModule, Object, MigrationArgs) ->
     supervisor:start_child(?SERVER, [{CallbackModule, Object, MigrationArgs}]).
-

--- a/src/chef-mover/src/mover_sup.erl
+++ b/src/chef-mover/src/mover_sup.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Kevin Smith <kevin@chef.io>
-%% @copyright 2011 Opscode, Inc.
+%% @copyright 2011 Chef Software, Inc.
 -module(mover_sup).
 
 -behaviour(supervisor).

--- a/src/chef-mover/src/mover_transient_migration_queue_sup.erl
+++ b/src/chef-mover/src/mover_transient_migration_queue_sup.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %%
 %% @author Marc Paradise <marc@chef.io>
-%% @copyright 2013, Opscode Inc
+%% @copyright Chef Software, Inc.
 %%
 
 -module(mover_transient_migration_queue_sup).
@@ -23,4 +23,3 @@ init([]) ->
             {mover_transient_migration_queue, start_link, []},
                  permanent, brutal_kill, worker, [mover_transient_migration_queue]},
     {ok, {{one_for_one, 10, 10}, [Spec]}}.
-

--- a/src/chef-mover/src/mover_transient_worker.erl
+++ b/src/chef-mover/src/mover_transient_worker.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Marc Paradise <marc@chef.io>
-%% @copyright 2013 Opscode, Inc.
+%% @copyright 2013 Chef Software, Inc.
 %%
 %% @doc a gen_fsm that performs a generic migration using the supplied fun.
 

--- a/src/chef-mover/src/mover_transient_worker_sup.erl
+++ b/src/chef-mover/src/mover_transient_worker_sup.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil;fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Marc Paradise <marc@chef.io>
-%% @copyright 2013 Opscode, Inc.
+%% @copyright 2013 Chef Software, Inc.
 %%
 %% @doc a supervisor for mover_transient_worker
 

--- a/src/chef-mover/src/mover_user_hash_converter.erl
+++ b/src/chef-mover/src/mover_user_hash_converter.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %%
 %% @author Marc Paradise <marc@chef.io>
-%% @copyright 2013, Opscode Inc
+%% @copyright Chef Software, Inc.
 %%
 
 -module(mover_user_hash_converter).
@@ -147,5 +147,3 @@ all_unconverted_users_count_sql() ->
 
 all_users_count_sql() ->
     <<"SELECT count(*) FROM users">>.
-
-

--- a/src/chef-mover/src/mover_util.erl
+++ b/src/chef-mover/src/mover_util.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Marc A. Paradise <marc@chef.io>
-%% @copyright (C) 2013, Opscode Inc.
+%% @copyright (C) Chef Software, Inc..
 %%
 %% @doc
 %% Some simple org migration utilities.

--- a/src/chef-mover/src/mv_oc_chef_authz_http.erl
+++ b/src/chef-mover/src/mv_oc_chef_authz_http.erl
@@ -3,7 +3,7 @@
 %% @author Kevin Smith <kevin@chef.io>
 %% @doc oc_chef_authz's interface to the authz server
 %%
-%% Copyright 2011-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/chef-mover/test/mover_tests.erl
+++ b/src/chef-mover/test/mover_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% @copyright 2011 Opscode, Inc.
+%% @copyright 2011 Chef Software, Inc.
 
 -module(mover_tests).
 

--- a/src/chef-server-ctl/plugins/cleanup.rb
+++ b/src/chef-server-ctl/plugins/cleanup.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Opscode, Inc.
+# Copyright (c) 2013 Chef Software, Inc.
 # All Rights Reserved
 
 add_command_under_category "cleanup", "general", "Perform post-upgrade removal of now-obsolete data, configuration files, logs, etc.  Add the '--no-op' flag to see what *would* be removed.", 2 do

--- a/src/chef-server-ctl/plugins/password.rb
+++ b/src/chef-server-ctl/plugins/password.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 # All Rights Reserved
 #

--- a/src/chef-server-ctl/plugins/test.rb
+++ b/src/chef-server-ctl/plugins/test.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) Chef Software, Inc.
 #
 # All Rights Reserved
 #

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/command_line.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/command_line.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/concern.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/concern.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/config.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/config.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/rspec/common.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/rspec/common.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/rspec/http_status_codes.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/rspec/http_status_codes.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/rspec/matchers.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/rspec/matchers.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/ui.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/ui.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/utility.rb
+++ b/src/oc_bifrost/oc-bifrost-pedant/lib/pedant/utility.rb
@@ -1,4 +1,4 @@
-# Copyright: Copyright (c) 2012 Opscode, Inc.
+# Copyright: Copyright (c) Chef Software, Inc.
 # License: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/oc_erchef/apps/chef_db/README.md
+++ b/src/oc_erchef/apps/chef_db/README.md
@@ -40,7 +40,7 @@ Documentation:
 
 # LICENSE:
 
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/oc_erchef/apps/chef_db/priv/README.md
+++ b/src/oc_erchef/apps/chef_db/priv/README.md
@@ -28,7 +28,7 @@ Note that depending on settings the database and or username are subject to be d
 
 # LICENSE
 
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
+++ b/src/oc_erchef/apps/chef_db/priv/pgsql_statements.config
@@ -1,5 +1,5 @@
 %% -*- mode:erlang, erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -19,7 +19,7 @@
 
 {ping, <<"SELECT 'pong' as ping LIMIT 1">>}.
 
-{stats, 
+{stats,
  <<"SELECT *"
    " FROM"
    "   ( SELECT SUM(seq_scan) as seq_scan,"

--- a/src/oc_erchef/apps/chef_db/src/chef_db.app.src
+++ b/src/oc_erchef/apps/chef_db/src/chef_db.app.src
@@ -1,5 +1,5 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_db/src/chef_db_darklaunch.erl
+++ b/src/oc_erchef/apps/chef_db/src/chef_db_darklaunch.erl
@@ -1,5 +1,5 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -32,7 +32,3 @@ is_enabled(_, _) ->
 is_enabled(Feature, Darklaunch) ->
     ?CHEF_DB_DARKLAUNCH:is_enabled(Feature, Darklaunch).
 -endif.
-
-
-
-

--- a/src/oc_erchef/apps/chef_db/src/chefp.erl
+++ b/src/oc_erchef/apps/chef_db/src/chefp.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_db/test/chef_db_test_utils.erl
+++ b/src/oc_erchef/apps/chef_db/test/chef_db_test_utils.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Mark Anderson <mark@chef.io>
 %% @version 0.0.1
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_db/test/chef_db_tests.erl
+++ b/src/oc_erchef/apps/chef_db/test/chef_db_tests.erl
@@ -1,5 +1,5 @@
 %% B
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_db/test/chef_sql_tests.erl
+++ b/src/oc_erchef/apps/chef_db/test/chef_sql_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -19,4 +19,3 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include("chef_types.hrl").
-

--- a/src/oc_erchef/apps/chef_db/test/chefp_tests.erl
+++ b/src/oc_erchef/apps/chef_db/test/chefp_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_index/src/chef_index.app.src
+++ b/src/oc_erchef/apps/chef_index/src/chef_index.app.src
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_index/src/chef_index_sup.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_sup.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author Kevin Smith <kevin@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
+++ b/src/oc_erchef/apps/chef_index/src/chef_lucene.peg
@@ -69,7 +69,7 @@ special_char <- '[' / ']' / '\\' / '/' / '"' / [!(){}^~*?:] ~;
 
 %{
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_index/src/chef_solr.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_solr.erl
@@ -4,7 +4,7 @@
 %% @doc Helper module for calling various Chef REST endpoints
 %% @end
 %%
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_index/test/chef_index_query_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_query_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_solr_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/README.md
+++ b/src/oc_erchef/apps/chef_objects/README.md
@@ -40,7 +40,7 @@ Documentation:
 
 # LICENSE:
 
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/oc_erchef/apps/chef_objects/src/chef_cert_http.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cert_http.erl
@@ -3,7 +3,7 @@
 %% @author James Casey <james@chef.io>
 %% @doc interface to the certificate generation service
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -82,5 +82,3 @@ check_http_response(Code, Headers, Body) ->
         "5" ++ _Digits ->
             throw({error, {server_error, {Code, Headers, Body}}})
     end.
-
-

--- a/src/oc_erchef/apps/chef_objects/src/chef_client.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_client.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Douglas Triggs <doug@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_config.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_config.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cookbook_version.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author James Casey <james@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_data_bag.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_data_bag.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_data_bag_item.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_data_bag_item.erl
@@ -3,7 +3,7 @@
 %% @author Seth Falcon <seth@chef.io>
 %% @author Christopher Maier <cm@chef.io>
 %% @author Mark Anderson <mark@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_db_compression.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_db_compression.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Kevin Smith <kevin@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_deep_merge.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_deep_merge.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Dan Deleo <dan@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_depsolver.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_depsolver.erl
@@ -4,7 +4,7 @@
 %%
 %% Regex from chef_json_validator.erl
 %% @author Marc Paradise <marc@chef.io>
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -124,4 +124,3 @@ solve_dependencies(AllVersions, EnvConstraints, Cookbooks) ->
 
 depsolver_timeout() ->
     envy:get(chef_objects, depsolver_timeout, ?DEFAULT_DEPSOLVER_TIMEOUT, non_neg_integer).
-

--- a/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_depsolver_worker.erl
@@ -3,7 +3,7 @@
 %%%-------------------------------------------------------------------
 %%% @author Stephen Delano <stephen@chef.io>
 %%% @doc Worker module for chef_depsolver resource
-%%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%%% Copyright Chef Software, Inc. All Rights Reserved.
 %%%
 %%% This file is provided to you under the Apache License,
 %%% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_environment.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_environment.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author John Keiser <jkeiser@chef.io>
 %% @author Doug Triggs <doug@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_json.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_json.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Doug Triggs <doug@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_json_validator.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_json_validator.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_metrics.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_metrics.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_node.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_node.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_object.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_object.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_objects.app.src
+++ b/src/oc_erchef/apps/chef_objects/src/chef_objects.app.src
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_parallel.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_parallel.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_regex.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_regex.erl
@@ -6,7 +6,7 @@
 %%
 %% Regex used in erchef
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_role.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_role.erl
@@ -1,8 +1,8 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% @copyright 2012 Opscode, Inc.
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% @copyright Chef Software, Inc.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
@@ -6,7 +6,7 @@
 %% @author Ho-Sheng Hsiao <hosh@chef.io>
 %% @doc chef_s3 - Manage S3 activities for erchef
 %%
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_s3_ops.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_s3_ops.erl
@@ -3,7 +3,7 @@
 %% @author Kevin Smith <kevin@chef.io>
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Chisamore <schisamo@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/src/chef_sandbox.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_sandbox.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -180,4 +180,3 @@ proplist_to_checksum(Proplist) ->
 
 set_api_version(ObjectRec, ApiVersion) ->
     ObjectRec#chef_sandbox{server_api_version = ApiVersion}.
-

--- a/src/oc_erchef/apps/chef_objects/test/chef_cert_http_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cert_http_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_client_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_client_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_config_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_config_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Chisamore <schisamo@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -57,8 +57,8 @@ config_option_test_() ->
 					     chef_config:config_option(TestApplication, TestOption, Type))
 			end
 		end}
-       end} || {Description, Value, Type, ErrorState} <- 
-		   [{"Positive integer: " ++ Label, V, pos_integer, E } || 
+       end} || {Description, Value, Type, ErrorState} <-
+		   [{"Positive integer: " ++ Label, V, pos_integer, E } ||
 		       {Label, V, E} <- [{"Succeeds with positive integer", 5, no_error},
 					 {"Fails with 0", 0, error},
 					 {"Fails with negative integer", -5, error},
@@ -68,4 +68,3 @@ config_option_test_() ->
 					 {"Fails with a binary", <<"This is also bad">>, error},
 					 {"Fails when undefined", undefined, always_error}]
 		   ]]}.
-	      

--- a/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cookbook_version_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_db_compression_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_db_compression_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_deep_merge_test.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_deep_merge_test.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -65,4 +65,3 @@ compat_test_() ->
     end
 
   }.
-

--- a/src/oc_erchef/apps/chef_objects/test/chef_depsolver_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_depsolver_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author James Casey <james@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_environment_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_environment_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_json_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_json_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_json_validator_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_json_validator_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_metrics_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_metrics_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_node_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_node_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_object_base_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_object_base_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -169,5 +169,3 @@ semantic_duplication_test_() ->
 
 parse_date_test() ->
     ?assertEqual(?INFINITY_TIMESTAMP, chef_object_base:parse_date(<<"infinity">>)).
-
-

--- a/src/oc_erchef/apps/chef_objects/test/chef_objects_test_utils.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_objects_test_utils.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Mark Anderson <mark@chef.io>
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_password_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_password_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_regex_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_regex_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_role_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_role_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_s3_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_s3_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Christopher Maier <cm@chef.io>
 %% @author Seth Chisamore <schisamo@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_sandbox_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_sandbox_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 %% @author Seth Falcon <seth@chef.io>
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -138,4 +138,3 @@ sandbox_rows() ->
     {<<"checksum">>, <<"dddddddddddddddddddddddddddddddd">>},
     {<<"uploaded">>, true}]
   ].
-

--- a/src/oc_erchef/apps/chef_objects/test/chef_test_utility.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_test_utility.erl
@@ -4,7 +4,7 @@
 %%
 %% @doc Broadly useful EUnit testing utilities.
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_user_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/depsolver/Makefile
+++ b/src/oc_erchef/apps/depsolver/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2012 Opscode, Inc. All Rights Reserved.
+# Copyright Chef Software, Inc. All Rights Reserved.
 #
 # This file is provided to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/depsolver/README.md
+++ b/src/oc_erchef/apps/depsolver/README.md
@@ -71,7 +71,7 @@ License and Authors
 * Author:: Eric Merritt (<ericbmerritt@gmail.com>)
 * Author:: James Casey (<james@chef.io>)
 
-Copyright 2012 Opscode, Inc. All Rights Reserved.
+Copyright Chef Software, Inc. All Rights Reserved.
 
 This file is provided to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/depsolver/priv/log_test.rb
+++ b/src/oc_erchef/apps/depsolver/priv/log_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# Copyright 2012 Opscode, Inc. All Rights Reserved.
+# Copyright Chef Software, Inc. All Rights Reserved.
 #
 # This file is provided to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/depsolver/src/depsolver.app.src
+++ b/src/oc_erchef/apps/depsolver/src/depsolver.app.src
@@ -3,7 +3,7 @@
 %%
 %% @author Eric Merritt <ericbmerritt@gmail.com>
 %%
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/depsolver/src/depsolver.erl
+++ b/src/oc_erchef/apps/depsolver/src/depsolver.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4; indent-tabs-mode: nil; fill-column: 80 -*-
 %% ex: ts=4 sw=4 et
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/depsolver/test/depsolver_tests.erl
+++ b/src/oc_erchef/apps/depsolver/test/depsolver_tests.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %%
 %%-------------------------------------------------------------------
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/README.md
+++ b/src/oc_erchef/apps/oc_chef_authz/README.md
@@ -61,7 +61,7 @@ Documentation:
 
 # LICENSE:
 
-Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+Copyright Chef Software, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.app.src
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz.app.src
@@ -1,4 +1,4 @@
-%% Copyright 2012-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_acl.erl
@@ -3,7 +3,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Douglas Triggs <doug@chef.io>
 %% @author Mark Anderson <mark@chef.io>
-%% Copyright 2014-2016 Chef Software, Inc.
+%% Copyright Chef Software, Inc.
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
 %% except in compliance with the License.  You may obtain

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_cleanup.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_cleanup.erl
@@ -10,7 +10,7 @@
 %%% @end
 %%% Created :  6 Nov 2013 by Oliver Ferrigni <>
 %%%-------------------------------------------------------------------
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.hrl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_db.hrl
@@ -3,7 +3,7 @@
 %% @author Seth Falcon <seth@chef.io>
 %%
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_http.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_http.erl
@@ -3,7 +3,7 @@
 %% @author Kevin Smith <kevin@chef.io>
 %% @doc oc_chef_authz's interface to the authz server
 %%
-%% Copyright 2011-2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_container.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_container.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_container).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_group.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_group.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_group).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_org_user_association.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_org_user_association.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Tyler Cloke <tyler@chef.io>
-%% Copyright 2014 Opscode, Inc. All Rights Reserved.
+%% Copyright 2014 Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_org_user_association).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_organization.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_organization.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Tyler Cloke <tyler@chef.io>
 %% @author Mark Anderson <mark@chef.io>
-%% Copyright 2014 Opscode, Inc. All Rights Reserved.
+%% Copyright 2014 Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_organization).
 

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Oliver Ferrigni <oliver@chef.io>
-%% Copyright 2012-2015 Opscode, Inc. All Rights Reserved.
+%% Copyright 2012-2015 Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_group.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Daniel DeLeo <dan@chef.io>
-%% Copyright 2012-2015 Opscode, Inc. All Rights Reserved.
+%% Copyright 2012-2015 Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_revision.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_policy_revision.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Daniel DeLeo <dan@chef.io>
-%% Copyright 2012-2015 Opscode, Inc. All Rights Reserved.
+%% Copyright 2012-2015 Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_test_utils.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_authz_test_utils.erl
@@ -3,7 +3,7 @@
 %% @author Mark Anderson <mark@chef.io>
 %% @version 0.0.1
 %% @end
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_group_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/test/oc_chef_group_tests.erl
@@ -1,7 +1,7 @@
 %% @author Ho-Sheng Hsiao <hosh@chef.io>
 %% @doc group operations
 %%
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -97,4 +97,3 @@ handle_error_test_() ->
             end
         }
     ].
-

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_policies_SUITE).
 

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_sanboxes_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_sanboxes_SUITE.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_sanboxes_SUITE).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_enforce.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_enforce.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_action.erl
@@ -3,7 +3,7 @@
 %%
 %% @author James Casey <james@chef.io>
 %%
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_acl_permission.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Douglas Triggs <doug@chef.io>
 %% @author Mark Mzyk <mm@chef.io>
-%% Copyright 2014-2015 Chef Software, Inc.
+%% Copyright Chef Software, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_containers.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_containers).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_groups.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_groups).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_container.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_named_container).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Jean Rouge <jean@chef.io>
-%% Copyright 2013-2015 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_named_cookbook_artifact).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact_version.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_cookbook_artifact_version.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Jean Rouge <jean@chef.io>
-%% Copyright 2013-2015 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_named_cookbook_artifact_version).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_group.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_organizations.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Oliver Ferrigni <oliver@chef.io>
 %% @author Jean Rouge <jean@chef.io>
-%% Copyright 2013-2014 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_policies).
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_group_policy_rev.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_group_policy_rev.erl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author Oliver Ferrigni <oliver@chef.io>
 %% @author Jean Rouge <jean@chef.io>
-%% Copyright 2013-2015 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 -module(oc_chef_wm_policy_group_policy_rev).
 

--- a/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_status_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_util_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/chef_wm_util_tests.erl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %%
-%% Copyright 2013-2015 Chef Software, Inc.
+%% Copyright Chef Software, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -88,5 +88,3 @@ base_uri_test_() ->
             end
         }
     ].
-
-

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_action_tests.erl
@@ -1,4 +1,4 @@
-%% Copyright 2013-2014 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/test/oc_chef_wm_base_tests.erl
@@ -1,6 +1,6 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
-%% Copyright 2013 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -238,12 +238,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -252,12 +252,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -266,12 +266,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -280,12 +280,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -294,12 +294,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -308,12 +308,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_key_base, update_object_embedded_key_data_v0}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -322,12 +322,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               halt
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -336,12 +336,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 0,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               halt
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -351,12 +351,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_base, update_from_json}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -365,12 +365,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_base, update_from_json}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -379,12 +379,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_base, update_from_json}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -393,12 +393,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = false, 
+               EmailUpdateConfig = false,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_base, update_from_json}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -407,12 +407,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_base, update_from_json}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -421,12 +421,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "web",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               {ok, oc_chef_wm_base, update_from_json}
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -435,12 +435,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               halt
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end},
@@ -449,12 +449,12 @@ verify_email_updates_test_() ->
                OrigEmail = <<"user@example.com">>,
                NewEmail = <<"user2@example.com">>,
                RequestOrigin = "knife",
-               EmailUpdateConfig = true, 
+               EmailUpdateConfig = true,
                ApiVersion = 1,
                meck:expect(oc_chef_wm_named_user, verify_update_request, fun(_, _, _, _, _) ->
                                                               halt
                                                       end),
-               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail, 
+               oc_chef_wm_named_user:verify_update_request(OrigEmail, NewEmail,
                        RequestOrigin, EmailUpdateConfig, ApiVersion),
                ?assert(meck:validate(oc_chef_wm_named_user))
        end}

--- a/src/oc_erchef/include/chef_db.hrl
+++ b/src/oc_erchef/include/chef_db.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/include/chef_index.hrl
+++ b/src/oc_erchef/include/chef_index.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/include/chef_regex.hrl
+++ b/src/oc_erchef/include/chef_regex.hrl
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 %% @author James Casey <james@chef.io>
 %%
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -45,5 +45,3 @@
 -type re_msg() :: <<_:64,_:_*8>>.
 
 -type regex_pattern() :: [1..255,...].
-
-

--- a/src/oc_erchef/include/chef_solr.hrl
+++ b/src/oc_erchef/include/chef_solr.hrl
@@ -1,4 +1,4 @@
-%% Copyright 2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/oc_erchef/include/oc_chef_authz.hrl
+++ b/src/oc_erchef/include/oc_chef_authz.hrl
@@ -8,7 +8,7 @@
 %%
 %% This module is an Erlang port of the mixlib-authorization Ruby gem.
 %%
-%% Copyright 2011-2012 Opscode, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -51,4 +51,3 @@
           'path',           % 'path' of container (not used? Orig part of inheritance mech?; safe to delete? Yea!)
           'last_updated_by' % authz guid of last actor to update object
          }).
-

--- a/src/oc_erchef/include/oc_chef_types.hrl
+++ b/src/oc_erchef/include/oc_chef_types.hrl
@@ -1,7 +1,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
 %% ex: ts=4 sw=4 et
 %% @author Stephen Delano <stephen@chef.io>
-%% Copyright 2014-2016 Chef Software, Inc. All Rights Reserved.
+%% Copyright Chef Software, Inc. All Rights Reserved.
 
 
 -type chef_authz_type() :: 'actor' |

--- a/src/oc_erchef/priv/reindex-opc-organization
+++ b/src/oc_erchef/priv/reindex-opc-organization
@@ -2,7 +2,7 @@
 %% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92-*-
 %% ex: ts=4 sw=4 et
 
-%% Copyright (c) 2013 Opscode, Inc.
+%% Copyright (c) 2013 Chef Software, Inc.
 %% All Rights Reserved
 
 %% TODO: The cookie used by erchef should be part of config
@@ -45,7 +45,7 @@ main(Args) ->
       init_network(),
       [Command, OrgInfo, Context] = validate_args(Args),
       perform(Command, Context, OrgInfo)
-    catch 
+    catch
         error:{badmatch,{error,{conn_failed,{error,econnrefused}}}} ->
             io:format("~n Unable to start new erlang node due to network issue~n Please check if the localhost is resolved to 127.0.0.1 or check if firewall is blocking the connection~n");
         error:{badmatch,{error,{already_started,Pid}}} ->


### PR DESCRIPTION
Also nuke the dates since these aren't required and this way we don't
have to worry about updating them.

Signed-off-by: Tim Smith <tsmith@chef.io>