### PR TITLE
Don't source veil from git in oc-bifrost-pedant

### DIFF
--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile
@@ -4,4 +4,4 @@ gemspec
 
 # TODO(ssd) 2017-03-15: This in in this gemfile because bifrost
 # expects it to be in the path
-gem 'veil', git: 'https://github.com/chef/chef_secrets', branch: 'main'
+gem 'veil'

--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/chef/chef_secrets
-  revision: 47ae8d8d868fdc20c2d5bc19c77c65ae5da0a568
-  branch: main
-  specs:
-    veil (0.3.9)
-      bcrypt (~> 3.1)
-      pbkdf2
-
 PATH
   remote: .
   specs:
@@ -36,7 +27,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
-    i18n (1.9.1)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -70,6 +61,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8)
+    veil (0.3.9)
+      bcrypt (~> 3.1)
+      pbkdf2
     zeitwerk (2.5.4)
 
 PLATFORMS
@@ -77,7 +71,7 @@ PLATFORMS
 
 DEPENDENCIES
   oc-bifrost-pedant!
-  veil!
+  veil
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
We shipped the latest to rubygems here

Signed-off-by: Tim Smith <tsmith@chef.io>