### PR TITLE
remove GTM scripts

### DIFF
--- a/docs-chef-io/content/server/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/config_rb_server_optional_settings.md
@@ -1453,27 +1453,11 @@ This configuration file has the following settings for `oc-id`:
 
     Defaults to the `'from_email'` value.
 
-`oc_id['enable_gtm']`
-
-:   Whether to enable Google Tag Manager. Set the Google Tag Manager ID with `oc_id['gtm_id']`.
-
-    Default value: `false`.
-
-    **New in Chef Infra Server 15.9.18**
-
 `oc_id['enable_onetrust']`
 
 :   Whether to enable OneTrust cookie consent verification.
 
     Default value: `false`.
-
-    **New in Chef Infra Server 15.9.18**
-
-`oc_id['gtm_id']`
-
-:   The Google Tag Manager's container ID. You must also set `oc_id['enable_gtm']` to `true`.
-
-    Default value: `nil`.
 
     **New in Chef Infra Server 15.9.18**
 

--- a/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
@@ -748,8 +748,6 @@ default['private_chef']['oc_id']['sentry_dsn'] = nil
 default['private_chef']['oc_id']['sign_up_url'] = nil
 default['private_chef']['oc_id']['email_from_address'] = node['private_chef']['from_email']
 default['private_chef']['oc_id']['origin'] = node['private_chef']['api_fqdn']
-default['private_chef']['oc_id']['gtm_id'] = nil
-default['private_chef']['oc_id']['enable_gtm'] = false
 default['private_chef']['oc_id']['enable_onetrust'] = false
 
 default['private_chef']['oc_id']['administrators'] = []

--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/oc_id.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/oc_id.rb
@@ -57,9 +57,7 @@ app_settings = {
   'sign_up_url' => sign_up_url,
   'email_from_address' => node['private_chef']['oc_id']['email_from_address'],
   'origin' => node['private_chef']['oc_id']['origin'],
-  'enable_gtm' => node['private_chef']['oc_id']['enable_gtm'],
   'enable_onetrust' => node['private_chef']['oc_id']['enable_onetrust'],
-  'gtm_id' => node['private_chef']['oc_id']['gtm_id'] || '',
 }
 
 oc_id_dir = node['private_chef']['oc_id']['dir']

--- a/src/oc-id/app/helpers/feature_flag_helper.rb
+++ b/src/oc-id/app/helpers/feature_flag_helper.rb
@@ -1,8 +1,4 @@
 module FeatureFlagHelper
-  def gtm_enabled?
-    Settings.enable_gtm == true
-  end
-
   def onetrust_enabled?
     Settings.enable_onetrust == true
   end

--- a/src/oc-id/app/views/application/_analytics.html.erb
+++ b/src/oc-id/app/views/application/_analytics.html.erb
@@ -1,45 +1,4 @@
-<% if gtm_enabled? %>
-  <!-- Google Tag Manager conditional -->
-  <%= javascript_tag type: "text/javascript" do %>
-    var oneTrustHelper = (function () {
-      function evalGTMScript() {
-          var gtmScript = document.getElementById("GTMScript");
-          gtmScript.type = "text/javascript";
-          gtmScript.classList.remove("optanon-category-1");
-          eval(gtmScript.innerHTML);
-      };
-
-      return {
-        gtmFallback: function () {
-          console.warn('OneTrust not loaded.');
-          if (document.readyState !== 'loading') {
-            evalGTMScript();
-          } else {
-            document.addEventListener('readystatechange', function () {
-              if (document.readyState === 'interactive') {
-                evalGTMScript();
-                }
-            });
-          };
-        }
-      };
-    })();
-  <% end %>
-<% end %>
-
 <% if onetrust_enabled? %>
   <!-- Onetrust Script -->
-  <script async src="https://cdn.cookielaw.org/consent/e231efa5-3ed9-4b92-96bc-f4c0872ca486/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="e231efa5-3ed9-4b92-96bc-f4c0872ca486" onerror="oneTrustHelper.gtmFallback()"></script>
-<% end %>
-
-<% if gtm_enabled? && Settings.gtm_id.present? %>
-  <!-- Google Tag Manager Script -->
-  <%= javascript_tag type: "text/plain", id: "GTMScript", class: "optanon-category-1" do %>
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','<%= Settings.gtm_id %>');
-  <% end %>
-  <!-- End Google Tag Manager -->
+  <script async src="https://cdn.cookielaw.org/consent/e231efa5-3ed9-4b92-96bc-f4c0872ca486/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="e231efa5-3ed9-4b92-96bc-f4c0872ca486"></script>
 <% end %>

--- a/src/oc-id/app/views/layouts/application.html.erb
+++ b/src/oc-id/app/views/layouts/application.html.erb
@@ -11,11 +11,6 @@
   <%= render 'application/analytics' %>
 </head>
 <body>
-  <% if gtm_enabled? && Settings.gtm_id.present? %>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.gtm_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
-  <% end %>
   <div class="contain-to-grid">
     <nav class="top-bar" data-topbar role="navigation">
       <ul class="title-area">


### PR DESCRIPTION
### Description

As GTM is not working correctly with onetrust, owing to timelines we decided to go ahead only with onetrust. Hence reverting GTM integration code.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
