### PR TITLE
Refine instructions for external PostgreSQL upgrade

### DIFF
--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -351,7 +351,9 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
    su postgres
    ```
 1. Ensure that you are in a directory where you can successfully run the `pg_upgrade` command.
+
    Example:
+   
    ```bash
    cd /tmp
    ```

--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -313,7 +313,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 
    If the upgrade was successful, start the Chef Infra Server services and cleanup.
 
-   ```
+   ```bash
    sudo chef-server-ctl start
    sudo chef-server-ctl cleanup
    ```
@@ -326,7 +326,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 
 1. Update packages and install your selected PostgreSQL version.
    Example (Ubuntu/PostgreSQL 13.3):
-   ```
+   ```bash
    sudo apt-get update
    sudo apt-get install postgresql-13
    ```
@@ -334,7 +334,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 1. Check if there are any differences in the config files. Make sure to update the new config files if required.
    Example (PostgreSQL 13.3):
 
-   ```
+   ```bash
    diff /etc/postgresql/OLD_POSTGRESQL_VERSION/main/postgresql.conf /etc/postgresql/13/main/postgresql.conf
    diff /etc/postgresql/OLD_POSTGRESQL_VERSION/main/pg_hba.conf     /etc/postgresql/13/main/pg_hba.conf
    ```
@@ -350,11 +350,17 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
    ```bash
    su postgres
    ```
+1. Ensure that you are in a directory where you can successfully run the `pg_upgrade` command.
+   Example:
+   ```bash
+   cd /tmp
+   ```
+
 
 1. Check clusters (notice the `--check` argument, this will not change any data).
    Example (PostgreSQL 13.3):
 
-   ```
+   ```bash
    /usr/lib/postgresql/13/bin/pg_upgrade \
    --old-datadir=/var/lib/postgresql/9.6/main \
    --new-datadir=/var/lib/postgresql/13/main \
@@ -368,7 +374,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 1. Migrate the data (without the `--check` argument).
    Example (PostgreSQL 13.3):
 
-   ```
+   ```bash
    /usr/lib/postgresql/13/bin/pg_upgrade \
    --old-datadir=/var/lib/postgresql/9.6/main \
    --new-datadir=/var/lib/postgresql/13/main \
@@ -387,7 +393,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 1. Swap the ports for the old and new PostgreSQL versions.
    Example (PostgreSQL 13.3):
 
-   ```
+   ```bash
    $ sudo vim /etc/postgresql/13/main/postgresql.conf
    # change "port = 5433" to "port = 5432"
 
@@ -404,7 +410,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 1. Log in as the `postgres` user and confirm that the new PostgreSQL version is correct.
    Example (PostgreSQL 13.3):
 
-   ```
+   ```bash
    $ sudo su postgres
    $ psql -c "SELECT version();"
                                                                       version
@@ -416,7 +422,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 
 1. Run `reindexdb`. Example:
 
-   ```
+   ```bash
    $ /usr/bin/reindexdb --all
    reindexdb: reindexing database "bifrost"
    reindexdb: reindexing database "oc_id"
@@ -429,7 +435,7 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 
 1. Check the status of Chef Infra Server. PostgreSQL should be connected.
 
-   ```
+   ```bash
    $ sudo chef-server-ctl status
    -------------------
     Internal Services


### PR DESCRIPTION
I got bit by this today while following the external PostgreSQL upgrade instructions, and it took me a while to solve the issue.  You need to issue some instructions as `root`, so you will typically be  `cd`'d into the `/root` directory.  But once you start issuing instructions as the `postgres` user, if you are still in the `/root` directory you will get hangs, permissions errors, etc.

This docs edit clarifies that you need to be in another directory, e.g. `/tmp`.  While I was there, I also cleaned up a few things (added missing `bash` labels).