### PR TITLE
Update address ranges in use for vbox compat

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -30,14 +30,14 @@ Requirements:
 
 First, add the following configuration to your `/etc/hosts` file:
 
-    192.168.33.100 api.chef-server.dev manage.chef-server.dev
-    192.168.33.150 database.chef-server.dev
-    192.168.33.151 backend.chef-server.dev
-    192.168.33.152 ldap.chef-server.dev
-    192.168.33.153 custom.chef-server.dev
-    192.168.33.155 reportingdb.chef-server.dev
-    192.168.33.156 elasticsearch.chef-server.dev
-    192.168.33.157 solr.chef-server.dev
+    192.168.56.100 api.chef-server.dev manage.chef-server.dev
+    192.168.56.150 database.chef-server.dev
+    192.168.56.151 backend.chef-server.dev
+    192.168.56.152 ldap.chef-server.dev
+    192.168.56.153 custom.chef-server.dev
+    192.168.56.155 reportingdb.chef-server.dev
+    192.168.56.156 elasticsearch.chef-server.dev
+    192.168.56.157 solr.chef-server.dev
 
 Next, bring up the VMs!
 
@@ -126,7 +126,7 @@ Ruby project dependency loading support coming soon.
 ### Installing Chef Server Plugins
 
 If you wish to install Chef Server plugins with pre-downloaded or pre-built
-binaries, set the corresponding attribute in your `config.yml` to true. 
+binaries, set the corresponding attribute in your `config.yml` to true.
 The corresponding package needs to be either in `~/Downloads`, `../omnibus/pkg`,
 or you can set an environment variable with the path to the package.
 
@@ -330,7 +330,7 @@ vm:
     start: true
     use-external: true
 ```
-# Using elasticsearch 
+# Using elasticsearch
 
 To create a separate elasticsearch vm create a `config.yml` file with the following contents:
 ```
@@ -339,7 +339,7 @@ To create a separate elasticsearch vm create a `config.yml` file with the follow
     # The major version family to use - either "2" or "5".
     version: "5"
 ```
-# Using external solr 
+# Using external solr
 
 To create a separate solr vm create a `config.yml` file with the following contents:
 ```

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -7,17 +7,17 @@ require "fileutils"
 load "dvmtools.rb"
 
 Variant = ENV['VAGRANT_MACHINE_VARIANT'] ? ("-" + ENV['VAGRANT_MACHINE_VARIANT'] ) : ''
-VMName = "chef-server#{Variant}" 
+VMName = "chef-server#{Variant}"
 
 IPS = {
-  cs: "192.168.33.100",
-  db: "192.168.33.150",
-  be: "192.168.33.151",
-  ldap: "192.168.33.152",
-  custom: "192.168.33.153",
-  reportingdb: "192.168.33.155",
-  elasticsearch: "192.168.33.156",
-  solr: "192.168.33.157"
+  cs: "192.168.56.100",
+  db: "192.168.56.150",
+  be: "192.168.56.151",
+  ldap: "192.168.56.152",
+  custom: "192.168.56.153",
+  reportingdb: "192.168.56.155",
+  elasticsearch: "192.168.56.156",
+  solr: "192.168.56.157"
 }
 
 # to run a chef-server vm with external postgresql,
@@ -56,7 +56,6 @@ end
 
 Vagrant.configure("2") do |config|
   attributes = load_settings
-  config.omnibus.chef_version = :latest
   config.vm.network 'public_network' if USE_AZURE
   # Use the official Ubuntu 18.04 box
   # Vagrant will auto resolve the url to download from Atlas
@@ -171,7 +170,7 @@ def define_chef_server(config, attributes)
              "opscode_erchef['db_pool_size']" => 10,
              "oc_id['db_pool_size']" => 10,
              "oc_bifrost['db_pool_size']" => 10 }
