### PR TITLE
Clarify support for External PostgreSQL configurations

### DIFF
--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -242,6 +242,8 @@ Check the [post upgrade steps](#post-upgrade-steps) if you are upgrading from a 
 
 ### External PostgreSQL
 
+The following External PostgreSQL upgrade steps are provided as a courtesy only.  It is the responsibility of the user to upgrade and maintain any External PostgreSQL configurations.
+
 #### Upgrade Chef Infra Server
 
 1. Log into the external PostgreSQL machine.


### PR DESCRIPTION
Clarify support for External PostgreSQL configurations.

"The following External PostgreSQL upgrade steps are provided as a courtesy only. It is the responsibility of the user to upgrade and maintain any External PostgreSQL configurations."

![image](https://user-images.githubusercontent.com/51833247/139113900-85782f07-31e0-4d59-b4ab-89bcc299ce17.png)
