### PR TITLE
Fixing growing bifros DB issue

### DIFF
--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_sandboxes.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_sandboxes.erl
@@ -84,10 +84,11 @@ from_json(Req, #base_state{chef_db_context = DbContext,
                            requestor_id = ActorId,
                            organization_guid = OrgId,
                            resource_state =
-                               #sandbox_state{sandbox_data = SandboxData}} = State) ->
+                               #sandbox_state{sandbox_data = SandboxData, sandbox_authz_id = SBAuthz}} = State) ->
     Checksums = checksums_from_sandbox_ejson(SandboxData),
     case chef_db:make_sandbox(DbContext, OrgId, ActorId, Checksums) of
         #chef_sandbox{} = Sandbox ->
+            ok = oc_chef_authz:delete_resource(ActorId, object, SBAuthz),
             Response = sandbox_to_response(Req, Sandbox),
             {true, chef_wm_util:set_json_body(Req, Response), State};
         {conflict, _Msg} ->


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

The bifrost DB is growing due to a bug in the sandbox APIs. We use sandboxes APIs while uploading the cookbooks to bookshelf to make sure that partial cookbook content isn't served up.
When creating the sandbox, we also generate the authz_id for that sandbox. In the second half of the sandbox process, after we upload the cookbooks, we use an API to verify the checksum and delete the sandbox. In this API we are not deleting the authz_id of the sandbox. Because of this the data is growing in the bifrost database.

### Issues Resolved
https://chefio.atlassian.net/browse/INFS-138

### Issues Related
https://github.com/chef/umbrella/pull/253

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
