### PR TITLE
Updating the sequel of knife-ec-backup and chef_fixie from 4.49 to 5.49

### DIFF
--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       appbundler
       chef
       chef_backup
-      chef_fixie
+      chef_fixie (>= 1.0.3)
       ffi-yajl (>= 1.2.0)
       highline (~> 1.6, >= 1.6.9)
       knife-ec-backup
@@ -96,7 +96,7 @@ GEM
       concurrent-ruby (~> 1.0)
     chef-utils (16.13.16)
     chef-vault (4.1.4)
-    chef-zero (15.0.9)
+    chef-zero (15.0.11)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 5.0)
       mixlib-log (>= 2.0, < 4.0)
@@ -106,12 +106,12 @@ GEM
     chef_backup (0.1.1)
       highline (~> 1.6, >= 1.6.9)
       mixlib-shellout (>= 2.0, < 4.0)
-    chef_fixie (1.0.2)
+    chef_fixie (1.0.3)
       chef (>= 16)
       ffi-yajl (>= 1.2.0)
       pg (~> 1.2, >= 1.2.3)
       pry (~> 0.13)
-      sequel (~> 4.11)
+      sequel (>= 4.11)
       uuidtools (~> 2.1, >= 2.1.3)
       veil
     chefstyle (2.1.0)
@@ -182,11 +182,11 @@ GEM
       tty-table (~> 0.10)
     ipaddress (0.8.3)
     json (2.6.0)
-    knife-ec-backup (2.4.15)
+    knife-ec-backup (2.5.3)
       chef (>= 11.8)
       knife-tidy
       pg
-      sequel
+      sequel (~> 5.9)
       veil
     knife-opc (0.4.7)
     knife-tidy (2.1.2)
@@ -269,7 +269,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     rb-readline (0.5.5)
-    redis (4.5.0)
+    redis (4.5.1)
     regexp_parser (2.1.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -313,7 +313,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     semverse (3.0.0)
-    sequel (4.49.0)
+    sequel (5.49.0)
     solve (4.0.4)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 4.0)
@@ -402,4 +402,4 @@ DEPENDENCIES
   toml
 
 BUNDLED WITH
-   2.2.22
+   2.1.4

--- a/src/chef-server-ctl/chef-server-ctl.gemspec
+++ b/src/chef-server-ctl/chef-server-ctl.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   # tools we bundle in the chef-server install and include here so we can have a single Gemfile.lock
   # for the overall chef-server "app"
   spec.add_runtime_dependency "knife-ec-backup"
-  spec.add_runtime_dependency "chef_fixie"
+  spec.add_runtime_dependency "chef_fixie", ">= 1.0.3"
 
   # Used to resolve download urls
   spec.add_runtime_dependency "mixlib-install"


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

knife-ec-backup  and chef_fixie was using out dated version of sequel due to which `knife-ec-backup` command was failing with the following error

```
root@chef-server:# /opt/opscode/bin/knife ec backup /var/opt/knife-ec-backup/ --with-user-sql --with-key-sql -c /etc/opscode/pivotal.rb
Downloading Users
ERROR: knife encountered an unexpected error
This may be a bug in the 'ec backup' knife command or plugin
Please collect the output of this command with the -VVV option before filing a bug report.
Exception: NameError: undefined method new' for class #Class:BigDecimal'
root@chef-server:#
```
The following change was discovered in the Sequel change-log:

https://github.com/jeremyevans/sequel/blob/master/CHANGELOG === 5.9.0 (2018-06-01)

    Switch use of BigDecimal.new() to BigDecimal(), since the former is deprecated (jeremyevans)


knife-ec-backup PR - chef/knife-ec-backup#164
fixie PR - chef/fixie#57

### Issues Resolved

Resolves #2835 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
