### PR TITLE
INFS-331 - Making sure to clean the cache before apt-get update

### DIFF
--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -21,6 +21,8 @@ if [[ "${BUILDKITE:-false}" == "true" ]]; then
   # Since we don't use any software from this repository in our tests,
   # we can temporarily remove it from our sources.
   rm /etc/apt/sources.list.d/microsoft-prod.list
+  apt-get clean
+  apt-get autoremove 
   apt-get update
   apt-get install -y libpq-dev libsqlite3-dev
 fi


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

### Description

Fixing the verify pipeline.
https://chefio.atlassian.net/browse/INFS-331
### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
