### PR TITLE
Pin chef for omnibus to v 17

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -10,5 +10,6 @@ end
 group :test do
   gem 'test-kitchen' # for Test Kitchen testing of the omnibus builds
   gem 'berkshelf' # depsolving the Test Kitchen suite
+  gem 'chef', '< 18' # Do not pull in chef 18 until the build image is updated with > ruby 3.0
   gem 'rake'
 end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -379,6 +379,7 @@ PLATFORMS
 DEPENDENCIES
   artifactory
   berkshelf
+  chef (< 18)
   omnibus!
   omnibus-software!
   rake

--- a/omnibus/files/server-ctl-cookbooks/infra-server/Gemfile
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gem 'cookstyle'
 gem 'chefspec'
 gem 'veil'
+gem 'chef', '< 18' # Do not pull in chef 18 until the build image is updated with > ruby 3.0


### PR DESCRIPTION
Chef 18+ requires ruby 3.0+, which is not yet available on our test image chefes/a1-buildkite.  We should revert this once that image has been updated.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
