### PR TITLE
Updating for CVE-2023-22796

### DIFF
--- a/oc-chef-pedant/oc-chef-pedant.gemspec
+++ b/oc-chef-pedant/oc-chef-pedant.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.executables   = ["oc-chef-pedant"]
 
   s.add_dependency("rspec", "~> 3.2")
-  s.add_dependency("activesupport", ">= 4.2.7.1", "<= 7.1.3.2") # For active_support/concern
+  s.add_dependency("activesupport", ">= 4.2.7.1", "~> 7.1.5") # For active_support/concern
   s.add_dependency("chef-utils", ">= 16.17.51")
   s.add_dependency("mixlib-authentication", "> 1.4", "< 4.0")
   s.add_dependency("mixlib-config", ">= 2", "< 4")


### PR DESCRIPTION
### Description

The current version of activesupport - 7.1.3.2 - is affected by CVE-2023-22796. Thew new version, 7.1.5.2, is the correct one to load.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
