### PR TITLE
Warn on external data store conversion

### DIFF
--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -569,7 +569,17 @@ The Chef Infra Server 14 upgrade does not automatically reindex existing externa
 
 #### Upgrading to 14.14
 
-Chef Infra Server 14.14 supports external OpenSearch for indexing. Please follow the migration section below to migrate from Elasticsearch to external OpenSearch.
+Chef Infra Server 14.14 supports external OpenSearch for indexing. Please follow the migration section below to migrate from
+Elasticsearch to external OpenSearch.
+
+{{< warning >}} 
+
+Moving to an external data store install topology results in many additional requirements and responsibilities of the customer, as maintenance, management, and upgrades of external data stores are not automated as they are with embedded data stores.
+
+If you are not aware of these items and have a standalone Chef Infra Server installation with embedded data stores, move back to the
+general upgrade steps and the 14.16.x section at the [14.16.19 specific upgrade steps](#upgrading-to-1416)
+
+{{< /warning >}}
 
 #### Steps To Enable External OpenSearch
 


### PR DESCRIPTION


### Description

Customers should be warned that they are taking on additional responsibilities when choosing external databases.

Point back to the safe and automaticlly maintained embedded data stores.

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### Issues Resolved

Warning customers about additional responsibility taken with external data stores.

For example: Only certain postgres/Opensearch versions are compatible with Chef Infra Server.

### Check List

- [ ] New functionality includes tests (No code)
- [X] All buildkite tests pass
- [X] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
