### PR TITLE
Enable cookbook version response caching

### DIFF
--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -1456,6 +1456,23 @@ This configuration file has the following settings for `opscode-erchef`:
 
 :   The virtual IP address. Default value: `127.0.0.1`.
 
+`opscode_erchef['cbv_cache_enabled']`
+
+:   Enable cookbook versions caching by setting this to `true`. If you are frequently seeing
+    very long response times from `cookbook_versions` when under load, this is worth enabling.
+    Default value: `false`.
+
+`opscode_erchef['cbv_cache_item_ttl']`
+
+:   The minimum time in milliseconds that given cookbook versions list will be expired
+    when cbv_cache_enabled is enabled.
+    Default value: `30000`.
+{{< note >}}
+
+Be careful if increasing this number - requests for a given set of cookbook_versions will be stale if the resolved cookbook versions are updated before the cache entry times out.Not an issue if you are incrementing cookbook version with every change.
+
+{{< /note >}}
+
 ### Elasticsearch
 
 This configuration file has the following settings for `elasticsearch`:

--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -974,7 +974,7 @@ This configuration file has the following settings for `oc_chef_authz`:
 
 `oc_chef_authz['max_connection_request_limit']`
 
-:   The max number of requests allowed per connections.
+:   The maximum number of requests allowed per connection.
     Default value: `100`.
 
 ### oc-chef-pedant
@@ -1458,22 +1458,22 @@ This configuration file has the following settings for `opscode-erchef`:
 
 `opscode_erchef['cbv_cache_enabled']`
 
-:   Enable cookbook version response caching by setting this to `true`. If you are frequently seeing
+:   Enable cookbook version response caching by setting this to `true`. If you frequently see
     very long response times from `cookbook_versions` when under load, this is worth enabling.
-    Enabling this does open a window for a client to receive stale results. When a cookbook is updated
-    in place (without incrementing the version), and the old response has not been expired from cache,
-    the old response will be given to the client.  Subsequent client runs will receive the updated response.
-    Default value: `false`.
+    Enabling this makes it possible for a client to receive stale results. When a cookbook is updated
+    in place (without incrementing the version), and the old response has not expired from the cache,
+    the Infra Server will give the old response to the client. Subsequent client runs will receive the
+    updated response. Default value: `false`.
 
 `opscode_erchef['cbv_cache_item_ttl']`
 
-:   The minimum time in milliseconds that any given cookbook version response will be expired from the cache when
-    when cbv_cache_enabled is enabled.
+:   The minimum time in milliseconds that Chef Infra Server will keep any given cookbook version response in the cache when
+    when `cbv_cache_enabled` is enabled.
     Default value: `30000`.
 {{< note >}}
 
-Be careful if increasing this number - requests for a given set of cookbook_versions will be stale if the resolved cookbook versions are updated before the cache entry times out. This will
-not occur if cookbook version is incremented with every cookbook update, which is the recommended approach to updating cookbooks.
+Be careful if increasing this number - requests for a given set of cookbook versions will be stale if the resolved cookbook versions are updated before the cache entry times out. This will
+not occur if you increment the version of a cookbook with every cookbook update, which is the recommended approach to updating cookbooks.
 
 {{< /note >}}
 

--- a/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/v14/config_rb_server_optional_settings.md
@@ -974,7 +974,7 @@ This configuration file has the following settings for `oc_chef_authz`:
 
 `oc_chef_authz['max_connection_request_limit']`
 
-:   The max number of requests allowed per connections. 
+:   The max number of requests allowed per connections.
     Default value: `100`.
 
 ### oc-chef-pedant
@@ -1458,18 +1458,22 @@ This configuration file has the following settings for `opscode-erchef`:
 
 `opscode_erchef['cbv_cache_enabled']`
 
-:   Enable cookbook versions caching by setting this to `true`. If you are frequently seeing
+:   Enable cookbook version response caching by setting this to `true`. If you are frequently seeing
     very long response times from `cookbook_versions` when under load, this is worth enabling.
+    Enabling this does open a window for a client to receive stale results. When a cookbook is updated
+    in place (without incrementing the version), and the old response has not been expired from cache,
+    the old response will be given to the client.  Subsequent client runs will receive the updated response.
     Default value: `false`.
 
 `opscode_erchef['cbv_cache_item_ttl']`
 
