### PR TITLE
Disable caching on SSL pages

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -56,6 +56,8 @@
     # Whitelist the docs necessary to serve up error pages and friendly
     # html to non-chef clients hitting this host.
     location ~ "^/[0-9]{3,3}\.(json|html)|favicon.ico|index.html$" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
@@ -67,6 +69,8 @@
     }
 
     location "/css/" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
@@ -78,6 +82,8 @@
     }
 
     location "/images/" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
@@ -89,6 +95,8 @@
     }
 
     location /version {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       add_header Content-Security-Policy "default-src 'self';";
       add_header X-Frame-Options DENY;
       add_header X-Content-Type-Options nosniff;
@@ -103,6 +111,8 @@
     }
 
     location ~ "^/organizations/([^/]+)/validate" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       allow 127.0.0.1;
       allow ::1;
       deny all;
@@ -111,6 +121,8 @@
     <% if node['private_chef']['data_collector']['proxy'] -%>
 
     location "/data-collector/" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -122,6 +134,8 @@
     <% if node['private_chef']['data_collector']['root_url'] -%>
     
     location ~ "^/organizations/([^/]+)/data-collector$" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       set $request_org $1;
       access_by_lua_block { validator.validate("POST") }
       proxy_set_header x-data-collector-token $data_collector_token;
@@ -132,6 +146,8 @@
     <% end -%>
 
     location ~ "^/organizations/([^/]+)/required_recipe$" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
     <% if node['private_chef']['required_recipe']['enable'] -%>
       set $request_org $1;
       access_by_lua_block { validator.validate("GET") }
@@ -159,6 +175,8 @@
     location ~ <%= @compliance_proxy_regex -%> {
       set $request_org $1;
       access_by_lua_block { validator.validate("GET") }
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       proxy_set_header x-data-collector-token $data_collector_token;
       proxy_set_header x-data-collector-auth "version=1.0";
       rewrite ^<%= @compliance_proxy_regex -%> /compliance/profiles/$2$3 break;
@@ -170,6 +188,8 @@
     <% if node['private_chef']['opscode-erchef']['nginx_bookshelf_caching'] != :off -%>
     location ~ "^/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/organization-.+" {
       set $destination @cached;
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       if ($request_method !~ ^(GET)$) {
          set $destination @uncached;
       }
@@ -177,6 +197,8 @@
       return 404;
     }
     location @cached {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       proxy_cache cookbooks;
       <% if node['private_chef']['bookshelf']['external_url'] == :host_header -%>
       proxy_cache_key $scheme$host$request_uri;
@@ -186,16 +208,22 @@
       proxy_pass http://bookshelf;
     }
     location @uncached {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       proxy_pass http://bookshelf;
     }
     <% else -%>
     location ~ "^/<%= node['private_chef']['opscode-erchef']['s3_bucket'] %>/organization-.+" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       proxy_pass http://bookshelf;
     }
     <% end -%>
 
     # erchef status endpoint
     location ~ "^/_status/?$" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       types { }
       default_type application/json;
       proxy_pass http://opscode_erchef;
