### PR TITLE
Added opensearch-index-init.json for habitat builds

### DIFF
--- a/src/oc_erchef/habitat/config/elasticsearch-init.sh
+++ b/src/oc_erchef/habitat/config/elasticsearch-init.sh
@@ -14,4 +14,4 @@ HOST="{{cfg.elasticsearch.vip}}"
 PORT="{{cfg.elasticsearch.port}}"
 {{/if}}
 
-curl -sS --retry 10 --retry-delay 2 --retry-connrefused -XPUT http://${HOST}:${PORT}/chef/ -d @{{pkg.svc_config_path}}/elasticsearch-index-init.json
+curl -sS --retry 10 --retry-delay 2 --retry-connrefused -XPUT http://${HOST}:${PORT}/chef/ -d @{{pkg.svc_config_path}}/opensearch-index-init.json

--- a/src/oc_erchef/habitat/config/opensearch-index-init.json
+++ b/src/oc_erchef/habitat/config/opensearch-index-init.json
@@ -1,0 +1,44 @@
+{
+    "settings": {
+      "analysis": {
+        "analyzer": {
+          "default": {
+            "type": "whitespace"
+          }
+        }
+      },
+      "number_of_shards": 3,
+      "number_of_replicas": 2
+    },
+    "mappings": {
+      "_source": {
+        "enabled": false
+      },
+      "properties": {
+        "X_CHEF_database_CHEF_X": {
+          "type": "keyword",
+          "index": true,
+          "norms": false
+        },
+        "X_CHEF_type_CHEF_X": {
+          "type": "keyword",
+          "index": true,
+          "norms": false
+        },
+        "X_CHEF_id_CHEF_X": {
+          "type": "keyword",
+          "index": true,
+          "norms": false
+        },
+        "data_bag": {
+          "type": "keyword",
+          "index": true,
+          "norms": false
+        },
+        "content": {
+          "type": "text",
+          "index": true
+        }
+      }
+    }
+  }


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Added opensearch index json for habitat builds.

### Issues Resolved

Added opensearch index json for habitat builds.Automate search is not working due index issues

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
