### PR TITLE
Construct PostgreSQL version object using a regex.

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -186,7 +186,7 @@ class PostgresqlPreflightValidator < PreflightValidator
   def backend_verify_postgres_version(connection)
     # Make sure the server is a supported version.
     r = connection.exec('SHOW server_version;')
-    v = Gem::Version.new(r[0]['server_version'].to_f)
+    v = Gem::Version.new /^([0-9\.]+)/.match(r[0]['server_version'])[0]
 
     # Note that we're looking for the same major, and using our minor as the minimum version
     # This provides compatibility with external databases that use < 9.6 before we make use


### PR DESCRIPTION
The PostgreSQL version comes in as string, for example:
13.3 (Ubuntu 13.3-1.pgdg16.04+1)

Naturally, the version varies and could be anything.

For our purposes, we want to convert the above example to:
13.3

Currently we do this via:
`v = Gem::Version.new(r[0]['server_version'].to_f)`

This works as long as PostgreSQL does x.y versions but it will
fail in the future if they move to x.y.z.

To future-proof this, we propose conversion via the following:
`Gem::Version.new /^([0-9\.]+)/.match(r[0]['server_version'])[0]`

adhoc:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/3070

umbrella:
https://buildkite.com/chef/chef-umbrella-master-chef-server/builds/621#72e7074a-22f3-4570-80cb-405c2dbffd83

Signed-off-by: Lincoln Baker <lbaker@chef.io>

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
