### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/dev/defaults.yml
+++ b/dev/defaults.yml
@@ -126,8 +126,8 @@ projects:
           - ldap.bind_password
   oc-id:
     type: rails
-    install_options: --without development test doc
     build_steps:
+      - bundle config set --local without development test doc
       # We used to build assets in the pipeline, and needed to build them before loading. Now we've commited those assets to git, and
       #    - bundle exec rake assets:precompile --trace
       - bundle exec --keep-file-descriptors rake db:migrate

--- a/omnibus/config/software/oc_id.rb
+++ b/omnibus/config/software/oc_id.rb
@@ -47,9 +47,9 @@ build do
          " --with-xml2-config=#{install_dir}/embedded/bin/xml2-config" \
          " --with-xslt-config=#{install_dir}/embedded/bin/xslt-config"
 
+  bundle "config set --local without development test doc", env: env
   bundle "install" \
-         " --path=#{install_dir}/embedded/service/gem" \
-         " --without development test doc", env: env
+         " --path=#{install_dir}/embedded/service/gem", env: env
 
   bundle "exec rake assets:precompile", env: env
   sync project_dir, "#{install_dir}/embedded/service/oc_id/", exclude: ['**/.gitignore', 'log/', 'tmp/']

--- a/omnibus/config/software/partybus.rb
+++ b/omnibus/config/software/partybus.rb
@@ -26,9 +26,9 @@ dependency "postgresql13"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
+  bundle "config set --local without mysql", env: env
   bundle "install" \
-         " --path=#{install_dir}/embedded/service/gem" \
-         " --without mysql", env: env
+         " --path=#{install_dir}/embedded/service/gem", env: env
 
   sync project_dir, "#{install_dir}/embedded/service/partybus"
 end

--- a/omnibus/config/software/private-chef-ctl.rb
+++ b/omnibus/config/software/private-chef-ctl.rb
@@ -28,7 +28,7 @@ build do
 
   env = with_standard_compiler_flags(with_embedded_path)
 
-  # we would like to do this '--without development' but appbundler is insisting
+  # we would like to do this 'bundle config set --local without development' but appbundler is insisting
   # on installing
   bundle "install", env: env
 

--- a/src/chef-server-ctl/Makefile
+++ b/src/chef-server-ctl/Makefile
@@ -1,5 +1,5 @@
 
-# Hitting an issue where appbundler is using development dependencies, so can't add --without development --deployment here
+# Hitting an issue where appbundler is using development dependencies, so can't run bundle config set --local without development --deployment here
 install:
 	bundle install
 

--- a/src/oc-id/Makefile
+++ b/src/oc-id/Makefile
@@ -1,5 +1,6 @@
 install:
-	bundle install --without development --deployment
+	bundle config set --local without development
+	bundle install --deployment
 	psql -c 'create database oc_id_test;' -U postgres
 
 travis: ci

--- a/src/oc-id/lib/tasks/bk-ci.rake
+++ b/src/oc-id/lib/tasks/bk-ci.rake
@@ -10,7 +10,7 @@ begin
   end
 
 rescue LoadError
-  # In production, we `bundle --without development test`, so RSpec is not
+  # In production, we `bundle config set --local without development test`, so RSpec is not
   # included. Whenever you run a rake task or load the app it loads all of the
   # tasks in lib/tasks, so this will fail in those cases. We don't need this
   # task in those cases, so just fail gracefully and print a warning.

--- a/src/oc-id/lib/tasks/travis-ci.rake
+++ b/src/oc-id/lib/tasks/travis-ci.rake
@@ -10,7 +10,7 @@ begin
   end
 
 rescue LoadError
-  # In production, we `bundle --without development test`, so RSpec is not
+  # In production, we `bundle config set --local without development test`, so RSpec is not
   # included. Whenever you run a rake task or load the app it loads all of the
   # tasks in lib/tasks, so this will fail in those cases. We don't need this
   # task in those cases, so just fail gracefully and print a warning.


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
