### PR TITLE
fixes /etc/opscode/logrotate.d/nginx file to be owned by root

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/nginx.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/nginx.rb
@@ -254,8 +254,8 @@ end
 # log rotation
 template '/etc/opscode/logrotate.d/nginx' do
   source 'logrotate.erb'
-  owner OmnibusHelper.new(node).ownership['owner']
-  group OmnibusHelper.new(node).ownership['group']
+  owner 'root'
+  group 'root'
   mode '0644'
   variables(node['private_chef']['nginx'].to_hash.merge(
     'postrotate' => "/opt/opscode/embedded/sbin/nginx -c #{nginx_config} -s reopen",


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

### Description

Fixes issue with permissions on `/etc/opscode/logrotate.d/nginx` which should be owned by `root` user.  This was changed incorrectly in #2570 and `/etc/opscode/logrotate.d/nginx` ownership settings are reverted back with this update.

### Issues Resolved

#2960 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG
