### PR TITLE
Fix chef_authn reference

### DIFF
--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -14,7 +14,7 @@
   0},
  {<<"chef_authn">>,
   {git,"https://github.com/chef/chef_authn",
-       {ref,"2ba22845aa5d706cd4e3d5b867f0d9ca038e649a"}},
+       {ref,"57ae954ab231e4cd24740315eddc932aaf5515fc"}},
   0},
  {<<"chef_secrets">>,
   {git,"https://github.com/chef/chef_secrets",


### PR DESCRIPTION
Fix chef_authn SHA reference after PR merge there.

See SHA reference on last main commit here:
https://github.com/chef/chef_authn/

adhoc:
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5160
umbrella:
https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/1664

Signed-off-by: Lincoln Baker <lbaker@chef.io>
