### PR TITLE
CHEF-6434 Update server platforms in docs

### DIFF
--- a/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
+++ b/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
@@ -6,5 +6,6 @@ The following table lists the commercially supported platforms for Chef Infra Se
 | CentOS                       | `x86_64`     | `7.x`, `8.x`                        |
 | Oracle Enterprise Linux      | `x86_64`     | `7.x`, `8.x`                        |
 | Red Hat Enterprise Linux     | `x86_64`     | `7.x`, `8.x`, `9.x`                 |
+| Rocky Linux                  | `x86_64`     | `9.x`                               |
 | SUSE Linux Enterprise Server | `x86_64`     | `12.x`, `15.x`                      |
 | Ubuntu                       | `x86_64`     | `20.04`, `22.04`                    |

--- a/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
+++ b/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
@@ -3,7 +3,7 @@ The following table lists the commercially supported platforms for Chef Infra Se
 | Platform                     | Architecture | Version                             |
 |------------------------------|--------------|-------------------------------------|
 | Amazon Linux                 | `x86_64`     | `2.x`, `2023`                       |
-| CentOS                       | `x86_64`     | `7.x`, `8.x`                        |
+| CentOS                       | `x86_64`     | `7.x`                               |
 | Oracle Enterprise Linux      | `x86_64`     | `7.x`, `8.x`                        |
 | Red Hat Enterprise Linux     | `x86_64`     | `7.x`, `8.x`, `9.x`                 |
 | Rocky Linux                  | `x86_64`     | `9.x`                               |

--- a/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
+++ b/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
@@ -7,4 +7,4 @@ The following table lists the commercially-supported platforms for Chef Infra Se
 | Oracle Enterprise Linux      | `x86_64`     | `7.x`, `8.x`                        |
 | Red Hat Enterprise Linux     | `x86_64`     | `7.x`, `8.x`, `9.x`                 |
 | SUSE Linux Enterprise Server | `x86_64`     | `12.x`, `15.x`                      |
-| Ubuntu                       | `x86_64`     | `16.04`, `18.04`, `20.04`, `22.04`  |
+| Ubuntu                       | `x86_64`     | `20.04`, `22.04`                    |

--- a/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
+++ b/docs-chef-io/content/server/reusable/md/adopted_platforms_server.md
@@ -1,8 +1,8 @@
-The following table lists the commercially-supported platforms for Chef Infra Server:
+The following table lists the commercially supported platforms for Chef Infra Server:
 
 | Platform                     | Architecture | Version                             |
 |------------------------------|--------------|-------------------------------------|
-| Amazon Linux 2               | `x86_64`     | `2.x`                               |
+| Amazon Linux                 | `x86_64`     | `2.x`, `2023`                       |
 | CentOS                       | `x86_64`     | `7.x`, `8.x`                        |
 | Oracle Enterprise Linux      | `x86_64`     | `7.x`, `8.x`                        |
 | Red Hat Enterprise Linux     | `x86_64`     | `7.x`, `8.x`, `9.x`                 |


### PR DESCRIPTION
### Description

Remove:

- Centos 8 (EOL)
- Ubuntu 16 and 18 (EOL)

Add:
- Amazon 2023
- Rocky Linux 9

### Related PRs / Issues

#3720
#3732

CHEF-10296
CHEF-6434

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
