### PR TITLE
Knife search issue: when search entries are more than 10K

### DIFF
--- a/docs-chef-io/content/server/config_rb_server_optional_settings.md
+++ b/docs-chef-io/content/server/config_rb_server_optional_settings.md
@@ -2023,6 +2023,11 @@ This configuration file has the following settings for `opscode-erchef`:
 
     Default value: `127.0.0.1`.
 
+`opscode_erchef['track_total_hits']`
+
+:   Whether to return how many documents matched the query.
+
+    Default value: `false`.
 
 ### opscode-expander
 

--- a/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
+++ b/oc-chef-pedant/spec/running_configs/basic_config_spec.rb
@@ -142,6 +142,10 @@ describe "running configs required by Chef Server and plugins", :config do
       expect(config['opscode-erchef']['solr_http_max_age'].to_s).not_to eq ''
     end
 
+    it "opscode-erchef/track_total_hits" do
+      expect(config['opscode-erchef']['track_total_hits'].to_s).not_to eq ''
+    end
+
     it "opscode-erchef/solr_http_max_connection_duration" do
       expect(config['opscode-erchef']['solr_http_max_connection_duration'].to_s).not_to eq ''
     end

--- a/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/attributes/default.rb
@@ -344,6 +344,7 @@ default['private_chef']['opscode-erchef']['search_queue_mode'] = 'batch'
 default['private_chef']['opscode-erchef']['search_batch_max_size'] = '5000000'
 default['private_chef']['opscode-erchef']['search_batch_max_wait'] = '10'
 default['private_chef']['opscode-erchef']['search_auth_username'] = 'opensearch_user'
+default['private_chef']['opscode-erchef']['track_total_hits'] = false
 # default['private_chef']['opscode-erchef']['search_auth_password'] = "admin"
 # solr_service configuration for erchef. These are used to configure an opscoderl_httpc pool
 # of HTTP connecton workers.

--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/oc_erchef.config.erb
@@ -189,6 +189,7 @@
         {solr_elasticsearch_major_version, <%= @solr_elasticsearch_major_version %>},
         {search_auth_username, "<%= node['private_chef']['opscode-erchef']['search_auth_username'] %>"},
         {search_auth_password, "<%= @helper.search_auth_password() %>"},
+        {track_total_hits, <%= node['private_chef']['opscode-erchef']['track_total_hits'] -%>},
         {solr_service, [
             {root_url, "<%= @helper.search_engine_url() %>"},
             {timeout, <%= @solr_timeout %>},

--- a/src/oc_erchef/apps/chef_index/src/chef_index_query.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_query.erl
@@ -30,6 +30,7 @@ from_params(Provider, ObjType, QueryString, Start, Rows) ->
                      search_provider = Provider,
                      start = decode({nonneg_int, "start"}, Start, 0),
                      rows = decode({nonneg_int, "rows"}, Rows, 1000),
+                     track_total_hits = envy:get(chef_index, track_total_hits, false, boolean),
                      sort = "X_CHEF_id_CHEF_X asc",
                      index = index_type(ObjType)}.
 

--- a/src/oc_erchef/apps/chef_index/test/chef_index_query_tests.erl
+++ b/src/oc_erchef/apps/chef_index/test/chef_index_query_tests.erl
@@ -40,6 +40,7 @@ query_from_params_test_() ->
             sort = "X_CHEF_id_CHEF_X asc",
             start = 2,
             rows = 5,
+            track_total_hits=false,
             index = node},
           ?assertEqual(Expect, Query)
       end},
@@ -57,6 +58,7 @@ query_from_params_test_() ->
             sort = "X_CHEF_id_CHEF_X asc",
             start = 0,
             rows = 1000,
+            track_total_hits=false,
             index = role},
           ?assertEqual(Expect, Query)
       end},

--- a/src/oc_erchef/habitat/config/sys.config
+++ b/src/oc_erchef/habitat/config/sys.config
@@ -173,6 +173,7 @@
         {search_batch_max_wait, 10},
         {reindex_sleep_min_ms, 500},
         {reindex_sleep_max_ms, 2000},
+        {track_total_hits, {{track_total_hits}} },
         {reindex_item_retries, 3},
         {solr_elasticsearch_major_version, 5},
         {solr_service, [

--- a/src/oc_erchef/habitat/default.toml
+++ b/src/oc_erchef/habitat/default.toml
@@ -30,6 +30,7 @@ keygen_timeout=5000
 [chef_db]
 
 [chef_index]
+track_total_hits=false
 
 [chef_objects]
 

--- a/src/oc_erchef/include/chef_solr.hrl
+++ b/src/oc_erchef/include/chef_solr.hrl
@@ -21,6 +21,7 @@
           search_provider = solr :: 'solr' | 'elasticsearch' | 'opensearch',
           start :: integer() | undefined,
           rows :: integer()  | undefined,
+          track_total_hits :: boolean() |undefined,
           sort :: string()   | undefined,
           index :: 'node'
                  | 'role'


### PR DESCRIPTION
### Description

[Please describe what this change achieves]
This PR contains the changes for issue on Jira: 
https://progresssoftware.atlassian.net/browse/CHEF-5783


### Issues Resolved
When user do 
Knife search wildcard [ knife search 'name:*' -i | wc -l] was only providing 10k results where as user gets more than 10 when doing lets say [knife node list | wc -l].
The fix here contains adding track_total_hits value in the opensearch request body, If set as true will give all the data when searching using wildcard approach. 
```
curl -XPUT "http://127.0.0.1:10144/chef/_settings" -d '{ "index" :
{ "max_result_window" : 50000 } 
}' -H "Content-Type: application/json"
```
which tells the max_window_size a response can accommodate. 

To use this feature change the value of 
```
track_total_hits =true
```
in the erchef which is false by default. 
[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
