### PR TITLE
CHEF-37962 - Add faraday >= 2.14.3 floor to chef-server-ctl and oc-id Gemfiles

### DIFF
--- a/src/chef-server-ctl/Gemfile
+++ b/src/chef-server-ctl/Gemfile
@@ -123,3 +123,18 @@ gem "rexml", ">= #{resolve_safe_version.call(:MINIMUM_SAFE_REXML_VERSION)}"
 # of this bare floor only if a future ticket or test finding creates that
 # second (cleanup) consumer.
 gem "concurrent-ruby", ">= 1.3.8"
+
+# faraday (CHEF-37252 / GHSA-98m9-hrrm-r99r [high], GHSA-5rv5-xj5j-3484 [low] --
+# Dependabot alerts 385, 345). Declared as a plain, direct floor here -- NOT
+# routed through the SafeVersions/resolve_safe_version mechanism above, unlike
+# rack/rexml. That indirection exists specifically so ruby_gems_cleanup.rb (in
+# chef-server-omnibus-config) and a Gemfile floor for the *same* gem can't drift
+# apart -- it's a single source of truth for two consumers, not a generic place
+# to declare any gem's minimum version. There is no ruby_gems_cleanup.rb entry
+# for faraday (no ticket or on-disk test finding has established a
+# stale/vulnerable-version-left-on-disk cleanup need for it, unlike
+# rack/rexml/net-imap), so there is only one consumer here -- nothing for
+# SafeVersions to keep in sync. Add a SafeVersions constant instead of this bare
+# floor only if a future ticket or test finding creates that second (cleanup)
+# consumer.
+gem "faraday", ">= 2.14.3"

--- a/src/chef-server-ctl/Gemfile.lock
+++ b/src/chef-server-ctl/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     ed25519 (1.4.0)
     erubi (1.13.1)
     erubis (2.7.0)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -210,7 +210,7 @@ GEM
       faraday (>= 1, < 3)
     faraday-http-cache (2.5.1)
       faraday (>= 0.8)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.16.3)
     ffi-libarchive (1.1.14)
@@ -512,6 +512,7 @@ DEPENDENCIES
   chef-server-ctl!
   chefstyle
   concurrent-ruby (>= 1.3.8)
+  faraday (>= 2.14.3)
   knife (~> 19.0.105)
   knife-ec-backup (~> 3.0.8)
   public_suffix (< 7.0)

--- a/src/oc-id/Gemfile
+++ b/src/oc-id/Gemfile
@@ -136,6 +136,13 @@ gem 'net-imap', ">= #{resolve_safe_version.call(:NET_IMAP_FIX_VERSION)}"
 # resolve_safe_version.call(...)/safe_versions.rb.
 gem 'concurrent-ruby', ">= 1.3.8"
 
+# faraday (CHEF-37252 / GHSA-98m9-hrrm-r99r [high], GHSA-5rv5-xj5j-3484 [low] --
+# Dependabot alerts 384, 344). Bare floor, same reasoning as
+# src/chef-server-ctl/Gemfile's identical line: no ruby_gems_cleanup.rb consumer
+# exists for this gem, so it does not go through
+# resolve_safe_version.call(...)/safe_versions.rb.
+gem 'faraday', ">= 2.14.3"
+
 gem 'omniauth-chef', '~> 0.4.1',
     git: "https://github.com/talktovikas/omniauth-chef.git",
     branch: "vikas/chef-upgrade"

--- a/src/oc-id/Gemfile.lock
+++ b/src/oc-id/Gemfile.lock
@@ -316,13 +316,13 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.16.3)
     ffi-libarchive (1.1.14)
@@ -769,6 +769,7 @@ DEPENDENCIES
   config (~> 4.1)
   doorkeeper (~> 5.0)
   factory_bot_rails (~> 6.4)
+  faraday (>= 2.14.3)
   jbuilder (~> 2.11)
   jquery-rails
   jwt (>= 3.2.0)


### PR DESCRIPTION
## Summary

Adds an explicit `faraday` version floor (`>= 2.14.3`) directly to two Gemfiles: `src/chef-server-ctl/Gemfile` and `src/oc-id/Gemfile`. faraday is a real (transitive) dependency in both — via `chef-licensing`, `faraday-follow_redirects`, `faraday-http-cache`, `inspec-core`, `octokit`, `sawyer` on chef-server-ctl; `faraday-follow_redirects`, `inspec-core` on oc-id.

Declared as a bare floor rather than routed through the `SafeVersions`/`resolve_safe_version.call` mechanism (unlike rack/rexml/net-imap/concurrent-ruby immediately above it in both Gemfiles): that mechanism exists to keep a cleanup-recipe threshold (`ruby_gems_cleanup.rb`, in `chef-server-omnibus-config`) and a Gemfile floor from drifting apart *for the same gem*. faraday has no on-disk cleanup consumer — no ticket or test/scan finding has established a stale-version-left-on-disk cleanup need for it — so there's no second consumer for that mechanism to keep in sync with this floor.

## Jira

https://progresssoftware.atlassian.net/browse/CHEF-37962

## CVEs closed

- **GHSA-98m9-hrrm-r99r** / CVE-2026-54297 (high, CVSS 7.5): uncontrolled recursion in `NestedParamsEncoder` allows stack exhaustion DoS via deeply nested query parameters. Fixed in 2.14.3. Dependabot alerts **385** (chef-server-ctl), **384** (oc-id).
- **GHSA-5rv5-xj5j-3484** / CVE-2026-33637 (low): incomplete fix for GHSA-33mh-2634-fwr2 — protocol-relative URI objects still bypass host scoping. Fixed in 2.14.2 (2.14.3 supersedes it). Dependabot alerts **345** (chef-server-ctl), **344** (oc-id).

## Testing

* **Lockfile regeneration** (Docker, `ruby:3.1.3` + bundler 2.3.27, matching the pinned `BUNDLED WITH`): confirmed a minimal, expected diff in both lockfiles — `faraday` 2.14.1 → 2.14.3, transitive `faraday-net_http` 3.4.2 → 3.4.4 (expected resolver side effect, not drift), plus the new `faraday (>= 2.14.3)` line in each `DEPENDENCIES` section. `BUNDLED WITH` unchanged in both files.
* **Manual VM verification (fresh install + upgrade) is still pending.** Will confirm the `ruby_gems_cleanup` recipe does **not** touch faraday during a real upgrade run (expected, matching this bare-floor/no-cleanup-entry design), and will report results here once done.

## Related

Supersedes #4184 (oc-id-only, stale at 2.14.2, no chef-server-ctl fix) — recommend closing that PR once this one merges.

Sibling fix: chef/chef-server-omnibus-config#33 — a second, independent source of the same faraday vulnerability, found in that repo's own top-level Gemfile (build/CI tooling only, never shipped in chef-server-core). This branch also carries a temporary "REVERT ME" commit bumping the `omnibus/` submodule pointer to #33's unmerged commit, so an adhoc build can validate that fix end-to-end before #33 merges — see the commit message for revert instructions; it must be reverted before this PR merges.