### PR TITLE
Automate upgrade of Erlang rebar dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,47 @@ bump: bump_rebars bump_bundles
 bump_rebars: rebar_bookshelf rebar_oc_bifrost rebar_oc_erchef
 bump_bundles: bundle_oc-id
 
-rebar_%:
-	cd src/$* && ./rebar3 upgrade --all $$TARGET
+# After the rebar3 upgrade from 3.6.2 to 3.20.0, license scout has issues
+# with transitive dependencies referenced as packages in rebar.lock files.
+# So, if we do a blanket upgrade of all dependencies (rebar3 upgrade --all),
+# some transitive dependencies will be referenced as packages, causing license
+# scout issues. Therefore, we upgrade only the dependencies that don't pull in
+# transitive dependencies.
+#
+# To arrive at the list of dependencies to upgrade for an app, start with the
+# deps in the rebar.config, and subtract from that anything pulling in a
+# transitive dependency as seen by running a `rebar3 tree` in the appropriate
+# directory. Problem dependencies in a lock file will be referenced by `pkg`,
+# and will have an entry in a pkg_hash and possibly a pkg_hash_ext section at
+# the bottom (the rebar.lock should not contain these entries).
+#
+# Anything pulling in a problem dependency, and any problem dependencies themselves,
+# should be upgraded by hand.
+#
+# It was observed that upgrading a single dependency, e.g. `./rebar3 upgrade eper`,
+# rewrote the entire lockfile, removing packages.  So if a lockfile ever gets
+# inadvertently polluted, it's something to try.
+#
+#rebar_%:
+#	cd src/$* && ./rebar3 upgrade --all $$TARGET
+
+rebar_bookshelf:
+	cd src/bookshelf; \
+	./rebar3 upgrade cf,chef_secrets,envy,eper,erlsom,erlware_commons,iso8601,meck,mini_s3,mixer,mochiweb,opscoderl_wm,sqerl; \
+	echo "some references are pulled in as git:// - rewriting to https://"; \
+	sed -i '' 's/git:\/\//https:\/\//g' rebar.lock
+
+rebar_oc_bifrost:
+	cd src/oc_bifrost; \
+	./rebar3 upgrade chef_secrets,edown,ej,eper,jiffy,mixer,mochiweb,opscoderl_wm,sqerl,stats_hero; \
+	echo "some references are pulled in as git:// - rewriting to https://"; \
+	sed -i '' 's/git:\/\//https:\/\//g' rebar.lock
+
+rebar_oc_erchef:
+	cd src/oc_erchef; \
+	./rebar3 upgrade cf,chef_authn,chef_secrets,darklaunch,edown,efast_xs,ej,envy,eper,folsom,folsom_graphite,ibrowse,jiffy,mini_s3,mixer,mochiweb,neotoma,opscoderl_folsom,opscoderl_httpc,opscoderl_wm,pooler,prometheus,sqerl,stats_hero,uuid; \
+	echo "some references are pulled in as git:// - rewriting to https://"; \
+	sed -i '' 's/git:\/\//https:\/\//g' rebar.lock
 
 bundle_%:
 	cd src/$* && bundle install --no-deployment && bundle update $$TARGET

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -27,6 +27,11 @@ In order to release, you will need the following accounts/permissions:
 
 ## THE PROCESS
 
+### Upgrade Erlang Dependencies
+
+Upgrade Erlang dependencies via automated script.  
+See https://github.com/chef/chef-server/blob/main/dev-docs/FrequentTasks.md#updating-erlang-dependencies-using-rebar3 .
+
 ### Update Release Notes
 
 #### Pending Release Notes In Wiki


### PR DESCRIPTION
### Description

Implement automated bumping of Erlang dependencies as part of the release process.

This is written for Mac.  For Linux, you may have to change the options on the `sed` command.

To try this, `cd` into your chef-server repo, then `make bump_rebars`.
NOTE that you will need an upgraded rebar3 for this to work correctly, so `cd chef-server; pushd /tmp; wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3; popd; cp /tmp/rebar3 src/bookshelf && cp /tmp/rebar3 src/oc_bifrost && cp /tmp/rebar3 src/oc_erchef`
```
$ make bump_rebars
cd src/bookshelf; \
        ./rebar3 upgrade cf,chef_secrets,envy,eper,erlsom,erlware_commons,iso8601,meck,mini_s3,mixer,mochiweb,opscoderl_wm,sqerl; \
        echo "some references are pulled in as git://. rewrite to https://"; \
        sed -i '' 's/git:\/\//https:\/\//g' rebar.lock
===> Rebar3 detected a lock file from a newer version. It will be loaded in compatibility mode, but important information may be missing or lost. It is recommended to upgrade Rebar3.
===> Verifying dependencies...
===> Upgrading meck ({git,"https://github.com/eproxus/meck",
                                 {ref,"06192a984750070ace33b60a492ca27ec9bc6806"}})
===> Upgrading mochiweb ({git,"https://github.com/mochi/mochiweb",
                                 {ref,
                                  "070594e4d66163d662ac7e3bfb75dadcc922dd7c"}})
===> Upgrading sqerl ({git,"https://github.com/chef/sqerl",
<SNIP>
```

adhoc: https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5215