-:   The minimum time in milliseconds that given cookbook versions list will be expired
+:   The minimum time in milliseconds that any given cookbook version response will be expired from the cache when
     when cbv_cache_enabled is enabled.
     Default value: `30000`.
 {{< note >}}
 
-Be careful if increasing this number - requests for a given set of cookbook_versions will be stale if the resolved cookbook versions are updated before the cache entry times out.Not an issue if you are incrementing cookbook version with every change.
+Be careful if increasing this number - requests for a given set of cookbook_versions will be stale if the resolved cookbook versions are updated before the cache entry times out. This will
+not occur if cookbook version is incremented with every cookbook update, which is the recommended approach to updating cookbooks.
 
 {{< /note >}}
 

--- a/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
@@ -353,6 +353,16 @@ default['private_chef']['opscode-erchef']['strict_search_result_acls'] = false
 default['private_chef']['opscode-erchef']['ssl_session_caching']['enabled'] = false
 default['private_chef']['opscode-erchef']['include_x_ops_api_info'] = false
 
+# Enable cookbook versions caching by setting this to true. If you are frequently seeing
+# very long response times from `cookbook_versions` when under load, this is worth enabling.
+default['private_chef']['opscode-erchef']['cbv_cache_enabled'] = false
+# When CBV caching is enabled, this indicates the minimum time in milliseconds that given
+# CBV list will be expired. Be careful if increasing this number - requests for a given
+# set of cookbook_versions will be stale if the resolved cookbook versions
+# are updated before the cache entry times out.
+# Not an issue if you are incrementing cookbook version with every change.
+default['private_chef']['opscode-erchef']['cbv_cache_item_ttl'] = 30000
+
 # The amount of milliseconds before we timeout and assume an endpoint is down for
 # the /_status endpoint.
 

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
@@ -224,7 +224,10 @@
         {s3_parallel_ops_timeout, <%= node['private_chef']['opscode-erchef']['s3_parallel_ops_timeout'] %>},
         {s3_parallel_ops_fanout, <%= node['private_chef']['opscode-erchef']['s3_parallel_ops_fanout'] %>},
         {depsolver_timeout, <%= @depsolver_timeout %>},
-        {depsolver_pooler_timeout, <%= @depsolver_pooler_timeout %>}
+        {depsolver_pooler_timeout, <%= @depsolver_pooler_timeout %>},
+        {cbv_cache_enabled, <%= node['private_chef']['opscode-erchef']['cbv_cache_enabled'] %>},
+        {cbv_cache_item_ttl, <%= node['private_chef']['opscode-erchef']['cbv_cache_item_ttl'] %>}
+
     ]},
 
     <% if node['private_chef']['data_collector']['root_url'] %>

