### PR TITLE
Avoid shell interpretation of HAB_LISTEN_CTL in secrets bootstrap

### DIFF
--- a/src/chef-server-ctl/habitat/config/secrets-bootstrap.rb
+++ b/src/chef-server-ctl/habitat/config/secrets-bootstrap.rb
@@ -86,10 +86,14 @@ def secrets_apply_loop
     puts "Changed Secrets need to be applied."
     File.write("{{pkg.svc_data_path}}/hab-secrets-modified.toml", TOML::Generator.new(new_secrets).body)
     version = Time.now.getutc.to_i
-    cmd = "hab config apply chef-server-ctl.default #{version} {{pkg.svc_data_path}}/hab-secrets-modified.toml"
+    # Invoke hab with an explicit argument vector (no shell) so the value
+    # of HAB_LISTEN_CTL is passed as a literal argument rather than being
+    # interpreted by a shell.
+    cmd = ["hab", "config", "apply", "chef-server-ctl.default", version.to_s,
+           "{{pkg.svc_data_path}}/hab-secrets-modified.toml"]
     sup_listen_ctl = ENV["HAB_LISTEN_CTL"]
-    cmd += " --remote-sup #{sup_listen_ctl}" if sup_listen_ctl
-    system cmd
+    cmd += ["--remote-sup", sup_listen_ctl] if sup_listen_ctl
+    system(*cmd)
   else
     puts "Secrets Unchanged - nothing to do."
   end


### PR DESCRIPTION
## Problem

The secrets bootstrap loop in `src/chef-server-ctl/habitat/config/secrets-bootstrap.rb` builds a `hab config apply` command as a single string and executes it with `system cmd`, appending the value of the `HAB_LISTEN_CTL` environment variable unescaped:

```ruby
cmd = "hab config apply chef-server-ctl.default #{version} {{pkg.svc_data_path}}/hab-secrets-modified.toml"
sup_listen_ctl = ENV["HAB_LISTEN_CTL"]
cmd += " --remote-sup #{sup_listen_ctl}" if sup_listen_ctl
system cmd
```

Passing a single string to `system` runs it through a shell. Any shell metacharacters in `HAB_LISTEN_CTL` are therefore interpreted by the shell instead of being passed to `hab` as a literal argument, allowing command injection via that environment variable.

## Fix

Build an explicit argument vector and call `system(*cmd)`. With multiple arguments Ruby does not invoke a shell, so `HAB_LISTEN_CTL` is delivered to `hab` as a single literal argument:

```ruby
cmd = ["hab", "config", "apply", "chef-server-ctl.default", version.to_s,
       "{{pkg.svc_data_path}}/hab-secrets-modified.toml"]
sup_listen_ctl = ENV["HAB_LISTEN_CTL"]
cmd += ["--remote-sup", sup_listen_ctl] if sup_listen_ctl
system(*cmd)
```

The Habitat template placeholder (`{{pkg.svc_data_path}}`) is unchanged and is still rendered before the script runs, exactly as it is for the adjacent `File.write` call.

Note: this file is a Habitat config template; I verified the Ruby with `ruby -c`.