### PR TITLE
Fix verify pipeline: The repository... does not have a Release file.

### DIFF
--- a/scripts/bk_tests/bk_install.sh
+++ b/scripts/bk_tests/bk_install.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# Error:
+# `The repository 'http://apt.postgresql.org/pub/repos/apt bionic-pgdg Release' does not have a Release file.`
+# The cause:
+# https://www.postgresql.org/message-id/ZN4OigxPJA236qlg%40msg.df7cb.de
+# The fix:
+# 1. Add `deb https://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg main` to sources.list
+# 2. Remove /etc/apt/sources.list.d/pgdg.list
+sudo echo "deb https://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg main">>/etc/apt/sources.list
+rm /etc/apt/sources.list.d/pgdg.list
+
 echo "Removing postgresql-9.3"
 apt-get --purge remove -y postgresql-9.3
 


### PR DESCRIPTION
### Description
Error:
`The repository 'http://apt.postgresql.org/pub/repos/apt bionic-pgdg Release' does not have a Release file.`

The cause:
https://www.postgresql.org/message-id/ZN4OigxPJA236qlg%40msg.df7cb.de

The fix:
1. Added `deb https://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg main` to sources.list
2. Remove /etc/apt/sources.list.d/pgdg.list

Test before fix:
![image](https://github.com/chef/chef-server/assets/51833247/0b785c69-e91d-4da5-8a3e-ff2fca9bc59b)

Test after fix:
![image](https://github.com/chef/chef-server/assets/51833247/13693221-883b-43dc-b289-47350b2b6cd6)
