### PR TITLE
reverted the chef version to 16.13.16 due to mtls scenario failure

### DIFF
--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "chef", "= 16.16.13"
+gem "chef", "= 16.13.16"
 gem "toml" # for habitat-land

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -47,12 +47,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.4)
-    chef (16.16.13)
+    chef (16.13.16)
       addressable
       bcrypt_pbkdf (~> 1.1)
       bundler (>= 1.10)
-      chef-config (= 16.16.13)
-      chef-utils (= 16.16.13)
+      chef-config (= 16.13.16)
+      chef-utils (= 16.13.16)
       chef-vault
       chef-zero (>= 14.0.11)
       diff-lcs (>= 1.2.4, < 1.4.0)
@@ -84,9 +84,9 @@ GEM
       tty-screen (~> 0.6)
       tty-table (~> 0.11)
       uuidtools (>= 2.1.5, < 3.0)
-    chef-config (16.16.13)
+    chef-config (16.13.16)
       addressable
-      chef-utils (= 16.16.13)
+      chef-utils (= 16.13.16)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -94,7 +94,7 @@ GEM
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (16.16.13)
+    chef-utils (16.13.16)
     chef-vault (4.1.4)
     chef-zero (15.0.9)
       ffi-yajl (~> 2.2)
@@ -138,7 +138,7 @@ GEM
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
-    faraday_middleware (1.1.0)
+    faraday_middleware (1.2.0)
       faraday (~> 1.0)
     ffi (1.15.4)
     ffi-libarchive (1.1.3)
@@ -181,7 +181,7 @@ GEM
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
     ipaddress (0.8.3)
-    json (2.5.1)
+    json (2.6.0)
     knife-ec-backup (2.4.15)
       chef (>= 11.8)
       knife-tidy
@@ -250,7 +250,7 @@ GEM
       plist (~> 3.1)
       train-core
       wmi-lite (~> 1.0)
-    omnibus-ctl (0.6.0)
+    omnibus-ctl (0.6.4)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -269,7 +269,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     rb-readline (0.5.5)
-    redis (4.4.0)
+    redis (4.5.0)
     regexp_parser (2.1.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -394,7 +394,7 @@ PLATFORMS
 DEPENDENCIES
   berkshelf
   bundler
-  chef (= 16.16.13)
+  chef (= 16.13.16)
   chef-server-ctl!
   chefstyle
   rake


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Mtl sceanrio is failing with chef version 16.16.13.
https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/781#e1adf7b6-ce5f-48f2-bdc5-702e9199f8b8

### Issues Resolved

knife issue in the umbrella mtl scenario 
https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/781#e1adf7b6-ce5f-48f2-bdc5-702e9199f8b8

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
