### PR TITLE
Minor updates to the static website

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/files/default/html/index.html
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/files/default/html/index.html
@@ -5,12 +5,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
   <title>Chef Infra Server API</title>
   <link media="all" rel="stylesheet" type="text/css" href="/css/all.css" />
-  <!--[if lt IE 7]><link rel="stylesheet" type="text/css" href="/css/lt7.css" /><![endif]-->
 </head>
 <body>
   <div class="header-block">
     <div id="header">
-      <strong class="logo"><a href="https://chef.io">Chef</a></strong>
+      <strong class="logo"><a href="https://www.chef.io/">Chef</a></strong>
     </div>
   </div>
   <div id="wrapper">
@@ -39,7 +38,7 @@
       <div class="mybox">
       </div>
       <div class="footer-bottom">
-        <span>&copy; 2010&thinsp;&ndash;&thinsp;2021 Chef Software, Inc. All Rights Reserved</span>
+        <span>&copy; 2010&thinsp;&ndash;&thinsp;2022 Chef Software, Inc. All Rights Reserved</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Update copyright to 2022
- Update the Chef website to avoid a redirect
- Remove IE 6 logic that wouldn't even work since the CSS file isn't there

Signed-off-by: Tim Smith <tsmith@chef.io>