### PR TITLE
Cookbook version caching updates 

### DIFF
--- a/src/oc_erchef/apps/chef_objects/src/chef_cbv_cache.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cbv_cache.erl
@@ -131,7 +131,7 @@ enabled() ->
     envy:get(chef_objects, cbv_cache_enabled, false, boolean).
 
 %% Internal function that checks in with the process message queue for chef_cbv_cache intermittently
-%% and tracks whether its mailbox has grown to large. If that happens, response with '{error, busy}' instead
+%% and tracks whether its mailbox has grown too large. If that happens, response with '{error, busy}' instead
 %% of sending the request through.
 send_if_available(Msg) ->
     case enabled() of

--- a/src/oc_erchef/apps/chef_objects/test/chef_cbv_cache_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cbv_cache_tests.erl
@@ -103,7 +103,7 @@ put_does_not_return_busy_when_cache_queue_limit_exceeded_test_() ->
        timer:sleep(100), % QUEUE_LEN_REFRESH_INTERVAL
 
        % verify that rquests that use the breaker are failing
-       ?assertEqual(busy, chef_cbv_cache:get(my_key)),
+       ?assertEqual({error, busy}, chef_cbv_cache:get(my_key)),
 
        % Let it start processing the junk
        erlang:resume_process(Pid),
@@ -135,8 +135,8 @@ get_and_claim_return_busy_when_cache_queue_limit_exceeded_test_() ->
        timer:sleep(100), % QUEUE_LEN_REFRESH_INTERVAL
 
        % Any calls should be stopped before a message is sent to chef_cbv_cache
-       ?assertEqual(busy, chef_cbv_cache:get(anything)),
-       ?assertEqual(busy, chef_cbv_cache:claim(anything)),
+       ?assertEqual({error, busy}, chef_cbv_cache:get(anything)),
+       ?assertEqual({error, busy}, chef_cbv_cache:claim(anything)),
        erlang:resume_process(Pid)
    end
   }.

--- a/src/oc_erchef/apps/chef_objects/test/chef_cbv_cache_tests.erl
+++ b/src/oc_erchef/apps/chef_objects/test/chef_cbv_cache_tests.erl
@@ -71,7 +71,7 @@ claim_replies_retry_when_another_pid_has_claimed_first_test_() ->
    fun() ->
        spawn(fun() -> chef_cbv_cache:claim(other_key) end),
        timer:sleep(100), % Give the claim time to go through
-       ?assertEqual(retry, chef_cbv_cache:claim(other_key))
+       ?assertEqual({error, retry}, chef_cbv_cache:claim(other_key))
    end
   }.
 
@@ -180,7 +180,7 @@ get_returns_retry_when_another_proc_has_invoked_claim_test_() ->
                          timer:sleep(200)
              end),
        timer:sleep(100),
-       ?assertEqual(retry, chef_cbv_cache:get(reserved_key))
+       ?assertEqual({error, retry}, chef_cbv_cache:get(reserved_key))
    end
   }.
 get_returns_undefined_when_another_proc_has_invoked_claim_and_died_test_() ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -307,7 +307,7 @@ make_json_list(_CookbookVersions, _URI, _ApiVersion, Hash, ?CACHE_MAX_RETRIES) -
     {error, busy};
 make_json_list(CookbookVersions, URI, ApiVersion, Hash, NumAttempts) ->
     case chef_cbv_cache:get(Hash) of
-        retry ->
+        {error, retry} ->
             % Someone else is calculating this, pause to let them finish and try again
             timer:sleep(?CACHE_RETRY_INTERVAL),
             make_json_list(CookbookVersions, URI, ApiVersion, Hash, NumAttempts + 1);
@@ -327,12 +327,12 @@ make_json_list(CookbookVersions, URI, ApiVersion, Hash, NumAttempts) ->
                      },
                     chef_cbv_cache:put(Hash, Result),
                     Result;
-                retry ->
+                {error, retry} ->
                     % Someone snuck in and claimed it at around the same time as us. They got
                     % there first, so we'll wait and retry the get.
                     timer:sleep(?CACHE_RETRY_INTERVAL),
                     make_json_list(CookbookVersions, URI, ApiVersion, Hash, NumAttempts + 1);
-                busy ->
+                {error, busy} ->
                     % cache service is overloaded, we're done here.
                     {error, busy}
             end;


### PR DESCRIPTION
Fixes #3077 by including the OrgId as part of the CBV cache key, eliminating the chance of cross-org cache pollution 
Fixes #3078 by ensuring consistent responses from `chef_cbv_cache` for `{error, busy}` and `{error, retry}`
 
#### Pending: 
* [x] pipeline run (blocked on pipeline/license failure) 
* [x] functional testing with cache enabled (in progress) 