### PR TITLE
upgrading redis to 6.2.7

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 50d05bcfaa7fc5e7c00a87b149acaf9e5795ab1c
+  revision: 80234e741fdbfb55b01a99a14453d8fb37a4e6cf
   branch: main
   specs:
     omnibus-software (4.0.0)
-      omnibus (>= 8.0.0)
+      omnibus (>= 9.0.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git

--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/redis_lb.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/redis_lb.rb
@@ -109,9 +109,13 @@ ruby_block 'set_lb_redis_values' do
   only_if { is_data_master? }
   block do
     require 'redis'
+    require 'mixlib/shellout'
+    password = PrivateChef.credentials.get('redis_lb', 'password')
     redis = Redis.new(host: redis_data['vip'],
                       port: redis_data['port'],
-                      password: PrivateChef.credentials.get('redis_lb', 'password'))
+                      password: password)
+    command = "echo 'CONFIG SET requirepass #{password}' | /opt/opscode/embedded/bin/redis-cli -p 16379 -a #{password}"
+    Mixlib::ShellOut.new(command, {}).run_command
     xdl = node['private_chef']['lb']['xdl_defaults']
     xmaint_allowed_ips_list = node['private_chef']['lb']['xmaint_allowed_ips_list']
     banned_ips = PrivateChef['banned_ips']

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -8,7 +8,7 @@ override :chef, version: "v16.17.51"
 override :ohai, version: "v16.17.0"
 override :ruby, version: "2.7.5"
 override :perl, version: "5.34.0"
-override :redis, version: "5.0.14"
+override :redis, version: "6.2.7"
 override :runit, version: "2.1.1" #standalone upgrade is failing, Needs to be reverted to 2.1.2 after fixing the umbrella
 override :sqitch, version: "0.973"
 


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description

upgrading redis to 6.2.7

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
