### PR TITLE
OCID: Triggered email update only if email is getting change .

### DIFF
--- a/src/oc-id/app/controllers/profiles_controller.rb
+++ b/src/oc-id/app/controllers/profiles_controller.rb
@@ -16,7 +16,7 @@ class ProfilesController < ApplicationController
   #
   def update
     @user = current_user
-    updated_email = permit_all_params.has_key? :email
+    updated_email = (permit_all_params.has_key? :email) && (permit_all_params[:email] != @user.email)
 
     # Note that if an email address is provided, don't update it right away.
     # Instead send a verification email and let that email link update the


### PR DESCRIPTION
Fixed the profile's email update condition as it was throwing error, if we directly hit the Save Changes button on profile update page and fixed spec failure.

Signed-off-by: antima-gupta <agupta@msystechnologies.com>

### Description
- Fixed profile email update failure.
- Fixed spec failure for update email.

### Issues Resolved
#3104 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
