### PR TITLE
Added cookbook version cache configs in hab

### DIFF
--- a/src/oc_erchef/habitat/config/sys.config
+++ b/src/oc_erchef/habitat/config/sys.config
@@ -214,7 +214,9 @@
         {s3_parallel_ops_timeout, 5000},
         {s3_parallel_ops_fanout, 10},
         {depsolver_timeout, 20000},
-        {depsolver_pooler_timeout, 0}
+        {depsolver_pooler_timeout, 0},
+        {cbv_cache_enabled, {{cbv_cache_enabled}}},
+        {cbv_cache_item_ttl, {{cbv_cache_item_ttl}}}
     ]},
 {{#if cfg.data_collector.enabled ~}}
     {data_collector, [


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

After upgrading the automate from 20200728181447 to the latest then they started seeing 503 and 401 frequently 

https://chefio.atlassian.net/jira/software/c/projects/INFS/boards/369?modal=detail&selectedIssue=INFS-111

### Issues Resolved

Upgrading the chef-server version in automate to enable cookbook version cache
https://github.com/chef/automate/pull/6726

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