--- a/src/oc_erchef/apps/chef_objects/src/chef_cbv_cache.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cbv_cache.erl
@@ -1,0 +1,228 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Marc Paradise <marc@chef.io>
+%% @doc Cache module for caching solved and formatted cookbook results.
+%%
+%% Copyright Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_cbv_cache).
+-behavior(gen_server).
+
+-define(SERVER, ?MODULE).
+
+% How long does each key live for?
+-define(DEFAULT_TTL, 30000).
+
+% How often (ms) to poll for the number of messages in the cbv_cache process queue.
+% This needs to be kept low because under high volume a lot of requests can come in over a
+% short period of time.  Keeping this number low allows us to catch that before overwhelming
+% the process.
+-define(QUEUE_LEN_REFRESH_INTERVAL, 100).
+% Threshold for determining when to stop allowing requests to pass through to chef_cbv_cache
+%  Don't forget to change it in chef_cbv_cache_test if you chagne it here.
+-define(MAX_QUEUE_LEN, 10).
+
+-record(state, { tid = undefined, ttl = ?DEFAULT_TTL, enabled = false, claims = undefined }).
+-export([
+         start_link/0,
+         get/1,
+         claim/1,
+         put/2,
+         %% Debug and testing
+         force_breaker/1,
+         stop/0
+        ]).
+
+%% gen_server callbacks
+-export([
+         code_change/3,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         init/1,
+         terminate/2
+        ]).
+
+
+
+start_link() ->
+    Enabled = envy:get(chef_objects, cbv_cache_enabled, false, boolean),
+    TTL = envy:get(chef_objects, cbv_cache_item_ttl, ?DEFAULT_TTL, integer),
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [Enabled, TTL], []).
+
+get(Key) ->
+    send_if_available({get, Key}).
+
+claim(Key) ->
+    send_if_available({claim, Key}).
+
+put(Key, Value) ->
+    % We do not protect this with the breaker - this function is only to be called
+    % after a successful 'claim', and we want to allow caller to put the claim
+    % instead of `busy` response which would cause another caller to have to claim,
+    % do the work, then put the result.
+    gen_server:call(?SERVER, {put, Key, Value}).
+
+send_if_available(Msg) ->
+    case breaker_tripped() of
+        true -> busy;
+        false -> gen_server:call(?SERVER, Msg)
+    end.
+
+stop() ->
+    gen_server:call(?SERVER, stop).
+
+% gen_server implementation
+
+init([Enabled, TTL]) ->
+    process_flag(trap_exit, true),
+    spawn_breaker(),
+    {ok, #state{enabled = Enabled,
+                ttl = round(TTL/2), % Splay is TTL/2 + (0-100% of TTL) for max of TTL.
+                claims = dict:new(),
+                tid = ets:new(chef_cbv_cache, [set, private, {read_concurrency, true}])
+               }}.
+handle_call(stop, _From, State) ->
+    exit(whereis(cbv_cache_breaker), kill),
+    {stop, normal, ok, State};
+handle_call(_Msg, _From, #state{enabled = false} = State) ->
+    {reply, undefined, State};
+handle_call({get, Key}, _From, #state{tid = Tid, claims = Claims} = State) ->
+    case dict:take(Key, Claims) of
+        error ->
+            % Nobody is currently working on it, so it's either here or not.
+            case ets:lookup(Tid, Key) of
+                [{_, Value}] -> {reply, Value, State};
+                [] -> {reply, undefined, State}
+            end;
+        {Pid, Claims1} ->
+            case is_process_alive(Pid) of
+                true -> {reply, retry, State};
+                false ->
+                    case ets:lookup(Tid, Key) of
+                        [{_, Value}] -> {reply, Value, State};
+                        [] -> {reply, undefined, State#state{claims = Claims1}}
+                    end
+            end
+    end;
+handle_call({claim, Key}, {From, _Tag}, #state{claims = Claims} = State) ->
+    case dict:take(Key, Claims) of
+        error -> % Nobody has claimed it yet
+            {reply, ok, State#state{claims = dict:store(Key, From, Claims)}};
+        {From, _Claims1} ->
+            % This caller has already claimed it, that's fine..
+            {reply, ok, State};
+        {_OtherPid, _Claims1} -> % Someone has already claimed it, so caller should retry the GET
+            {reply, retry, State}
+    end;
+handle_call({put, Key, Value}, { From, _Tag }, #state{tid = Tid, ttl = TTL, claims = Claims} = State) ->
+    case dict:take(Key, Claims) of
+        error ->
+            % Mis-usage. Claim must be called before put.
+            {reply, {error, no_claim}, State};
+        { From, Claims1 } ->
+            % It is claimed and by this caller, they can go ahead and put.
+            % Update claims dictionary in state to remove the claim on this key
+            insert_into_cache(Tid, Key, Value, TTL),
+            {reply, ok, State#state{claims = Claims1}};
+        { _OtherPid, _Claims1 } ->
+            % Mis-usage: Someon else claimed it and is still active/working on it,
+            % but we have been invoked anyway. `put` should only be invoked when the caller
+            % has first invoked `claim`.
+            {reply, {error, already_claimed}, State }
+    end.
+
+insert_into_cache(Tid, Key, Value, TTL) ->
+    case ets:insert_new(Tid, {Key, Value}) of
+        true ->
+            % - we see that often the pattern is that many requests for new keys
+            % come in clusters when traffic is first directed to the server.
+            % We can't avoid the initial cluster and corresponding CPU spike
+            % when we have nothing cached, but staggering the expirations after that
+            % will reduce CPU/VM utilization spikes that can impact the overall system.
+            erlang:send_after(TTL + rand:uniform(TTL), self(), {expire, Key});
+        false ->
+            % Value already exists.  Given the enforced ordering to prevent more than
+            % one caller from trying to put the same key, this should rarely occur
+            % (may happen if caller who invoked claim/1 then dies before put/2)
+            lager:info("chef_cbv_cache: Key ~p already present, ignoring.", [Key])
+    end.
+
+handle_info({expire, Key}, #state{tid = Tid} = State) ->
+    ets:delete(Tid, Key),
+    {noreply, State};
+handle_info({'EXIT', _From, Reason}, State) ->
+    lager:error("chef_cbv_cache: circuit breaker proc failed because ~p, restarting", [Reason]),
+    spawn_breaker(),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% Internal implementation
+
+spawn_breaker() ->
+    spawn_link(fun() -> breaker(0, false) end) ! init.
+
+breaker_tripped() ->
+  whereis(cbv_cache_breaker) ! { self(), check_limit },
+  receive
+    { result, limit_reached } ->
+      true;
+    { result, ok } ->
+      false
+  end.
+
+force_breaker(Disable) ->
+  whereis(cbv_cache_breaker) ! { force_disable, Disable }.
+
+% A circuit breaker that is spawn_linked to
+% cbv_cache, and monitors the state of the cache queue.
+% This prevents the overhead of checking the queue size on every request
+breaker(Count, Disabled) ->
+  receive
+    {Sender, check_limit} when Count >= ?MAX_QUEUE_LEN orelse Disabled =:= true ->
+      Sender ! {result, limit_reached},
+      breaker(Count, Disabled);
+    {Sender, check_limit} ->
+      Sender ! {result, ok},
+      breaker(Count, Disabled);
+    {force_disable, Disabled2} ->
+      breaker(Count, Disabled2);
+    init ->
+      register(cbv_cache_breaker, self()),
+      self() ! update,
+      breaker(Count, Disabled);
+    update ->
+      case whereis(chef_cbv_cache) of
+        undefined ->
+          Count2 = Count;
+        Pid ->
+          {_, Count2} = process_info(Pid, message_queue_len)
+      end,
+      erlang:send_after(?QUEUE_LEN_REFRESH_INTERVAL, self(), update),
+      breaker(Count2, Disabled)
+  end.

--- a/src/oc_erchef/apps/chef_objects/test/chef_cbv_cache_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cbv_cache_tests.erl
@@ -1,0 +1,235 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil; fill-column: 92 -*-
+%% ex: ts=4 sw=4 et
+%% @author Marc Paradise <marc@chef.io>
+%%
+%% Copyright Chef Software, Inc. All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(chef_cbv_cache_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+start_cbv_cache(Enabled, TTL) ->
+    application:set_env(chef_objects, cbv_cache_enabled, Enabled),
+    application:set_env(chef_objects, cbv_cache_item_ttl, TTL),
+    {ok, CachePid} = chef_cbv_cache:start_link(),
+    CachePid.
+
+cleanup_cache(_) ->
+    chef_cbv_cache:stop(),
+    application:set_env(chef_objects, cbv_cache_enabled, false),
+    application:set_env(chef_objects, cbv_cache_item_ttl, 30000),
+    ok.
+
+chef_cbv_cache_expires_key_after_ttl_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 250)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       chef_cbv_cache:claim(expiring_key),
+       chef_cbv_cache:put(expiring_key, "a value"),
+       % Make sure it's really there
+       ?assertEqual("a value", chef_cbv_cache:get(expiring_key)),
+
+       % wait for our specified key TTL to pass
+       timer:sleep(250),
+       ?assertEqual(undefined, chef_cbv_cache:get(expiring_key))
+   end
+  }.
+
+claim_replies_retry_when_another_pid_has_claimed_first_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       spawn(fun() -> chef_cbv_cache:claim(other_key) end),
+       timer:sleep(100), % Give the claim tiem to go through
+       ?assertEqual(retry, chef_cbv_cache:claim(other_key))
+   end
+  }.
+
+put_does_not_return_busy_when_cache_queue_limit_exceeded_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       Pid = whereis(chef_cbv_cache),
+
+
+       % Claim our key so we can test that 'put' works when it's busy
+       % Not strictly required, but otherwise our put will fail and I'd rather test
+       % the usage case here. (calling put without 'claim' is an error condition tested elsewhere).
+       chef_cbv_cache:claim(my_key),
+
+       % Prevent the cache from processing any further messages
+       erlang:suspend_process(Pid, []),
+
+       % Fill mailbox with junk messages to exceed the limit. We'll go well beyond the default
+       % of 10, because want to make sure it doesn't drop below that limit after
+       % we resume it
+       [ Pid ! N || N <- lists:seq(21, 40) ],
+
+       % Make sure our circuit breaker has a chance to see that the
+       % queue is backed up
+       timer:sleep(100), % QUEUE_LEN_REFRESH_INTERVAL
+
+       % verify that rquests that use the breaker are failing
+       ?assertEqual(busy, chef_cbv_cache:get(my_key)),
+
+       % Let it start processing the junk
+       erlang:resume_process(Pid),
+       % Meanwhile, we should be able to put our reserved key (it'll wait
+       % for other messgaes to proces, but will allow ours through ignoring the limit)
+       ?assertEqual(ok, chef_cbv_cache:put(my_key, <<"my value">>))
+   end
+  }.
+
+get_and_claim_return_busy_when_cache_queue_limit_exceeded_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       Pid = whereis(chef_cbv_cache),
+
+       % Prevent the cache from processing any messages
+       erlang:suspend_process(Pid, []),
+
+       % Fill mailbox with junk messages to exceed the limit.
+       % The limit is currently defined as MAX_QUEUE_LEN (default 10) in chef_cbv_cache,
+       % but we don't have access to that here.
+       [ Pid ! N || N <- lists:seq(1, 15) ],
+
+       % Make sure our circuit breaker has a chance to see that the
+       % queue is backed up
+       timer:sleep(100), % QUEUE_LEN_REFRESH_INTERVAL
+
+       % Any calls should be stopped before a message is sent to chef_cbv_cache
+       ?assertEqual(busy, chef_cbv_cache:get(anything)),
+       ?assertEqual(busy, chef_cbv_cache:claim(anything)),
+       erlang:resume_process(Pid)
+   end
+  }.
+
+put_returns_error_when_claimed_by_another_pid_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       spawn(fun() -> chef_cbv_cache:claim(reserved_key) end),
+       timer:sleep(100), % give time for that msg to process
+       ?assertEqual({error, already_claimed}, chef_cbv_cache:put(reserved_key, <<"hello">>))
+   end
+  }.
+
+put_returns_error_when_claim_not_called_first_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       ?assertEqual({error, no_claim}, chef_cbv_cache:put(unclaimed_key, <<"hello">>))
+   end
+  }.
+
+get_returns_retry_when_another_proc_has_invoked_claim_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+
+           spawn(fun() ->
+                         chef_cbv_cache:claim(reserved_key),
+                         % Sleep to keep this process alive for the duration -
+                         % if it dies, the claim is released.
+                         timer:sleep(200)
+             end),
+       timer:sleep(100),
+       ?assertEqual(retry, chef_cbv_cache:get(reserved_key))
+   end
+  }.
+get_returns_undefined_when_another_proc_has_invoked_claim_and_died_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       spawn(fun() -> chef_cbv_cache:claim(reserved_key) end),
+       timer:sleep(100),
+       % This will return undefined because the process that claimed the key
+       % died without putting a value before `get` was next called.
+       ?assertEqual(undefined, chef_cbv_cache:get(reserved_key))
+   end
+  }.
+
+
+get_returns_undefined_for_uncache_value_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       ?assertEqual(undefined, chef_cbv_cache:get(uncached_value))
+   end
+  }.
+
+get_returns_value_for_cached_value_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       chef_cbv_cache:claim(my_value),
+       chef_cbv_cache:put(my_value, <<"hello">>),
+       ?assertEqual(<<"hello">>, chef_cbv_cache:get(my_value))
+   end
+  }.
+
+
+get_returns_value_for_cached_value_from_another_pid_test_() ->
+  {setup,
+   fun() ->
+       start_cbv_cache(true, 30000)
+   end,
+   fun cleanup_cache/1,
+   fun() ->
+       spawn(fun() ->
+                 chef_cbv_cache:claim(their_value),
+                 chef_cbv_cache:put(their_value, <<"hello">>)
+             end),
+
+       % Ensure there is time to process the request
+       timer:sleep(100),
+       ?assertEqual(<<"hello">>, chef_cbv_cache:get(their_value))
+   end
+  }.
+

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -287,7 +287,8 @@ assemble_response(Req, #base_state{server_api_version = ApiVersion} = State, Coo
             case make_json_list(CookbookVersions, chef_wm_util:base_uri(Req), ApiVersion) of
                 {error, busy} ->
                   % Force backoff until the cache catches up with demand. Occurs when caching is enabled
-                  % and the cache message queue is overloaded.
+                  % and the cache message queue is overloaded. Also occurs when we give up on waiting for
+                  % another process that has claimed a given cache key to complete its work.
                   wm_halt(503, Req, State, <<"cookbook versions cache unavailable. Try again shortly.">>, cbv_cache_timeout);
                 JsonList ->
                  {true, wrq:append_to_response_body(chef_json:encode(JsonList), Req), State}

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -48,6 +48,8 @@
 
 %% Internal types
 -type cookbook_with_version() :: binary() | {binary(), binary()}.
+-define(CACHE_RETRY_INTERVAL, 200).
+-define(CACHE_MAX_RETRIES, 10).
 
 init(Config) ->
     oc_chef_wm_base:init(?MODULE, Config).
@@ -246,11 +248,12 @@ handle_depsolver_results(ok, {error, {unreachable_package, Unreachable}}, Req, S
     precondition_failed(Req, State,
                         not_reachable_message(Unreachable),
                         unreachable_dep);
-handle_depsolver_results(ok, {ok, Cookbooks}, Req, #base_state{chef_db_context = DbContext,
+handle_depsolver_results(ok, {ok, Cookbooks}, Req, #base_state{reqid = _ReqId,
+                                                               chef_db_context = DbContext,
                                                                organization_guid = OrgId } = State) ->
     %% TODO - helper function to deal with the call and match on a chef_cookbook version
-    CookbookRecords = chef_db:bulk_fetch_minimal_cookbook_versions(DbContext, OrgId, Cookbooks),
-    assemble_response(Req, State, CookbookRecords).
+    assemble_response(Req, State,
+                      chef_db:bulk_fetch_minimal_cookbook_versions(DbContext, OrgId, Cookbooks)).
 
 %% @doc Utility function to remove some of the verbosity
 precondition_failed(Req, State, ErrorData, LogMsg) ->
@@ -278,20 +281,62 @@ wm_halt(Code, Req, State, ErrorData, LogMsg) ->
 %% removing large fields such as long_description and attributes in
 %% the metadata that are not required by chef-client
 assemble_response(Req, #base_state{server_api_version = ApiVersion} = State, CookbookVersions) ->
+
     case oc_chef_wm_base:check_cookbook_authz(CookbookVersions, Req, State) of
         ok ->
-            %% We iterate over the list again since we only want to construct the s3urls
-            %% if the authz check has succeeded.  We use a minimal version of the
-            %% cookbook which has just enough information for chef-client to run
-            JsonList = {
-                    [ { CBV#chef_cookbook_version.name,
-                       chef_cookbook_version:minimal_cookbook_ejson(CBV, chef_wm_util:base_uri(Req), ApiVersion) }
-                      || CBV <- CookbookVersions ]
-                    },
-            CBMapJson = chef_json:encode(JsonList),
-            {true, wrq:append_to_response_body(CBMapJson, Req), State};
+            case make_json_list(CookbookVersions, chef_wm_util:base_uri(Req), ApiVersion) of
+                {error, busy} ->
+                  % Force backoff until the cache catches up with demand. Occurs when caching is enabled
+                  % and the cache message queue is overloaded.
+                  wm_halt(503, Req, State, <<"cookbook versions cache unavailable. Try again shortly.">>, cbv_cache_timeout);
+                JsonList ->
+                 {true, wrq:append_to_response_body(chef_json:encode(JsonList), Req), State}
+            end;
         {error, Msg} ->
             forbid(Req, State, Msg, {forbidden, read})
+    end.
+
+make_json_list(CookbookVersions, URI, ApiVersion) ->
+    Hash = erlang:phash2(CookbookVersions, 134217728),
+    make_json_list(CookbookVersions, URI, ApiVersion, Hash, 0).
+
+make_json_list(_CookbookVersions, _URI, _ApiVersion, Hash, ?CACHE_MAX_RETRIES) ->
+    % Waiting is good, but let's not hang the client up forever.
+    lager:info("chef_wm_depsolver:make_json_list ~p - forcing retry after giving up on ~p", [self(), Hash]),
+    {error, busy};
+make_json_list(CookbookVersions, URI, ApiVersion, Hash, NumAttempts) ->
+    case chef_cbv_cache:get(Hash) of
+        retry ->
+            % Someone else is calculating this, pause to let them finish and try again
+            timer:sleep(?CACHE_RETRY_INTERVAL),
+            make_json_list(CookbookVersions, URI, ApiVersion, Hash, NumAttempts + 1);
+        undefined ->
+            % It is not in the cache and nobody is working on it. Stake our claim and
+            % do the work.
+            case chef_cbv_cache:claim(Hash) of
+                Response when Response =:= undefined orelse Response =:= ok->
+                    %% We iterate over the list again since we only want to construct the s3urls
+                    %% if the authz check has succeeded (in caller).  We respond with a minimal version of the
+                    %% cookbook which has just enough information for chef-client to run
+                    %% Note that it is possible for the final result to contain thousands of entries.
+                    Result = {
+                      [ { CBV#chef_cookbook_version.name,
+                          chef_cookbook_version:minimal_cookbook_ejson(CBV, URI, ApiVersion) }
+                        || CBV <- CookbookVersions ]
+                     },
+                    chef_cbv_cache:put(Hash, Result),
+                    Result;
+                retry ->
+                    % Someone snuck in and claimed it at around the same time as us. They got
+                    % there first, so we'll wait and retry the get.
+                    timer:sleep(?CACHE_RETRY_INTERVAL),
+                    make_json_list(CookbookVersions, URI, ApiVersion, Hash, NumAttempts + 1);
+                busy ->
+                    % cache service is overloaded, we're done here.
+                    {error, busy}
+            end;
+        Result ->
+            Result
     end.
 
 %%------------------------------------------------------------------------------

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
@@ -54,12 +54,15 @@ init([]) ->
                 {chef_keygen_cache, start_link, []},
                 permanent, 5000, worker, [chef_keygen_cache]},
 
+    CBVCache = {chef_cbv_cache, {chef_cbv_cache, start_link, []},
+                permanent, 5000, worker, [chef_cvb_cache]},
+
     Index = {chef_index_sup,
              {chef_index_sup, start_link, []},
              permanent, 5000, supervisor, [chef_index_sup]},
 
     {ok, { {one_for_one, 10, 10}, [KeyRing, Index, KeyGenWorkerSup,
-                                   KeyCache, Web]}}.
+                                   KeyCache, Web, CBVCache]}}.
 
 load_ibrowse_config() ->
     %% FIXME: location of the ibrowse.config should be itself configurable. Also need to


