### PR TITLE
Clarify tls_enabled usage

### DIFF
--- a/docs-chef-io/layouts/shortcodes/chef-server/config_rb_server_settings_ldap.md
+++ b/docs-chef-io/layouts/shortcodes/chef-server/config_rb_server_settings_ldap.md
@@ -125,7 +125,7 @@ This configuration file has the following settings for `ldap`:
 
 `ldap['ssl_enabled']`
 
-:   Cause the Chef Infra Server to connect to the LDAP server using SSL.
+:   Cause the Chef Infra Server to connect to the LDAP server using SSL. Synonymous with simple_tls
     Default value: `false`. Must be `false` when `ldap['tls_enabled']`
     is `true`.
 
@@ -176,7 +176,7 @@ This configuration file has the following settings for `ldap`:
 `ldap['tls_enabled']`
 
 :   Enable TLS. When enabled, communication with the LDAP server is done
-    using a secure SSL connection on a dedicated port. When `true`,
+    using a secure SSL connection on a dedicated port. Synonymous with STARTTLS. This mode is rarely used. When `true`,
     `ldap['port']` is also set to `636`. Default value: `false`. Must be
     `false` when `ldap['ssl_enabled']` is `true`.
 


### PR DESCRIPTION
### Description

Almost no one should use tls_enabled, as it means "Use STARTTLS"
As in, upgrade the LDAP connection. This mode is almost never used in real production installations.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### Issues Resolved

May prevent unintentional usage of STARTTLS

### Check List

Just docs change

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
