### PR TITLE
Build RHEL 8 on RHEL 8 builders

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,8 +9,9 @@ fips-platforms:
 builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
-    - el-8-x86_64
     - amazon-2-x86_64
+  el-8-x86_64:
+    - el-8-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64

--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.4)
+    activesupport (6.1.4.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -80,4 +80,4 @@ DEPENDENCIES
   veil!
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
This resolves some Qualys scan failures related to FedRAMP

Signed-off-by: Tim Smith <tsmith@chef.io>