### PR TITLE
Updating habitat build channel to stable2021q2

### DIFF
--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -1,3 +1,15 @@
 ---
+env:
+  HAB_BLDR_CHANNEL: "stable2021-q2"
+  HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable2021-q2"
+  HAB_FALLBACK_CHANNEL: "stable2021-q2"
+
 origin: chef
 smart_build: false
+studio_secrets:
+  HAB_BLDR_CHANNEL:
+    value: "stable2021-q2"
+  HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL:
+    value: "stable2021-q2"
+  HAB_FALLBACK_CHANNEL:
+    value: "stable2021-q2"

--- a/.expeditor/create_manifest.rb
+++ b/.expeditor/create_manifest.rb
@@ -26,7 +26,7 @@ end
 def get_hab_deps_latest()
   ret = {}
   ["hab", "hab-sup", "hab-launcher"].each do |name|
-    d = get_latest("stable", "core", name)
+    d = get_latest("stable2021q2", "core", name)
     ret[name] = "#{d["origin"]}/#{d["name"]}/#{d["version"]}/#{d["release"]}"
   end
   ret

--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -15,6 +15,8 @@ habitat:
   channel_for_origin:
     - origin: chef
       channel: unstable
+    - origin: core
+      channel: stable2021-q2
 
 allowed_licenses:
   - Apache-1.0

--- a/src/oc_bifrost/schema/sqitch.plan
+++ b/src/oc_bifrost/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=bifrost
-%uri=https://github.com/opscode/oc_bifrost
+%uri=https://github.com/chef/oc_bifrost
 
 base 2013-06-24T11:10:23Z Christopher Maier <cm@opscode.com> # The initial base install of the bifrost schema
 forbid_group_cycles [base] 2013-06-24T13:04:05Z Christopher Maier <cm@opscode.com> # Add forbid_group_cycles function and accompanying trigger

--- a/src/oc_erchef/schema/baseline/sqitch.plan
+++ b/src/oc_erchef/schema/baseline/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=oss_chef
-%uri=https://github.com/opscode/chef-server-schema
+%uri=https://github.com/chef/chef-server-schema
 
 osc_users 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # Open Source users table
 nodes 2013-09-04T14:07:22Z Christopher Maier <cm@opscode.com> # Nodes table

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0
 %project=enterprise_chef
-%uri=https://github.com/opscode/enterprise-chef-server-schema
+%uri=https://github.com/chef/enterprise-chef-server-schema
 
 drop_osc_users [oss_chef:osc_users] 2013-09-05T19:22:00Z Christopher Maier <cm@opscode.com> # Remove osc_users table
 users [drop_osc_users] 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # users table


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

Currently when we do the chef-server release, the chef-server components for the habitat environment are built on the `stable` channel, meaning the dependencies are pulled from `stable` channel. The chef-server components are use in the automate environment. When we try to update the version of chef-server components in the automate we are getting dependency check failure as all the dependencies in the automate environment are pulled from the `stable2021q2` channel. We need to build the chef-server components in the `stable2021q2` in order for it to be comparable with the automate.

### Issues Resolved

https://github.com/chef/chef-server/issues/2652
https://github.com/chef/automate/pull/6183

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