### PR DESCRIPTION
Most of our time post-depsolve in the `cookbook_versions/` endpoint is spent assembling the results for the client to consume.    On a heavily loaded server since OTP 20, the same
call can take 60+ seconds to complete and significantly degrade performance of the entire system.   Prior to that, it could still take 3-6 seconds though without systemic performance degradation.

This change introduces an ets-based cache that:
- allows callers to cache the results 
- has overload protection, allowing the caller to force client retry (via 503 response) instead of waiting for the cache to become available
- has synchronization capabilities, so that one caller can determine that another process is already calculating results for a given key and retry the request instead of allowing multiple callers to do the same results calculation. 

Some numbers, using sample org data that tends towards generating large
responses to cookbook_version endpoint, because of the total number of
cookbook files:

7k clients/15min interval - cache disabled - CPU 1800-2000%, LA 25. cookbook_versions rough average time range 2-5s
7k clients/15min interval - cache enabled - CPU 150-200%, LA 5-6. cookbook_versions rough average time range 0.2-1.1s (edited)
40k clients/15min interval - cache enabled - CPU 1000-1200%, LA 19 . CBV time range: 0.2-3s with most on the < 0.5 end.
40k clients/15min interval - cache disabled - server fails within a minute


For more details, see the commit messages in this PR. 


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
