### PR TITLE
Updated openresty release version to stable version 1.21.4.1

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -15,4 +15,4 @@ override :sqitch, version: "0.973"
 override :logrotate, version: "3.19.0"
 
 # update `src/openresty-noroot/habitat/plan.sh` when updating this version.
-override :openresty, version: "1.21.4.1rc1"
+override :openresty, version: "1.21.4.1"


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

[Please describe what this change achieves]
openresty has been updated to stable release candidate instead of release version in omnibus_overrides.rb file
release version - 1.21.4.1 instead of 1.21.4.1rc1 .

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
