### PR TITLE
opensearch_index recipe is not applied if elasticsearch['enable'] = false

### DIFF
--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -52,6 +52,7 @@ Chef Infra Server 14.14 supports external OpenSearch for indexing. Please follow
 
 #### Steps To Enable External OpenSearch
 
+1. Set the `elasticsearch['enable']` attribute to `false`.
 1. Set the `opensearch['external']` attribute to `true`.
 1. Set the `opensearch['external_url']` attribute to the external OpenSearch URL.
 1. Set the `opscode_erchef['search_queue_mode']` attribute to `batch`.
@@ -62,12 +63,13 @@ Chef Infra Server 14.14 supports external OpenSearch for indexing. Please follow
 For example:
 
 ```bash
+elasticsearch['enable'] = false
 opscode_erchef['search_queue_mode'] = 'batch'
 opscode_erchef['search_provider'] = 'opensearch'
 opensearch['external'] = true
 opensearch['external_url'] = "http://127.0.0.1:9200"
-opscode_erchef['search_auth_username'] = 'OPEN_SEARCH_USER'
-opscode_erchef['search_auth_password'] = 'OPEN_SEARCH_PWD'
+opscode_erchef['search_auth_username'] = "OPEN_SEARCH_USER"
+opscode_erchef['search_auth_password'] = "OPEN_SEARCH_PWD"
 ```
 
 #### Steps To Migrate from Elasticsearch to External OpenSearch

--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/default.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/default.rb
@@ -149,11 +149,9 @@ include_recipe 'infra-server::fix_permissions'
       action :disable
     end
   elsif node['private_chef'][service]['enable']
-    if service == 'elasticsearch' && node['private_chef']['opscode-erchef']['search_provider'] == 'opensearch' && node['private_chef']['opensearch']['external']
-      include_recipe 'infra-server::opensearch-external'
-    else
-      include_recipe "infra-server::#{service}"
-    end
+    include_recipe "infra-server::#{service}"
+  elsif service == 'elasticsearch' && node['private_chef']['opscode-erchef']['search_provider'] == 'opensearch' && node['private_chef']['opensearch']['external']
+    include_recipe 'infra-server::opensearch-external'
   else
     # bootstrap isn't a service, nothing to disable.
     next if service == 'bootstrap'

--- a/src/chef-server-ctl/plugins/reindex.rb
+++ b/src/chef-server-ctl/plugins/reindex.rb
@@ -68,22 +68,22 @@ end
 
 # Disk space verification for running reindex
 # It needs enough disk space to hold a second copy of the data plus whatever change in size the new index might need if the schema has changed.
-# Required Disk Space = (2 * size of ES data directory)
+# Required Disk Space = (2 * size of OS data directory)
 def verify_disk_space
-  data_dir = running_config["private_chef"]["elasticsearch"]["data_dir"]
+  data_dir = running_config["private_chef"]["opensearch"]["data_dir"]
   if Dir.exist?(data_dir)
     data_dir_size = Du.du(data_dir)
     free_disk_space = Statfs.new("#{data_dir}/..").free_space
     if (2.2 * data_dir_size) < free_disk_space # The minimum space should be double the existing data size
-      puts "Free space is sufficient to start Elasticsearch reindex"
+      puts "Free space is sufficient to start OpenSearch reindex"
     else
       $stderr.puts "Insufficient free space on disk to complete reindex."
-      $stderr.puts "The current elasticsearch data directory contains #{data_dir_size} KB of data but only #{free_disk_space} KB is available on disk."
+      $stderr.puts "The current opensearch data directory contains #{data_dir_size} KB of data but only #{free_disk_space} KB is available on disk."
       $stderr.puts "The reindex process requires at least #{2.2 * data_dir_size} KB."
       exit 1
     end
   else
-    puts "Elasticsearch data path does not exist, so skipping the disk space verification: #{data_dir}"
+    puts "OpenSearch data path does not exist, so skipping the disk space verification: #{data_dir}"
   end
 rescue => exception
   puts "Skipping the disk space verification due to #{exception.message}"


### PR DESCRIPTION
### Description

opensearch_index recipe is not getting applied if elasticsearch['enable'] flag is set to false.

### Issues Resolved

opensearch_index recipe is not getting applied if elasticsearch['enable'] flag is set to false. Updated the docs to instruct this while using external opensearch

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
