### PR TITLE
CHEF-37625 - Add concurrent-ruby >= 1.3.8 floor across chef-server-ctl, oc-id, oc-chef-pedant, oc_bifrost-pedant Gemfiles

### DIFF
--- a/oc-chef-pedant/Gemfile
+++ b/oc-chef-pedant/Gemfile
@@ -106,6 +106,13 @@ gem 'chef-zero', git: "https://github.com/chef/chef-zero.git", branch: "main"
 # gem "rack", ">= #{resolve_safe_version.call(:MINIMUM_SAFE_RACK_VERSION)}", "= X.Y.Z" # pinned <reason>, YYYY-MM-DD
 gem "rack", ">= #{resolve_safe_version.call(:MINIMUM_SAFE_RACK_VERSION)}"
 
+# concurrent-ruby (CHEF-37625 / GHSA-6wx8-w4f5-wwcr, GHSA-h8w8-99g7-qmvj [high],
+# GHSA-wv3x-4vxv-whpp -- Dependabot alerts 375, 378, 381). Bare floor, same
+# reasoning as src/chef-server-ctl/Gemfile's identical line: no
+# ruby_gems_cleanup.rb consumer exists for this gem, so it does not go through
+# resolve_safe_version.call(...)/safe_versions.rb.
+gem "concurrent-ruby", ">= 1.3.8"
+
 # If you want to load debugging tools into the bundle exec sandbox,
 # # add these additional dependencies into Gemfile.local
 eval(File.read(__FILE__ + ".local"), binding) if File.exist?(__FILE__ + ".local")

--- a/oc-chef-pedant/Gemfile.lock
+++ b/oc-chef-pedant/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     chef-utils (19.2.110)
       concurrent-ruby
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
     debug_inspector (1.2.0)
     diff-lcs (1.6.2)
@@ -149,6 +149,7 @@ PLATFORMS
 
 DEPENDENCIES
   chef-zero!
+  concurrent-ruby (>= 1.3.8)
   oc-chef-pedant!
   pry
   pry-byebug

--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -108,3 +108,18 @@ gem "rack", ">= #{resolve_safe_version.call(:MINIMUM_SAFE_RACK_VERSION)}"
 # Example only -- how to pin an exact version: replace X.Y.Z before uncommenting:
 # gem "rexml", ">= #{resolve_safe_version.call(:MINIMUM_SAFE_REXML_VERSION)}", "= X.Y.Z" # pinned <reason>, YYYY-MM-DD
 gem "rexml", ">= #{resolve_safe_version.call(:MINIMUM_SAFE_REXML_VERSION)}"
+
+# concurrent-ruby (CHEF-37625 / GHSA-6wx8-w4f5-wwcr, GHSA-h8w8-99g7-qmvj [high],
+# GHSA-wv3x-4vxv-whpp -- Dependabot alerts 377, 380, 383). Declared as a plain,
+# direct floor here -- NOT routed through the SafeVersions/resolve_safe_version
+# mechanism above, unlike rack/rexml. That indirection exists specifically so
+# ruby_gems_cleanup.rb (in chef-server-omnibus-config) and a Gemfile floor for
+# the *same* gem can't drift apart -- it's a single source of truth for two
+# consumers, not a generic place to declare any gem's minimum version. There is
+# no ruby_gems_cleanup.rb entry for concurrent-ruby (no ticket or on-disk test
+# finding has established a stale/vulnerable-version-left-on-disk cleanup need
+# for it, unlike rack/rexml/net-imap), so there is only one consumer here --
+# nothing for SafeVersions to keep in sync. Add a SafeVersions constant instead
+# of this bare floor only if a future ticket or test finding creates that
+# second (cleanup) consumer.
+gem "concurrent-ruby", ">= 1.3.7"

--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -122,4 +122,4 @@ gem "rexml", ">= #{resolve_safe_version.call(:MINIMUM_SAFE_REXML_VERSION)}"
 # nothing for SafeVersions to keep in sync. Add a SafeVersions constant instead
 # of this bare floor only if a future ticket or test finding creates that
 # second (cleanup) consumer.
