### PR TITLE
fix: correct source URL for OpenSearch

### DIFF
--- a/omnibus/config/software/opensearch.rb
+++ b/omnibus/config/software/opensearch.rb
@@ -71,9 +71,8 @@ version "1.3.19" do
 end
 
 version "1.3.20" do
-  source url: "#{ENV['ARTIFACTORY_REPO_URL']}/opensearch-2/#{name}-#{version}.tuxcare.1-linux-x64.tar.gz",
-                  authorization: "X-JFrog-Art-Api:#{ENV['ARTIFACTORY_TOKEN']}",
-                  sha256: "42028f94ac743959385f58a4527dc01966a98b7551b20bde0be022d5ba543da4"
+  source url: "https://artifacts.opensearch.org/releases/bundle/opensearch/#{version}/opensearch-#{version}-linux-x64.tar.gz",
+        sha256: "a786fe52b4d25db85cc49f34df6118f19c434b25935f28bd98c0f874ae77ccc3"
 internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/opensearch/#{name}-#{version}.tuxcare.1-linux-x64.tar.gz",
                 authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
 end


### PR DESCRIPTION
### Description

#4066 seems to introduce a little bug on public source for opensearch [here](https://github.com/chef/chef-server/blob/15.10.61/omnibus/config/software/opensearch.rb#L74)
chef-oss builds no longer work. see #4090 

### Issues Resolved
This PR fixes #4090 

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
