### PR TITLE
updated chef-server version for oc_id['enable_onetrust'].

### DIFF
--- a/docs-chef-io/content/server/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/config_rb_server_optional_settings.md
@@ -1459,7 +1459,7 @@ This configuration file has the following settings for `oc-id`:
 
     Default value: `false`.
 
-    **New in Chef Infra Server 15.9.19**
+    **New in Chef Infra Server 15.9.20**
 
 `oc_id['log_directory']`
 


### PR DESCRIPTION
### Description
updated chef-server version for oc_id['enable_onetrust'].
[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
