### PR TITLE
Remove newrelic_rpm gem from oc-id

### DIFF
--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -18,7 +18,6 @@ gem 'pg', '>= 0.18', '< 2.0' # active_record 4.2.8 pins this but doesn't manifes
 gem 'mixlib-authentication', '>= 2.1', '< 4'
 gem 'sentry-raven'
 gem 'responders', '~> 3.0', '>= 3.0.1'
-gem 'newrelic_rpm'
 gem 'doorkeeper', '~> 4.0'
 gem "sprockets-rails", git: 'https://github.com/rails/sprockets-rails.git'
 gem 'therubyracer', '~> 0.12.3'

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -342,7 +342,6 @@ GEM
     net-sftp (3.0.0)
       net-ssh (>= 5.0.0, < 7.0.0)
     net-ssh (6.1.0)
-    newrelic_rpm (8.3.0)
     nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
@@ -607,7 +606,6 @@ DEPENDENCIES
   jwt
   mailcatcher
   mixlib-authentication (>= 2.1, < 4)
-  newrelic_rpm
   nokogiri (= 1.13.1)
   omniauth-chef (~> 0.4)
   pg (>= 0.18, < 2.0)

--- a/src/oc-id/config/newrelic.yml
+++ b/src/oc-id/config/newrelic.yml
@@ -1,6 +1,0 @@
-development:
-  app_name: oc-id (Development)
-  monitor_mode: false
-  developer_mode: true
-production:
-  monitor_mode: false


### PR DESCRIPTION
We're not actively using this anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>