### PR TITLE
Pin pg gem version < 1.6 for older linux distros

### DIFF
--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       mixlib-install
       mixlib-log
       omnibus-ctl (<= 0.6.10)
-      pg (~> 1.2, >= 1.2.3)
+      pg (~> 1.2, >= 1.2.3, < 1.6)
       redis
       rest-client
       uuidtools (~> 2.1, >= 2.1.3)

--- a/src/chef-server-ctl/chef-server-ctl.gemspec
+++ b/src/chef-server-ctl/chef-server-ctl.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "ffi-yajl", ">= 1.2.0"
 
-  spec.add_runtime_dependency "pg", "~> 1.2", ">= 1.2.3"
+  spec.add_runtime_dependency "pg", "~> 1.2", ">= 1.2.3", "< 1.6"
 
   spec.add_runtime_dependency "redis"
 

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -14,7 +14,7 @@ gem 'sass-rails', '>= 4.0.3'
 gem 'turbolinks', '~> 5'
 gem 'unicorn-rails', '~> 2.2', '>= 2.2.1'
 gem 'nokogiri', '1.15.6'
-gem 'pg', '>= 0.18', '< 2.0' # active_record 4.2.8 pins this but doesn't manifest this in the gemspec for some reason
+gem 'pg', '>= 0.18', '< 1.6' # active_record 4.2.8 pins this but doesn't manifest this in the gemspec for some reason
 gem 'mixlib-authentication', '>= 2.1', '< 4'
 gem 'responders', '~> 3.0', '>= 3.0.1'
 gem 'doorkeeper', '~> 5.0'

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -616,7 +616,7 @@ DEPENDENCIES
   mixlib-authentication (>= 2.1, < 4)
   nokogiri (= 1.15.6)
   omniauth-chef (~> 0.4)
-  pg (>= 0.18, < 2.0)
+  pg (>= 0.18, < 1.6)
   pry-byebug
   rails (~> 7.0.8.1)
   rails-controller-testing


### PR DESCRIPTION
### Description
This pull request introduces a version constraint update for the `pg` gem in two locations to ensure compatibility with the codebase and dependencies. The changes primarily focus on restricting the upper version limit of the `pg` gem to `< 1.6`.

### Dependency Updates:

* Updated the `pg` runtime dependency to include an upper version constraint of `< 1.6` to prevent compatibility issues with versions beyond `1.5.x`.
* Modified the `pg` gem version specification to set an upper limit of `< 1.6`, aligning it with the constraints in the gemspec file.



### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
