### PR TITLE
CHEF-37669 - [verify pipeline fix] Fall back to omnibus submodule's safe_versions.rb when not copied into place

### DIFF
--- a/oc-chef-pedant/Gemfile
+++ b/oc-chef-pedant/Gemfile
@@ -40,10 +40,25 @@ source "https://rubygems.org"
 # files out from under this app's still-referencing Gemfile.lock at the
 # next reconfigure, breaking it at runtime instead of failing loudly at
 # bundle install/CI time the way a floor-plus-pin combination would.
+# Fallback location of safe_versions.rb inside the checked-out
+# chef-server-omnibus-config git submodule (omnibus/ in this repo), used
+# only when the Omnibus production build hasn't copied a local copy into
+# this directory first.
+OMNIBUS_SAFE_VERSIONS_PATH = '../omnibus/files/server-ctl-cookbooks/infra-server/libraries/safe_versions'.freeze
+
 begin
   require_relative 'safe_versions'
-rescue LoadError => e
-  warn "[Gemfile] safe_versions.rb not reachable (#{e.message}) -- no rack floor enforced this run."
+rescue LoadError
+  # Not present here unless the Omnibus production build copied it in first
+  # (see config/software/oc-chef-pedant.rb in chef-server-omnibus-config).
+  # Outside that build -- the bare Buildkite CI job, or a local dev with git
+  # submodules initialized -- fall back to reading it directly from the
+  # checked-out chef-server-omnibus-config submodule instead.
+  begin
+    require_relative OMNIBUS_SAFE_VERSIONS_PATH
+  rescue LoadError => e
+    warn "[Gemfile] safe_versions.rb not reachable (#{e.message}) -- no rack floor enforced this run."
+  end
 end
 
 resolve_safe_version = lambda do |const_name|

--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -40,10 +40,25 @@ source "https://rubygems.org"
 # files out from under this app's still-referencing Gemfile.lock at the
 # next reconfigure, breaking it at runtime instead of failing loudly at
 # bundle install/CI time the way a floor-plus-pin combination would.
+# Fallback location of safe_versions.rb inside the checked-out
+# chef-server-omnibus-config git submodule (../omnibus/ from here), used
+# only when the Omnibus production build hasn't copied a local copy into
+# this directory first.
+OMNIBUS_SAFE_VERSIONS_PATH = '../../omnibus/files/server-ctl-cookbooks/infra-server/libraries/safe_versions'.freeze
+
 begin
   require_relative 'safe_versions'
-rescue LoadError => e
-  warn "[Gemfile] safe_versions.rb not reachable (#{e.message}) -- no rack/rexml floor enforced this run."
+rescue LoadError
+  # Not present here unless the Omnibus production build copied it in first
+  # (see config/software/private-chef-ctl.rb in chef-server-omnibus-config).
+  # Outside that build -- the bare Buildkite CI job, or a local dev with git
+  # submodules initialized -- fall back to reading it directly from the
+  # checked-out chef-server-omnibus-config submodule instead.
+  begin
+    require_relative OMNIBUS_SAFE_VERSIONS_PATH
+  rescue LoadError => e
+    warn "[Gemfile] safe_versions.rb not reachable (#{e.message}) -- no rack/rexml floor enforced this run."
+  end
 end
 
 resolve_safe_version = lambda do |const_name|

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -42,10 +42,25 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # files out from under this app's still-referencing Gemfile.lock at the
 # next reconfigure, breaking it at runtime instead of failing loudly at
 # bundle install/CI time the way a floor-plus-pin combination would.
+# Fallback location of safe_versions.rb inside the checked-out
+# chef-server-omnibus-config git submodule (../../omnibus/ from here), used
+# only when the Omnibus production build hasn't copied a local copy into
+# this directory first.
+OMNIBUS_SAFE_VERSIONS_PATH = '../../omnibus/files/server-ctl-cookbooks/infra-server/libraries/safe_versions'.freeze
+
 begin
   require_relative 'safe_versions'
