### PR TITLE
Fix 'occured' -> 'occurred' typo in key_ctl_helper exit_failure message

### DIFF
--- a/src/chef-server-ctl/lib/chef_server_ctl/helpers/key_ctl_helper.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/helpers/key_ctl_helper.rb
@@ -93,7 +93,7 @@ EOS
       end
 
       def exit_http_fail(err)
-        exit_failure("Error: An unexpected error has occured (the server returned a #{err.response.code}).\nError: Please contact a system admin if the problem persists.")
+        exit_failure("Error: An unexpected error has occurred (the server returned a #{err.response.code}).\nError: Please contact a system admin if the problem persists.")
       end
 
       def get_required_arg!(options, args, usage, field_symbol, field_name, field_number)


### PR DESCRIPTION
`exit_failure` message in `src/chef-server-ctl/lib/chef_server_ctl/helpers/key_ctl_helper.rb:96` read `An unexpected error has occured (the server returned ...)`. User-visible in `chef-server-ctl` key command error output. `ruby -c` clean.