### PR TITLE
Fix ldap for dev vm.

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -245,6 +245,7 @@ def define_ldap_server(config, attributes)
     chef.cookbooks_path = "cookbooks"
     chef.add_recipe("provisioning::ldap-server")
     chef.nodes_path = "nodes"
+    chef.install = false
     chef.json = {
       'provisioning' => { 'hosts' =>  ips_to_fqdns },
       'ldap' => {'password' => LDAP_PASSWORD }


### PR DESCRIPTION
**SUMMARY:**

The ldap config for the dev vm was not working.  This is a quick fix
until a deeper dive can be arranged.

**NOTE:**

Note that in addition to this change, you must currently make the following change in `dev/defaults.yml` to enable ldap (it is unknown why the change is not being picked up in `config,yml`):

```
   ldap:
-    start: false
+    start: true

```

**THE ERROR:**

Several errors were encountered, depending on whatever permute of config
settings were tried.  Here are a few:

```
$ vagrant status
Current machine states:

ldap                      not created (virtualbox)
chef-server               running (virtualbox)
```
```
==> ldap: Running provisioner: chef_zero...
    ldap: Installing Chef (latest)...
Vagrant could not detect Chef on the guest! Even after Vagrant
attempted to install Chef, it could still not find Chef on the system.
Please make sure you are connected to the Internet and can access
Chef's package distribution servers. If you already have Chef
installed on this guest, you can disable the automatic Chef detection
by setting the 'install' option in the Chef configuration section of
your Vagrantfile:

    chef.install = false
```
Signed-off-by: Lincoln Baker <lbaker@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
