### PR TITLE
change find command to ignore /var/log/lastlog

### DIFF
--- a/omnibus/files/private-chef-scripts/gather-logs
+++ b/omnibus/files/private-chef-scripts/gather-logs
@@ -50,7 +50,7 @@ for i in /opt/{chef,opscode}*/version-manifest.txt \
     fi
 done
 
-for i in `find -L /var/log/${path}* -type f -mmin -"$modified_within_last_x_minutes"`; do
+for i in `find -L /var/log/${path}* -type f -mmin -"$modified_within_last_x_minutes" -not -name "lastlog"`; do
     if [[ -e "$i" ]]; then
         mkdir -p "$tmpdir/`dirname ${i:1}`"
         tail -"$tail_lines" "$i" > "$tmpdir/${i:1}"


### PR DESCRIPTION
The find tends to detect the `lastlog` because it's been recently modified. the `lastlog` can report as very large on disk and when copying to the temp directory, erroneously creates a large tar.gz file.

Note
The lastlog file is a database which contains info on the last login of each user. You should not rotate it. It is a sparse file, so its size on the disk is usually much smaller than the one shown by "ls -l" (which can indicate a really big file if you have in passwd users with a high UID). You can display its real size with "ls -s".

### Description

The find tends to detect the `lastlog` because it's been recently modified. the `lastlog` can report as very large on disk and when copying to the temp directory, erroneously creates a large tar.gz file. this change just ignores the lastlog file.

### Issues Resolved

N/A but had this bug come up a couple times for existing customers.

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
