### PR TITLE
Replace removed crypto:random_bytes/1 with crypto:strong_rand_bytes/1

### DIFF
--- a/src/bookshelf/test/bkswt_api_SUITE.erl
+++ b/src/bookshelf/test/bkswt_api_SUITE.erl
@@ -702,7 +702,7 @@ random_path() ->
     filename:join(random_binary(), random_binary()).
 
 test_data(Size) ->
-    crypto:random_bytes(Size).
+    crypto:strong_rand_bytes(Size).
 
 test_data_text(Size) ->
     random_string(Size, " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\n" ).


### PR DESCRIPTION
## Problem

`bkswt_api_SUITE:test_data/1` calls `crypto:random_bytes/1`, which was removed from OTP years ago and does not exist in any currently supported release. Calling it raises `undef` — on the pinned OTP 26 today, and equally on 27 and 28:

```erlang
1> crypto:random_bytes(4).
** exception error: undefined function crypto:random_bytes/4
   {'EXIT', {undef, [{crypto,random_bytes,[4],[]}, ...]}}
```

Two things have kept this hidden:

1. Remote calls are not resolved at compile time, so the build never flags it.
2. `test_data/1` is currently unreferenced within the suite (only its sibling `test_data_text/1` is called), and it survives the "function unused" check only because the suite sets `-compile(export_all)`.

It is therefore a latent landmine rather than a live failure — but it is exactly the kind of thing worth clearing out before an OTP upgrade, since anyone wiring `test_data/1` into a case would hit an `undef` that looks like an OTP regression.

## Fix

`crypto:strong_rand_bytes/1` is the supported replacement, and is already what `bookshelf_bench` uses to build test payloads of a given size (`bookshelf_bench.erl:109` and `:149`), so this keeps the helper consistent with the rest of the app.

```erlang
 test_data(Size) ->
-    crypto:random_bytes(Size).
+    crypto:strong_rand_bytes(Size).
```

## How this was found

While auditing the Erlang sources ahead of an OTP upgrade, I checked every `module:function` pair in the tree against the exports of a real OTP 28 runtime. Nine pairs came back unresolved; eight were remote *type* references in specs and records (`calendar:datetime()`, `dict:dict()`, `file:io_device()`, `file:posix()`, `re:mp()`, `proplists:proplist()`, `gb_trees:tree()`, `calendar:datetime1970()`), which are all legitimate. `crypto:random_bytes` was the only genuine hit in the entire tree.