### PR TITLE
changing hardcoded date in test case.

### DIFF
--- a/oc-chef-pedant/spec/api/keys/client_keys_spec.rb
+++ b/oc-chef-pedant/spec/api/keys/client_keys_spec.rb
@@ -228,7 +228,8 @@ describe "Client keys endpoint", :keys, :client_keys do
   context "when a client's default key has an expiration date" do
     before(:each) do
       delete_client_key(org_name, client["name"], "default")
-      add_client_key(org_name, client["name"], :key, "default", expires: "2025-03-24T21:00:00Z").should look_like(status: 201)
+      future_time = Time.now.utc + 60 * 60 * 24 * 365 # 1 year from now
+      add_client_key(org_name, client["name"], :key, "default", expires: future_time.strftime("%Y-%m-%dT%H:%M:%SZ")).should look_like(status: 201)
     end
 
     context "and is updated via a PUT to /organizations/:org/clients/:client" do
@@ -247,7 +248,8 @@ describe "Client keys endpoint", :keys, :client_keys do
 
   context "when a client key has an expiration date and isn't expired" do
     before(:each) do
-      add_client_key(org_name, client["name"], :key, key_name, expires: "2025-03-24T21:00:00Z").should look_like(status: 201)
+      future_time = Time.now.utc + 60 * 60 * 24 * 365 # 1 year from now
+      add_client_key(org_name, client["name"], :key, key_name, expires: future_time.strftime("%Y-%m-%dT%H:%M:%SZ")).should look_like(status: 201)
     end
 
     it "should authenticate against the key" do

--- a/oc-chef-pedant/spec/api/keys/user_keys_spec.rb
+++ b/oc-chef-pedant/spec/api/keys/user_keys_spec.rb
@@ -216,7 +216,8 @@ describe "User keys endpoint", :keys, :user_keys do
 
   context "when a user key has an expiration date and isn't expired" do
     before(:each) do
-      add_user_key(user["name"], :key, key_name, expires: "2025-03-24T21:00:00Z").should look_like(status: 201)
+      future_time = Time.now.utc + 60 * 60 * 24 * 365 # 1 year from now
+      add_user_key(user["name"], :key, key_name, expires: future_time.strftime("%Y-%m-%dT%H:%M:%SZ")).should look_like(status: 201)
     end
 
     after(:each) do
@@ -231,7 +232,8 @@ describe "User keys endpoint", :keys, :user_keys do
   context "when a user's default key has an expiration date" do
     before(:each) do
       delete_user_key(user["name"], "default")
-      add_user_key(user["name"], :key, "default", expires: "2025-03-24T21:00:00Z").should look_like(status: 201)
+      future_time = Time.now.utc + 60 * 60 * 24 * 365 # 1 year from now
+      add_user_key(user["name"], :key, "default", expires: future_time.strftime("%Y-%m-%dT%H:%M:%SZ")).should look_like(status: 201)
     end
 
     context "and is updated via a PUT to /users/:user" do


### PR DESCRIPTION
### Description
In pedant test to give future date is hardcoded to 2025-03 which caused pedant test to fail, in this PR this hardcoded date is replaced with current date + 1 year which should not fail.

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
