### PR TITLE
Added max_connection_request_limit in oc_chef_authz pool config

### DIFF
--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -972,6 +972,11 @@ This configuration file has the following settings for `oc_chef_authz`:
 :   The amount of time (in milliseconds) to wait for a connection to be
     established. Default value: `'[{connect_timeout, 5000}]'`.
 
+`oc_chef_authz['max_connection_request_limit']`
+
+:   The max number of requests allowed per connections. 
+    Default value: `100`.
+
 ### oc-chef-pedant
 
 This configuration file has the following settings for `oc-chef-pedant`:

--- a/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
@@ -648,6 +648,7 @@ default['private_chef']['oc_chef_authz']['http_max_age'] = '{70, sec}'
 default['private_chef']['oc_chef_authz']['http_max_connection_duration'] = '{70, sec}'
 default['private_chef']['oc_chef_authz']['http_retry_on_conn_closed'] = true
 default['private_chef']['oc_chef_authz']['ibrowse_options'] = '[{connect_timeout, 5000}]'
+default['private_chef']['oc_chef_authz']['max_connection_request_limit'] = 100
 
 ####
 # Bookshelf

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
@@ -168,7 +168,8 @@
             {max_age, <%= node['private_chef']['oc_chef_authz']['http_max_age'] %>},
             {max_connection_duration, <%= node['private_chef']['oc_chef_authz']['http_max_connection_duration'] %>},
             {retry_on_conn_closed, <%= node['private_chef']['oc_chef_authz']['http_retry_on_conn_closed']=%>},
-            {ibrowse_options, <%= node['private_chef']['oc_chef_authz']['ibrowse_options'] %>}
+            {ibrowse_options, <%= node['private_chef']['oc_chef_authz']['ibrowse_options'] %>},
+            {max_connection_request_limit, <%= node['private_chef']['oc_chef_authz']['max_connection_request_limit'] %>}
         ]},
         {cleanup_batch_size, <%= node['private_chef']['opscode-erchef']['cleanup_batch_size'] %>}
     ]},


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Added max_connection_request_limit in oc_chef_authz pool config for testing high CPU usage issue after upgrade from 12.3.1.
Configuration details:
'max_connection_request_limit' limits the max number of requests allowed per ibrowse_http_client connections.This config is used by oc_httpc_worker module while adding the oc_chef_authz pool.

### Issues Resolved

#2858 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
