### PR TITLE
URL-encode credentials in PostgreSQL connection URI

### DIFF
--- a/src/chef-server-ctl/lib/chef_server_ctl/config.rb
+++ b/src/chef-server-ctl/lib/chef_server_ctl/config.rb
@@ -1,5 +1,6 @@
 require "chef_server_ctl/log"
 require "chef-utils/dist"
+require "erb"
 
 # ChefServerCtl::Config is a global configuration class for
 # ChefServerCtl subcommands.
@@ -148,7 +149,15 @@ Patents:       #{ChefUtils::Dist::Org::PATENTS}
       pg_config = @@ctl.running_service_config("postgresql")
       host = pg_config["vip"]
       port = pg_config["port"]
-      "postgresql:///#{db_name}?user=#{db_user}&password=#{db_password}&host=#{host}&port=#{port}"
+      # URL-encode the credentials. A username or password containing
+      # characters that are significant in a libpq connection URI (such as
+      # '&', '?', '#', '/', or spaces) would otherwise break the URI or
+      # inject additional connection parameters. The DB superuser password,
+      # for example, can be set to an arbitrary value via
+      # set-db-superuser-password.
+      user = ERB::Util.url_encode(db_user.to_s)
+      password = ERB::Util.url_encode(db_password.to_s)
+      "postgresql:///#{db_name}?user=#{user}&password=#{password}&host=#{host}&port=#{port}"
     end
 
     def self.ssl_params


### PR DESCRIPTION
## Problem

`ChefServerCtl::Config.make_connection_string` in `src/chef-server-ctl/lib/chef_server_ctl/config.rb` interpolates the database username and password directly into a libpq connection URI without URL-encoding:

```ruby
"postgresql:///#{db_name}?user=#{db_user}&password=#{db_password}&host=#{host}&port=#{port}"
```

If a username or password contains characters that are significant in a connection URI — `&`, `?`, `#`, `/`, or spaces — the resulting URI is either malformed or carries **extra connection parameters** that the credential value injects. For example a password value of `secret&sslmode=disable` would append an unintended `sslmode` parameter to the connection.

The DB superuser password is not limited to randomly generated values — it can be set to an arbitrary string via `chef-server-ctl set-db-superuser-password` — so this is reachable in practice, not just in theory.

## Fix

URL-encode the username and password with `ERB::Util.url_encode` before building the URI:

```ruby
user = ERB::Util.url_encode(db_user.to_s)
password = ERB::Util.url_encode(db_password.to_s)
"postgresql:///#{db_name}?user=#{user}&password=#{password}&host=#{host}&port=#{port}"
```

Plain alphanumeric credentials are unchanged; only URI-significant characters are percent-encoded, which libpq decodes back to the original value. (`ERB::Util.url_encode` encodes spaces as `%20` rather than `+`, which is what a libpq URI expects.)

Note: the chef-server-ctl gem bundle targets Ruby 3.1 and could not be installed in my local environment (Ruby 4.x), so I verified the change with `ruby -c` and confirmed the encoding behavior of `ERB::Util.url_encode` directly.