### PR TITLE
WIP/Pinning the version of openssl to 1.1.1m

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -17,3 +17,5 @@ override :logrotate, version: "3.9.2" # 3.18.0 patches fail
 
 # update `src/openresty-noroot/habitat/plan.sh` when updating this version.
 override :openresty, version: "1.21.4.1rc1"
+
+override :openssl, version: "1.1.1m"


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

Pinning the version of openssl to 1.1.1m

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
