### PR TITLE
Fixing redis errors

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/redis_lb.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/redis_lb.rb
@@ -109,13 +109,8 @@ ruby_block 'set_lb_redis_values' do
   only_if { is_data_master? }
   block do
     require 'redis'
-    require 'mixlib/shellout'
-    password = PrivateChef.credentials.get('redis_lb', 'password')
     redis = Redis.new(host: redis_data['vip'],
-                      port: redis_data['port'],
-                      password: password)
-    command = "echo 'CONFIG SET requirepass #{password}' | /opt/opscode/embedded/bin/redis-cli -p 16379 -a #{password}"
-    Mixlib::ShellOut.new(command, {}).run_command
+                      port: redis_data['port'])
     xdl = node['private_chef']['lb']['xdl_defaults']
     xmaint_allowed_ips_list = node['private_chef']['lb']['xmaint_allowed_ips_list']
     banned_ips = PrivateChef['banned_ips']

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/scripts/config.lua.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/scripts/config.lua.erb
@@ -42,7 +42,9 @@ local function auth_not_required(err)
   -- conservatively try to determine if auth is not required.
   -- if auth isn't required, we can safely ignore an error from
   -- the AUTH command
-  return err == "ERR Client sent AUTH, but no password is set"
+  -- return err == "ERR Client sent AUTH, but no password is set"
+  -- The above error message was for redis 5 and it was replaced with the below error message in redis 6
+  return err == "ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?"
 end
 
 local function connect_redis()

--- a/src/chef-server-ctl/plugins/maintenance.rb
+++ b/src/chef-server-ctl/plugins/maintenance.rb
@@ -6,8 +6,7 @@ def redis
   @redis ||= begin
                vip = running_config["private_chef"]["redis_lb"]["vip"]
                port = running_config["private_chef"]["redis_lb"]["port"]
-               password = credentials.get("redis_lb", "password")
-               Redis.new(port: port, ip: vip, password: password)
+               Redis.new(port: port, ip: vip)
              end
 end
 

--- a/src/chef-server-ctl/plugins/reindex.rb
+++ b/src/chef-server-ctl/plugins/reindex.rb
@@ -40,8 +40,7 @@ def redis
   @redis ||= begin
                vip = running_config["private_chef"]["redis_lb"]["vip"]
                port = running_config["private_chef"]["redis_lb"]["port"]
-               password = credentials.get("redis_lb", "password")
-               Redis.new(port: port, ip: vip, password: password)
+               Redis.new(port: port, ip: vip)
              end
 end
 


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

### Description
We make a redis connection in the re-indexing script. Need to set the `requirepass` config before making any operations.


### Issues Related

https://github.com/chef/chef-server/pull/3284
https://github.com/chef/umbrella/pull/255

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
