### PR TITLE
Fix error (malformed version number string)

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -186,7 +186,7 @@ class PostgresqlPreflightValidator < PreflightValidator
   def backend_verify_postgres_version(connection)
     # Make sure the server is a supported version.
     r = connection.exec('SHOW server_version;')
-    v = Gem::Version.new(r[0]['server_version'])
+    v = Gem::Version.new(r[0]['server_version'].to_f)
 
     # Note that we're looking for the same major, and using our minor as the minimum version
     # This provides compatibility with external databases that use < 9.6 before we make use


### PR DESCRIPTION
Fix the following error:

```
ArgumentError
---------------
Malformed version number string 13.3 (Ubuntu 13.3-1.pgdg16.04+1)
```

passing adhoc:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/3065#22274f9e-534a-45be-9aea-671a1cc0e4b0

passing umbrella:
https://buildkite.com/chef/chef-umbrella-master-chef-server/builds/617#a95a2110-4764-4ca3-a1ff-729147c3dc6a

Full context:

https://buildkite.com/chef/chef-umbrella-master-chef-server/builds/610#424ef0ab-3a18-41ce-b734-9319d00c7fbd

```
https://buildkite.com/chef/chef-umbrella-master-chef-server/builds/615#a7d96342-befc-4a5e-8eb9-5e0f50948249

null_resource.chef_server_config (remote-exec): r[0]['server_version'] =
13.3 (Ubuntu 13.3-1.pgdg16.04+1)

null_resource.chef_server_config (remote-exec):
================================================================================
null_resource.chef_server_config (remote-exec):   Recipe Compile Error
in
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/recipes/default.rb
null_resource.chef_server_config (remote-exec):
================================================================================

null_resource.chef_server_config (remote-exec):   ArgumentError
null_resource.chef_server_config (remote-exec):   -------------
null_resource.chef_server_config (remote-exec):   Malformed version
number string 13.3 (Ubuntu 13.3-1.pgdg16.04+1)

null_resource.chef_server_config (remote-exec):   Cookbook Trace: (most
recent call first)
null_resource.chef_server_config (remote-exec):
----------------------------------------
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_postgres_validator.rb:190:in
`backend_verify_postgres_version'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_postgres_validator.rb:145:in
`block in backend_validation'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_checks.rb:104:in
`block in connect_as'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/ec_postgres.rb:46:in
`with_connection'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_checks.rb:96:in
`connect_as'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_postgres_validator.rb:143:in
`backend_validation'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_postgres_validator.rb:42:in
`run!'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_checks.rb:144:in
`run!'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/recipes/config.rb:98:in
`from_file'
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/recipes/default.rb:49:in
`from_file'

null_resource.chef_server_config (remote-exec):   Relevant File Content:
null_resource.chef_server_config (remote-exec):   ----------------------
null_resource.chef_server_config (remote-exec):
/var/opt/opscode/local-mode-cache/cookbooks/private-chef/libraries/preflight_postgres_validator.rb:

null_resource.chef_server_config (remote-exec):   183:      end
null_resource.chef_server_config (remote-exec):   184:    end
null_resource.chef_server_config (remote-exec):   185:
null_resource.chef_server_config (remote-exec):   186:    def
backend_verify_postgres_version(connection)
null_resource.chef_server_config (remote-exec):   187:      # Make sure
the server is a supported version.
null_resource.chef_server_config (remote-exec):   188:      r =
connection.exec('SHOW server_version;')
null_resource.chef_server_config (remote-exec):   189:
puts"\n\nr[0]['server_version'] = #{r[0]['server_version']}\n\n"
null_resource.chef_server_config (remote-exec):   190>>     v =
Gem::Version.new(r[0]['server_version'])
null_resource.chef_server_config (remote-exec):   191:
null_resource.chef_server_config (remote-exec):   192:      # Note that
we're looking for the same major, and using our minor as the minimum
version
null_resource.chef_server_config (remote-exec):   193:      # This
provides compatibility with external databases that use < 9.6 before we
make use
null_resource.chef_server_config (remote-exec):   194:      # of any
features available in > 9.2.
null_resource.chef_server_config (remote-exec):   195:
null_resource.chef_server_config (remote-exec):   196:      if v ==
REQUIRED_VERSION || v == SUPPORTED_VERSION
null_resource.chef_server_config (remote-exec):   197:        :ok
null_resource.chef_server_config (remote-exec):   198:      elsif v <
REQUIRED_VERSION || v > SUPPORTED_VERSION
null_resource.chef_server_config (remote-exec):   199:        fail_with
err_CSPG014_bad_postgres_version(v)
```

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
