### PR TITLE
Switch main back to master for wiki in publish-release-notes

### DIFF
--- a/.expeditor/publish-release-notes.sh
+++ b/.expeditor/publish-release-notes.sh
@@ -24,7 +24,7 @@ EOH
   # Push changes back up to GitHub
   git add .
   git commit -m "Release Notes for promoted build $EXPEDITOR_VERSION"
-  git push origin main
+  git push origin master
 popd
 
 rm -rf chef-server.wiki


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

The default branch in the wiki is still master. 

I'm not sure what the problem is with the announce-release part, but this should fix resetting the wiki.

### Issues Resolved

chef/release-engineering#1714

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
