### PR TITLE
Remove require rubygems in chef-server-ctl

### DIFF
--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -1,6 +1,5 @@
 #!/opt/opscode/embedded/bin/ruby
 
-require 'rubygems'
 gem 'omnibus-ctl'
 require 'omnibus-ctl'
 require 'veil'


### PR DESCRIPTION
This isn't a thing you need to do in ruby anymore

Signed-off-by: Tim Smith <tsmith@chef.io>