### PR TITLE
Updated _status endpoint status code to 200 OK incase of any service failure

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
@@ -53,12 +53,8 @@ content_types_provided(Req, State) ->
 
 to_json(Req, #base_state{otp_info = {_, ServerVersion}} = State) ->
     ServerVersionBinary = list_to_binary(ServerVersion),
-    case check_health(ServerVersionBinary) of
-        {fail, Body} ->
-            {{halt, 500}, wrq:set_resp_body(Body, Req), State};
-        {pong, Body} ->
-            {Body, Req, State}
-    end.
+    {_Status, Body} = check_health(ServerVersionBinary),
+    {Body, Req, State}.
 
 %% private functions
 


### PR DESCRIPTION
…failure

Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Update _status endpoint status code to 200 OK incase of any service failure as the automate is interpreting it in a wrong way.

### Issues Resolved
Updated _status endpoint status code to 200 OK incase of any service failure

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
