### PR TITLE
Fix broken secrets-file restore on failed credential rotation

### DIFF
--- a/src/chef-server-ctl/plugins/rotate_credentials.rb
+++ b/src/chef-server-ctl/plugins/rotate_credentials.rb
@@ -221,7 +221,7 @@ end
 
 def restore_secrets_file(backup_file)
   log("Restoring #{backup_file} to #{secrets_file_path}...")
-  FileUtils.cp(secrets_file_path, backup_file)
+  FileUtils.cp(backup_file, secrets_file_path)
 end
 
 def secrets_file_path

--- a/src/chef-server-ctl/spec/rotate_credentials_spec.rb
+++ b/src/chef-server-ctl/spec/rotate_credentials_spec.rb
@@ -169,6 +169,25 @@ describe "chef-server-ctl rotate credentials" do
     end
   end
 
+  context "restore_secrets_file" do
+    it "copies the backup back over the live secrets file" do
+      allow(subject.ctl).to receive(:restore_secrets_file).and_call_original
+      allow(subject.ctl)
+        .to receive(:secrets_file_path)
+        .and_return("/etc/opscode/private-chef-secrets.json")
+
+      # The restore must copy backup -> live secrets file. Copying in the
+      # other direction would overwrite the only good backup with the
+      # (possibly broken) current secrets, making a failed rotation
+      # unrecoverable.
+      expect(FileUtils)
+        .to receive(:cp)
+        .with("/tmp/backup.json", "/etc/opscode/private-chef-secrets.json")
+
+      subject.ctl.send(:restore_secrets_file, "/tmp/backup.json")
+    end
+  end
+
   context "require_credential_rotation_pre_hook" do
     let(:credential_rotation_required_file) do
       "/tmp/var/opt/opscode/credential_rotation_required"


### PR DESCRIPTION
## Problem

`restore_secrets_file` in `src/chef-server-ctl/plugins/rotate_credentials.rb` copies in the wrong direction:

```ruby
def restore_secrets_file(backup_file)
  log("Restoring #{backup_file} to #{secrets_file_path}...")
  FileUtils.cp(secrets_file_path, backup_file)   # live -> backup (wrong)
end
```

This is the rollback path invoked by `rotate-credentials`, `rotate-all-credentials`, and `rotate-shared-secrets` when credential rotation raises (see the `rescue` blocks that call `restore_secrets_file(backup_file)`).

Because the copy goes **live secrets file → backup** (the same direction as `backup_secrets_file`), a failed rotation:

1. **Does not roll back** — the partially-rotated / broken secrets file is left in place as the live `private-chef-secrets.json`.
2. **Destroys the only good backup** — the pre-rotation copy is overwritten with the broken current secrets, so there is no artifact to recover from either.

The net effect is that a failed credential rotation can leave the Chef Server with unusable credentials and no automated way to recover, which is the opposite of what this rescue path is intended to guarantee.

## Fix

Copy **backup → live secrets file** so the rollback actually restores the pre-rotation state:

```ruby
FileUtils.cp(backup_file, secrets_file_path)
```

## Tests

The existing `rotate_credentials_spec.rb` stubbed `restore_secrets_file` out entirely and only asserted that it was *called*, so the copy direction was never exercised — which is how the bug went unnoticed. Added a focused regression test that calls the real method with `FileUtils.cp` mocked and asserts the argument order (`backup_file`, `secrets_file_path`).

Note: the chef-server-ctl gem bundle targets Ruby 3.1 and could not be installed in my local environment (Ruby 4.x), so I verified the changed files with `ruby -c` and am relying on CI to run the rspec suite.