### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -12,8 +12,14 @@ on:
   schedule:
     - cron: '22 13 * * 3'
 
+permissions:
+  contents: read
+
 jobs:
   brakeman-scan:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: Brakeman Scan
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,14 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@main


### PR DESCRIPTION
Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>