### PR TITLE
Documentation note about ES read-only

### DIFF
--- a/docs-chef-io/content/server/ctl_chef_server.md
+++ b/docs-chef-io/content/server/ctl_chef_server.md
@@ -955,6 +955,21 @@ This subcommand has the following options:
     option only works when run on a standalone Chef Infra Server or on a
     primary backend Chef server within a legacy tier.
 
+{{< note >}}
+If `knife search` does not return the expected results and data is present in the Chef Infra Server after reindex, then verify the search index configuration with the command:
+
+```bash
+curl -XGET http://127.0.0.1:9200/_all/_settings`
+```
+
+Set the `read_only_allow_delete` to false. Use this command to reset the search index configuration :
+
+```bash
+curl -XPUT -H "Content-Type: application/json" http://127.0.0.1:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete": null}'
+```
+
+{{< /note >}}
+
 ## Server Admins
 
 {{% server_rbac_server_admins %}}

--- a/docs-chef-io/content/server/server_backup_restore.md
+++ b/docs-chef-io/content/server/server_backup_restore.md
@@ -148,6 +148,10 @@ The Chef Infra Server HA install documentation includes a [second process](https
     chef-server-ctl reindex --all
     ```
 
+{{< note >}}
+If `knife search` does not return the expected results and data is present in the Chef Infra Server after reindex, then [verify the search index configuration](/server/ctl_chef_server/#reindex).
+{{< /note >}}
+
 ### Verify
 
 The best practice for maintaining useful backup is to periodically verify your backup by restoring:


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

The search will not work as expected if the indexes are configured to read-only. This PR adds a documentation about the same.

### Issues Resolved

https://github.com/chef/chef-server/pull/3181

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
