### PR TITLE
Remove logic for configuring ES to support RHEL < 7 

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/elasticsearch.yml.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/elasticsearch.yml.erb
@@ -19,7 +19,7 @@ network.host: "<%= @listen %>"
 http.port: <%= @port %>
 
 <%
-  # ES7 mandatory configuration.These settings are applicable only for the users using standalone or tiered configurations. 
+  # ES7 mandatory configuration.These settings are applicable only for the users using standalone or tiered configurations.
   # For BYOD(external elasticsearch) none of the omnibus configs are applicable.
   # Note: we have not enabled bootstrap checks, so failing bootstrap checks will appear as warnings in the es logs.
   if node['private_chef']['elasticsearch']['es_version'].to_f > 7.0
@@ -28,20 +28,3 @@ discovery.type: single-node
 <%
   end
 %>
-
-<%
-  # ES uses secomp in production mode. This is not supported in RHEL <  7
-  # Reference:
-  # https://www.elastic.co/guide/en/elasticsearch/reference/master/_system_call_filter_check.html
-  # https://github.com/elastic/elasticsearch/issues/22899
-  case node["platform_family"]
-  when "rhel", "fedora"
-    if node["platform_version"].to_f < 7.0
-%>
-bootstrap.system_call_filter: false
-<%
-    end
-  end
-%>
-
-


### PR DESCRIPTION
Remove EL 6 support logic from the ES config template

This build off #2709 so that needs to be merged first