### PR TITLE
update license_scout version

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       tomlrb (>= 1.2, < 3.0)
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
-    license_scout (1.3.15)
+    license_scout (1.3.16)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)


### PR DESCRIPTION
### Description

chef-server builds are failing due to licensing errors , PFA.

<img width="1724" alt="Screenshot 2024-12-30 at 9 13 18 PM" src="https://github.com/user-attachments/assets/0278f267-fb67-46a0-b399-409fd8a7219a" />

This pr change has the fix , for exact fix we can refer this pr https://github.com/chef/license_scout/pull/327 

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
