### PR TITLE
Add el 8 builders

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,7 +9,6 @@ fips-platforms:
 builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
-    - el-8-x86_64
     - amazon-2-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
@@ -18,3 +17,5 @@ builder-to-testers-map:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
+  el-8-x86_64:
+    - el-8-x86_64

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -7,12 +7,11 @@ override :'omnibus-ctl', version: "main"
 override :chef, version: "v16.17.51"
 override :ohai, version: "v16.17.0"
 override :ruby, version: "2.7.5"
-override :perl, version: "5.18.1"
+override :perl, version: "5.34.0"
 override :redis, version: "5.0.14"
 override :runit, version: "2.1.1" #standalone upgrade is failing, Needs to be reverted to 2.1.2 after fixing the umbrella
 override :sqitch, version: "0.973"
 
-override :cpanminus, version: "1.7004" # 1.9019 breaks installs currently
 override :logrotate, version: "3.9.2" # 3.18.0 patches fail
 
 # update `src/openresty-noroot/habitat/plan.sh` when updating this version.


### PR DESCRIPTION
### Description

Adding el 8 builder and tester to the adhoc pipeline.

### Issues Resolved

Testing the perl upgrade - https://github.com/chef/chef-server/pull/3261

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
