### PR TITLE
Enable FIPS - RHEL6

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -7,6 +7,8 @@ fips-platforms:
   - el-*-x86_64
   - ubuntu-*-x86_64
 builder-to-testers-map:
+  el-6-x86_64:
+    - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
     - amazon-2-x86_64


### PR DESCRIPTION
### Description

To ensure FIPS mode enabled builds for all platforms  as mentioned in  the docs, enabling  and testing FIPS  on RHEL6.
Current testing pipeline for FIPS on server only tests on the rhel7 platforms. 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
