### PR TITLE
Changing the uri in the sqitch.plan causes sqitch to deploy some of the older changes that do not exist and fail an upgrade in automate. Reverting this change currently until we figure that out.

### DIFF
--- a/src/bookshelf/schema/sqitch.plan
+++ b/src/bookshelf/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=bookshelf
-%uri=https://github.com/chef/chef-server/tree/main/src/bookshelf
+%uri=https://github.com/opscode/chef-server/tree/main/src/bookshelf
 
 base_schema 2015-11-23T18:56:06Z Mark Anderson <mark@chef.io> # Basic schema for bookshelf file storage
 smart_delete 2016-01-13T18:39:12Z Mark Anderson <mark@chef.io> # Stored procedures for create/delete

--- a/src/oc_bifrost/schema/sqitch.plan
+++ b/src/oc_bifrost/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=bifrost
-%uri=https://github.com/chef/oc_bifrost
+%uri=https://github.com/opscode/oc_bifrost
 
 base 2013-06-24T11:10:23Z Christopher Maier <cm@opscode.com> # The initial base install of the bifrost schema
 forbid_group_cycles [base] 2013-06-24T13:04:05Z Christopher Maier <cm@opscode.com> # Add forbid_group_cycles function and accompanying trigger

--- a/src/oc_erchef/schema/baseline/sqitch.plan
+++ b/src/oc_erchef/schema/baseline/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=oss_chef
-%uri=https://github.com/chef/chef-server-schema
+%uri=https://github.com/opscode/chef-server-schema
 
 osc_users 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # Open Source users table
 nodes 2013-09-04T14:07:22Z Christopher Maier <cm@opscode.com> # Nodes table

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0
 %project=enterprise_chef
-%uri=https://github.com/chef/enterprise-chef-server-schema
+%uri=https://github.com/opscode/enterprise-chef-server-schema
 
 drop_osc_users [oss_chef:osc_users] 2013-09-05T19:22:00Z Christopher Maier <cm@opscode.com> # Remove osc_users table
 users [drop_osc_users] 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # users table


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

Update to version 14.8 in automate fails with :
```
[2021-09-06T06:53:15+00:00] pg-sidecar-service.default(O): time="2021-09-06T06:53:15Z" level=error msg="failed to deploy sqitch" action=deploy_sqitch conn_info="postgresql://automate@127.0.0.1:10145/<database>?ss
lmode=verify-ca&sslcert=/hab/svc/automate-postgresql/config/server.crt&sslkey=/hab/svc/automate-postgresql/config/server.key&sslrootcert=/hab/svc/automate-postgresql/config/root.crt" db=automate-cs-oc-erchef db_d
atabase=postgres error="exit status 2" sqitch_dir=/hab/pkgs/chef/oc_erchef/14.8.7/20210810024854/schema/baseline user=automate
[2021-09-06T06:53:15+00:00] automate-cs-oc-erchef.default(O): time="2021-09-06T06:53:15Z" level=fatal msg="rpc error: code = Unknown desc = exit status 2"
```

TODO: create an issue to investigate this issue further.