### PR TITLE
updated config default value of allow_email_update_only_from_manage

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_user.erl
@@ -199,7 +199,7 @@ from_json(Req, #base_state{server_api_version = ApiVersion, resource_state =
         _ -> string:lowercase(OrigEmail0)
     end,
     NewEmail = ej:get({<<"email">>}, UserData),
-    EmailUpdateConfig = envy:get(oc_chef_wm, allow_email_update_only_from_manage, boolean),
+    EmailUpdateConfig = envy:get(oc_chef_wm, allow_email_update_only_from_manage, false, boolean),
     %% check if the request originated from the webui or client (client /knife)
     RequestOrigin = wrq:get_req_header("x-ops-request-source", Req),
     % in v1+ keys may only be updated via the keys endpoint.


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

updated config default value of allow_email_update_only_from_manage to avoid crashing in automate

### Issues Resolved


### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
