### PR TITLE
Correct typo in versions

### DIFF
--- a/docs-chef-io/content/server/upgrade_server_ha_v2.md
+++ b/docs-chef-io/content/server/upgrade_server_ha_v2.md
@@ -168,13 +168,13 @@ Upgrading from Chef Backend 1.x to Chef Backend 2.x requires full cluster downti
 ## Chef Backend Upgrade 2.x to 3.x
 
 The Chef Backend 3.0 upgrade requires Chef Backend 2.1 or later.
-Upgrade earlier versions to Chef Backend 2.1 or later. Chef Backend 2.3.19 is the latest of the version 2 releases.
+Upgrade earlier versions to Chef Backend 2.1 or later. Chef Backend 2.3.16 is the latest of the version 2 stable releases.
 
 | Chef Backend Version | Upgrade Target |
 |:---------|:---------|
-| 2.1.0--2.3.19 | 3.0.0 or later|
-| 2.0.0--2.0.45 | 2.3.19 |
-| 0.1.0--1.4.40| 2.3.19 |
+| 2.1.0--2.3.16 | 3.0.0 or later|
+| 2.0.0--2.0.45 | 2.3.16 |
+| 0.1.0--1.4.40| 2.3.16 |
 
 ### Planning
 


### PR DESCRIPTION
There are several references to version 2.3.19 as latest of 2.x releases.
While there is a 2.3.19 tag, it hasn't been build and released to the stable channel.

https://downloads.chef.io has 2.3.16 as latest

Our YUM repo has the following versions:-

```
[root@chef ~]# yum search chef-backend --showduplicates
Last metadata expiration check: 3:29:02 ago on Tue 01 Mar 2022 18:47:46 GMT.
======================================================== Name & Summary Matched: chef-backend ========================================================
chef-backend-3.0.0-1.el8.x86_64 : The full stack of chef-backend
chef-backend-2.3.16-1.el8.x86_64 : The full stack of chef-backend
chef-backend-2.1.0-1.el7.x86_64 : The full stack of chef-backend
chef-backend-2.2.0-1.el7.x86_64 : The full stack of chef-backend
[root@chef ~]#
```

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG

Signed-off-by: Richard Nixon [richard.nixon@btinternet](mailto:richard.nixon@btinternet)