### PR TITLE
Correct config_rb_backend.md to include elasticsearch.jvm_opts

### DIFF
--- a/docs-chef-io/content/server/config_rb_backend.md
+++ b/docs-chef-io/content/server/config_rb_backend.md
@@ -277,8 +277,8 @@ for more information.
 : Automatically computed by Elasticsearch based on available memory.
   Specify in MB if you wish to override.
 
-`elasticsearch.java_opts`
-: Flags to directly pass to the JVM when launching Elasticsearch.
+`elasticsearch.jvm_opts`
+: Flags in an array to directly pass to the JVM when launching Elasticsearch.
   If you override a heap flag here, the setting here takes precedence.
 
 `elasticsearch.new_size`


### PR DESCRIPTION
In ticket 29474, a user reported that `elasticsearch.jvm_opts ['-Dlog4j2.formatMsgNoLookups=true']` worked as a configuration option in chef-backend.rb but `elasticsearch.java_opts  '-Dlog4j2.formatMsgNoLookups=true'` did not.  Examining output from `chef-backend-ctl gen-sample-backend-config` confirmed the current setting on the most recent chef-backend build.

### Description
Corrects the documentation.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ x] PR title is a worthy inclusion in the CHANGELOG

Signed-off-by: Brian Schwegmann <schwegma@progress.com>