### PR TITLE
Elastsearch gather-log updates

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -67,10 +67,10 @@ fi
 
 # Gather some information from Elasticsearch, if it's available
 gather_es() {
-    curl -sS -X GET "http://localhost:$1/_cluster/health?pretty" > "$tmpdir/elasticsearch-cluster-health.txt"
-    curl -sS -X GET "http://localhost:$1/_cat/indices?v" > "$tmpdir/elasticsearch-cat-indices.txt"
-    curl -sS -X GET "http://localhost:$1/_cat/shards?h=index,shard,prirep,state,unassigned.reason&pretty" > "$tmpdir/elasticsearch-cat-shards.txt"
-    curl -sS -X GET "http://localhost:$1/_cluster/allocation/explain?pretty" > "$tmpdir/elasticsearch-cluster-shards-explain.txt"
+    curl -sS -X GET "http://localhost:$1/_cluster/health?pretty" > "$tmpdir/elasticsearch_cluster_health.txt"
+    curl -sS -X GET "http://localhost:$1/_cat/indices?v" > "$tmpdir/elasticsearch_cat_indices.txt"
+    curl -sS -X GET "http://localhost:$1/_cat/shards?h=index,shard,prirep,state,unassigned.reason&pretty" > "$tmpdir/elasticsearch_cat_shards.txt"
+    curl -sS -X GET "http://localhost:$1/_cluster/allocation/explain?pretty" > "$tmpdir/elasticsearch_cluster_shards_explain.txt"
 }
 ES_9200="$(curl -s -XGET 'http://localhost:9200/' | grep 'for Search')"
 ES_10144="$(curl -s -XGET 'http://localhost:10144/' | grep 'for Search')"

--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -67,10 +67,10 @@ fi
 
 # Gather some information from Elasticsearch, if it's available
 gather_es() {
-    curl -s -X GET "http://localhost:$1/_cluster/health?pretty" > "$tmpdir/elasticsearch-cluster-health.txt"
-    curl -s -X GET "http://localhost:$1/_cat/indices?v" > "$tmpdir/elasticsearch-cat-indices.txt"
-    curl -s -X GET "http://localhost:$1/_cat/shards?h=index,shard,prirep,state,unassigned.reason&pretty" > "$tmpdir/elasticsearch-cat-shards.txt"
-    curl -s -X GET "http://localhost:$1/_cluster/allocation/explain?pretty" > "$tmpdir/elasticsearch-cluster-shards-explain.txt"
+    curl -sS -X GET "http://localhost:$1/_cluster/health?pretty" > "$tmpdir/elasticsearch-cluster-health.txt"
+    curl -sS -X GET "http://localhost:$1/_cat/indices?v" > "$tmpdir/elasticsearch-cat-indices.txt"
+    curl -sS -X GET "http://localhost:$1/_cat/shards?h=index,shard,prirep,state,unassigned.reason&pretty" > "$tmpdir/elasticsearch-cat-shards.txt"
+    curl -sS -X GET "http://localhost:$1/_cluster/allocation/explain?pretty" > "$tmpdir/elasticsearch-cluster-shards-explain.txt"
 }
 ES_9200="$(curl -s -XGET 'http://localhost:9200/' | grep 'for Search')"
 ES_10144="$(curl -s -XGET 'http://localhost:10144/' | grep 'for Search')"

--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -68,6 +68,7 @@ fi
 # Gather some information from Elasticsearch, if it's available
 gather_es() {
     curl -sS -X GET "http://localhost:$1/_cluster/health?pretty" > "$tmpdir/elasticsearch_cluster_health.txt"
+    curl -sS -X GET "http://localhost:$1/_cluster/state?pretty" > "$tmpdir/elasticsearch_cluster_state.txt"
     curl -sS -X GET "http://localhost:$1/_cat/indices?v" > "$tmpdir/elasticsearch_cat_indices.txt"
     curl -sS -X GET "http://localhost:$1/_cat/shards?h=index,shard,prirep,state,unassigned.reason&pretty" > "$tmpdir/elasticsearch_cat_shards.txt"
     curl -sS -X GET "http://localhost:$1/_cluster/allocation/explain?pretty" > "$tmpdir/elasticsearch_cluster_shards_explain.txt"


### PR DESCRIPTION
### Description

Some improvements to the Elasticsearch gather-log files I noticed while looking at updating the reporter.

1. Use `curl -sS` so we can get any errors that might happen when talking to ES
2. Filenames should use _ instead - to match what gets created by `chef-automate gather-logs`
3. Added an additional output for `_cluster/state` which we use to detect if the cluster is read-only due to the disk filling up.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
