### PR TITLE
The default PostgreSQL version is 13.4

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -532,7 +532,7 @@ default['private_chef']['nginx']['ssl_verify_depth'] = 2
 # PostgreSQL
 ###
 # For now, we're hardcoding the version directory suffix here:
-default['private_chef']['postgresql']['version'] = '13.3'
+default['private_chef']['postgresql']['version'] = '13.4'
 # In the future, we're probably going to want to do something more elegant so we
 # don't accidentally overwrite this directory if we upgrade PG to 9.3: keeping these
 # directories straight is important because in the distant future (the year 2000)


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Upgrades from 12.17.15 -> 14.9.21 fails with 
```
STDOUT:
STDERR: sh: 1: /opt/opscode/embedded/postgresql/13.3/bin/pg_upgrade: not found
```
which is true:
```
root@api:~# ls /opt/opscode/embedded/postgresql/
13.4  9.6
```
Changing the default version to match https://github.com/chef/chef-server/commit/c9f95b7fe94cec54ab8de7f8fa22d006138bc750