### PR TITLE
Revert "Bump doorkeeper from 4.4.3 to 5.6.0 in /src/oc-id"

### DIFF
--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -17,7 +17,7 @@ gem 'nokogiri', '1.13.9'
 gem 'pg', '>= 0.18', '< 2.0' # active_record 4.2.8 pins this but doesn't manifest this in the gemspec for some reason
 gem 'mixlib-authentication', '>= 2.1', '< 4'
 gem 'responders', '~> 3.0', '>= 3.0.1'
-gem 'doorkeeper', '~> 5.6'
+gem 'doorkeeper', '~> 4.0'
 gem "sprockets-rails", ">= 3.4.2"
 gem 'therubyracer', '~> 0.12.3'
 gem 'bigdecimal', '3.1.2'

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -171,8 +171,8 @@ GEM
     debug_inspector (1.1.0)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
-    doorkeeper (5.6.0)
-      railties (>= 5)
+    doorkeeper (4.4.3)
+      railties (>= 4.2)
     dry-configurable (0.14.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.6)
@@ -205,7 +205,7 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.9, >= 1.9.1)
-    erubi (1.11.0)
+    erubi (1.10.0)
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.8.1)
@@ -246,7 +246,7 @@ GEM
       tilt
     hashie (4.1.0)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
     inspec-core (4.56.17)
@@ -295,7 +295,7 @@ GEM
     logging (2.3.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
-    loofah (2.19.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -315,7 +315,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.3)
+    minitest (5.15.0)
     mixlib-archive (1.1.7)
       mixlib-log
     mixlib-authentication (3.0.10)
@@ -377,11 +377,11 @@ GEM
       stringio
     public_suffix (4.0.7)
     racc (1.6.0)
-    rack (2.2.4)
+    rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
-    rack-test (2.0.2)
-      rack (>= 1.3)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rails (6.1.4.6)
       actioncable (= 6.1.4.6)
       actionmailbox (= 6.1.4.6)
@@ -541,7 +541,7 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -586,7 +586,7 @@ GEM
     wmi-lite (1.0.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.1)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
@@ -599,7 +599,7 @@ DEPENDENCIES
   chef (~> 17)
   coffee-rails (~> 5.0)
   config (~> 4.0)
-  doorkeeper (~> 5.6)
+  doorkeeper (~> 4.0)
   factory_girl_rails (~> 4.9.0)
   jbuilder (~> 2.11)
   jquery-rails


### PR DESCRIPTION
This reverts commit 09157044dd7c3fbd3abfe893397760227b4dc8e4. because its failing supermarket instance

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
