### PR TITLE
Removing the log4j files on reconfigure

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/cleanup.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/cleanup.rb
@@ -33,3 +33,10 @@ directory "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/sv/rabbitmq" do
   recursive true
   action :delete
 end
+
+::Dir.glob(::File.join(node['private_chef']['user']['home'], '/elasticsearch/lib/log4j*2.11.1*')).each do |filename|
+  file filename do
+    action :delete
+  end
+end
+


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

 In some setups of the server install with 14.11.36, the files related to log4j still exists. This PR adds cleanup step to remove these on reconfigure.

### Issues Resolved

https://chefio.atlassian.net/browse/INFS-87

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
