### PR TITLE
Remove the Chef Backend deprecation warning from tiered

### DIFF
--- a/docs-chef-io/content/server/install_server_tiered.md
+++ b/docs-chef-io/content/server/install_server_tiered.md
@@ -14,8 +14,6 @@ aliases = ["/install_server_tiered.html", "/install_server_tiered/"]
     weight = 50
 +++
 
-{{% EOL_backend %}}
-
 This topic describes how to set up the Chef Infra Server with a single
 back end and multiple load-balanced frontend servers.
 


### PR DESCRIPTION
These are not the same thing.

Signed-off-by: Tim Smith <tsmith@chef.io>