### PR TITLE
fixing bootstrap for external postgresql

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/bootstrap.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/bootstrap.rb
@@ -26,6 +26,12 @@ end
 
 # These should always be running by this point, but let's be certain.
 %w(postgresql oc_bifrost).each do |service|
+  # external postgres cannot be managed through chef-server-ctl.
+  # But when we migrate the server manually (manual bootstrap), we touch the file `/var/opt/opscode/bootstrapped`
+  # and create the file `/var/opt/opscode/upgrades/migration-level`
+  # with the major and minor version of the migration file to be run.
+  # ex : {"major":1,"minor":34}
+  # After we do the needed migration, `OmnibusHelper.has_been_bootstrapped` will return `true`.
   execute "/opt/opscode/bin/chef-server-ctl start #{service}" do
     not_if { OmnibusHelper.has_been_bootstrapped? }
   end


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

Upgrade and Reconfigure for external postgresql  scenario was failing when bootstrap was enabled. This was because in the bootstrap.rb recipe we start again postgresql service without out checking the external postgresql scenario.

### Issues Resolved

Resolves https://github.com/chef/chef-server/issues/2894

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
