### PR TITLE
Skipping auto reindex for external postgreSQL

### DIFF
--- a/omnibus/files/private-chef-upgrades/001/036_reindex_postgres13.rb
+++ b/omnibus/files/private-chef-upgrades/001/036_reindex_postgres13.rb
@@ -6,7 +6,10 @@ define_upgrade do
     start_services(['postgresql'])
     sleep 30
     # Run reindex for postgresql 13
-    log 'Reindexing postgreSQL...'
-    run_command("sudo -H -u  opscode-pgsql bash -c \'/opt/opscode/embedded/bin/reindexdb --all\'")
+    running_config = JSON.parse(File.read("/etc/opscode/chef-server-running.json"))
+    unless running_config['private_chef']['postgresql']['external']
+      log 'Reindexing postgreSQL...'
+      run_command("sudo -H -u  opscode-pgsql bash -c \'/opt/opscode/embedded/bin/reindexdb --all\'")
+    end
   end
 end


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Skipping auto reindex for external postgreSQL

adhoc:
https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/3072#d03986be-14f0-4d58-b8b0-ab502a70a8b6

### Issues Resolved

Skip auto reindex for external PostgreSQL

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
