### PR TITLE
Reindex all orgs - sending ssl options to ibrowse for automate

### DIFF
--- a/src/chef-server-ctl/plugins/reindex.rb
+++ b/src/chef-server-ctl/plugins/reindex.rb
@@ -85,8 +85,8 @@ def verify_disk_space
   else
     puts "OpenSearch data path does not exist, so skipping the disk space verification: #{data_dir}"
   end
-rescue => exception
-  puts "Skipping the disk space verification due to #{exception.message}"
+rescue
+  # This is to catch the exceptions while checking data directory sizes.
 end
 
 add_command_under_category "reindex", "general", "Reindex all server data for a given organization.", 2 do

--- a/src/oc_erchef/priv/reindex-opc-organization
+++ b/src/oc_erchef/priv/reindex-opc-organization
@@ -158,7 +158,14 @@ init_network() ->
 find_dl_headers(OrgNameBin, IntLB) when is_binary(OrgNameBin) ->
     find_dl_headers(binary_to_list(OrgNameBin), IntLB);
 find_dl_headers(OrgName, IntLB) when is_list(OrgName) ->
-    {ok, "200", _Headers, Body} = rpc:call(?ERCHEF, ibrowse,send_req, [IntLB ++ "/_route/organizations/" ++ OrgName, [], get]),
+    Ssl1 = rpc:call(?ERCHEF, envy, get, [oc_chef_authz, authz_service, list]),
+    Ssl2 = proplists:get_value(ibrowse_options, Ssl1, []),
+    % To support nginx ssl configurations, The ibrowse needs the ssl to passed in the request
+    % otheriwse nginx rejects with 400 bad request. To solve this issue,We are passing the ssl options
+    % to nginx in the request but skipping the verification as we are making the RPC call.
+    % as chef-server-ctl reindex --all-org can be triggered only from inside the box and with root privileges.
+    Ssl3 = proplists:delete(verify, proplists:get_value(ssl_options, Ssl2,[])),
+    {ok, "200", _Headers, Body} = rpc:call(?ERCHEF, ibrowse,send_req, [IntLB ++ "/_route/organizations/" ++ OrgName, [], get, [], [{ssl_options, Ssl3}]]),
     Json = rpc:call(?ERCHEF, jiffy, decode, [Body]),
     SubJson = rpc:call(?ERCHEF, ej, get, [{<<"config">>, <<"merged">>}, Json]),
     {KVList} = SubJson,


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

[Please describe what this change achieves]
chef-server-ctl reindex --all-orgs failing in the automate environment due to ssl options expected by nginx

 https://getchef.zendesk.com/agent/tickets/30038

### Issues Resolved
#3390
[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
