### PR TITLE
Clarify Next Steps for 14.16.x Upgrades

### DIFF
--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -676,7 +676,7 @@ chef-server-ctl cleanup-bifrost
 
 ##### Upgrade Steps
 
-Follow the Chef Infra Server upgrade instructions below.
+Continue with the upgrade by following the general upgrade steps at [General Standalone Upgrade Process](#general-chef-infra-server-upgrade-process). You will only have to perform the full vacuumdb once.
 
 {{< note >}}
 


### PR DESCRIPTION
### Description

* If you have already done the `vacuumdb full`, then you are good to upgrade to 14.16.19 using the general upgrade steps
* Afterward, you will want to cleanup any extra bifrost auth IDs using the new functionality documented in the section

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### Issues Resolved

Confusion over pre-reqs and next steps for a Chef Infra Server 14.16.19 upgrade

### Check List

- [ ] New functionality includes tests (No code)
- [X] All buildkite tests pass
- [X] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
