### PR TITLE
Non default api_fqdn / bookshelf examples

### DIFF
--- a/docs-chef-io/content/server/install_server_pre.md
+++ b/docs-chef-io/content/server/install_server_pre.md
@@ -305,7 +305,10 @@ ensure that hostname is resolvable.
     recognize it as an IPv6 address. For example:
 
     ```ruby
-    bookshelf['url'] "https://[2001:db8:85a3:8d3:1319:8a2e:370:7348]"
+    bookshelf['vip'] = "hostname.example.com"
+
+    # If we're getting weird. Change to IPv6
+    bookshelf['vip'] = "[2001:db8:85a3:8d3:1319:8a2e:370]"
     ```
 
 The `api_fqdn` setting can be added to the private-chef.rb file (it is


### PR DESCRIPTION
### Description

Show good examples of setting the bookshelf vip to match a non-default api_fqdn

Fixes the following failures in opscode-erchef service current log:

```
  2015-01-29_21:28:28.69569 [error] Checking presence of checksum: <<"59b2fe13f9c6a776b9f69eb00ac2b49f">> for org <<"c8d751a6b6d1445aa5cdc6c7552e4dee">>  from bucket "bookshelf" has taken longer than 5000 ms

```

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
