### PR TITLE
Consider the host header as part of the proxy cache key

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -178,6 +178,9 @@
     }
     location @cached {
       proxy_cache cookbooks;
+      <% if node['private_chef']['bookshelf']['external_url'] == :host_header -%>
+      proxy_cache_key $scheme$host$request_uri;
+      <% end -%>
       more_clear_headers 'Cache-Control';
       add_header X-Proxy-Cache $upstream_cache_status;
       proxy_pass http://bookshelf;


### PR DESCRIPTION
### Description

Consider the Host header as part of the proxy cache key.  If you have an unconventional deployment where clients access the server via multiple DNS or maybe raw IP, this will prevent a cached response with the different "host" from being returned.

The default is `proxy_cache_key $scheme$proxy_host$request_uri;`

https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_key

If your Chef Server is addressable by multiple hostnames, this can cause an issue if a cached response from bookshelf is not resolvable by a client.  

Lets say you have `:host_header` and `nginx_bookshelf_caching` enabled for Bookshelf.

Consider the following scenario:
```
# Two DNS's
1. chef.ha.prd.myorg.local
2. chef.devops-tools.myorg.local
```

Cached response was requested via `chef.devops-tools.myorg.local`.  NginX serves cached response for this DNS instead of that coming in via `host` header.  Cached bookshelf response URL's hostname is not resolvable and/or inaccessible within the client environment.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
