### PR TITLE
moving back to opscode from chef in the uri of sqitch.plan

### DIFF
--- a/src/oc_bifrost/schema/sqitch.plan
+++ b/src/oc_bifrost/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=bifrost
-%uri=https://github.com/chef/oc_bifrost
+%uri=https://github.com/opscode/oc_bifrost
 
 base 2013-06-24T11:10:23Z Christopher Maier <cm@opscode.com> # The initial base install of the bifrost schema
 forbid_group_cycles [base] 2013-06-24T13:04:05Z Christopher Maier <cm@opscode.com> # Add forbid_group_cycles function and accompanying trigger

--- a/src/oc_erchef/schema/baseline/sqitch.plan
+++ b/src/oc_erchef/schema/baseline/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0-b2
 %project=oss_chef
-%uri=https://github.com/chef/chef-server-schema
+%uri=https://github.com/opscode/chef-server-schema
 
 osc_users 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # Open Source users table
 nodes 2013-09-04T14:07:22Z Christopher Maier <cm@opscode.com> # Nodes table

--- a/src/oc_erchef/schema/sqitch.plan
+++ b/src/oc_erchef/schema/sqitch.plan
@@ -1,6 +1,6 @@
 %syntax-version=1.0.0
 %project=enterprise_chef
-%uri=https://github.com/chef/enterprise-chef-server-schema
+%uri=https://github.com/opscode/enterprise-chef-server-schema
 
 drop_osc_users [oss_chef:osc_users] 2013-09-05T19:22:00Z Christopher Maier <cm@opscode.com> # Remove osc_users table
 users [drop_osc_users] 2013-09-04T13:54:01Z Christopher Maier <cm@opscode.com> # users table


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

The a1 migration scripts were failing as it tries to rebuild the cs services.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
