### PR TITLE
Add `allow_email_update_only_from_manage` to hab plan to resolve automate user issue

### DIFF
--- a/src/oc_erchef/habitat/config/sys.config
+++ b/src/oc_erchef/habitat/config/sys.config
@@ -71,6 +71,7 @@
 
     {oc_chef_wm, [
 {{~#with cfg/oc_chef_wm}}
+        {allow_email_update_only_from_manage, false},
         {ip_mode, [ {{../cfg.private_chef.ip_mode}} ] },
         {api_version, "{{api_version}}" },
         {server_flavor, "cs" },


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

The automate build is failing for user related test - https://buildkite.com/chef/chef-automate-main-verify-private/builds/16787#abb651ea-6e18-4813-a000-47a6a206358e

This is because the variable `allow_email_update_only_from_manage` is missing in sys.config. Need to make sure that this variable is part of the oc_erchef habitat build.

### Issues Resolved

resolves #2727

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] automate verify pipeline must pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
