### PR TITLE
set the default pg version to only 13

### DIFF
--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -532,7 +532,7 @@ default['private_chef']['nginx']['ssl_verify_depth'] = 2
 # PostgreSQL
 ###
 # For now, we're hardcoding the version directory suffix here:
-default['private_chef']['postgresql']['version'] = '13.4'
+default['private_chef']['postgresql']['version'] = '13'
 # In the future, we're probably going to want to do something more elegant so we
 # don't accidentally overwrite this directory if we upgrade PG to 9.3: keeping these
 # directories straight is important because in the distant future (the year 2000)

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/preflight_postgres_validator.rb
@@ -23,7 +23,7 @@ class PostgresqlPreflightValidator < PreflightValidator
   REQUIRED_VERSION  = Gem::Version.new(9.6)
 
   # supported PG version
-  SUPPORTED_VERSION = Gem::Version.new(13.3)
+  SUPPORTED_VERSION = Gem::Version.new(13)
 
   def run!
     warn_about_removed_attribute('checkpoint_segments')


### PR DESCRIPTION
### Description

Set the default version of postgresql to the major version 13 instead of 13.x. All the data and log directories of postgres will be having only the major version in its path.

### Issues Resolved

Resolves the upgrade conflicts between different postgres upgrade scenarios.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