@@ -203,6 +231,8 @@
 
     # erchef stats endpoint
     location ~ "^/_stats/?$" {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       <% if node['private_chef']['opscode-erchef']['stats_auth_enable'] -%>
       auth_basic "Chef Server Admin Stats";
       auth_basic_user_file <%= node['private_chef']['opscode-erchef']['stats_password_file'] %>;
@@ -221,11 +251,15 @@
     include <%= node['private_chef']['nginx']['dir'] %>/etc/addon.d/*_external.conf;
 
     location /_route/ {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       default_type 'application/json';
       content_by_lua_file '<%= @script_path %>/dispatch_route.lua';
     }
 
     location / {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       satisfy any;
 
       <% if @access_by_lua_file %>
@@ -242,7 +276,10 @@
       proxy_pass http://$upstream;
       proxy_redirect http://$upstream /;
     }
+
     location @errorrespfilter {
+      add_header Cache-Control no-store always;
+      add_header Pragma no-cache always;
       header_filter_by_lua_block { ngx.header.content_length = nil }
       body_filter_by_lua '
       ngx.arg[1] = ngx.re.sub(ngx.arg[1],"openresty", "")


### PR DESCRIPTION
We were asked to disable caching on all SSL pages or all pages that contain
sensitive data, pursuant to cacheable SSL pages being discovered with a DAST scan.

This commit adds `Cache-Control: no-store` and `Pragma: no-cache` headers to SSL pages.

**curl commands**
**before:**
```
root@api:~# curl --insecure -I https://api.chef-server.dev:443
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:36:55 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/index
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:38:18 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/css
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:38:30 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/images
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:38:36 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/version
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:39:01 GMT
Content-Type: text/plain
Content-Length: 6605
Last-Modified: Wed, 11 Jan 2023 06:41:12 GMT
Connection: keep-alive
ETag: "63be5a08-19cd"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/organizations/blah/validate
HTTP/1.1 404 Not Found
Date: Wed, 11 Jan 2023 10:39:35 GMT
Content-Type: text/html
Connection: keep-alive

root@api:~# curl --insecure -I https://api.chef-server.dev:443/data-collector
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:39:59 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/organizations/blah/data-collector
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:40:19 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/organizations/blah/required_recipe
HTTP/1.1 404 Not Found
Date: Wed, 11 Jan 2023 10:40:51 GMT
Content-Type: text/html
Content-Length: 1084
Connection: keep-alive
ETag: "63be8bd4-43c"

root@api:~# curl --insecure -I https://api.chef-server.dev:443/_status
HTTP/1.1 405 Method Not Allowed
Date: Wed, 11 Jan 2023 10:42:32 GMT
Content-Type: text/html
Content-Length: 177
Connection: keep-alive
Allow: GET

root@api:~# curl --insecure -I https://api.chef-server.dev:443/stats
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:42:52 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/_route
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:43:22 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:43:36 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes
```
**curl commands**
**after:**
```
root@api:~# curl --insecure -I https://api.chef-server.dev:443
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:36:55 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/index
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:38:18 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/css
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:38:30 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/images
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:38:36 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/version
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:39:01 GMT
Content-Type: text/plain
Content-Length: 6605
Last-Modified: Wed, 11 Jan 2023 06:41:12 GMT
Connection: keep-alive
ETag: "63be5a08-19cd"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/organizations/blah/validate
HTTP/1.1 404 Not Found
Date: Wed, 11 Jan 2023 10:39:35 GMT
Content-Type: text/html
Connection: keep-alive
Cache-Control: no-store
Pragma: no-cache

root@api:~# curl --insecure -I https://api.chef-server.dev:443/data-collector
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:39:59 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/organizations/blah/data-collector
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:40:19 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/organizations/blah/required_recipe
HTTP/1.1 404 Not Found
Date: Wed, 11 Jan 2023 10:40:51 GMT
Content-Type: text/html
Content-Length: 1084
Connection: keep-alive
ETag: "63be8bd4-43c"
Cache-Control: no-store
Pragma: no-cache

root@api:~# curl --insecure -I https://api.chef-server.dev:443/_status
HTTP/1.1 405 Method Not Allowed
Date: Wed, 11 Jan 2023 10:42:32 GMT
Content-Type: text/html
Content-Length: 177
Connection: keep-alive
Allow: GET
Cache-Control: no-store
Pragma: no-cache

root@api:~# curl --insecure -I https://api.chef-server.dev:443/stats
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:42:52 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/_route
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:43:22 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes

root@api:~# curl --insecure -I https://api.chef-server.dev:443/
HTTP/1.1 200 OK
Date: Wed, 11 Jan 2023 10:43:36 GMT
Content-Type: text/html
Content-Length: 1749
Last-Modified: Wed, 11 Jan 2023 10:13:40 GMT
Connection: keep-alive
ETag: "63be8bd4-6d5"
Cache-Control: no-store
Pragma: no-cache
Content-Security-Policy: default-src 'self';
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Permissions-Policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
Referrer-Policy: strict-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
Accept-Ranges: bytes
```
**knife cookbook commands**
**before**
```
# /opt/opscode/embedded/bin/knife cookbook list -VVV
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:19:57 GMT
TRACE: content-type: application/json
TRACE: content-length: 2
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: ---- End HTTP Status/Header Data ----
example   1.0.0
yoda      0.1.0

# /opt/opscode/embedded/bin/knife cookbook upload -VVV --all --cookbook-path ./cookbooks/
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:23:53 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
Uploading example        [1.0.0]
Uploading yoda           [0.1.0]
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 201 Created
TRACE: date: Wed, 15 Feb 2023 08:23:53 GMT
TRACE: content-type: application/json
TRACE: content-length: 863
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: location: http://api.chef-server.dev/organizations/clownville/sandboxes/4f8e54a82c0e05890e85cd76f53206c8
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:23:53 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:23:53 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:23:53 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
Uploaded all cookbooks.

# /opt/opscode/embedded/bin/knife cookbook download example -VVV --force
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:28:39 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:28:39 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:28:39 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAbct2IACa5JYSU=
TRACE: last-modified: Wed, 15 Feb 2023 08:22:27 GMT
TRACE: etag: W/"Mk8/P9GhTIheKo35tpfZ7A=="
TRACE: cache-control: max-age=28800
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:28:39 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAbct2IACeejYWU=
TRACE: last-modified: Wed, 15 Feb 2023 08:22:27 GMT
TRACE: etag: W/"B2UrBKnTfzFy0MzRf6inbQ=="
TRACE: cache-control: max-age=28800
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:28:39 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAbct2IACh9WYaU=
TRACE: last-modified: Wed, 15 Feb 2023 08:22:27 GMT
TRACE: etag: W/"TJ2+dVcNfzhP1anZysYuIA=="
TRACE: cache-control: max-age=28800
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:28:39 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAbct2IACnphYeU=
TRACE: last-modified: Wed, 15 Feb 2023 08:22:27 GMT
TRACE: etag: W/"uCEBjMRwPf2fyfP8BlmAjw=="
TRACE: cache-control: max-age=28800
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 08:28:39 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAbct2IACtMkYgAAASU=
TRACE: last-modified: Wed, 15 Feb 2023 08:22:27 GMT
TRACE: etag: W/"Vv43JGPrpKAc8lMWT4fHCA=="
TRACE: cache-control: max-age=28800
TRACE: x-frame-options: DENY
TRACE: content-security-policy: default-src 'self';
TRACE: x-content-type-options: nosniff
TRACE: permissions-policy: camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()
TRACE: referrer-policy: strict-origin
TRACE: strict-transport-security: max-age=31536000; includeSubDomains
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
Cookbook downloaded to /host/repo/example-1.0.0
```
**knife cookbook commands**
**after**
```
# /opt/opscode/embedded/bin/knife cookbook list -VVV
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 03:52:19 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
example   1.0.0
yoda      0.1.0

# /opt/opscode/embedded/bin/knife cookbook upload -VVV --all --cookbook-path ./cookbooks/
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 03:59:26 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
Uploading example        [1.0.0]
Uploading yoda           [0.1.0]
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 201 Created
TRACE: date: Wed, 15 Feb 2023 03:59:26 GMT
TRACE: content-type: application/json
TRACE: content-length: 863
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: location: http://api.chef-server.dev/organizations/clownville/sandboxes/2c6d289c31d53423a17b657a3da13300
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: ---- End HTTP Status/Header Data ----
INFO: Uploading files
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 03:59:26 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 03:59:26 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 03:59:26 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
INFO: Upload complete!
Uploaded all cookbooks.

# /opt/opscode/embedded/bin/knife cookbook download example -VVV --force
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 04:04:21 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 04:04:22 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-ops-server-api-version: {"min_version":"0","max_version":"2","request_version":"2","response_version":"2"}
TRACE: cache-control: no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 04:04:22 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAaexmIAAG63YgAAASQ=
TRACE: last-modified: Wed, 15 Feb 2023 03:39:38 GMT
TRACE: etag: W/"Mk8/P9GhTIheKo35tpfZ7A=="
TRACE: cache-control: max-age=28800, no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 04:04:22 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAaexmIAAMdBYgAAAWQ=
TRACE: last-modified: Wed, 15 Feb 2023 03:39:38 GMT
TRACE: etag: W/"B2UrBKnTfzFy0MzRf6inbQ=="
TRACE: cache-control: max-age=28800, no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 04:04:22 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAaexmIAARvGYgAAAaQ=
TRACE: last-modified: Wed, 15 Feb 2023 03:39:38 GMT
TRACE: etag: W/"TJ2+dVcNfzhP1anZysYuIA=="
TRACE: cache-control: max-age=28800, no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 04:04:22 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAaexmIAAXCZYgAAAeQ=
TRACE: last-modified: Wed, 15 Feb 2023 03:39:38 GMT
TRACE: etag: W/"uCEBjMRwPf2fyfP8BlmAjw=="
TRACE: cache-control: max-age=28800, no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
TRACE: ---- HTTP Status and Header Data: ----
TRACE: HTTP 1.1 200 OK
TRACE: date: Wed, 15 Feb 2023 04:04:22 GMT
TRACE: content-type: application/json
TRACE: transfer-encoding: chunked
TRACE: connection: close
TRACE: x-amz-request-id: g2gDZAATYm9va3NoZWxmQDEyNy4wLjAuMWgDYgAABoxiAAaexmIAAct/YgAAAiQ=
TRACE: last-modified: Wed, 15 Feb 2023 03:39:38 GMT
TRACE: etag: W/"Vv43JGPrpKAc8lMWT4fHCA=="
TRACE: cache-control: max-age=28800, no-store
TRACE: pragma: no-cache
TRACE: content-encoding: gzip
TRACE: ---- End HTTP Status/Header Data ----
Cookbook downloaded to /host/repo/example-1.0.0
```
**manage**

![image](https://user-images.githubusercontent.com/51833247/219409903-bbcc6deb-de0a-4709-aea2-ebc27a8da978.png)


**Adhoc:**
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5404
**Umbrella:**
https://buildkite.com/chef/chef-umbrella-main-chef-server/builds/1807

- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
