### PR TITLE
Upgrading to node.js 14.21.3 in oc-id

### DIFF
--- a/src/oc-id/habitat/plan.sh
+++ b/src/oc-id/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(
   core/sqitch_pg
   core/curl
-  core/node
+  core/node14
   core/ruby30
   core/rsync
   core/sed


### PR DESCRIPTION
### Description
Upgrading current node.js version 4.18.1 to 14.23.3 to address CVE-2023-23918, CVE-2023-23919, CVE-2023-23920, CVE-2023-23936 and CVE-2023-24807.
oc-id component of Infra Server embedded in Chef Automate(4.12.69) has these vulnerabilities. 
[Please describe what this change achieves]
Upgrading plan.sh of oc-id to consume node14 hab package to resolve these vulnerabilities.

Tested this change in `oc-id` embeded Chef Automate in the following environments:

1.  [Non air-gapped installation of automate HA](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EUvD_SZ2peFNhQvpQxN0bYsBHHTeQHuMlFu5uGvFjurM1g?e=KKVU1Y)
2. [On-prem deployment with Chef-managed database](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EaU57xqdcpVNst1mhLMTmiMByf5fUD4MPKZ_hgtwU2jkFQ?e=GiF48V)
4. [AWS  deployment with Chef-managed database](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EUvD_SZ2peFNhQvpQxN0bYsBHHTeQHuMlFu5uGvFjurM1g?e=KKVU1Y)

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
