### PR TITLE
Prevent shell command injection in psql --options

### DIFF
--- a/src/chef-server-ctl/plugins/psql.rb
+++ b/src/chef-server-ctl/plugins/psql.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 require "json"
+require "shellwords"
 
 known_dbs = {
   "opscode_chef" => { "dbname" => "opscode_chef", "config_key" => "opscode-erchef", "hashseed" => "private_chef" },
@@ -34,8 +35,12 @@ add_command_under_category "psql", "Database", "Launches an interactive PostgreS
   service_name = ARGV[1]
   write_arg = "--write"
   options_arg = "--options"
+  psql_options = []
   if ARGV.include?(options_arg)
-    psql_options = " #{ARGV[ARGV.index(options_arg) + 1]}"
+    # Split the user-supplied options string into individual tokens
+    # (honoring shell-style quoting) so each becomes a literal argv
+    # element passed to psql. This avoids handing the string to a shell.
+    psql_options = Shellwords.split(ARGV[ARGV.index(options_arg) + 1].to_s)
   end
 
   known_db_names = known_dbs.keys.sort.join(", ")
@@ -96,6 +101,14 @@ add_command_under_category "psql", "Database", "Launches an interactive PostgreS
   ENV["PGPASSWORD"] = db_password
   ENV["PAGER"] = "less"
   ENV["LESS"] = "-iMSx4 -FX"
-  cmd = "/opt/opscode/embedded/bin/psql --host #{db_host} --username #{db_username} --port #{db_port} --dbname #{db_name}#{psql_options}"
-  exec cmd
+  # Exec psql with an explicit argument vector (no shell). Passing the
+  # command as separate arguments means user-supplied --options tokens are
+  # delivered to psql verbatim and are never interpreted as shell syntax.
+  cmd = ["/opt/opscode/embedded/bin/psql",
+         "--host", db_host.to_s,
+         "--username", db_username.to_s,
+         "--port", db_port.to_s,
+         "--dbname", db_name.to_s,
+         *psql_options]
+  exec(*cmd)
 end


### PR DESCRIPTION
## Problem

The `psql` command in `src/chef-server-ctl/plugins/psql.rb` builds a single command string and executes it with `exec cmd`:

```ruby
if ARGV.include?(options_arg)
  psql_options = " #{ARGV[ARGV.index(options_arg) + 1]}"
end
...
cmd = "/opt/opscode/embedded/bin/psql --host #{db_host} --username #{db_username} --port #{db_port} --dbname #{db_name}#{psql_options}"
exec cmd
```

When `exec` is given a single string that contains shell metacharacters, Ruby runs it through `/bin/sh`. The user-supplied `--options` value is interpolated into that string unescaped, so it is interpreted by the shell. For example:

```
chef-server-ctl psql opscode_chef --options '; <command>'
```

executes the injected command rather than passing it to psql as an option.

## Fix

Build an explicit argument vector and call `exec(*cmd)`. With multiple arguments Ruby does **not** invoke a shell, so arguments are passed to psql verbatim. The `--options` value is tokenized with `Shellwords.split` (honoring shell-style quoting) and each token becomes a literal argv element, preserving the ability to pass real psql options without allowing shell interpretation:

```ruby
psql_options = []
if ARGV.include?(options_arg)
  psql_options = Shellwords.split(ARGV[ARGV.index(options_arg) + 1].to_s)
end
...
cmd = ["/opt/opscode/embedded/bin/psql",
       "--host", db_host.to_s,
       "--username", db_username.to_s,
       "--port", db_port.to_s,
       "--dbname", db_name.to_s,
       *psql_options]
exec(*cmd)
```

Note: the chef-server-ctl gem bundle targets Ruby 3.1 and could not be installed in my local environment (Ruby 4.x), so I verified the change with `ruby -c` and am relying on CI for the rspec suite.