### PR TITLE
Bump mochiweb to 3.5.0 so it compiles on OTP 27

### DIFF
--- a/src/bookshelf/rebar.lock
+++ b/src/bookshelf/rebar.lock
@@ -80,7 +80,7 @@
   0},
  {<<"mochiweb">>,
   {git,"https://github.com/mochi/mochiweb",
-       {ref,"666ac57d5cad8da0341e53db884855ee9a9805b0"}},
+       {ref,"52bc688521efb5b11d1faf9d0d38c14c31b03b5a"}},
   0},
  {<<"observer_cli">>,
   {git,"https://github.com/zhongwencool/observer_cli",

--- a/src/oc_bifrost/rebar.lock
+++ b/src/oc_bifrost/rebar.lock
@@ -44,7 +44,7 @@
   0},
  {<<"mochiweb">>,
   {git,"https://github.com/mochi/mochiweb",
-       {ref,"666ac57d5cad8da0341e53db884855ee9a9805b0"}},
+       {ref,"52bc688521efb5b11d1faf9d0d38c14c31b03b5a"}},
   0},
  {<<"observer_cli">>,
   {git,"https://github.com/zhongwencool/observer_cli",

--- a/src/oc_erchef/rebar.lock
+++ b/src/oc_erchef/rebar.lock
@@ -108,7 +108,7 @@
   0},
  {<<"mochiweb">>,
   {git,"https://github.com/mochi/mochiweb",
-       {ref,"666ac57d5cad8da0341e53db884855ee9a9805b0"}},
+       {ref,"52bc688521efb5b11d1faf9d0d38c14c31b03b5a"}},
   0},
  {<<"neotoma">>,
   {git,"https://github.com/seancribbs/neotoma",


### PR DESCRIPTION
OTP 27 enables the `maybe` expression (EEP-49) by default, which makes **`maybe` a reserved word**. mochiweb 3.1.1 uses it as a bare atom in `mochiweb_multipart`, so the module no longer parses:

```
mochiweb_multipart.erl:278:13: syntax error before: ','
mochiweb_multipart.erl:331:9: syntax error before: ','
```

Those are `{maybe, Start}` and `{maybe, Skip}`. The half-dozen `function ... is unused` warnings reported alongside them are **fallout from the failed parse**, not separate problems — worth noting, because at a glance they look like the actual issue.

## The fix

Upstream quoted the atom (`{'maybe', ...}`) in **3.2.2**. This goes to **3.5.0** = `52bc688521efb5b11d1faf9d0d38c14c31b03b5a`, which is the current head of the `main` branch that all three `rebar.config` files **already declare they track**:

```erlang
{mochiweb, ".*", {git, "https://github.com/mochi/mochiweb", {branch, "main"}}},
```

The lockfiles had simply held at `666ac57` (3.1.1, 2023-02-12) since then. So this is the lock catching up with the declared intent, landing on a tagged release.

## Verified

In containers, from a clean `_build`:

| | Result |
| --- | --- |
| **OTP 26** | `oc_bifrost`, `bookshelf` and `oc_erchef` all compile — no regression |
| **OTP 27** | with this plus the `pc` bump, **`oc_bifrost` compiles through to completion** — no mochiweb syntax errors, no further blockers in that service |

The OTP 27 runs relax `require_otp_vsn`, still pinned to `26.2.5.21`, which is a separate decision.

## Related

- #4243 bumps the `pc` plugin, the blocker immediately before this one. Both are needed for `oc_bifrost` on OTP 27.

One incidental finding while testing: **lager itself compiles cleanly on OTP 27**. It is not a compile-time blocker, whatever its other problems.