### PR TITLE
Correcting es preflight validation after helper file changes

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/libraries/preflight_indexing_validator.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/libraries/preflight_indexing_validator.rb
@@ -133,7 +133,7 @@ class IndexingPreflightValidator < PreflightValidator
 
   def verify_search_engine_permissions
     if node['private_chef']['opscode-erchef']['search_provider'] != 'solr'
-      search_provider_url = helper.solr_url
+      search_provider_url = helper.search_engine_url
       begin
         client = Chef::HTTP.new("#{search_provider_url}/_all/_settings")
         response = JSON.parse(client.get(''))


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

The method in the helper file `solr_url` was changed to `search_engine_url`. The same is being updated in the `preflight_indexing_validator`

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
