### PR TITLE
Fix PostgreSQL major version detection and use for binaries & data paths

### DIFF
--- a/omnibus/config/software/postgresql13.rb
+++ b/omnibus/config/software/postgresql13.rb
@@ -36,7 +36,7 @@ relative_path "postgresql-#{version}"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  short_version = version.gsub(/^([0-9]+).([0-9]+).[0-9]+$/, '\1.\2')
+  short_version = version.gsub(/^([0-9]+).[0-9]+$/, '\1')
 
   update_config_guess(target: "config")
 

--- a/omnibus/config/software/server-complete.rb
+++ b/omnibus/config/software/server-complete.rb
@@ -29,7 +29,7 @@ dependency "runit"
 dependency "openssl-fips-config" if fips_mode?
 
 # the backend
-dependency "postgresql96-bin" # for upgrading 9.6 -> 13.3
+dependency "postgresql96-bin" # for upgrading 9.6 -> 13
 dependency "postgresql13"
 dependency "redis" # dynamic routing controls
 dependency "haproxy"

--- a/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/attributes/default.rb
@@ -532,7 +532,7 @@ default['private_chef']['nginx']['ssl_verify_depth'] = 2
 # PostgreSQL
 ###
 # For now, we're hardcoding the version directory suffix here:
-default['private_chef']['postgresql']['version'] = '13.3'
+default['private_chef']['postgresql']['version'] = '13'
 # In the future, we're probably going to want to do something more elegant so we
 # don't accidentally overwrite this directory if we upgrade PG to 9.3: keeping these
 # directories straight is important because in the distant future (the year 2000)

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/pgversion.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/pgversion.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+#
+##
+# PostgreSQL has a slightly complicated way of representing server versions over
+# the course of its history, in particular, what is considered a major version.
+# The full version is reflected in the read-only configuration parameter
+# server_version.
+#
+# This major version is reflected in the PG_VERSION file in the top level of the
+# PostgreSQL data directory. In theory, the data format on-disk changes only
+# with major releases.
+#
+# Additionally, since PostgreSQL 8.2, the version is available in integer
+# format, stored in the read-only configuration parameter server_version_num.
+# This is intended to be a machine-readable and consistent format for reliable
+# version comparisons.
+#
+# Before version 10, the first two values are considered 'major':
+#   server_version = major1 . major2 . minor
+#   server_version_num = ( '%d%02d%02d' <- major1, major2, minor )
+#
+# After version 10, only the first value is considered 'major':
+#   server_version = major . minor
+#   server_version_num = ( '%d%04d' <- major, minor )
+#
+# Examples:
+#
+#   server_version = 9.6.22 :
+#     - has major version of '9.6'
+#     - has minor version of '22'
+#     - has server_version_num value of 90622
+#     - PG_VERSION file contains '9.6'
+#
+#   server_version = 13.4 :
+#     - has major version of '13'
+#     - has minor version of '4'
+#     - has server_version_num value of 130004
+#     - PG_VERSION file contains '13'
+#
+# Ref:
+# http://www.databasesoup.com/2016/05/changing-postgresql-version-numbering.html
+
+class PgVersion < Gem::Version
+
+  @@major = {}
+
+  def major
+    @@major[self] ||=
+      begin
+        segments = self.segments
+        if segments[0].to_i >= 10
+          self.class.new segments[0].to_s
+        else
+          self.class.new segments[0..1].join('.')
+        end
+      end
+  end
+
+  # We override here to also accept the server_version_num value, and coerce the
+  # value into a proper dotted version string.
+  def self.new(input)
+    if self === input
+      super
+    elsif input.to_i >= 100000
+      new input.to_s.match(/([0-9]+)([0-9]{4})$/).captures.map(&:to_i).join('.')
+    elsif input.to_i >= 80200
+      new input.to_s.match(/([0-9]+)([0-9]{2})([0-9]{2})$/).captures.map(&:to_i).join('.')
+    else
+      super
+    end
+  end
+
+  # Return the version in server_version_num integer format, if server_version
+  # is at or greater than 8.2, otherwise, zero.
+  def to_i
+    segments = self.segments
+    if segments[0].to_i >= 10
+      sprintf('%d%04d', segments[0].to_i, segments[1].to_i).to_i
+    elsif segments[0].to_i == 9 || ( segments[0].to_i == 8 && segments[1].to_i >= 2 )
+      sprintf('%d%02d%02d', segments[0].to_i, segments[1].to_i, segments[2].to_i).to_i
+    else
+      nil.to_i
+    end
+  end
+end