-      
+
       pg.merge!({
                   "postgresql['db_connection_superuser']" => "'#{DB_SUPERUSER}@#{IPS[:db]}'",
                   "postgresql['sql_connection_user']" => "'#{DB_SUPERUSER}@#{IPS[:db]}'",

--- a/dev/config.yml.example
+++ b/dev/config.yml.example
@@ -57,7 +57,7 @@ vm:
       # and tcp-based access.
       #chef-server-config:
       #  postgresql['external']: true
-      #  postgresql['vip']:  "\"192.168.33.1\""
+      #  postgresql['vip']:  "\"192.168.56.1\""
       #  postgresql['port']: 5432
       #  postgresql['db_superuser']: "\"bob\""
       #  postgresql['db_superuser_password']: "\"i like bob\""

--- a/dev/cookbooks/provisioning/templates/default/hosts.erb
+++ b/dev/cookbooks/provisioning/templates/default/hosts.erb
@@ -1,6 +1,6 @@
 127.0.0.1 localhost
 <% @fqdns.each do |fqdn| %>
-192.168.33.100  <%=fqdn.split(".")[0]%> <%=fqdn%>
+192.168.56.100  <%=fqdn.split(".")[0]%> <%=fqdn%>
 <% end %>
 
 <% @global_fqdns.each do |entry| %>

--- a/dev/scripts/provision-postgres.sh
+++ b/dev/scripts/provision-postgres.sh
@@ -15,7 +15,7 @@
 #
 #CS_IP=
 #     Chef Infra Server IP address
-#     default: '192.168.33.100'
+#     default: '192.168.56.100'
 #
 #PG_MAJOR=
 #     PostgreSQL major version
@@ -54,7 +54,7 @@
 #### Set default values (if not overridden by environment variables)
 #
 
-test -n "${CS_IP}"        || CS_IP=${1:-'192.168.33.100'} # Allow old $1 parameter
+test -n "${CS_IP}"        || CS_IP=${1:-'192.168.56.100'} # Allow old $1 parameter
 test -n "${PG_MAJOR}"     || PG_MAJOR=13
 test -n "${PG_MINOR}"     || PG_MINOR='latest'
 test -n "${PG_HBA_AUTH}"  || PG_HBA_AUTH='md5'

--- a/dev/scripts/reporting/reporting-dvm-preflight.sh
+++ b/dev/scripts/reporting/reporting-dvm-preflight.sh
@@ -60,11 +60,11 @@ fi
 echo "postgresql['db_superuser'] = \"bofh\"" > /tmp/external-postgres-1.rb
 echo "postgresql['db_superuser_password'] = \"i1uvd3v0ps\"" >> /tmp/external-postgres-1.rb
 echo "postgresql['external'] = true" >> /tmp/external-postgres-1.rb
-echo "postgresql['vip'] = \"192.168.33.150\"" >> /tmp/external-postgres-1.rb
+echo "postgresql['vip'] = \"192.168.56.150\"" >> /tmp/external-postgres-1.rb
 
 # External Server Config 2)
 
 echo "postgresql['db_superuser'] = \"bofh\"" > /tmp/external-postgres-2.rb
 echo "postgresql['db_superuser_password'] = \"i1uvd3v0ps\"" >> /tmp/external-postgres-2.rb
 echo "postgresql['external'] = true" >> /tmp/external-postgres-2.rb
-echo "postgresql['vip'] = \"192.168.33.155\"" >> /tmp/external-postgres-2.rb
+echo "postgresql['vip'] = \"192.168.56.155\"" >> /tmp/external-postgres-2.rb

--- a/dev/scripts/reporting/reporting-preflight.sh
+++ b/dev/scripts/reporting/reporting-preflight.sh
@@ -61,11 +61,11 @@ fi
 echo "postgresql['db_superuser'] = \"bofh\"" > /tmp/external-postgres-1.rb
 echo "postgresql['db_superuser_password'] = \"i1uvd3v0ps\"" >> /tmp/external-postgres-1.rb
 echo "postgresql['external'] = true" >> /tmp/external-postgres-1.rb
-echo "postgresql['vip'] = \"192.168.33.150\"" >> /tmp/external-postgres-1.rb
+echo "postgresql['vip'] = \"192.168.56.150\"" >> /tmp/external-postgres-1.rb
 
 # External Server Config 2)
 
 echo "postgresql['db_superuser'] = \"bofh\"" > /tmp/external-postgres-2.rb
 echo "postgresql['db_superuser_password'] = \"i1uvd3v0ps\"" >> /tmp/external-postgres-2.rb
 echo "postgresql['external'] = true" >> /tmp/external-postgres-2.rb
-echo "postgresql['vip'] = \"192.168.33.155\"" >> /tmp/external-postgres-2.rb
+echo "postgresql['vip'] = \"192.168.56.155\"" >> /tmp/external-postgres-2.rb


### PR DESCRIPTION
Newer versions of VirtualBox no lnoger default to allowing
hosts to be assigned arbitrary IP addressed.  Instead, the
range 192.168.56.0/24 is permitted.

This change updates our dev vm environment and related tools/scripts
to use addresses in acceptable range.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
