### PR TITLE
Adding information about Key-DB in Chef-server CLI subcommands

### DIFF
--- a/src/chef-server-ctl/bin/chef-server-ctl
+++ b/src/chef-server-ctl/bin/chef-server-ctl
@@ -296,6 +296,19 @@ Cleansing data in a remote Opensearch instance is not currently supported.
       # opscode-solr4 status is seen as elasticsearch status"
     end
 
+  # Overrideing the service_list command to add the keyDB message.
+  def service_list(*args)
+    super(*args)
+    log "We are using keydb instead of redis underneath. All the functions are supposed to work the same because keydb is a fork of redis."
+  end
+  # Overrideing the status command to add the keyDB message.
+  def run_sv_command(sv_cmd, service = nil)
+    super(sv_cmd, service)
+    if sv_cmd == "status" && (service.nil? || service == "redis_lb")
+      log "We are using keydb instead of redis underneath. All the functions are supposed to work the same because keydb is a fork of redis."
+    end
+  end
+
     # Override reconfigure to skip license checking
     def reconfigure(*args)
       puts ::ChefServerCtl::Config::DOC_PATENT_MSG
@@ -316,6 +329,7 @@ Cleansing data in a remote Opensearch instance is not currently supported.
       mtls_enabled ? run_command(command) : :ok
 
       if status.success?
+        log "We are using keydb instead of redis underneath. All the functions are supposed to work the same because keydb is a fork of redis."
         log "#{display_name} Reconfigured!"
         exit! 0
       else

--- a/src/oc_erchef/src/oc_erchef_app.erl
+++ b/src/oc_erchef/src/oc_erchef_app.erl
@@ -22,7 +22,7 @@ start(_StartType, _StartArgs) ->
     %% See comment in app.src for details.
     { ok, AppList } =  application:get_key(oc_erchef, included_applications),
     [ application:ensure_all_started(App, permanent) || App <- AppList ],
-
+    {error,{already_started,_}} = application:start(chef_telemetry),
     %% If we're in a dev vm environment, start the code sync & compile tools
     case os:getenv("DEVVM") of
         "1" ->


### PR DESCRIPTION
### Description

https://chefio.atlassian.net/browse/CHEF-15097

[Please describe what this change achieves]
In this PR we have added information about the keydb (which we are replacing with redis), in some of the subcommands in chef-server-cli. 

These subcommands are
> reconfigure
> service-list
> status

now at the end of these commands are are showing one line regarding replacement. i.e, 
```
"We are using keydb instead of redis underneath. All the functions are supposed to work the same because keydb is a fork of redis."
```

For about status and its more subcommands please check this screenshot out:

![Screenshot 2024-08-21 at 2 45 20 PM](https://github.com/user-attachments/assets/a09324eb-30e1-45bb-b8a1-dea0586ad80b)


### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
