### PR TITLE
Upgrade restclient gem version in erchef

### DIFF
--- a/src/oc_erchef/Gemfile_habitat
+++ b/src/oc_erchef/Gemfile_habitat
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rest-client'
+gem 'rest-client', '~> 2.1.0'
 gem 'pg'
 gem 'openssl'

--- a/src/oc_erchef/Gemfile_habitat.lock
+++ b/src/oc_erchef/Gemfile_habitat.lock
@@ -1,23 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.20170404)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.3)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
-    mime-types (3.1)
+    mime-types (3.5.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2023.1003)
     netrc (0.11.0)
     openssl (2.0.6)
     pg (0.21.0)
-    rest-client (2.0.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.8.2)
 
 PLATFORMS
   ruby
@@ -25,7 +27,7 @@ PLATFORMS
 DEPENDENCIES
   openssl
   pg
-  rest-client
+  rest-client (~> 2.1.0)
 
 BUNDLED WITH
    2.2.19


### PR DESCRIPTION
### Description

Upgrade restclient gem version in erchef to fix the ruby 3 incompatibility issue that is coming in the oc_erchef habitat package when used in automate

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
