### PR TITLE
Fix "can't find sqitch.plan" omnibus/adhoc build failure following rebar3 upgrade

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/bookshelf_database.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/bookshelf_database.rb
@@ -32,7 +32,7 @@ pg_database 'bookshelf' do
   owner bookshelf_attrs['sql_user']
   # This is used to trigger creation of the schema during install.
   # For upgrades, create a partybus migration to perform any schema changes.
-  notifies :deploy, "pg_sqitch[/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/bookshelf/schema]", :immediately
+  notifies :deploy, "pg_sqitch[/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/bookshelf]", :immediately
 end
 
 pg_user_table_access bookshelf_attrs['sql_user'] do
@@ -50,7 +50,7 @@ end
 # Note that these migrations are only deployed during an initial install via the
 # :deploy notification above.  Upgrades to existing installations must be managed
 # via partybus migrations.
-pg_sqitch "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/bookshelf/schema" do
+pg_sqitch "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/bookshelf" do
   hostname postgres_attrs['vip']
   port     postgres_attrs['port']
   username postgres_attrs['db_connection_superuser'] || postgres_attrs['db_superuser']

--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/erchef_database.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/erchef_database.rb
@@ -28,7 +28,7 @@ end
 
 pg_database 'opscode_chef' do
   owner erchef['sql_user']
-  notifies :deploy, "pg_sqitch[/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef/schema/baseline]", :immediately
+  notifies :deploy, "pg_sqitch[/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef/baseline]", :immediately
 end
 
 # For existing installations, make sure the database owner is set to sql_user
@@ -44,7 +44,7 @@ end
 # At this time, we're using partybus to apply upgrade-related sqitch migrations,
 # so that we can also apply any necessary data migrations (not yet managed through sqitch)
 # at that time.
-pg_sqitch "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef/schema/baseline" do
+pg_sqitch "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef/baseline" do
   hostname  postgres['vip']
   port      postgres['port']
   username  postgres['db_connection_superuser'] || postgres['db_superuser']
@@ -52,10 +52,10 @@ pg_sqitch "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscod
   database  'opscode_chef'
   sslmode   postgres['sslmode']
   action :nothing
-  notifies :deploy, "pg_sqitch[/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef/schema]", :immediately
+  notifies :deploy, "pg_sqitch[/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef]", :immediately
 end
 
-pg_sqitch "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef/schema" do
+pg_sqitch "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/service/opscode-erchef" do
   hostname  postgres['vip']
   port      postgres['port']
   username  postgres['db_connection_superuser'] || postgres['db_superuser']


### PR DESCRIPTION
Fix "can't find sqitch.plan" omnibus/adhoc build failure following rebar3 upgrade
```
chef-server:       [execute] Possible precedence issue with control flow operator at /opt/opscode/embedded/lib/perl5/site_perl/5.34.0/App/Sqitch/Plan.pm line 578.
chef-server:                 Plan file /opt/opscode/embedded/service/opscode-erchef/schema/baseline/sqitch.plan does not exist
```
Failure:
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5178

Adhoc:
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5181

Umbrella:
https://buildkite.com/chef/chef-umbrella-main-chef-server-full/builds/375
Compare with main:
https://buildkite.com/chef/chef-umbrella-main-chef-server-full/builds/374

Merge with license scout fixes, rebar3 upgrade https://github.com/chef/chef-server/pull/3529, deps upgrade, etc.

Signed-off-by: Lincoln Baker <lbaker@chef.io>

