### PR TITLE
skip transitive licensing for server-ctl-cookbooks

### DIFF
--- a/omnibus/config/software/server-ctl-cookbooks.rb
+++ b/omnibus/config/software/server-ctl-cookbooks.rb
@@ -19,7 +19,7 @@ name "server-ctl-cookbooks"
 source path: "#{project.files_path}/#{name}"
 
 license :project_license
-
+skip_transitive_dependency_licensing true
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 


### PR DESCRIPTION
This works around an issue where license_scout is flagging this due to not having the berkshelf gem available to inspect further.  We are still looking into the underlying cause, as nothing changed recently that should affect license scout for server-ctl-cookbooks.
