### PR TITLE
Add ubuntu-22.04 builder and tester

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -17,5 +17,6 @@ builder-to-testers-map:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
+    - ubuntu-22.04-x86_64
   el-8-x86_64:
     - el-8-x86_64


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

### Description

[Please describe what this change achieves]
Add 22.04 to the testers matrix for the 16.04 builder.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5092

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
