### PR TITLE
Enable authentication for ElasticSearch/OpenSearch

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
@@ -317,6 +317,9 @@ default['private_chef']['opscode-erchef']['search_provider'] = 'elasticsearch'
 default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch'
 default['private_chef']['opscode-erchef']['search_batch_max_size'] = '5000000'
 default['private_chef']['opscode-erchef']['search_batch_max_wait'] = '10'
+default['private_chef']['opscode-erchef']['search_auth_enabled'] = false
+default['private_chef']['opscode-erchef']['search_auth_username'] = 'admin'
+default['private_chef']['opscode-erchef']['search_auth_password'] = 'admin'
 # solr_service configuration for erchef. These are used to configure an opscoderl_httpc pool
 # of HTTP connecton workers.
 default['private_chef']['opscode-erchef']['solr_timeout'] = 30000

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
@@ -188,6 +188,9 @@
         {reindex_sleep_max_ms, <%= @reindex_sleep_max_ms -%>},
         {reindex_item_retries, <%= @reindex_item_retries -%>},
         {solr_elasticsearch_major_version, <%= @solr_elasticsearch_major_version %>},
+        {search_auth_enabled, <%= node['private_chef']['opscode-erchef']['search_auth_enabled'] %>},
+        {search_auth_username, <%= node['private_chef']['opscode-erchef']['search_auth_username'] %>},
+        {search_auth_password, <%= node['private_chef']['opscode-erchef']['search_auth_password'] %>},
         {solr_service, [
             {root_url, "<%= @helper.solr_url() %>"},
             {timeout, <%= @solr_timeout %>},

--- a/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_elasticsearch.erl
@@ -13,7 +13,7 @@
         ]).
 
 -include("chef_solr.hrl").
--define(JSON_HEADER, [{"Content-Type", "application/json"}]).
+-define(JSON_HEADER, chef_index_http:get_headers()).
 
 -spec ping() -> pong | pang.
 ping() ->

--- a/src/oc_erchef/apps/chef_index/src/chef_index_http.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_http.erl
@@ -11,11 +11,11 @@
          delete/2,
          delete/3,
          create_pool/0,
-         delete_pool/0
+         delete_pool/0,
+         get_headers/0
         ]).
 
--define(DEFAULT_HEADERS, [{"Content-Type", "application/xml"}]).
-
+-define(DEFAULT_HEADERS, get_headers()).
 request(Path, Method, Body) ->
     request(Path, Method, Body, ?DEFAULT_HEADERS).
 
@@ -115,3 +115,14 @@ delete_pool() ->
 get_pool_configs() ->
     Config = envy:get(chef_index, solr_service, [], any),
     [{?MODULE, Config}].
+
+get_headers() ->
+    case envy:get(chef_index, search_auth_enabled, false, boolean) of
+        true ->
+            User = envy:get(chef_index, search_auth_username, "admin", boolean),
+            Pass = envy:get(chef_index, search_auth_password, "admin", boolean),
+            Encoded = base64:encode_to_string(lists:append([User,":",Pass])),
+            [{"Authorization","Basic " ++ Encoded}, {"Content-Type", "application/json"}];
+        _ ->
+            [{"Content-Type", "application/json"}]
+    end.


### PR DESCRIPTION
### Description
List of itesm to be added

1. Investigate auth plugin - (should also support Opensearch)
2. Investigate omnibus changes for omnibus build
3. Investigate es_gateway to add basic authentication header
4. Investigate habitat changes for habitat build


### Issues Resolved
#2233 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
