### PR TITLE
Use shortcode in server repo

### DIFF
--- a/docs-chef-io/content/server/server_services.md
+++ b/docs-chef-io/content/server/server_services.md
@@ -308,7 +308,7 @@ chef-server-ctl tail elasticsearch
 
 ### nginx
 
-{{% server_services_nginx %}}
+{{% chef-server/server_services_nginx %}}
 
 #### status
 


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

One more change related to #3295

Use the shortcode in chef-server repo.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
