### PR TITLE
Escape all knife wrapper arguments to prevent shell command injection

### DIFF
--- a/src/chef-server-ctl/plugins/wrap-knife.rb
+++ b/src/chef-server-ctl/plugins/wrap-knife.rb
@@ -117,16 +117,13 @@ cmds.each do |cmd, args|
     auth_args << "-c" << knife_config
     # auth_args << "--config-option" << "ssl_verify_mode=verify_none"
     
-    # Build command args - don't escape config options with = signs
+    # Build command args. Escape every argument before it is interpolated
+    # into the shell command string. Shellwords.escape leaves benign
+    # characters (including "=") untouched, so "key=value" style config
+    # options still pass through unchanged, while shell metacharacters in
+    # any argument are neutralized rather than executed.
     all_args = transformed_args + auth_args
-    escaped_args = all_args.map do |arg|
-      # Don't escape arguments that contain = (like config options)
-      if arg.include?('=')
-        arg
-      else
-        Shellwords.escape(arg)
-      end
-    end.join(" ")
+    escaped_args = all_args.map { |arg| Shellwords.escape(arg) }.join(" ")
     
     knife_command = "#{knife_cmd} #{opc_noun} #{opc_cmd} #{escaped_args}"
     status = run_command(knife_command)


### PR DESCRIPTION
## Problem

The `org-*` / `user-*` management commands in `src/chef-server-ctl/plugins/wrap-knife.rb` assemble a knife invocation as a single string and run it through a shell via `run_command`:

```ruby
escaped_args = all_args.map do |arg|
  # Don't escape arguments that contain = (like config options)
  if arg.include?('=')
    arg
  else
    Shellwords.escape(arg)
  end
end.join(" ")

knife_command = "#{knife_cmd} #{opc_noun} #{opc_cmd} #{escaped_args}"
status = run_command(knife_command)
```

Every argument is escaped with `Shellwords.escape` **except** arguments containing `=`, which are concatenated verbatim. The carve-out was meant to preserve `key=value` config options, but it means any argument containing `=` can inject arbitrary shell syntax. A positional field or option value such as:

```
x=y; touch /tmp/pwned
```

has its `;` and following command interpreted by the shell rather than being passed to `knife` as a literal argument.

## Fix

Escape every argument unconditionally:

```ruby
escaped_args = all_args.map { |arg| Shellwords.escape(arg) }.join(" ")
```

`Shellwords.escape` leaves benign characters (including `=`, `-`, `_`, `.`, `/`, and alphanumerics) untouched, so legitimate `key=value` config options continue to work unchanged, while shell metacharacters in any argument are neutralized instead of executed.

Note: the chef-server-ctl gem bundle targets Ruby 3.1 and could not be installed in my local environment (Ruby 4.x), so I verified the change with `ruby -c` and am relying on CI for the rspec suite.