### PR TITLE
Forward ports from dev vm to host

### DIFF
--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -61,6 +61,8 @@ end
 
 Vagrant.configure("2") do |config|
   config.vm.network 'public_network' if USE_AZURE
+  config.vm.network "forwarded_port", guest: 80,  host: 8080
+  config.vm.network "forwarded_port", guest: 443, host: 8443
   config.vm.box = "bento/ubuntu-20.04"
   config.ssh.forward_agent = true
   config.omnibus.chef_version = :latest


### PR DESCRIPTION
On a Mac host using VirtualBox, useful ports were not being forwarded from the dev vm.  This fixes the issue.