### PR TITLE
Bump addressable to 2.9.0 in chef-server-ctl (CVE fix)

### DIFF
--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -9,3 +9,5 @@ gem "toml" # for habitat-land
 
 gem "knife","~> 19.0.105"
 gem "knife-ec-backup", "~> 3.0.8"
+
+gem "public_suffix", "< 7.0" # public_suffix 7.0+ requires Ruby >= 3.2; pin for Ruby 3.1 compatibility

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -117,8 +117,8 @@ GEM
       mutex_m
       securerandom (>= 0.3)
       tzinfo (~> 2.0)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
     aws-partitions (1.1246.0)
@@ -777,6 +777,7 @@ DEPENDENCIES
   nokogiri (= 1.18.9)
   omniauth-chef (~> 0.4.1)!
   pg (>= 0.18, < 1.6)
+  public_suffix (< 7.0)
   pry-byebug
   rack (>= 3.2.4)
   rails (= 7.1.5.2)


### PR DESCRIPTION
addressable < 2.9.0 is vulnerable to ReDoS via URI template catastrophic backtracking. Bumping to 2.9.0 fully remediates both vulnerability classes.

Also pin public_suffix < 7.0 to maintain Ruby 3.1 compatibility, consistent with the same fix applied to oc-id.

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
