### PR TITLE
Update opensearch version to 1.3.6.

### DIFF
--- a/omnibus/config/software/opensearch.rb
+++ b/omnibus/config/software/opensearch.rb
@@ -15,7 +15,7 @@
 #
 
 name "opensearch"
-default_version "1.3.2"
+default_version "1.3.6"
 
 dependency "server-open-jre"
 
@@ -43,6 +43,11 @@ end
 version "1.3.2" do
   source url: "https://artifacts.opensearch.org/releases/bundle/opensearch/#{version}/opensearch-#{version}-linux-x64.tar.gz",
          sha256: "14199251a8aae2068fd54aa39c778ff29dcc8be33d57f36a8cc2d19e07ff4149"
+end
+
+version "1.3.6" do
+  source url: "https://artifacts.opensearch.org/releases/bundle/opensearch/#{version}/opensearch-#{version}-linux-x64.tar.gz",
+         sha256: "0784cc05ec03dc9cac17dca923272ae08ebc9a43fbbbb61397024f1c90cdb024"
 end
 
 target_path = "#{install_dir}/embedded/opensearch"


### PR DESCRIPTION
Signed-off-by: sreepuramsudheer <ssudheer@progress.com>

### Description
Update Opensearch version to 1.3.6 in chef-server softwares/Omnibus softwares

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
