### PR TITLE
Update Redis to 5.0.14

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -8,7 +8,7 @@ override :chef, version: "v16.17.4"
 override :ohai, version: "v16.17.0"
 override :ruby, version: "2.7.5"
 override :perl, version: "5.18.1"
-override :redis, version: "5.0.7"
+override :redis, version: "5.0.14"
 
 override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently
 override :logrotate, version: "3.9.2" # 3.18.0 patches fail


### PR DESCRIPTION
This resolves multiple CVEs:

- CVE-2021-41099
- CVE-2021-32762
- CVE-2021-32687
- CVE-2021-32675
- CVE-2021-32672
- CVE-2021-32628
- CVE-2021-32627
- CVE-2021-32626
- CVE-2021-32761
- CVE-2021-21309
- CVE-2015-8080

Signed-off-by: Tim Smith <tsmith@chef.io>