### PR TITLE
activesupport <= 7.1.3.2

### DIFF
--- a/oc-chef-pedant/Gemfile.lock
+++ b/oc-chef-pedant/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     oc-chef-pedant (2.2.0)
-      activesupport (>= 4.2.7.1, < 8.0)
+      activesupport (>= 4.2.7.1, <= 7.1.3.2)
       addressable
       chef-utils (>= 16.17.51)
       erubis (~> 2.7)

--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.executables   = ['oc-chef-pedant']
 
   s.add_dependency('rspec', '~> 3.2')
-  s.add_dependency('activesupport', '>= 4.2.7.1', '< 8.0') # For active_support/concern
+  s.add_dependency('activesupport', '>= 4.2.7.1', '<= 7.1.3.2') # For active_support/concern
   s.add_dependency('chef-utils', '>= 16.17.51')
   s.add_dependency('mixlib-authentication', '> 1.4', '< 4.0')
   s.add_dependency('mixlib-config', '>= 2', '< 4')


### PR DESCRIPTION
The ChefFS=1 verify pipeline was failing with:

<html><body>
<!--StartFragment-->
activesupport-7.2.0 requires ruby version >= 3.1.0, which is incompatible with
--

<span style="position: relative;"><span>Error running bundle update of /workdir/vendor/bundle/ruby/3.0.0/bundler/gems/chef-zero-01105d9aff00/Gemfile.oc-chef-pedant-external-test in /workdir/vendor/bundle/ruby/3.0.0/bundler/gems/chef-zero-01105d9aff00: 5</span></span><!--EndFragment-->
</body>
</html>

Should anything else be changed besides Gemfile.locks?

https://buildkite.com/chef/chef-chef-server-main-verify/builds/10620
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/6646