### PR TITLE
Revert selenium-webdriver from 4.12.0 to 4.7.1 in /src/oc-id

### DIFF
--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -59,6 +59,6 @@ end
 group :test do
   gem 'capybara', '~> 3.39'
   gem 'factory_girl_rails', '~> 4.9.0'
-  gem 'selenium-webdriver', '~> 4.12.0'
+  gem 'selenium-webdriver', '~> 4.7.1'
   gem 'timecop'
 end

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -432,7 +432,7 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.6)
+    rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -472,7 +472,7 @@ GEM
       tilt
     sdoc (2.6.1)
       rdoc (>= 5.0)
-    selenium-webdriver (4.12.0)
+    selenium-webdriver (4.7.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -572,7 +572,7 @@ GEM
       bcrypt (~> 3.1)
       pbkdf2
     webrick (1.8.1)
-    websocket (1.2.10)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -629,7 +629,7 @@ DEPENDENCIES
   rspec-rails (~> 6.0)
   sass-rails (>= 4.0.3)
   sdoc
-  selenium-webdriver (~> 4.12.0)
+  selenium-webdriver (~> 4.7.1)
   spring
   spring-commands-rspec
   sprockets-rails (>= 3.4.2)


### PR DESCRIPTION
### Description
Verify pipeline is failing because of selenium changes. This PR is to revert selenium upgrade.
[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
