### PR TITLE
Bump hugo version to 0.91.2

### DIFF
--- a/docs-chef-io/netlify.toml
+++ b/docs-chef-io/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.83.1"
+  HUGO_VERSION = "0.91.2"
   HUGO_ENABLEGITINFO = "true"
   GO_VERSION = "1.15"
   NODE_ENV = "development"


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

Bump Hugo version to 0.91.2

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
