### PR TITLE
Update rack version from 2.2.6.2 -> 2.2.6.4 because of possible DOS Vulnerability in Multipart MIME parsing chef-server-ctl

### DIFF
--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (5.0.0)
-    rack (2.2.6.2)
+    rack (2.2.6.4)
     rainbow (3.1.1)
     rake (13.0.6)
     redis (4.7.1)


### PR DESCRIPTION
### Description

Since the last  version had "Rack" had this vulnerability of DOS in Multipart parsing in chef-server-ctl upgrading it to the latest version would fix this issue. 

This Issue was primarily seen with the dependabot alert which also suggested the fix to it. 

Here are the link: 
```
https://github.com/chef/chef-server/security/dependabot/73

https://github.com/chef/chef-server/security/dependabot/73
```

### Issues Resolved

Now, Upgrading Rack  fixes our vulnerability.

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
