### PR TITLE
CHEF-3465 Replace download links

### DIFF
--- a/docs-chef-io/content/server/install_server.md
+++ b/docs-chef-io/content/server/install_server.md
@@ -70,7 +70,7 @@ loop.
 
 To install Chef Infra Server:
 
-1.  Download the package from <https://www.chef.io/downloads/tools/infra-server/>.
+1.  Download the package from [Chef Downloads](https://www.chef.io/downloads).
 
 2.  Upload the package to the machine that will run the Chef Infra
     Server, and then record its location on the file system. The rest of

--- a/docs-chef-io/content/server/install_server_ha.md
+++ b/docs-chef-io/content/server/install_server_ha.md
@@ -120,8 +120,7 @@ These instructions assume you are using the minimum versions:
 -   Chef Server : 12.5.0
 -   Chef Backend : 0.8.0
 
-Download [Chef Infra Server](https://www.chef.io/downloads/tools/infra-server) and
-[Chef Backend (chef-backend)](https://www.chef.io/downloads/tools/backend)
+Download Chef Infra Server and Chef Backend from [Chef Downloads](https://www.chef.io/downloads)
 if you do not have them already.
 
 Before creating the backend HA cluster and building at least one Chef
@@ -149,7 +148,7 @@ different from any other back-end node.
 1.  Install the Chef Backend package on the first backend node **as root**.
 
     -   Download [Chef Backend
-        (chef-backend)](https://www.chef.io/downloads/tools/backend)
+        (chef-backend)](https://www.chef.io/downloads)
     -   In Red Hat/CentOS: `yum install PATH_TO_RPM`
     -   In Debian/Ubuntu: `dpkg -i PATH_TO_DEB`
 
@@ -200,7 +199,7 @@ join nodes in parallel the cluster may fail to become available):
 1.  Install the Chef Backend package on the node.
 
     -   Download [Chef Backend
-        (chef-backend)](https://www.chef.io/downloads/tools/backend)
+        (chef-backend)](https://www.chef.io/downloads)
     -   In Red Hat/CentOS: `yum install PATH_TO_RPM`
     -   In Debian/Ubuntu: `dpkg -i PATH_TO_DEB`
 

--- a/docs-chef-io/content/server/install_server_tiered.md
+++ b/docs-chef-io/content/server/install_server_tiered.md
@@ -128,7 +128,7 @@ following:
 
 Use the following steps to set up the backend Chef Infra Server:
 
-1.  Download the packages from <https://www.chef.io/downloads/tools/infra-server>.
+1.  Download the packages from [Chef Downloads](https://www.chef.io/downloads).
     For Red Hat and CentOS 6:
 
     ```bash

--- a/docs-chef-io/content/server/upgrades.md
+++ b/docs-chef-io/content/server/upgrades.md
@@ -88,7 +88,7 @@ See the [Release-Specific Steps](#release-specific-steps) for information about 
 
    After performing the stepped upgrade to 12.17.15, continue with the next step.
 
-1. Download the desired Chef Infra Server version from the [Chef Infra Server Downloads](https://www.chef.io/downloads/tools/infra-server).
+1. Download the desired Chef Infra Server version from the [Chef Infra Server Downloads](https://www.chef.io/downloads).
 
 1. Stop the Chef Infra Server:
 
@@ -248,7 +248,7 @@ The following External PostgreSQL upgrade steps are provided as a courtesy only.
 
    After performing the stepped upgrade, return here and continue with the next step below.
 
-1. [Download](https://www.chef.io/downloads/tools/infra-server) the desired version of Chef Infra Server.
+1. [Download](https://www.chef.io/downloads) the desired version of Chef Infra Server.
 
 1. Stop the Chef Infra Server:
 
@@ -480,7 +480,7 @@ To upgrade to Chef Infra Server on a tiered Chef Infra Server configuration, do 
     chef-server-ctl reconfigure
     ```
 
-3. Download the desired Chef Infra Server version from the [Chef Infra Server Downloads](https://www.chef.io/downloads/tools/infra-server) page, then copy it to each server.
+3. Download the desired Chef Infra Server version from [Chef Downloads](https://www.chef.io/downloads), then copy it to each server.
 
 4. Stop all front end servers:
 


### PR DESCRIPTION
### Description

Replace links to www.chef.io/downloads/tools/<something> with chef.io/downloads.

### Issues Resolved

https://chefio.atlassian.net/browse/CHEF-3465

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