-rescue LoadError => e
-  warn "[Gemfile] safe_versions.rb not reachable (#{e.message}) -- no rack/rexml floor enforced this run."
+rescue LoadError
+  # Not present here unless the Omnibus production build copied it in first
+  # (see config/software/oc_id.rb in chef-server-omnibus-config). Outside
+  # that build -- the bare Buildkite CI job, or a local dev with git
+  # submodules initialized -- fall back to reading it directly from the
+  # checked-out chef-server-omnibus-config submodule instead.
+  begin
+    require_relative OMNIBUS_SAFE_VERSIONS_PATH
+  rescue LoadError => e
+    warn "[Gemfile] safe_versions.rb not reachable (#{e.message}) -- no rack/rexml floor enforced this run."
+  end
 end
 
 resolve_safe_version = lambda do |const_name|

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
       time
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.5.14)
+    net-imap (0.5.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -773,7 +773,7 @@ DEPENDENCIES
   jwt (>= 3.2.0)
   mailcatcher
   mixlib-authentication (>= 2.1, < 4)
-  net-imap (>= 0.5.14)
+  net-imap (>= 0.5.15)
   omniauth-chef (~> 0.4.1)!
   pg (>= 0.18, < 1.6)
   pry-byebug


### PR DESCRIPTION
## Summary

`src/oc-id/Gemfile`, `src/chef-server-ctl/Gemfile`, and `oc-chef-pedant/Gemfile` each `require_relative 'safe_versions'` from their own directory to enforce minimum safe rack/rexml/net-imap versions. That file is only ever copied into place by the real Omnibus production build (`config/software/oc_id.rb`, `private-chef-ctl.rb`, `oc-chef-pedant.rb` in `chef-server-omnibus-config`). Outside that build -- bare Buildkite CI jobs, or a local dev running the plain bundler install command directly in one of these directories -- the `require_relative` raises `LoadError`, which each Gemfile catches and fails open (warns, enforces no floor at all).

This was harmless until CHEF-33469/CHEF-35182/CHEF-37568 baked real floor values into each `Gemfile.lock`. `oc-id`'s Buildkite job runs bundler's deployment-mode install, which hard-fails when the fresh (unconstrained) resolution doesn't match those baked-in floors -- **confirmed failing on `main` right now** (build #12721). `chef-server-ctl` and `oc-chef-pedant` carry the identical LoadError/fail-open bug, but don't currently break their own CI jobs for two unrelated reasons (no deployment mode; Gemfile substituted away entirely in the pedant test jobs). Fixing all three together since they share the identical root cause and fix.

This PR adds a fallback `require_relative` inside each existing `rescue LoadError`, reading `safe_versions.rb` from the checked-out `chef-server-omnibus-config` submodule (`omnibus/` in this repo) before giving up and warning.

## Jira

https://progresssoftware.atlassian.net/browse/CHEF-37669

## Cross-repo dependency

This fix is **dormant on merge** -- it stays a no-op until:
1. [chef/chef-server-omnibus-config#27](https://github.com/chef/chef-server-omnibus-config/pull/27) merges (still open as of this PR), and
2. this repo's `omnibus/` submodule pointer is advanced past that merge (currently pinned at `458ef0d4c`, one commit behind `chef-server-omnibus-config`'s `main`).

Until both land, `safe_versions.rb` doesn't exist at the fallback path either, so behavior is unchanged from today (fails open, same warning as before).

## Testing

Verified in an isolated sandbox (mirroring each Gemfile's directory depth and the submodule's relative path, without touching the real submodule) across all 3 real-world scenarios:
1. **File absent everywhere** (today's actual state) -> fails open, identical warning as before -- unchanged.
2. **File present only via the submodule fallback path** (future state, post PR #27 + submodule bump) -> loads successfully, no warning -- **the fix works**.
3. **File present via same-directory production copy** (the real Omnibus build) -> loads successfully, fallback never even attempted -- production path untouched.

All 3 Gemfiles syntax-checked (`ruby -c`) and diff-reviewed (33 insertions / 6 deletions total, minimal and identical in shape across all three).

## Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
