### PR TITLE
Update habitat build of openresty to 1.19.9.1

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -13,4 +13,5 @@ override :redis, version: "5.0.14"
 override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently
 override :logrotate, version: "3.9.2" # 3.18.0 patches fail
 
+# update `src/openresty-noroot/habitat/plan.sh` when updating this version.
 override :openresty, version: "1.19.9.1"

--- a/src/openresty-noroot/habitat/plan.sh
+++ b/src/openresty-noroot/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=openresty-noroot
 pkg_origin=chef
-pkg_version=1.19.3.2
+pkg_version=1.19.9.1
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_license=('BSD-2-Clause')
@@ -8,7 +8,7 @@ pkg_source=https://openresty.org/download/openresty-${pkg_version}.tar.gz
 pkg_dirname=openresty-${pkg_version}
 pkg_filename=openresty-${pkg_version}.tar.gz
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=ce40e764990fbbeb782e496eb63e214bf19b6f301a453d13f70c4f363d1e5bb9
+pkg_shasum=576ff4e546e3301ce474deef9345522b7ef3a9d172600c62057f182f3a68c1f6
 pkg_deps=(
   core/bzip2
   core/coreutils


### PR DESCRIPTION
The omnibus build was already updated to 1.19.9.1, but we should
generally bump the habitat build at the same time.

This is mostly bugfixes over the previous 1.19.3.2 (which had already
patched for nginx CVE-2021-23017).
