### PR TITLE
Pint to the original version redis was pointed at: 5.0.7

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -8,7 +8,7 @@ override :chef, version: "v16.13.16"
 override :ohai, version: "v16.13.0"
 override :ruby, version: "2.7.4"
 override :perl, version: "5.18.1"
-override :redis, version: "3.0.7"
+override :redis, version: "5.0.7"
 
 override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently
 override :logrotate, version: "3.9.2" # 3.18.0 patches fail


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

Pointing to the older version of redis causing server builds to fail with:
https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/657#58dbdb7d-5b87-4e4e-be79-1a5f2ab702e2