### PR TITLE
WIP Configure security headers (HSTS, etc)

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx.conf.erb
@@ -128,6 +128,7 @@ http {
     server {
       listen <%= @ssl_port %> ssl;
       add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+      add_header X-XSS-Protection "1; mode=block";
 
       ssl_certificate <%= @ssl_certificate %>;
       ssl_certificate_key <%= @ssl_certificate_key %>;

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx.conf.erb
@@ -127,6 +127,7 @@ http {
 
     server {
       listen <%= @ssl_port %> ssl;
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
       ssl_certificate <%= @ssl_certificate %>;
       ssl_certificate_key <%= @ssl_certificate_key %>;


### PR DESCRIPTION
Signed-off-by: Lincoln Baker <lbaker@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

https://github.com/chef/customer-bugs/issues/509

### Acceptance Criteria

The following headers  should be visible in response headers:

- [ ] Strict-Transport-Security (HSTS) [Appears to already be present]
- [ ] HPKP [Appears to be a DEPRECATED protocol]
- [ ] X-XSS [Appears to already be present]
- [ ] X-Content-Type-Options [Appears to already be present]
- [ ] Content-Security-Policy [Appears to already be present]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
