### PR TITLE
Changing the uri in the sqitch.plan causes sqitch to deploy some of the older changes that do not exist and fail an upgrade in automate. Reverting this change currently until we figure that out.

### DIFF
--- a/src/bookshelf/schema/sqitch.plan
+++ b/src/bookshelf/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=bookshelf
-%uri=https://github.com/opscode/chef-server/tree/main/src/bookshelf
+%uri=https://github.com/chef/chef-server/blob/master/src/bookshelf
 
 base_schema 2015-11-23T18:56:06Z Mark Anderson <mark@chef.io> # Basic schema for bookshelf file storage
 smart_delete 2016-01-13T18:39:12Z Mark Anderson <mark@chef.io> # Stored procedures for create/delete


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

REF: https://github.com/chef/chef-server/pull/2796