### PR TITLE
Update release process

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -64,7 +64,7 @@ Using the step-by-step Umbrella testing process detailed below...
 1. Test that the latest stable release can successfully upgrade to the new release. This is the _LATEST-STABLE -> YOUR-RELEASE_ upgrade path.
 
 Past stable releases:
-https://downloads.chef.io
+https://downloads.chef.io/tools/infra-server
 
 Umbrella Testing Step-by-Step:
 
@@ -204,7 +204,7 @@ Example:
 
   Please do this in the `#chef-server` channel.  Once this is
   done, the release is available to the public via the APT and YUM
-  repositories and downloads.chef.io.
+  repositories and https://downloads.chef.io/tools/infra-server.
 
 ### Announce the release post-promote to the following channels:
 
@@ -214,6 +214,15 @@ Example:
 
 Copying/pasting a discourse link to the post-promote channels should suffice.  You can find the link here.  Note that this is NOT the link to copy/paste, this is a link where you can find the link to copy/paste:
 https://discourse.chef.io/c/chef-release/9
+
+### Verifying Release Success
+
+1. Confirm the existence of the notification in the #chef-server-notify channel.
+1. Confirm that the release appears at https://downloads.chef.io/tools/infra-server.  This usually takes a while.
+1. Confirm that the release notes from Pending Release Notes are automatically posted on discourse.  Sample post:
+https://discourse.chef.io/t/chef-infra-server-14-10-23-released/20438
+1. Confirm that the data for the Pending Release Notes at https://github.com/chef/chef-server/wiki/Pending-Release-Notes is automatically deleted by expeditor, and only the titles remain.  Notify releng at https://github.com/chef/release-engineering/issues if this does not automatically happen on promote.
+1. Confirm that the release notes appear at https://docs.chef.io/release_notes_server/ .  This should happen automatically via expeditor, but if it does not you need to perform the steps manually and create an issue with releng at https://github.com/chef/release-engineering/issues.
 
 ### Automate
 


### PR DESCRIPTION
### Acceptance Criteria

Our release process should have a section for "verifying that a release is done"
1. See the notification in the notify channel.
1. It shows up on the downloads site
1. Discourse announcement post
a) is this just verifying that there exists such a post?
b) discourse.chef.io/c/chef-release/9 ?
1. Update to the release notes in docs-site
a) where? can we have more context here?
1. Deleting the existing test in Pending Release Notes.
???
1. Notifying releng if ^^ does not automatically happen on promote.
dumb question, but i don't seem to have releng or rel-eng or release-engineering or anything of the sort on my slack. what's the channel?

### Status
Minimal steps have been added.  Awaiting clarification on some questions.