### PR TITLE
Update default OpenJRE to 11.0.18+10

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 225e3576c48fcd0155f6049cb032b2370eccf29a
+  revision: 6a1c8896edf6c5606facc83b75ecaacf22019e2b
   branch: main
   specs:
-    omnibus-software (23.2.286)
+    omnibus-software (23.3.287)
       omnibus (>= 9.0.0)
 
 GIT


### PR DESCRIPTION
### Description

Update default OpenJRE to 11.0.18+10

https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5470
https://buildkite.com/chef/chef-umbrella-main-chef-server-full/builds/432
```
root@api:~# /opt/opscode/embedded/open-jre/bin/java --version
openjdk 11.0.18 2023-01-17
OpenJDK Runtime Environment Temurin-11.0.18+10 (build 11.0.18+10)
OpenJDK 64-Bit Server VM Temurin-11.0.18+10 (build 11.0.18+10, mixed mode)
```

### Check List

- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
