### PR TITLE
Changed erlang version to 24.

### DIFF
--- a/src/bookshelf/habitat/plan.sh
+++ b/src/bookshelf/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=chef
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_deps=(
-  core/erlang22
+  core/erlang24
   core/cacerts
   core/coreutils
   core/gcc-libs

--- a/src/oc_bifrost/habitat/plan.sh
+++ b/src/oc_bifrost/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=chef
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_deps=(
-  core/erlang22
+  core/erlang24
   core/cacerts
   core/coreutils
   core/curl

--- a/src/oc_erchef/apps/chef_objects/src/chef_objects.app.src
+++ b/src/oc_erchef/apps/chef_objects/src/chef_objects.app.src
@@ -31,7 +31,7 @@
                   pooler
                  ]},
   {env, [
-         {s3_url_type, undefined},
+         {s3_url_type, path},
 
          %% S3 Access credentials for Bookshelf operations
          {s3_access_key_id, undefined},

--- a/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_s3.erl
@@ -164,7 +164,7 @@ aws_config(S3Url) ->
     {ok, S3AccessKeyId} = chef_secrets:get(<<"bookshelf">>, <<"access_key_id">>),
     {ok, S3SecretKeyId} = chef_secrets:get(<<"bookshelf">>, <<"secret_access_key">>),
     SslOpts = envy:get(chef_objects, s3_ssl_opts, [], list),
-    PathOrVhost = envy:get(chef_objects, s3_url_type, atom),
+    PathOrVhost = envy:get(chef_objects, s3_url_type, path, atom),
     mini_s3:new(erlang:binary_to_list(S3AccessKeyId), erlang:binary_to_list(S3SecretKeyId), S3Url, PathOrVhost, SslOpts).
 
 %% @doc returns a url for accessing s3 internally. This is used

--- a/src/oc_erchef/habitat/plan.sh
+++ b/src/oc_erchef/habitat/plan.sh
@@ -3,7 +3,7 @@ pkg_origin=chef
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Chef Server Maintainers <support@chef.io>"
 pkg_deps=(
-  core/erlang22
+  core/erlang24
   core/cacerts
   core/coreutils
   core/curl


### PR DESCRIPTION
Made default value for PathOrVhost = envy:get(chef_objects, s3_url_type, atom, path).

Signed-off-by: sreepuramsudheer <ssudheer@progress.com>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
