### PR TITLE
Update postgresql13 13.22 -> 13.23

### DIFF
--- a/src/chef-server-ctl/plugins/notice.rb
+++ b/src/chef-server-ctl/plugins/notice.rb
@@ -411,7 +411,7 @@ cacerts | 2022-10-11 | MPL-2.0
 sslshake | 1.3.1 | MPL-2.0
 vault | 0.18.2 | MPL-2.0
 TermReadKey | 2.38 | Public Domain 
-postgresql13 | 13.22 | Commercial License
+postgresql13 | 13.23 | Commercial License
 postgresql96-bin | 9.6.23 | PostgreSQL
 chef-server-ctl |  | Proprietary
 cleanup | 1.0.0 | Proprietary
@@ -5679,7 +5679,7 @@ If you redistribute modified sources, we would appreciate that you include in th
 2.	Special Notices Regarding Commercially Licensed Third-Party Components incorporated into the Product: 
 
 Progress Chef Infra Server v15 incorporates OpenSearch 1.3.20 licensed from TuxCare.
-Progress Chef Infra Server v15 incorporates PostgreSQL 13.22 licensed from TuxCare.
+Progress Chef Infra Server v15 incorporates PostgreSQL 13.23 licensed from TuxCare.
 
 3.	Special Notices Regarding Progress Product Components incorporated into the Product:
 


### PR DESCRIPTION
## Summary

Update `notice.rb` to reflect the postgresql13 version bump from 13.22 to 13.23 (CVE-2025-12818).

### Changes
- `src/chef-server-ctl/plugins/notice.rb`: update two references — summary table entry and TuxCare attribution paragraph

### Context
- The postgresql13 13.22 → 13.23 bump is sourced entirely from `chef-server-omnibus-config/config/software/postgresql13.rb`, already updated to 13.23 on main via chef/chef-server-omnibus-config#16 (Sudheer/Poornima, Jun 1)
- No submodule advancement needed — the omnibus submodule already points to omnibus-config main at the correct HEAD
- No changes to `omnibus-software-private` are required for this bump — build #8394 (below) validates a full build/test pass using only the omnibus-config override, with no OSP branch pointer

Jira: CHEF-32461

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

omnibus/adhoc:
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/8378
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/8394

```
$ sudo  chef-server-ctl status
run: bookshelf: (pid 21318) 671s; run: log: (pid 20907) 768s
run: nginx: (pid 21205) 674s; run: log: (pid 21095) 690s
run: oc_bifrost: (pid 21180) 675s; run: log: (pid 20390) 889s
run: oc_id: (pid 21189) 675s; run: log: (pid 20431) 868s
run: opensearch: (pid 21239) 673s; run: log: (pid 20590) 855s
run: opscode-erchef: (pid 21356) 671s; run: log: (pid 21014) 762s
run: postgresql: (pid 21176) 676s; run: log: (pid 19901) 936s
run: redis_lb: (pid 21119) 679s; run: log: (pid 21425) 669s

$ sudo -u opscode-pgsql /opt/opscode/embedded/bin/psql --version
psql (PostgreSQL) 13.23

$ sudo  chef-server-ctl test
Finished in 3 minutes 18.2 seconds (files took 16.54 seconds to load)
174 examples, 0 failures, 2 pending
```