--- a/omnibus/files/private-chef-cookbooks/private-chef/libraries/pgversion.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/libraries/pgversion.rb
@@ -41,11 +41,8 @@
 # http://www.databasesoup.com/2016/05/changing-postgresql-version-numbering.html
 
 class PgVersion < Gem::Version
-
-  @@major = {}
-
   def major
-    @@major[self] ||=
+    @major ||=
       begin
         segments = self.segments
         if segments[0].to_i >= 10
@@ -59,7 +56,7 @@ class PgVersion < Gem::Version
   # We override here to also accept the server_version_num value, and coerce the
   # value into a proper dotted version string.
   def self.new(input)
-    if self === input
+    if input.is_a?(self)
       super
     elsif input.to_i >= 100000
       new input.to_s.match(/([0-9]+)([0-9]{4})$/).captures.map(&:to_i).join('.')
@@ -75,9 +72,16 @@ class PgVersion < Gem::Version
   def to_i
     segments = self.segments
     if segments[0].to_i >= 10
-      sprintf('%d%04d', segments[0].to_i, segments[1].to_i).to_i
-    elsif segments[0].to_i == 9 || ( segments[0].to_i == 8 && segments[1].to_i >= 2 )
-      sprintf('%d%02d%02d', segments[0].to_i, segments[1].to_i, segments[2].to_i).to_i
+      format('%<major>d%<minor>04d',
+             major: segments[0].to_i,
+             minor: segments[1].to_i
+            ).to_i
+    elsif segments[0].to_i == 9 || (segments[0].to_i == 8 && segments[1].to_i >= 2)
+      format('%<major1>d%<major2>02d%<minor>02d',
+             major1: segments[0].to_i,
+             major2: segments[1].to_i,
+             minor: segments[2].to_i
+            ).to_i
     else
       nil.to_i
     end

--- a/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_upgrade.rb
+++ b/omnibus/files/private-chef-cookbooks/private-chef/resources/pg_upgrade.rb
@@ -211,12 +211,9 @@ action_class do
         # Might not be initialized yet if a prior Chef run failed between
         # creating the directory and initializing a cluster in it
 
-        # the version file contains a single line with the version
-        # (e.g. "9.2\n")
-        pg_version = IO.read(version_file_for(data_dir)).strip
-
-        # read the version from data_dir and match with the pg_version
-        data_dir.split('/').select { |x| x.match?(pg_version) }.first
+        # the version file contains a single line with the major version
+        # (e.g. "9.6\n", "13\n")
+        IO.read(version_file_for(data_dir)).strip
       end
     end
   end
@@ -228,8 +225,8 @@ action_class do
   #   use Postgres software definitions.
   #
   # @param version [String] indicates the major release of Postgres,
-  #   e.g. "9.1", "9.2".  Note that this does NOT include patch-levels,
-  #   like "9.1.9" or "9.2.4"
+  #   e.g. "9.6", "13".  Note that this does NOT include minor release
+  #   levels, like "9.6.22" or "13.4"
   # @return [String] the absolute path to the binaries.
   def binary_path_for(version)
     "/opt/opscode/embedded/postgresql/#{version}/bin"
@@ -243,7 +240,6 @@ action_class do
         # The new data directory may have just been created; that's why
         # this needs to be evaluated lazily
 
-        # cannot use version_from_data_dir because from PostgreSQL 10 and later, the version is always a single number
         new_version = version_from_data_dir(new_data_dir)
 
         old_bins = binary_path_for(old_version)


### PR DESCRIPTION
### Description

This change corrects the PostgreSQL version detection logic to allow for proper validation and upgrades between major PostgreSQL releases. It introduces a new `PgVersion` class (built off of `Gem::Version`) to properly parse and extract major versions.

This does not correct for the need to use `pg_upgrade` for any past database versions to current (since this change properly sets the data directory path to use the major version), but will address any issues with `13.x` → `13.y` minor version upgrades going forward.

Signed-off-by: Aaron Pavely <aaron@pavely.net>

### Issues Resolved
#2811 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