-gem "concurrent-ruby", ">= 1.3.7"
+gem "concurrent-ruby", ">= 1.3.8"

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -511,6 +511,7 @@ DEPENDENCIES
   chef (~> 18.10.17)
   chef-server-ctl!
   chefstyle
+  concurrent-ruby (>= 1.3.7)
   knife (~> 19.0.105)
   knife-ec-backup (~> 3.0.8)
   public_suffix (< 7.0)

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -511,7 +511,7 @@ DEPENDENCIES
   chef (~> 18.10.17)
   chef-server-ctl!
   chefstyle
-  concurrent-ruby (>= 1.3.7)
+  concurrent-ruby (>= 1.3.8)
   knife (~> 19.0.105)
   knife-ec-backup (~> 3.0.8)
   public_suffix (< 7.0)

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -129,6 +129,13 @@ gem 'rexml', ">= #{resolve_safe_version.call(:MINIMUM_SAFE_REXML_VERSION)}"
 # gem 'net-imap', ">= #{resolve_safe_version.call(:NET_IMAP_FIX_VERSION)}", "= X.Y.Z" # pinned <reason>, YYYY-MM-DD
 gem 'net-imap', ">= #{resolve_safe_version.call(:NET_IMAP_FIX_VERSION)}"
 
+# concurrent-ruby (CHEF-37625 / GHSA-6wx8-w4f5-wwcr, GHSA-h8w8-99g7-qmvj [high],
+# GHSA-wv3x-4vxv-whpp -- Dependabot alerts 376, 379, 382). Bare floor, same
+# reasoning as src/chef-server-ctl/Gemfile's identical line: no
+# ruby_gems_cleanup.rb consumer exists for this gem, so it does not go through
+# resolve_safe_version.call(...)/safe_versions.rb.
+gem 'concurrent-ruby', ">= 1.3.8"
+
 gem 'omniauth-chef', '~> 0.4.1',
     git: "https://github.com/talktovikas/omniauth-chef.git",
     branch: "vikas/chef-upgrade"

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     config (4.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
@@ -765,6 +765,7 @@ DEPENDENCIES
   capybara (~> 3.39)
   chef (~> 18.10.17)
   coffee-rails (~> 5.0)
+  concurrent-ruby (>= 1.3.8)
   config (~> 4.1)
   doorkeeper (~> 5.0)
   factory_bot_rails (~> 6.4)

--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile
@@ -6,3 +6,12 @@ gemspec
 # expects it to be in the path
 gem 'veil'
 gem "rest-client", git: "https://github.com/chef/rest-client", branch: "jfm/ucrt_update1"
+
+# concurrent-ruby (CHEF-37625 / GHSA-6wx8-w4f5-wwcr, GHSA-h8w8-99g7-qmvj [high],
+# GHSA-wv3x-4vxv-whpp -- Dependabot alerts 372, 373, 374). Bare floor -- this
+# Gemfile has no safe_versions.rb/resolve_safe_version indirection at all (this
+# app isn't wired into any omnibus software definition's build step), so a
+# plain floor is the only option and is consistent with the same
+# no-cleanup-recipe-consumer reasoning documented in
+# src/chef-server-ctl/Gemfile's identical line.
+gem "concurrent-ruby", ">= 1.3.8"

--- a/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
+++ b/src/oc_bifrost/oc-bifrost-pedant/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       tzinfo (~> 2.0)
     base64 (0.3.0)
     bcrypt (3.1.20)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.8)
     diff-lcs (1.6.2)
     domain_name (0.6.20240107)
     fiddle (1.1.8)
@@ -77,6 +77,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  concurrent-ruby (>= 1.3.8)
   oc-bifrost-pedant!
   rest-client!
   veil


### PR DESCRIPTION
## NOTE

The oc-id verify failure is fixed here:
https://progresssoftware.atlassian.net/browse/CHEF-37669

## Summary

Adds an explicit `concurrent-ruby` version floor (`>= 1.3.8`) directly to **four** Gemfiles: `src/chef-server-ctl/Gemfile`, `src/oc-id/Gemfile`, `oc-chef-pedant/Gemfile`, and `src/oc_bifrost/oc-bifrost-pedant/Gemfile`. concurrent-ruby is a real (transitive, via chef/knife/berkshelf) dependency in all four.

