### PR TITLE
Fix external postgresql error on dev vm `vagrant up`

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -56,7 +56,7 @@ end
 
 Vagrant.configure("2") do |config|
   attributes = load_settings
-
+  config.omnibus.chef_version = :latest
   config.vm.network 'public_network' if USE_AZURE
   # Use the official Ubuntu 18.04 box
   # Vagrant will auto resolve the url to download from Atlas


### PR DESCRIPTION
Fix external postgresql error on dev vm `vagrant up`.

```
==> database: Running provisioner: chef_zero...
The chef binary (either `chef-solo` or `chef-client`) was not found on
the VM and is required for chef provisioning. Please verify that chef
is installed and that the binary is available on the PATH.
```

This gets us past the first error (above) and onto a second one.

Signed-off-by: Lincoln Baker <lbaker@chef.io>

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
