### PR TITLE
Find faster with fewer execs

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/fix_permissions.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/fix_permissions.rb
@@ -17,11 +17,11 @@ LIB_PATH = "/opt/#{ChefUtils::Dist::Org::LEGACY_CONF_DIR}/embedded/lib".freeze
 # The GEM_PATH should work since we allow only one version of ruby to be installed.
 GEM_PATH = "#{LIB_PATH}/ruby/gems/*/gems".freeze
 
-execute "find #{GEM_PATH} -perm /u=x,g=x,o=x -exec chmod 755 {} \\;" do
+execute "find #{GEM_PATH} -perm /u=x,g=x,o=x -exec chmod 755 {} \\+" do
   user 'root'
 end
 
-execute "find #{GEM_PATH} -perm /u=r,g=r,o=r ! -perm /u=x -exec chmod 644 {} \\;" do
+execute "find #{GEM_PATH} -perm /u=r,g=r,o=r ! -perm /u=x -exec chmod 644 {} \\+" do
   user 'root'
 end
 

--- a/omnibus/files/server-ctl-cookbooks/infra-server/recipes/nginx.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/recipes/nginx.rb
@@ -270,7 +270,7 @@ end
   "#{node['private_chef']['nginx']['dir']}",
   "#{node['private_chef']['nginx']['log_directory']}",
 ].each do |nginx_no_root_perms_fix_path|
-  execute "find #{nginx_no_root_perms_fix_path} -user 'root' -exec chown #{node['private_chef']['user']['username']} {} \\;" do
+  execute "find #{nginx_no_root_perms_fix_path} -user 'root' -exec chown #{node['private_chef']['user']['username']} {} \\+" do
     user 'root'
     only_if do
       node['private_chef']['nginx']['nginx_no_root'] &&


### PR DESCRIPTION
`chef-server-ctl reconfigure` runs incredibly slow because it has to fork off `chmod` for every applicable file instead of targeting as many files as possible with a single `chmod` execution.