### PR TITLE
Fix dev vm #1

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -63,6 +63,7 @@ Vagrant.configure("2") do |config|
   config.vm.network 'public_network' if USE_AZURE
   config.vm.box = "bento/ubuntu-20.04"
   config.ssh.forward_agent = true
+  config.omnibus.chef_version = :latest
 
   if start_external_service?("postgresql" , attributes)
     config.vm.define("database") do |c|


### PR DESCRIPTION
The team should confirm whether this is also an issue on their dev VMs (it is with mine).  If so, the WIP can be removed and this can be merged.  

The following error was encountered on `vagrant up`:
```
Bringing machine 'ldap' up with 'virtualbox' provider...
==> ldap: Checking if box 'bento/ubuntu-20.04' version '202112.19.0' is up to date...
==> ldap: Running provisioner: chef_zero...
The chef binary (either `chef-solo` or `chef-client`) was not found on
the VM and is required for chef provisioning. Please verify that chef
is installed and that the binary is available on the PATH.
```
Signed-off-by: Lincoln Baker <lbaker@chef.io>