### PR TITLE
Fix error: undefined method 'shell_out' for Du:Module

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/libraries/du.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/libraries/du.rb
@@ -10,7 +10,11 @@ module Du
     # TODO(ssd) 2017-08-18: Do we need to worry about sparse files
     # here? If so, can we expect the --apparent-size flag to exist on
     # all of our platforms.
-    command = shell_out("du -sk #{path}")
+
+    # Changed from: command = shell_out("du -sk #{path}")
+    # because of NoMethodError undefined method `shell_out' for Du:Module
+    command = Mixlib::ShellOut.new("du -sk #{path}")
+    command.run_command
     if command.status.success?
       command.stdout.split("\t").first.to_i
     else


### PR DESCRIPTION
Fix the following error (below) which appeared in various umbrella pipeline tests.

adhoc:
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/3336

umbrella:
https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/784

```
================================================================================
Error executing action `upgrade` on resource 'pg_upgrade[upgrade_if_necessary]'
================================================================================

NoMethodError
-------------
undefined method`shell_out' for Du:Module
```

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
