### PR TITLE
upgrade openssl to 1.0.2zi

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -16,3 +16,5 @@ override :logrotate, version: "3.19.0"
 
 # update `src/openresty-noroot/habitat/plan.sh` when updating this version.
 override :openresty, version: "1.25.3.1"
+
+override :openssl, version: "1.0.2zi"


### PR DESCRIPTION
### Description

This PR overrides the openssl to 1.0.2zi

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
