### PR TITLE
Disable busywaits

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/bookshelf.vm.args.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/bookshelf.vm.args.erb
@@ -33,3 +33,8 @@
 ## schedulers and increases performance of IO-heavy
 ## apps, like bookshelf.
 +A 10
+
+## Disable busywaits
++sbwt none
++sbwtdcpu none
++sbwtdio none

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_bifrost.vm.args.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_bifrost.vm.args.erb
@@ -22,3 +22,8 @@
 
 ## Increase logfile size to 10M
 -env RUN_ERL_LOG_MAXSIZE 10000000
+
+## Disable busywaits
++sbwt none
++sbwtdcpu none
++sbwtdio none

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.vm.args.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.vm.args.erb
@@ -29,3 +29,8 @@
 
 ## Increase logfile size to 10M
 -env RUN_ERL_LOG_MAXSIZE 10000000
+
+## Disable busywaits
++sbwt none
++sbwtdcpu none
++sbwtdio none


### PR DESCRIPTION
On VMs this often leads to increased CPU usage and in cloud environments increased consumption of CPU credits ($$).

The main offender is oc-bifrost which has been observed consuming 100% CPU making calls for CLOCK_MONOTONIC. With this change it only consumes 1% CPU.