### PR TITLE
Removed ubuntu-16.04 and el-7 from builder

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -7,16 +7,12 @@ fips-platforms:
   - el-*-x86_64
   - ubuntu-*-x86_64
 builder-to-testers-map:
-  el-7-x86_64:
-    - el-7-x86_64
-    - amazon-2-x86_64
   rocky-9-x86_64:
     - rocky-9-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  ubuntu-16.04-x86_64:
-    - ubuntu-16.04-x86_64
+  ubuntu-18.04-x86_64:
     - ubuntu-18.04-x86_64
     - ubuntu-20.04-x86_64
     - ubuntu-22.04-x86_64


### PR DESCRIPTION
### Description

[Please describe what this change achieves]
Removed ubuntu-16.04 and el7 from builder
### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
