### PR TITLE
rebuild-migration-level subcommand not documented

### DIFF
--- a/docs-chef-io/content/server/ctl_chef_server.md
+++ b/docs-chef-io/content/server/ctl_chef_server.md
@@ -1075,6 +1075,19 @@ This subcommand has the following options:
 
 :   Use to skip confirmation prompts during the upgrade process.
 
+## Rebuild Migration Level File
+
+The rebuild-migration-state subcommand attempts to recreate the migration-level file found at /var/opt/opscode/upgrades/migration-level
+by inferring the current state of the database and system.
+
+**Syntax**
+
+This subcommand has the following syntax:
+
+```bash
+chef-server-ctl rebuild-migration-state
+```
+
 ## User Management
 
 {{% ctl_chef_server_user %}}

--- a/docs-chef-io/content/server/ctl_chef_server.md
+++ b/docs-chef-io/content/server/ctl_chef_server.md
@@ -1077,7 +1077,7 @@ This subcommand has the following options:
 
 ## Rebuild Migration Level File
 
-The rebuild-migration-state subcommand attempts to recreate the migration-level file found at /var/opt/opscode/upgrades/migration-level
+The rebuild-migration-state subcommand attempts to recreate the migration-level file found at `/var/opt/opscode/upgrades/migration-level`
 by inferring the current state of the database and system.
 
 **Syntax**


### PR DESCRIPTION
Add rebuild-migration-level subcommand to docs

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### Description

Add description of the rebuild-migration-level subcommand for the chef-server-ctl system control command

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
