### PR TITLE
Fetch trusted certs on reconfigure if mtls is enabled

### DIFF
--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -258,6 +258,16 @@ Cleansing data in a remote Elasticsearch instance is not currently supported.
       ENV["CHEF_LICENSE"] = "accept-no-persist"
 
       status = run_chef("#{base_path}/embedded/cookbooks/dna.json")
+
+      # fetch trusted certs if mtls enabled
+      ca           = running_service_config('nginx')['ssl_client_ca']
+      cert         = running_service_config('nginx')['pivotal_ssl_client_cert']
+      key          = running_service_config('nginx')['pivotal_ssl_client_key']
+      command      = 'sudo --preserve-env=PATH /opt/opscode/embedded/bin/knife ssl fetch -c /etc/opscode/pivotal.rb'
+      # enabled if all are non-empty strings
+      mtls_enabled = [ca, cert, key].all? { |x| x && !x.empty? }
+      mtls_enabled ? run_command(command) : :ok
+
       if status.success?
         log "#{display_name} Reconfigured!"
         exit! 0


### PR DESCRIPTION
### Description

Fetch trusted certs on reconfigure if mtls is enabled.

### Issues Resolved

https://github.com/chef/chef-server/issues/2426

### Related

https://github.com/chef/umbrella/pull/204

### Builds/Tests

https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/3482
https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/912

```
[0m[1mnull_resource.mutual_tls_config (remote-exec):[0m [0mBEGIN USER LIST TEST
[0m[1mnull_resource.mutual_tls_config (remote-exec):[0m [0msudo chef-server-ctl user-list
[0m[1mnull_resource.mutual_tls_config (remote-exec):[0m [0m+ sudo chef-server-ctl user-list
[0m[1mnull_resource.mutual_tls_config (remote-exec):[0m [0mpivotal
[0m[1mnull_resource.mutual_tls_config (remote-exec):[0m [0mecho -e '
[0m[1mnull_resource.mutual_tls_config (remote-exec):[0m [0mEND USER LIST TEST
```

### Check List

- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
