### PR TITLE
Make onetrust key configurable

### DIFF
--- a/docs-chef-io/content/server/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/config_rb_server_optional_settings.md
@@ -1463,9 +1463,11 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['onetrust_id']`
 
-: The OneTrust data domain script ID for Chef Infra. You must also set `oc_id['enable_onetrust']` to `true`.
+:   The OneTrust data domain script ID for Chef Infra. You must also set `oc_id['enable_onetrust']` to `true`.
 
-  Default value: `nil`.
+    Default value: `nil`.
+
+    **New in Chef Infra Server 15.9.22**
 
 `oc_id['log_directory']`
 

--- a/docs-chef-io/content/server/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/config_rb_server_optional_settings.md
@@ -1463,7 +1463,7 @@ This configuration file has the following settings for `oc-id`:
 
 `oc_id['onetrust_id']`
 
-: The Onetrust ID for Chef Infra. You must also set `oc_id['enable_onetrust']` to `true`.
+: The OneTrust data domain script ID for Chef Infra. You must also set `oc_id['enable_onetrust']` to `true`.
 
   Default value: `nil`.
 

--- a/docs-chef-io/content/server/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/config_rb_server_optional_settings.md
@@ -1461,6 +1461,12 @@ This configuration file has the following settings for `oc-id`:
 
     **New in Chef Infra Server 15.9.20**
 
+`oc_id['onetrust_id']`
+
+: The Onetrust ID for Chef Infra. You must also set `oc_id['enable_onetrust']` to `true`.
+
+  Default value: `nil`.
+
 `oc_id['log_directory']`
 
 :   The directory in which log data is stored. The default value is the

--- a/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
@@ -749,6 +749,7 @@ default['private_chef']['oc_id']['sign_up_url'] = nil
 default['private_chef']['oc_id']['email_from_address'] = node['private_chef']['from_email']
 default['private_chef']['oc_id']['origin'] = node['private_chef']['api_fqdn']
 default['private_chef']['oc_id']['enable_onetrust'] = false
+default['private_chef']['oc_id']['onetrust_id'] = nil
 
 default['private_chef']['oc_id']['administrators'] = []
 

--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/oc_id.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/oc_id.rb
@@ -58,6 +58,7 @@ app_settings = {
   'email_from_address' => node['private_chef']['oc_id']['email_from_address'],
   'origin' => node['private_chef']['oc_id']['origin'],
   'enable_onetrust' => node['private_chef']['oc_id']['enable_onetrust'],
+  'onetrust_id' => node['private_chef']['oc_id']['onetrust_id'] || '',
 }
 
 oc_id_dir = node['private_chef']['oc_id']['dir']

--- a/src/oc-id/app/views/application/_analytics.html.erb
+++ b/src/oc-id/app/views/application/_analytics.html.erb
@@ -1,4 +1,3 @@
-<% if onetrust_enabled? %>
-  <!-- Onetrust Script -->
-  <script async src="https://cdn.cookielaw.org/consent/e231efa5-3ed9-4b92-96bc-f4c0872ca486/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="e231efa5-3ed9-4b92-96bc-f4c0872ca486"></script>
+<% if onetrust_enabled? && ENV['ONETRUST_ID'].present? %>
+  <%= javascript_include_tag "https://cdn.cookielaw.org/consent/#{ENV['ONETRUST_ID']}/otSDKStub.js", charset: "UTF-8", "data-domain-script": "#{ENV['ONETRUST_ID']}" %>
 <% end %>


### PR DESCRIPTION
### Description

Make onetrust ID configurable

Demo - [link](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EYfdwZ-4lV9Mr9oyx1DsDCEBJEBCnktXmZrV_7oM7YFYyQ?e=jFDOvS&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D)

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
