### PR TITLE
CHEF-28367: Chef Infra Server - suppress version/banner disclosure

### DIFF
--- a/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
+++ b/omnibus/files/server-ctl-cookbooks/infra-server/templates/default/nginx/nginx_chef_api_lb.conf.erb
@@ -95,19 +95,8 @@
     }
 
     location /version {
-      add_header Cache-Control no-store always;
-      add_header Pragma no-cache always;
-      add_header Content-Security-Policy "default-src 'self';";
-      add_header X-Frame-Options DENY;
-      add_header X-Content-Type-Options nosniff;
-      add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
-      add_header Referrer-Policy 'strict-origin';
-      <% if @server_proto == 'https' %>
-      add_header Strict-Transport-Security "max-age=<%= @helper.get_max_age_for_hsts %>; includeSubDomains";
-      <% end %>
-      types { }
-      default_type text/plain;
-      alias /opt/<%= ChefUtils::Dist::Org::LEGACY_CONF_DIR %>/version-manifest.txt;
+      deny all;
+      return 404;
     }
 
     location ~ "^/organizations/([^/]+)/validate" {

--- a/src/nginx/habitat/config/chef_http_lb_common
+++ b/src/nginx/habitat/config/chef_http_lb_common
@@ -58,9 +58,8 @@
     }
 
     location /version {
-      types { }
-      default_type text/plain;
-      alias {{../pkg.svc_config_path}}/version-manifest.txt;
+      deny all;
+      return 404;
     }
 
     location ~ "^/organizations/([^/]+)/validate" {

--- a/src/nginx/habitat/config/nginx.conf
+++ b/src/nginx/habitat/config/nginx.conf
@@ -16,6 +16,7 @@ http {
                     '"$http_referer" "$http_user_agent" "$upstream_addr" "$upstream_status" "$upstream_response_time" "$http_x_chef_version" "$http_x_ops_sign" "$http_x_ops_userid" "$http_x_ops_timestamp" "$http_x_ops_content_hash" $request_length';
 
   server_names_hash_bucket_size 128;
+  server_tokens off;
 
   sendfile on;
   tcp_nopush on;


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes information disclosure vulnerability where Chef Infra Server was exposing full package version details publicly via the <code>/version</code> endpoint, and advertising the nginx version in response headers.</p>

<h2>Jira Ticket</h2>
<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-28367">CHEF-28367</a></p>

<h2>Changes Made</h2>
<ul>
  <li><strong>omnibus nginx config</strong> (nginx_chef_api_lb.conf.erb): Replaced the location /version block (which served version-manifest.txt) with deny all; return 404. This single template renders both chef_http_lb.conf and chef_https_lb.conf.</li>
  <li><strong>Habitat nginx config</strong> (chef_http_lb_common): Same change - /version endpoint now returns 404 instead of serving the version manifest.</li>
  <li><strong>Habitat nginx.conf</strong>: Added server_tokens off; to suppress the nginx version number from Server: response headers. (The omnibus build already had this set.)</li>
</ul>

<h2>Testing</h2>
<p>Verified on a freshly built Chef Infra Server instance:</p>
<ul>
  <li>curl -sk https://localhost/version returns HTTP 404 with Chef custom error page, no version data</li>
  <li>curl -skI https://localhost/ - Server: header contains no nginx version number</li>
</ul>

```
$ curl -skI https://localhost/version
HTTP/1.1 404 Not Found
Date: Tue, 31 Mar 2026 01:51:31 GMT
Content-Type: text/html
Content-Length: 1084
Connection: keep-alive
ETag: "69cb24ce-43c"
Cache-Control: no-store
Pragma: no-cache

$ sudo chef-server-ctl test
Finished in 3 minutes 25.7 seconds (files took 16.14 seconds to load)
174 examples, 0 failures, 2 pending
```

<h2>AI Assistance</h2>
<p>This work was completed with AI assistance following Progress AI policies.</p>