Scope grew from the original single-file / `>= 1.3.7` plan (see first commit below) once investigation found the other three apps carry their own, separately-numbered Dependabot alerts for the same three CVEs in their own independent dependency graphs — all four are fixed together here. `>= 1.3.8` (rather than the ticket's literal `1.3.7` ask) was chosen so all four Gemfiles land on one consistent value.

Declared as a bare floor rather than routed through the `SafeVersions`/`resolve_safe_version.call` mechanism (unlike rack/rexml directly above it in `chef-server-ctl`'s Gemfile): that mechanism exists to keep a cleanup-recipe threshold (`ruby_gems_cleanup.rb`, in `chef-server-omnibus-config`) and a Gemfile floor from drifting apart *for the same gem*. concurrent-ruby has no on-disk cleanup consumer (no ticket or test/scan finding has established that need — live-VM testing confirmed a cleanup entry would actually break the embedded Chef Infra Client's own hard-pinned binstub, since the two share a gem root with no server/client separation), so there's no second consumer for that mechanism to keep in sync — see the companion `chef-server-omnibus-config` PR (documentation-only, same ticket) for the fuller rationale. `oc_bifrost-pedant`'s Gemfile has no `SafeVersions` indirection at all (it isn't wired into any omnibus software definition), so a bare floor is its only option regardless.

## Jira

https://progresssoftware.atlassian.net/browse/CHEF-37625

## CVEs closed

GHSA-6wx8-w4f5-wwcr, GHSA-h8w8-99g7-qmvj (high), GHSA-wv3x-4vxv-whpp — flagged independently per app: chef-server-ctl (Dependabot alerts 377, 380, 383), oc-id (376, 379, 382), oc-chef-pedant (375, 378, 381), oc_bifrost-pedant (372, 373, 374).

## Stacked branch note

This PR was originally stacked on top of `CHEF-33469/lbaker` (#4227, CHEF-35182 — the net-imap fix). **#4227 has since merged** (2026-08-19), so this PR's diff now reflects only this ticket's own 2 commits:
1. `7135543` — the original `>= 1.3.7`, chef-server-ctl-only floor.
2. `c4e2b400d` — expanded scope to `>= 1.3.8` across all four Gemfiles (see Summary above for why).

## Testing

* **Lockfile-mechanism consistency** (Docker, `ruby:3.1.3`, bundler 2.3.27): confirmed switching chef-server-ctl's floor from `resolve_safe_version.call`-indirection to a bare Gemfile line produced a byte-identical `Gemfile.lock` at the time (both forms interpolated to the same `>= 1.3.7` requirement) — a zero-regression mechanism change, prior to the later `1.3.8` version bump.
* **Real Vagrant/VirtualBox VM verification against the actual shipped build** (Buildkite build #8418, this branch's tip):
  * *Cold install*: confirmed concurrent-ruby resolves to `1.3.8` with the floor active in all 3 shippable Gemfile.locks (chef-server-ctl, oc-id, oc-chef-pedant — `oc_bifrost-pedant` is never packaged into the omnibus artifact), and the appbundler trampoline hard-pins exactly `1.3.8` for chef-server-ctl.
  * *Upgrade path*: real `dpkg -i` + `chef-server-ctl upgrade` + `chef-server-ctl start` from the latest stable release (15.10.114) to this build. Confirmed the floor is actively applied during a real upgrade, not just present on a cold install: concurrent-ruby goes from `1.3.7`/no-floor (chef-server-ctl) and `1.3.6`/no-floor (oc-id, oc-chef-pedant) pre-upgrade, to `1.3.8`/floored everywhere post-upgrade. Also confirmed the `ruby_gems_cleanup` recipe run during the upgrade touches only `rexml` — never `concurrent-ruby` — validating the no-cleanup-entry design decision on a real upgrade run, not just in source review.
* Full `chef-server-ctl` rspec suite (79/0) previously verified against the functionally-equivalent indirected version.
