### PR TITLE
Moving back to stable channel for building habitat packages

### DIFF
--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -1,15 +1,4 @@
 ---
-env:
-  HAB_BLDR_CHANNEL: "stable2021-q2"
-  HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable2021-q2"
-  HAB_FALLBACK_CHANNEL: "stable2021-q2"
 
 origin: chef
 smart_build: false
-studio_secrets:
-  HAB_BLDR_CHANNEL:
-    value: "stable2021-q2"
-  HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL:
-    value: "stable2021-q2"
-  HAB_FALLBACK_CHANNEL:
-    value: "stable2021-q2"

--- a/.expeditor/create_manifest.rb
+++ b/.expeditor/create_manifest.rb
@@ -26,7 +26,7 @@ end
 def get_hab_deps_latest()
   ret = {}
   ["hab", "hab-sup", "hab-launcher"].each do |name|
-    d = get_latest("stable2021-q2", "core", name)
+    d = get_latest("stable", "core", name)
     ret[name] = "#{d["origin"]}/#{d["name"]}/#{d["version"]}/#{d["release"]}"
   end
   ret

--- a/.license_scout.yml
+++ b/.license_scout.yml
@@ -16,7 +16,7 @@ habitat:
     - origin: chef
       channel: unstable
     - origin: core
-      channel: stable2021-q2
+      channel: stable
 
 allowed_licenses:
   - Apache-1.0

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -16,4 +16,4 @@ override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently
 override :logrotate, version: "3.9.2" # 3.18.0 patches fail
 
 # update `src/openresty-noroot/habitat/plan.sh` when updating this version.
-override :openresty, version: "1.19.9.1"
+override :openresty, version: "1.21.4.1rc1"

--- a/src/openresty-noroot/habitat/plan.sh
+++ b/src/openresty-noroot/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=openresty-noroot
 pkg_origin=chef
-pkg_version=1.19.9.1
+pkg_version=1.21.4.1rc1
 pkg_description="Scalable Web Platform by Extending NGINX with Lua"
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_license=('BSD-2-Clause')
@@ -8,7 +8,7 @@ pkg_source=https://openresty.org/download/openresty-${pkg_version}.tar.gz
 pkg_dirname=openresty-${pkg_version}
 pkg_filename=openresty-${pkg_version}.tar.gz
 pkg_upstream_url=http://openresty.org/
-pkg_shasum=576ff4e546e3301ce474deef9345522b7ef3a9d172600c62057f182f3a68c1f6
+pkg_shasum=1cb216bc57a253149cb5c4b815bfe00e1c0713e7355774bbc26cf306d2ff632f
 pkg_deps=(
   core/bzip2
   core/coreutils


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

We were building on `stable2021-q2` channel to be compatible with the automate environment.
Now all the packages in automate are back to `stable` channel, so we are going back to `stable`.
The current version of the openresty in the chef-server (1.19.9.1) is incompatible with the version in the automate (1.21.4.1rc1), so we are upgrading the openresty also as part of this.

This PR has the following changes
1. Moving back the habitat packages to `stable` channel
2. Upgrading the openresty to 1.21.4.1rc1 version.

### Issues Resolved

Adding openresty in omnibus-software - https://github.com/chef/omnibus-software/pull/1579
Updating chef-server in automate - https://github.com/chef/automate/pull/6726

Old reference PR moving the channel to stable2021-q2 - https://github.com/chef/chef-server/pull/2961/files

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
