### PR TITLE
Bump the pc plugin from 1.8.0 to 1.15.0

### DIFF
--- a/src/oc_bifrost/rebar.config
+++ b/src/oc_bifrost/rebar.config
@@ -82,7 +82,7 @@
     ]}
 ]}.
 
-{plugins, [{pc, "1.8.0"}]}. % Locked to avoid fallout related to: https://github.com/blt/port_compiler/issues/43
+{plugins, [{pc, "1.15.0"}]}.
 
 {ct_opts, [{ct_hooks, [cth_readable_shell]}]}.
 


### PR DESCRIPTION
port_compiler 1.8.0 does not build on OTP 27. Its `pc_port_env` module calls the two-argument `code:lib_dir/2`, deprecated in OTP 27, and rebar3 compiles plugins with warnings as errors — so the plugin fails to load before any of `oc_bifrost` is compiled:

```
===> Compiling _build/default/plugins/pc/src/pc_port_env.erl failed
pc_port_env.erl:197:10: code:lib_dir/2 is deprecated; this functionality will be removed in a future release
===> Errors loading plugin {pc,"1.8.0"}
```

1.15.0 uses the single-argument `code:lib_dir/1`, which is not deprecated.

## The pin's stated reason no longer applies

The comment cites [port_compiler#43](https://github.com/blt/port_compiler/issues/43), **closed 2018-05-02**; v1.10.0 shipped two weeks later.

`oc_erchef` and `bookshelf` already depend on `pc` **unpinned**, so they resolve 1.15.0 today. `oc_bifrost` is the only one held back — this brings it in line.

## Verified

Against `erlang:26` and `erlang:27` containers (the latter with `require_otp_vsn` relaxed, since that gate is a separate matter):

| OTP | pc | Result |
| --- | --- | --- |
| 26 | 1.15.0 | `Compiling bifrost` — no regression |
| 27 | 1.8.0 | plugin fails to load (above) |
| 27 | 1.15.0 | plugin loads, zero `code:lib_dir/2` diagnostics |

## Scope

This does **not** make `oc_bifrost` build on OTP 27 on its own — it removes the *first* blocker. The next is `mochiweb`, whose `mochiweb_multipart` module trips unused-function warnings under `warnings_as_errors`. That is a separate change.