### PR TITLE
Reverted runit to 2.1.1

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -9,6 +9,7 @@ override :ohai, version: "v16.17.0"
 override :ruby, version: "2.7.5"
 override :perl, version: "5.18.1"
 override :redis, version: "5.0.14"
+override :runit, version: "2.1.1" #standalone upgrade is failing, Needs to be reverted to 2.1.2 after fixing the umbrella
 
 override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently
 override :logrotate, version: "3.9.2" # 3.18.0 patches fail


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Umbrella pipeline-  standalone upgrade is failing due to runit version upgrade

### Issues Resolved

https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/1031#efd78c8b-c2c3-409c-b563-da9c7e9be2bb

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
