### PR TITLE
Remove deprecated gemfile format in oc_bifrost

### DIFF
--- a/src/oc_bifrost/Gemfile
+++ b/src/oc_bifrost/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'berkshelf', '~> 1.1.6'
 gem 'vagrant', '~> 1.0.6'


### PR DESCRIPTION
:rubygems is deprecated

Signed-off-by: Tim Smith <tsmith@chef.io>