### PR TITLE
Update Elasticsearch to 6.8.23

### DIFF
--- a/omnibus/config/software/elasticsearch.rb
+++ b/omnibus/config/software/elasticsearch.rb
@@ -15,7 +15,7 @@
 #
 
 name "elasticsearch"
-default_version "6.8.22"
+default_version "6.8.23"
 
 dependency "server-open-jre"
 
@@ -25,9 +25,9 @@ skip_transitive_dependency_licensing true
 
 relative_path "elasticsearch-#{version}"
 
-version "6.8.22" do
+version "6.8.23" do
   source url: "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-#{version}.tar.gz",
-         sha256: "836a50df324a98837dcadbc7d55782cc9525f15cc6a8aa0c657e199667ebb996"
+         sha256: "60e77b5ca3ce11771469bcc2e009c49c8aadb831faebd170e7abcedc16b3e36d"
 end
 
 version "7.9.3" do


### PR DESCRIPTION
This resolves CVE-2021-44832

Signed-off-by: Tim Smith <tsmith@chef.io>