### PR TITLE
Made nginx[ssl_port] read from config for reindex.

### DIFF
--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -72,7 +72,12 @@ Patents:       #{ChefUtils::Dist::Org::PATENTS}
       elsif fips_enabled
         DEFAULT_FIPS_LB_URL
       else
-        DEFAULT_LB_URL
+        nginx = @@ctl.running_service_config("nginx")
+        if nginx and nginx["ssl_port"] and (nginx["ssl_port"] != 443)
+          "#{DEFAULT_LB_URL}:#{nginx["ssl_port"]}"
+        else
+          DEFAULT_LB_URL
+        end
       end
     end
 


### PR DESCRIPTION
Signed-off-by: sreepuramsudheer <ssudheer@progress.com>

### Description
During reindex nginx listen port is read from config. 
[Please describe what this change achieves]

### Issues Resolved
https://chefio.atlassian.net/browse/INFS-175
[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
