### PR TITLE
Updating status and response header tests

### DIFF
--- a/oc-chef-pedant/pedant_config.rb
+++ b/oc-chef-pedant/pedant_config.rb
@@ -204,3 +204,6 @@ old_runlists_and_search true
 
 # Log HTTP Requests
 log_file "/var/log/opscode/oc-chef-pedant/http-traffic.log"
+
+include_version_in_status false
+include_x_ops_api_info false

--- a/oc-chef-pedant/spec/api/header_spec.rb
+++ b/oc-chef-pedant/spec/api/header_spec.rb
@@ -6,7 +6,6 @@
 describe "Headers", :headers do
   let (:request_url) { api_url("users") }
   let (:requestor) { platform.admin_user }
-  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
 
 
   context "Request Headers" do
@@ -54,7 +53,8 @@ describe "Headers", :headers do
   context "Responses Headers", :response_headers do
     it "x_ops_api_info should be configured" do
       response_header = get(request_url, requestor).headers
-      response_header[:x_ops_api_info].nil?.should eql !config['opscode-erchef']['include_x_ops_api_info']
+      include_x_ops_api_info = Pedant::Config.include_x_ops_api_info
+      response_header[:x_ops_api_info].nil?.should eql !include_x_ops_api_info
     end
   end # context "Responses Headers"
 

--- a/oc-chef-pedant/spec/api/status_spec.rb
+++ b/oc-chef-pedant/spec/api/status_spec.rb
@@ -1,12 +1,12 @@
 
-describe "Testing Status API with config", :config do
-  let (:config) { JSON.parse(IO.read("/etc/opscode/chef-server-running.json"))['private_chef'] }
+describe "Testing Status API" do
   context "Status API", :status, :smoke do
     it "GET /_status should respond with valid health data" do
       r = get("#{platform.server}/_status", superuser)
       r.should look_like(status_for_json: 200)
       data = JSON.parse(r)
-      data.has_key?("server_version").to_s.should eql config['opscode-erchef']['include_version_in_status'].to_s
+      include_version_in_status = Pedant::Config.include_version_in_status
+      data.has_key?("server_version").should eql include_version_in_status
       data.has_key?("status").should eql true
       data.has_key?("upstreams").should eql true
       data.has_key?("keygen").should eql true

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/pedant_config.rb.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/pedant_config.rb.erb
@@ -196,3 +196,6 @@ chef_pgsql_collector <%= @chef_pgsql_collector %>
 
 topology "<%= @topology %>"
 role "<%= @role %>"
+
+include_version_in_status <%= node['private_chef']['opscode-erchef']['include_version_in_status'] %>
+include_x_ops_api_info <%= node['private_chef']['opscode-erchef']['include_x_ops_api_info'] %>

--- a/src/chef-server-ctl/habitat/config/pedant_config.rb
+++ b/src/chef-server-ctl/habitat/config/pedant_config.rb
@@ -199,3 +199,6 @@ required_recipe_enabled false
 reindex_endpoint "https://127.0.0.1"
 
 chef_pgsql_collector true
+
+include_version_in_status false
+include_x_ops_api_info false


### PR DESCRIPTION

Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

We were using chef-server-running.json for testing Status and header response. In automate environment we do not have chef-server-running.json. Therefore we were skipping these test in automate. This PR updates the test to use the pedant_config.json instead of chef-server-running.json .

### Issues Resolved

JIRA - https://chefio.atlassian.net/browse/INFS-51
Updating chef-server in automate - https://github.com/chef/automate/pull/6726

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
