### PR TITLE
Fix a notification for firing partybus

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/recipes/partybus.rb
@@ -83,7 +83,7 @@ ruby_block 'migration-level file check' do
   not_if { ::File.exist?('/var/opt/opscode/upgrades/migration-level') }
   action :nothing
   if OmnibusHelper.has_been_bootstrapped?
-    subscribes :run, 'private-chef_pg_upgrade[upgrade_if_necessary]', :delayed
+    subscribes :run, 'pg_upgrade[upgrade_if_necessary]', :delayed
   else
     subscribes :run, 'execute[set initial migration level]', :immediately
   end


### PR DESCRIPTION
So this has been broken for a long time and I failed to fix it because
of the way it was broken.

If the cookbook is named 'private-chef' and the resource file is named
'pg_upgrade' then the resource becomes 'private_chef_pg_upgrade'. We
were notifying 'private-chef_pg_upgrade', which is not a resource. My
change renamed the resource to just 'pg_upgrade' and I failed to update
this notify because my find/replace missed this typo.

Signed-off-by: Tim Smith <tsmith@chef.io>