### PR TITLE
Fix JWT CVE: upgrade jwt to 3.2.0 in oc-id and chef-server-ctl

### DIFF
--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -389,7 +389,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.19.5)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kgio (2.11.4)
     language_server-protocol (3.17.0.5)
@@ -770,7 +770,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.4)
   jbuilder (~> 2.11)
   jquery-rails
-  jwt
+  jwt (>= 3.2.0)
   mailcatcher
   mixlib-authentication (>= 2.1, < 4)
   omniauth-chef (~> 0.4.1)!

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -7,7 +7,7 @@ gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt
 gem 'chef', '~> 18.10.17'
 gem 'jbuilder', '~> 2.11'
 gem 'jquery-rails'
-gem 'jwt' # For Zendesk SSO
+gem 'jwt', '>= 3.2.0' # For Zendesk SSO; >= 3.2.0 fixes empty-key HMAC bypass CVE
 gem 'config', '~> 4.1' # Replacement of rails_config gem
 gem 'rb-readline', '~> 0.5.2', require: false
 gem 'sass-rails', '>= 4.0.3'

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -389,7 +389,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.19.5)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kgio (2.11.4)
     language_server-protocol (3.17.0.5)
@@ -770,7 +770,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.4)
   jbuilder (~> 2.11)
   jquery-rails
-  jwt
+  jwt (>= 3.2.0)
   mailcatcher
   mixlib-authentication (>= 2.1, < 4)
   omniauth-chef (~> 0.4.1)!


### PR DESCRIPTION
jwt < 3.2.0 accepts attacker-forged tokens when an empty string key is used (empty-key HMAC bypass). JWT.decode with key '', nil, or a keyfinder returning '' would verify any signature via OpenSSL HMAC.

- Pin jwt >= 3.2.0 in src/oc-id/Gemfile
- Bump jwt 3.1.2 -> 3.2.0 in both Gemfile.lock files

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
