### PR TITLE
Use https URLs for the community slack site in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
+++ b/.github/ISSUE_TEMPLATE/SUPPORT_QUESTION.md
@@ -5,7 +5,7 @@ about: If you have a question 💬, please check out our Slack!
 
 We use GitHub issues to track bugs and feature requests. If you need help please post to our Mailing List or join the Chef Community Slack.
 
-* Chef Community Slack at http://community-slack.chef.io/.
+* Chef Community Slack at https://community-slack.chef.io/.
 * Chef Mailing List https://discourse.chef.io/
 
 Support issues opened here will be closed and redirected to Slack or Discourse.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you need to file an issue against another Chef project, you can find a list o
 
 We use GitHub issues to track bugs and feature requests. If you need help please post to our Mailing List or join the Chef Community Slack.
 
-* Chef Community Slack at http://community-slack.chef.io/.
+* Chef Community Slack at https://community-slack.chef.io/.
 * Chef Mailing List https://discourse.chef.io/
 
 ## Components of the Chef Server


### PR DESCRIPTION
Avoid non-https errors in new browsers

Signed-off-by: Tim Smith <tsmith@chef.io>