### PR TITLE
Upgrade nokogiri to 1.18.9

### DIFF
--- a/.expeditor/license_scout.sh
+++ b/.expeditor/license_scout.sh
@@ -20,12 +20,16 @@ if [[ "${BUILDKITE:-false}" == "true" ]]; then
   #
   # Since we don't use any software from this repository in our tests,
   # we can temporarily remove it from our sources.
-  rm /etc/apt/sources.list.d/microsoft-prod.list
+  rm -f /etc/apt/sources.list.d/microsoft-prod.list
+  # Remove problematic PostgreSQL repository if it exists
+  rm -f /etc/apt/sources.list.d/pgdg.list
   wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
   apt-get clean
   apt-get autoremove 
   apt-get update
-  apt-get install -y libpq-dev libsqlite3-dev libyaml-dev
+  # Install packages with dependency resolution, allowing downgrades if needed
+  apt-get install -y --allow-downgrades libpq-dev libsqlite3-dev libyaml-dev || \
+    (apt-get remove -y libpq5 libpq-dev && apt-get install -y libpq-dev libsqlite3-dev libyaml-dev)
   asdf plugin add erlang
   asdf install erlang 26.2.5.14
   asdf local erlang 26.2.5.14

--- a/omnibus/config/software/oc_id.rb
+++ b/omnibus/config/software/oc_id.rb
@@ -43,6 +43,12 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
   env['PATH'] = "#{env['PATH']}:#{install_dir}/embedded/nodejs/bin"
 
+  # Create bundle directory if it doesn't exist
+  mkdir ".bundle" unless File.exist?(".bundle")
+
+  # Create a bundle config file directly with command
+  bundle "config set --local force_ruby_platform true", env: env
+
   bundle "config build.nokogiri --use-system-libraries" \
          " --with-xml2-config=#{install_dir}/embedded/bin/xml2-config" \
          " --with-xslt-config=#{install_dir}/embedded/bin/xslt-config"

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -18,3 +18,6 @@ override :logrotate, version: "3.19.0"
 override :openresty, version: "1.25.3.1"
 
 override :openssl, version: "1.0.2zi"
+
+# Force nokogiri to use Ruby platform for glibc compatibility
+override :nokogiri, version: "1.18.9"

--- a/scripts/bk_tests/bk_install.sh
+++ b/scripts/bk_tests/bk_install.sh
@@ -9,7 +9,7 @@ set -e
 # The fix:
 # 1. Add `deb https://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg main` to sources.list
 # 2. Remove /etc/apt/sources.list.d/pgdg.list
-sudo echo "deb https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main 13">>/etc/apt/sources.list
+sudo echo "deb https://apt-archive.postgresql.org/pub/repos/apt/ focal-pgdg main 13">>/etc/apt/sources.list
 rm -f /etc/apt/sources.list.d/pgdg.list
 
 echo "Removing postgresql-9.3"

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -13,7 +13,7 @@ gem 'rb-readline', '~> 0.5.2', require: false
 gem 'sass-rails', '>= 4.0.3'
 gem 'turbolinks', '~> 5'
 gem 'unicorn-rails', '~> 2.2', '>= 2.2.1'
-gem 'nokogiri', '1.15.6'
+gem 'nokogiri', '1.18.9', platforms: :ruby # Force Ruby platform to avoid glibc compatibility issues
 gem 'pg', '>= 0.18', '< 1.6' # active_record 4.2.8 pins this but doesn't manifest this in the gemspec for some reason
 gem 'mixlib-authentication', '>= 2.1', '< 4'
 gem 'responders', '~> 3.0', '>= 3.0.1'

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -313,7 +313,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.8)
+    mini_portile2 (2.8.9)
     minitest (5.25.5)
     mixlib-archive (1.1.7)
       mixlib-log
@@ -343,7 +343,7 @@ GEM
       net-protocol
     net-ssh (6.1.0)
     nio4r (2.5.9)
-    nokogiri (1.15.6)
+    nokogiri (1.18.9)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nori (2.6.0)
@@ -614,7 +614,7 @@ DEPENDENCIES
   jwt
   mailcatcher
   mixlib-authentication (>= 2.1, < 4)
-  nokogiri (= 1.15.6)
+  nokogiri (= 1.18.9)
   omniauth-chef (~> 0.4)
   pg (>= 0.18, < 1.6)
   pry-byebug


### PR DESCRIPTION
### Description
This pull request introduces updates to ensure compatibility with the Ruby platform and improve dependency management for the `oc-id` project. The key changes include forcing the use of the Ruby platform for the `nokogiri` gem to address glibc compatibility issues and modifying the build configuration to support these changes.

### Dependency updates and compatibility improvements:

* **`omnibus/config/software/oc_id.rb`:** Added commands to create a `.bundle` directory if it doesn't exist and configured Bundler to force the Ruby platform for dependencies.
* **`omnibus_overrides.rb`:** Updated the `nokogiri` version to `1.18.9` and added a comment to explain the forced Ruby platform for glibc compatibility.
* **`src/oc-id/Gemfile`:** Updated the `nokogiri` gem version to `1.18.9` and specified the Ruby platform to avoid glibc compatibility issues.


### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
