### PR TITLE
Produce Ubuntu 16.04 packages again

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -14,6 +14,7 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  ubuntu-18.04-x86_64:
+  ubuntu-16.04-x86_64:
+    - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64


### PR DESCRIPTION
It's no longer EOL. New EOL data is April 2026.

Signed-off-by: Tim Smith <tsmith@chef.io>