### PR TITLE
Fix Parser::AST::Processor::Mixin error in chef-server-ctl reconfigure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "omnibus"]
 	path = omnibus
 	url = https://github.com/chef/chef-server-omnibus-config.git
-	branch = main
+	branch = shahid/fix-parser-ast-mixin-error


### PR DESCRIPTION
<h3>Summary</h3>
<p>Fixes <code>NameError: uninitialized constant Parser::AST::Processor::Mixin</code> which caused <code>chef-server-ctl reconfigure</code> to fail with a fatal error during cookbook compilation.</p>

<h3>Root Cause</h3>
<p>The infra-server cookbook <code>Gemfile</code> had no version constraints on <code>cookstyle</code>. On a fresh <code>bundle install</code>, the latest <code>cookstyle</code> resolved <code>rubocop-ast >= 1.49.0</code> which references <code>Parser::AST::Processor::Mixin</code> — a constant alias not defined in <code>parser 3.3.9.0</code> (the cached version satisfying the <code>>= 3.3.7.2</code> constraint). This caused the cookbook compilation phase to crash.</p>

<h3>Changes Made</h3>
<ul>
  <li>Updated omnibus submodule reference to <a href="https://github.com/chef/chef-server-omnibus-config/pull/13">chef/chef-server-omnibus-config#13</a> which pins <code>cookstyle 8.5.0</code> and <code>rubocop-ast ~> 1.47.1</code> in the infra-server cookbook Gemfile.</li>
</ul>

<h3>Related PR</h3>
<p>chef/chef-server-omnibus-config#13 — contains the actual Gemfile change.</p>

<h3>Testing</h3>
<p>Pins to the known-working gem combination confirmed in production backup: <code>cookstyle 8.5.0</code> + <code>rubocop-ast 1.47.1</code> + <code>parser 3.3.9.0</code>.</p>

<p>This work was completed with AI assistance following Progress AI policies.</p>