### PR TITLE
Improve security of the default site with more HTTP headers

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -42,7 +42,7 @@
     add_header Content-Security-Policy "default-src 'self';";
     add_header X-Content-Type-Options nosniff;
     add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
-    add_header Referrer-Policy 'origin';
+    add_header Referrer-Policy 'strict-origin';
       <% if @server_proto == 'https' %>
     add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
       <% end %>
@@ -60,7 +60,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
-      add_header Referrer-Policy 'origin';
+      add_header Referrer-Policy 'strict-origin';
     }
 
     location "/css/" {
@@ -68,7 +68,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
-      add_header Referrer-Policy 'origin';
+      add_header Referrer-Policy 'strict-origin';
     }
 
     location "/images/" {
@@ -76,7 +76,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
-      add_header Referrer-Policy 'origin';
+      add_header Referrer-Policy 'strict-origin';
     }
 
     location /version {
@@ -84,7 +84,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
-      add_header Referrer-Policy 'origin';
+      add_header Referrer-Policy 'strict-origin';
       types { }
       default_type text/plain;
       alias /opt/opscode/version-manifest.txt;

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -37,10 +37,11 @@
     proxy_send_timeout      300;
     proxy_read_timeout      300;
 
-    <% if !node['packages']['chef-manage'] %>
+    <% unless node['packages']['chef-manage'] %>
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection 1;
+    add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
       <% if @server_proto == 'https' %>
     add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
       <% end %>

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -39,8 +39,8 @@
 
     <% unless node['packages']['chef-manage'] %>
     add_header X-Frame-Options DENY;
+    add_header Content-Security-Policy "default-src 'self';";
     add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection 1;
     add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
     add_header Referrer-Policy 'origin';
       <% if @server_proto == 'https' %>
@@ -60,6 +60,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
+      add_header Referrer-Policy 'origin';
     }
 
     location "/css/" {
@@ -67,6 +68,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
+      add_header Referrer-Policy 'origin';
     }
 
     location "/images/" {
@@ -74,6 +76,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
+      add_header Referrer-Policy 'origin';
     }
 
     location /version {
@@ -81,6 +84,7 @@
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
+      add_header Referrer-Policy 'origin';
       types { }
       default_type text/plain;
       alias /opt/opscode/version-manifest.txt;

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -58,21 +58,29 @@
     location ~ "^/[0-9]{3,3}\.(json|html)|favicon.ico|index.html$" {
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
+      add_header X-Content-Type-Options nosniff;
+      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
     }
 
     location "/css/" {
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
+      add_header X-Content-Type-Options nosniff;
+      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
     }
 
     location "/images/" {
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
+      add_header X-Content-Type-Options nosniff;
+      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
     }
 
     location /version {
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
+      add_header X-Content-Type-Options nosniff;
+      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
       types { }
       default_type text/plain;
       alias /opt/opscode/version-manifest.txt;

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -42,6 +42,7 @@
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection 1;
     add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
+    add_header Referrer-Policy 'origin';
       <% if @server_proto == 'https' %>
     add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
       <% end %>

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -61,6 +61,9 @@
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
       add_header Referrer-Policy 'strict-origin';
+      <% if @server_proto == 'https' %>
+      add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
+      <% end %>
     }
 
     location "/css/" {
@@ -69,6 +72,9 @@
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
       add_header Referrer-Policy 'strict-origin';
+      <% if @server_proto == 'https' %>
+      add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
+      <% end %>
     }
 
     location "/images/" {
@@ -77,6 +83,9 @@
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
       add_header Referrer-Policy 'strict-origin';
+      <% if @server_proto == 'https' %>
+      add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
+      <% end %>
     }
 
     location /version {
@@ -85,6 +94,9 @@
       add_header X-Content-Type-Options nosniff;
       add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
       add_header Referrer-Policy 'strict-origin';
+      <% if @server_proto == 'https' %>
+      add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
+      <% end %>
       types { }
       default_type text/plain;
       alias /opt/opscode/version-manifest.txt;

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -41,7 +41,7 @@
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection 1;
-    add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
+    add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
     add_header Referrer-Policy 'origin';
       <% if @server_proto == 'https' %>
     add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
@@ -59,28 +59,28 @@
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
-      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
+      add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
     }
 
     location "/css/" {
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
-      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
+      add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
     }
 
     location "/images/" {
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
-      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
+      add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
     }
 
     location /version {
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
-      add_header Permissions-Policy "camera 'none'; payment 'none'; microphone 'none'; gyroscope 'none'; magnetometer 'none'; midi 'none'; geolocation 'none'";
+      add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
       types { }
       default_type text/plain;
       alias /opt/opscode/version-manifest.txt;


### PR DESCRIPTION
Our previous headers applied to the actual product endpoints, but not the static website. This was somewhat intentional since the static website doesn't matter and doesn't load any content so there's no security risk there. Not securing the additional endpoints did cause security scanners to incorrectly see the application as insecure. This gets us a passing grade now at securityheaders.com/