### PR TITLE
Move the Erlang services off lager onto OTP logger

### DIFF
--- a/src/bookshelf/rebar.config
+++ b/src/bookshelf/rebar.config
@@ -7,9 +7,6 @@
 {erl_dep_retries, 10}.
 
 {deps, [
-    %% lager has to come first since we use its parse transform
-    {lager, ".*",
-        {git, "https://github.com/erlang-lager/lager",              {branch, "master"}}},
     {cf, "",
         {git, "https://github.com/project-fifo/cf",                 {branch, "master"}}},
     {chef_secrets, ".*",
@@ -46,7 +43,6 @@
 
 {erl_opts, [
     debug_info,
-    {parse_transform, lager_transform},
     warnings_as_errors,
     {i, "include"}
 ]}.

--- a/src/bookshelf/src/bksw_cleanup_task.erl
+++ b/src/bookshelf/src/bksw_cleanup_task.erl
@@ -19,6 +19,8 @@
 %%
 
 -module(bksw_cleanup_task).
+
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 -export([start_link/0]).
@@ -79,20 +81,20 @@ code_change(_OldVsn, State, _Extra) ->
 do_delete_cleanup(#state{deleted_cleanup_interval = Interval}) ->
     case sqerl:select(purge_expired, [Interval], first_as_scalar, [purge_expired]) of
         {ok, Count} ->
-            lager:debug("Cleanup task: cleaned up ~p expired file_data elements", [Count]),
+            ?LOG_DEBUG("Cleanup task: cleaned up ~p expired file_data elements", [Count]),
             Count;
         _Error ->
-            lager:debug("Cleanup task: error cleaning up expired file_data elements", []),
+            ?LOG_DEBUG("Cleanup task: error cleaning up expired file_data elements", []),
             0
     end.
 
 do_upload_cleanup(#state{upload_cleanup_interval = Interval}) ->
     case sqerl:select(cleanup_abandoned_uploads, [Interval], first_as_scalar, [cleanup_abandoned_uploads]) of
         {ok, Count} ->
-            lager:debug("Cleanup task: cleaned up ~p expired file_data elements", [Count]),
+            ?LOG_DEBUG("Cleanup task: cleaned up ~p expired file_data elements", [Count]),
             Count;
         _Error ->
-            lager:debug("Cleanup task: error cleaning up expired file_data elements", []),
+            ?LOG_DEBUG("Cleanup task: error cleaning up expired file_data elements", []),
             0
     end.
 

--- a/src/bookshelf/src/bksw_sup.erl
+++ b/src/bookshelf/src/bksw_sup.erl
@@ -21,6 +21,8 @@
 
 -module(bksw_sup).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(supervisor).
 
 -export([start_link/0]).
@@ -71,9 +73,9 @@ ensure_default_bucket() ->
     DefaultBucket = <<"bookshelf">>,
     case bksw_sql:bucket_exists(DefaultBucket) of
         true ->
-            lager:info("Default bucket ~p already exists.", [DefaultBucket]),
+            ?LOG_INFO("Default bucket ~p already exists.", [DefaultBucket]),
             ok;
         false ->
-            lager:info("Create default bucket ~p.", [DefaultBucket]),
+            ?LOG_INFO("Create default bucket ~p.", [DefaultBucket]),
             bksw_sql:create_bucket(DefaultBucket)
     end.

--- a/src/bookshelf/src/bksw_wm_sql_object.erl
+++ b/src/bookshelf/src/bksw_wm_sql_object.erl
@@ -218,7 +218,7 @@ send_streamed_body(#context{entry_md = #db_file{chunk_count = ChunkCount, hash_s
         ShaExpected ->
             ok;
         S ->
-            lager:error("checksum mismatch on download: expected: ~p; sent: ~p", [ShaExpected, S])
+            ?LOG_ERROR("checksum mismatch on download: expected: ~p; sent: ~p", [ShaExpected, S])
     end,
     {<<>>, done};
 send_streamed_body(#context{entry_md = #db_file{data_id = DataId} = DbFile,
@@ -324,7 +324,7 @@ write_streamed_body({Data, done}, Rq0,
                     ok = finalize_maybe_create_file(Rq1, Ctx0, File1),
                     {{halt, 204}, Rq1, Ctx1};
                 _ ->
-                    lager:error("Mismatch between Content-MD5 and actual content. Content-MD5: ~p; Actual: ~p", [RequestMd5, HashMd5]),
+                    ?LOG_ERROR("Mismatch between Content-MD5 and actual content. Content-MD5: ~p; Actual: ~p", [RequestMd5, HashMd5]),
                     %% Exiting here causes uploads to be abandoned, but the upload_cleanup task will
                     %% eventually clean things up.
                     {{halt, 406}, Rq0, Ctx1}

--- a/src/bookshelf/src/bookshelf.app.src
+++ b/src/bookshelf/src/bookshelf.app.src
@@ -34,7 +34,6 @@
                     erlsom,
                     mini_s3,
                     inets,
-                    lager,
                     envy,
                     opscoderl_wm,
                     iso8601,

--- a/src/bookshelf/src/internal.hrl
+++ b/src/bookshelf/src/internal.hrl
@@ -26,17 +26,11 @@
 -define(PGSQL_RETRY_INTERVAL, 5).
 
 %% logging utilities
--compile([{parse_transform, lager_transform}]).
-%% For general info and error logging, we use error_logger and take advantage of lager's
-%% error_logger handler. The main benefit is seeing the logs via sasl instead of lager for
-%% common test. We _could_ take this approach to make lager a soft dependency, but once you
-%% want to add debug-level logging you need direct lager calls.
--define(LOG_INFO(X, Y), error_logger:info_msg(X, Y)).
--define(LOG_INFO(X), error_logger:info_msg(X)).
--define(LOG_ERROR(X, Y), error_logger:error_msg(X, Y)).
--define(LOG_ERROR(X), error_logger:error_msg(X)).
--define(LOG_DEBUG(X, Y), lager:debug(X, Y)).
--define(LOG_DEBUG(X), lager:debug(X)).
+%% OTP's logger provides ?LOG_INFO/?LOG_ERROR/?LOG_DEBUG at the same arities
+%% the lager/error_logger definitions it replaces did, so every existing call
+%% site is unchanged. The macros (rather than logger:Level/2 calls) are what
+%% capture module, function and line -- the job lager's parse transform did.
+-include_lib("kernel/include/logger.hrl").
 
 -include("bksw_obj.hrl").
 

--- a/src/bookshelf/test/bkswt_api_SUITE.erl
+++ b/src/bookshelf/test/bkswt_api_SUITE.erl
@@ -111,11 +111,6 @@ start_bookshelf() ->
     %% it from the ?APPS list so that we don't start/stop on each test.
     application:start(sasl),
 
-    %% we start lager since we depend on it for the release. However,
-    %% we want to keep error_logger on its own so that we continue to
-    %% see messages in common test output.
-    lager_common_test_backend:bounce(error),
-
     case application:ensure_all_started(bookshelf) of
         {ok, Apps} ->
             {ok, Apps};

--- a/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost.app.src
@@ -16,7 +16,6 @@
   %% manually in bifrost_app.erl.)
   {applications, [kernel,
                   stdlib,
-                  lager,
                   sasl,
                   stats_hero,
                   ej,

--- a/src/oc_bifrost/apps/bifrost/src/bifrost_wm_base.erl
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost_wm_base.erl
@@ -1,5 +1,7 @@
 -module(bifrost_wm_base).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([content_types_accepted/2,
          content_types_provided/2,
          create_path/2,
@@ -178,7 +180,7 @@ spawn_stats_hero_worker(Req, #base_state{reqid=ReqId,
             ok;
         {error, Reason} ->
             %% TODO: Need to put this to a separate file
-            lager:error(io_lib:format("FAILED stats_hero_worker_sup:new_worker: ~p~n", [Reason])),
+            ?LOG_ERROR(io_lib:format("FAILED stats_hero_worker_sup:new_worker: ~p~n", [Reason])),
             ok
     end.
 

--- a/src/oc_bifrost/apps/bifrost/src/bifrost_wm_status_resource.erl
+++ b/src/oc_bifrost/apps/bifrost/src/bifrost_wm_status_resource.erl
@@ -1,5 +1,7 @@
 -module(bifrost_wm_status_resource).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([
          allowed_methods/2,
          content_types_provided/2,
@@ -24,6 +26,6 @@ to_json(Req, State) ->
         ok ->
             {<<"{\"status\": \"ok\"}">>, Req, State};
         {error, Reason} ->
-            lager:error(io_lib:format("status check: ~999p~n", [Reason])),
+            ?LOG_ERROR(io_lib:format("status check: ~999p~n", [Reason])),
             {{halt, 500}, Req, State}
     end.

--- a/src/oc_bifrost/rebar.config
+++ b/src/oc_bifrost/rebar.config
@@ -4,7 +4,6 @@
 
 {erl_opts, [
             warnings_as_errors,
-            {parse_transform, lager_transform},
             debug_info
            ]}.
 {erl_first_files, ["src/bifrost_wm.erl"]}.
@@ -12,9 +11,6 @@
 {require_otp_vsn, "26.2.5.21"}.
 
 {deps, [
-    %% lager has to come first since we use its parse transform
-    {lager, ".*",
-        {git, "https://github.com/erlang-lager/lager",                  {branch, "master"}}},
     {chef_secrets, ".*",
         {git, "https://github.com/chef/chef_secrets",                   {branch, "main"}}},
     {edown, ".*",
@@ -102,7 +98,6 @@
         envy,
         sqerl,
         stats_hero,
-        lager,
         bifrost
    ]},
 

--- a/src/oc_erchef/apps/chef_index/src/chef_index.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index.erl
@@ -17,6 +17,8 @@
 
 -module(chef_index).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([search/1,
          update/1,
          update/2,
@@ -140,7 +142,7 @@ add_batch_item_with_retries(Item, Failures, Max) ->
             Error;
         Error ->
             Retries = Failures + 1,
-            lager:warning("chef_index:add failed for ~s[~s]: ~p retrying (~p/~p)", [TypeName, Id, Error, Retries, Max]),
+            ?LOG_WARNING("chef_index:add failed for ~s[~s]: ~p retrying (~p/~p)", [TypeName, Id, Error, Retries, Max]),
             wait_before_retry(),
             add_batch_item_with_retries(Item, Retries, Max)
     end.
@@ -153,14 +155,14 @@ wait_before_retry() ->
 wait_before_retry(0, 0) ->
     ok;
 wait_before_retry(Min, Min) ->
-    lager:info("chef_index: waiting ~B ms before retry", [Min]),
+    ?LOG_INFO("chef_index: waiting ~B ms before retry", [Min]),
     timer:sleep(Min);
 wait_before_retry(Min, Max) when Min > Max ->
-    lager:error("chef_index: reindex_sleep_max_ms less than reindex_sleep_min_ms. Sleeping ~B", [Max]),
+    ?LOG_ERROR("chef_index: reindex_sleep_max_ms less than reindex_sleep_min_ms. Sleeping ~B", [Max]),
     timer:sleep(Max);
 wait_before_retry(Min, Max) ->
     RandMinMax = Min + rand:uniform(Max - Min),
-    lager:info("chef_index: waiting ~B ms before retry", [RandMinMax]),
+    ?LOG_INFO("chef_index: waiting ~B ms before retry", [RandMinMax]),
     timer:sleep(RandMinMax).
 
 not_ok(Results) ->

--- a/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_index_batch.erl
@@ -16,6 +16,8 @@
 %%
 
 -module(chef_index_batch).
+
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 -ifdef(TEST).
@@ -179,7 +181,7 @@ flush(State = #chef_idx_batch_state{item_queue = Queue,
     spawn(
       fun() ->
               prometheus_gauge:inc(chef_index_batch_inflight_flushes_count),
-              lager:debug("Batch posting to ~s ~p documents (~p bytes)", [Provider, length(DocsToAdd), CurrentSize + WrapperSize]),
+              ?LOG_DEBUG("Batch posting to ~s ~p documents (~p bytes)", [Provider, length(DocsToAdd), CurrentSize + WrapperSize]),
               Now = erlang:monotonic_time(),
               Res = chef_index:update(Provider, Doc),
               Now1 = erlang:monotonic_time(),
@@ -238,7 +240,7 @@ handle_call(stats, _From, State = #chef_idx_batch_state{avg_queue_latency = OQL,
             ],
     {reply, Stats, State};
 handle_call(stop, From, State) ->
-    lager:info("Stop requested from ~p", [From]),
+    ?LOG_INFO("Stop requested from ~p", [From]),
     {stop, normal, ok, State};
 handle_call(_Request, _From, State) ->
     Reply = ok,
@@ -257,7 +259,7 @@ collect_process_info() ->
             prometheus_gauge:set(chef_index_batch_memory_size_bytes, MemorySizeBytes),
             prometheus_gauge:set(chef_index_batch_mailbox_size, MailboxSize);
         Other ->
-            lager:warning("unexpected process_info reponse: ~w", [Other])
+            ?LOG_WARNING("unexpected process_info reponse: ~w", [Other])
     end.
 
 

--- a/src/oc_erchef/apps/chef_index/src/chef_wait_group.erl
+++ b/src/oc_erchef/apps/chef_index/src/chef_wait_group.erl
@@ -16,6 +16,8 @@
 %%
 -module(chef_wait_group).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(gen_server).
 
 %% API Exports
@@ -124,7 +126,7 @@ handle_call(get_state, _From, State) ->
 handle_info({'EXIT', _From, normal}, State) ->
     {noreply, State};
 handle_info({'EXIT', From, Reason}, State) ->
-    lager:error("Worker ~p failed unexpectedly: ~p", [From, Reason]),
+    ?LOG_ERROR("Worker ~p failed unexpectedly: ~p", [From, Reason]),
     State1 = mark_job_failed(From, {worker_failed, Reason}, State),
     case maybe_reply_to_waiter(State1) of
         true ->

--- a/src/oc_erchef/apps/chef_license/src/chef_license_worker.erl
+++ b/src/oc_erchef/apps/chef_license/src/chef_license_worker.erl
@@ -1,5 +1,7 @@
 -module(chef_license_worker).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(gen_server).
 
 -include("../../../include/chef_types.hrl").
@@ -120,21 +122,21 @@ get_license_info(InstallTime, cli) ->
       case catch jiffy:decode(Bin) of
         {Json} -> Json;
         _ ->
-          lager:warning("CLI license check returned invalid JSON, falling back to default license"),
+          ?LOG_WARNING("CLI license check returned invalid JSON, falling back to default license"),
           make_license_payload(InstallTime, #{})
       end;
     {error, Reason} ->
-      lager:debug("CLI license file not found (~p), falling back to default license", [Reason]),
+      ?LOG_DEBUG("CLI license file not found (~p), falling back to default license", [Reason]),
       make_license_payload(InstallTime, #{})
   end;
 % This is for the file-based license mode, where we read the license directly from a file path.
 get_license_info(InstallTime, Path) ->
   case load_local_license(InstallTime, Path) of
     {ok, Json} ->
-      lager:debug("Loaded local license data: ~p", [Json]),
+      ?LOG_DEBUG("Loaded local license data: ~p", [Json]),
       Json;
     {error, Reason} ->
-      lager:warning("Failed to load local license, falling back to default: ~p", [Reason]),
+      ?LOG_WARNING("Failed to load local license, falling back to default: ~p", [Reason]),
       make_license_payload(InstallTime, #{})
   end.
 
@@ -200,7 +202,7 @@ make_license_payload(InstallTime, _Other) ->
   %% If we don't have the expected fields, we don't have a valid license - so let's make something that looks like one,
   %% but is valid from the install date + 90 days.
   ExpirationTime = InstallTime + (60 * 60 * 24 * 90), % 90 days from install time
-  lager:debug("License payload is missing expected fields, treating as valid license with expiration : ~p", [ExpirationTime]),
+  ?LOG_DEBUG("License payload is missing expected fields, treating as valid license with expiration : ~p", [ExpirationTime]),
   [ {<<"result">>, {[
                     {<<"license_id">>, <<>>},
                     {<<"customer_name">>, <<>>},
@@ -220,7 +222,7 @@ check_license(#state{install_time = InstallTime} = State,  ModeOrPath) ->
   JsonStr = case catch get_license_info(InstallTime, ModeOrPath) of
               Result when is_list(Result) -> Result;
               {'EXIT', N} ->
-                lager:error("License check failed with exit: ~p", [N]),
+                ?LOG_ERROR("License check failed with exit: ~p", [N]),
                 <<"">>
             end,
   case process_license(JsonStr) of

--- a/src/oc_erchef/apps/chef_objects/src/chef_cbv_cache.erl
+++ b/src/oc_erchef/apps/chef_objects/src/chef_cbv_cache.erl
@@ -21,6 +21,8 @@
 %%
 
 -module(chef_cbv_cache).
+
+-include_lib("kernel/include/logger.hrl").
 -behavior(gen_server).
 
 -define(SERVER, ?MODULE).
@@ -206,7 +208,7 @@ handle_info({expire, Key}, #state{tid = Tid} = State) ->
     ets:delete(Tid, Key),
     {noreply, State};
 handle_info({'EXIT', _From, Reason}, State) ->
-    lager:error("chef_cbv_cache: circuit breaker proc failed because ~p, restarting", [Reason]),
+    ?LOG_ERROR("chef_cbv_cache: circuit breaker proc failed because ~p, restarting", [Reason]),
     spawn_breaker(),
     {noreply, State};
 handle_info(_Info, State) ->
@@ -242,7 +244,7 @@ insert_into_cache(Tid, Key, Value, TTL) ->
         false ->
             % Value already exists.  Given the enforced ordering to prevent more than
             % one caller from trying to put the same key, this should no longer be possible
-            lager:info("chef_cbv_cache: Key ~p already present, ignoring.", [Key])
+            ?LOG_INFO("chef_cbv_cache: Key ~p already present, ignoring.", [Key])
     end.
 
 spawn_breaker() ->

--- a/src/oc_erchef/apps/chef_telemetry/rebar.config
+++ b/src/oc_erchef/apps/chef_telemetry/rebar.config
@@ -4,9 +4,6 @@
 
 {deps,
     [
-    %% lager has to come first since we use its parse transform
-    {lager, ".*",
-        {git, "https://github.com/erlang-lager/lager",                {branch, "master"}}}
     ]
 }.
 
@@ -19,7 +16,6 @@
 
 {erl_opts, [
     warnings_as_errors,
-    {parse_transform, lager_transform},
     debug_info
 ]}.
 

--- a/src/oc_erchef/apps/chef_telemetry/src/chef_telemetry.app.src
+++ b/src/oc_erchef/apps/chef_telemetry/src/chef_telemetry.app.src
@@ -26,7 +26,6 @@
     {applications, [
         kernel,
         stdlib,
-        lager,
         chef_secrets,
         opscoderl_httpc
     ]},

--- a/src/oc_erchef/apps/data_collector/rebar.config
+++ b/src/oc_erchef/apps/data_collector/rebar.config
@@ -4,9 +4,6 @@
 
 {deps,
     [
-    %% lager has to come first since we use its parse transform
-    {lager, ".*",
-        {git, "https://github.com/erlang-lager/lager",                {branch, "master"}}},
     {opscoderl_httpc, ".*",
         {git, "https://github.com/chef/opscoderl_httpc",              {branch, "main"}}},
     {pooler, ".*",
@@ -23,7 +20,6 @@
 
 {erl_opts, [
     warnings_as_errors,
-    {parse_transform, lager_transform},
     debug_info
 ]}.
 

--- a/src/oc_erchef/apps/data_collector/src/data_collector.app.src
+++ b/src/oc_erchef/apps/data_collector/src/data_collector.app.src
@@ -28,7 +28,6 @@
     {applications, [
         kernel,
         stdlib,
-        lager,
         chef_secrets,
         opscoderl_httpc
     ]},

--- a/src/oc_erchef/apps/data_collector/src/data_collector_http.erl
+++ b/src/oc_erchef/apps/data_collector/src/data_collector_http.erl
@@ -1,5 +1,7 @@
 -module(data_collector_http).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([
          request/3,
          request/4,
@@ -85,12 +87,12 @@ request_with_caught_errors(Path, Method, Body, Headers) ->
 %%
 -spec create_pool() -> ok.
 create_pool() ->
-    lager:info("Creating Data Collector HTTP pool"),
+    ?LOG_INFO("Creating Data Collector HTTP pool"),
     oc_httpc:add_pool(?MODULE, application:get_all_env()),
     ok.
 
 -spec delete_pool() -> ok.
 delete_pool() ->
-    lager:info("Removing Data Collector HTTP pool"),
+    ?LOG_INFO("Removing Data Collector HTTP pool"),
     oc_httpc:delete_pool(?MODULE),
     ok.

--- a/src/oc_erchef/apps/data_collector/test/data_collector_test_utils.erl
+++ b/src/oc_erchef/apps/data_collector/test/data_collector_test_utils.erl
@@ -37,7 +37,6 @@ setup(MockedModules) ->
         {ibrowse_options, [{connect_timeout, 10000}]}
     ],
     [application:set_env(data_collector, Name, Value) || {Name, Value} <- Env],
-    lager:start(),
     setup_chef_secrets(),
     application:start(pooler),
     application:start(ibrowse),

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_org_creator.erl
@@ -5,6 +5,8 @@
 
 -module(oc_chef_authz_org_creator).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([
          create_org/2,
          create_org/3
@@ -197,7 +199,7 @@ create_object(ApiVersion, OrgId, RequestorId, Type, [Name | Remaining], Cache) -
         Error ->
             %% Do we clean up created authz stuff here, or save it for
             %% general org deletion routine later?
-            lager:error("Could not create object ~p during creation of org ~s",
+            ?LOG_ERROR("Could not create object ~p during creation of org ~s",
                         [{Type, Name}, OrgId]),
             throw(Error)
     end.
@@ -355,6 +357,6 @@ find(Key, C) ->
     case dict:find(Key, C) of
         {ok, Value} -> Value;
         error ->
-            lager:error("Error processing org creation policy, no definition found for ~p", [Key]),
+            ?LOG_ERROR("Error processing org creation policy, no definition found for ~p", [Key]),
             throw( {error, bad_org_creation_policy})
     end.

--- a/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
+++ b/src/oc_erchef/apps/oc_chef_authz/src/oc_chef_authz_scoped_name.erl
@@ -20,6 +20,8 @@
 
 -module(oc_chef_authz_scoped_name).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("chef_types.hrl").
 -include("oc_chef_types.hrl").
 
@@ -432,7 +434,7 @@ render_names_from_org_id_f(_OrgId, {AnotherOrgId, Names}, Expanded) ->
     %% be robust to that. Thought we will log a warning message to be transparent.
     case org_id_to_name(AnotherOrgId) of
         not_found ->
-            lager:warning("Unable to find organization with id '~p'~n", [AnotherOrgId]),
+            ?LOG_WARNING("Unable to find organization with id '~p'~n", [AnotherOrgId]),
             Expanded;
         OrgName ->
             ENames = [ make_name(OrgName, Name) || Name <- Names ],

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_containers_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_containers_SUITE.erl
@@ -22,12 +22,13 @@
 
 -module(oc_chef_wm_containers_SUITE).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include_lib("common_test/include/ct.hrl").
 -include("chef_types.hrl").
 -include("oc_chef_types.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile([{parse_transform, lager_transform}]).
 
 -define(ORG_AUTHZ_ID, <<"10000000000000000000000000000000">>).
 -define(AUTHZ_ID, <<"00000000000000000000000000000001">>).
@@ -74,7 +75,7 @@ delete_all_containers() ->
                  Error ->
                      throw(Error)
              end,
-    lager:info("Delete containers: ~p", [Result]),
+    ?LOG_INFO("Delete containers: ~p", [Result]),
     ok.
 
 list_when_no_containers(_) ->

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_cookbook_artifact_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_cookbook_artifact_SUITE.erl
@@ -10,7 +10,6 @@
 -include("oc_chef_types.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile([{parse_transform, lager_transform}]).
 
 -define(ORG_AUTHZ_ID, <<"10000000000000000000000000000004">>).
 -define(AUTHZ_ID, <<"00000000000000000000000000000005">>).

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_keys_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_keys_SUITE.erl
@@ -25,7 +25,6 @@
 -include("oc_chef_wm.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile([{parse_transform, lager_transform}]).
 
 -define(CLIENT_NAME, <<"client1">>).
 -define(CLIENT_NAME2, <<"client2">>).

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_policies_SUITE.erl
@@ -10,7 +10,7 @@
 -include("oc_chef_types.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-%%-compile([export_all, {parse_transform, lager_transform}]).
+%%-compile([export_all]).
 
 -define(ORG_ID, <<"10000000000000000000000000000001">>).
 -define(ORG_AUTHZ_ID, <<"10000000000000000000000000000002">>).

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_sanboxes_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_sanboxes_SUITE.erl
@@ -10,7 +10,6 @@
 -include("oc_chef_types.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile([{parse_transform, lager_transform}]).
 
 -define(ORG_AUTHZ_ID, <<"10000000000000000000000000000003">>).
 -define(AUTHZ_ID, <<"00000000000000000000000000000004">>).

--- a/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_server_api_version_SUITE.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/oc_chef_wm_server_api_version_SUITE.erl
@@ -23,7 +23,6 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile([{parse_transform, lager_transform}]).
 
 -define(ORG_NAME, <<"org1">>).
 -define(ORG_AUTHZ_ID, <<"10000000000000000000000000000002">>).

--- a/src/oc_erchef/apps/oc_chef_wm/itest/setup_helper.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/itest/setup_helper.erl
@@ -50,8 +50,6 @@ start_server(Config) ->
     application:set_env(chef_db, couchdb_host, "localhost"),
     application:set_env(chef_db, couchdb_port, 6984),
 
-    application:set_env(lager, error_logger_redirect, false),
-
     %% Set bcrypt rounds to the minimum, speeding up password hashing during
     %% user record creation
     application:set_env(bcrypt, default_log_rounds, 4, [{persistent, true}]),
@@ -141,8 +139,6 @@ needed_apps() ->
      chef_objects,
      compiler,
      syntax_tools,
-     goldrush,
-     lager,
      chef_index,
      oc_chef_authz,
      oc_chef_wm].

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_reindex.erl
@@ -17,6 +17,8 @@
 %% under the License.
 
 -module(chef_reindex).
+
+-include_lib("kernel/include/logger.hrl").
 -compile([warnings_as_errors]).
 
 -ifdef(namespaced_types).
@@ -47,7 +49,7 @@
 -spec reindex(Ctx :: chef_db:db_context(), OrgInfo :: org_info()) ->
                      {ok, list()} | {error, list(), list()}.
 reindex(Ctx, {OrgId, OrgName}=OrgInfo) ->
-    lager:info("reindexing[~s]: reindex requested for ~s", [OrgName, OrgName]),
+    ?LOG_INFO("reindexing[~s]: reindex requested for ~s", [OrgName, OrgName]),
     AllIndexes = fetch_org_indexes(Ctx, OrgId),
     Results = [reindex(Ctx, OrgInfo, Index) || Index <- AllIndexes ],
     {FailedList, MissingList} = lists:unzip(Results),
@@ -55,10 +57,10 @@ reindex(Ctx, {OrgId, OrgName}=OrgInfo) ->
     FlatMissing = lists:flatten(MissingList),
     case FlatFailures of
         [] ->
-            lager:info("reindexing[~s]: reindex complete!", [OrgName]),
+            ?LOG_INFO("reindexing[~s]: reindex complete!", [OrgName]),
             {ok, FlatMissing};
         F ->
-            lager:info("reindexing[~s]: reindex FAILED!", [OrgName]),
+            ?LOG_INFO("reindexing[~s]: reindex FAILED!", [OrgName]),
             {error, F, FlatMissing}
     end.
 
@@ -121,7 +123,7 @@ reindex(Ctx, {OrgId, OrgName}=OrgInfo, Index) ->
     %% Grab all the database IDs to do batch retrieval on
     AllIds = all_ids_from_name_id_dict(NameIdDict),
     BatchSize = envy:get(oc_chef_wm, reindex_batch_size, pos_integer),
-    lager:info("reindexing[~s]: ~p items of type ~p to reindex", [OrgName, length(AllIds), Index]),
+    ?LOG_INFO("reindexing[~s]: ~p items of type ~p to reindex", [OrgName, length(AllIds), Index]),
     batch_reindex(Ctx, AllIds, BatchSize, OrgInfo, Index, NameIdDict).
 
 %% @doc Reindex the objects with the specified `Ids' in the given `Index'.
@@ -141,20 +143,20 @@ reindex_by_id(Ctx, {OrgId, _OrgName} = OrgInfo, Index, Ids) ->
                       Names :: [binary()]) -> {list(), list()}.
 reindex_by_name(Ctx, {OrgId, OrgName} = OrgInfo, Index, Names) ->
     NameIdDict = chef_db:create_name_id_dict(Ctx, Index, OrgId),
-    lager:debug("NameIdDict in reindex_by_name for Org: ~p Index: ~p is ~p ~n", [OrgName, Index, NameIdDict]),
+    ?LOG_DEBUG("NameIdDict in reindex_by_name for Org: ~p Index: ~p is ~p ~n", [OrgName, Index, NameIdDict]),
     {Ids, MissingList} = lists:foldl(
                           fun(Name, {Acc, Missing}) ->
                             case dict:find(Name, NameIdDict) of
                               {ok, Id} ->
                                 {[Id | Acc], Missing};
                               error ->
-                                lager:warning("skipping: no id found for name ~p", [Name]),
+                                ?LOG_WARNING("skipping: no id found for name ~p", [Name]),
                                 %% The lager warning does not print anything on the console
                                 {Acc, [Name | Missing]}
                             end
                           end, {[], []}, Names),
-    lager:debug("Ids that will be reindexed: ~p ~n", [Ids]),
-    lager:debug("Ids that are missing: ~p ~n", [MissingList]),
+    ?LOG_DEBUG("Ids that will be reindexed: ~p ~n", [Ids]),
+    ?LOG_DEBUG("Ids that are missing: ~p ~n", [MissingList]),
     {ok, BatchSize} = application:get_env(oc_chef_wm, reindex_batch_size),
     case MissingList of
         [] ->
@@ -218,7 +220,7 @@ batch_reindex(Ctx, Ids, BatchSize, OrgInfo, Index, NameIdDict) when is_list(Ids)
                     Index :: index(),
                     NameIdDict :: dict()) -> {ok, list()} | {{error, list()}, list()}.
 index_a_batch(Ctx, BatchOfIds, {OrgId, OrgName}, Index, NameIdDict) ->
-    lager:debug("reindexing[~s] indexing batch of ~p ~ss", [OrgName, length(BatchOfIds), Index]),
+    ?LOG_DEBUG("reindexing[~s] indexing batch of ~p ~ss", [OrgName, length(BatchOfIds), Index]),
     SerializedObjects = chef_db:bulk_get(Ctx, OrgName, chef_object_type(Index), BatchOfIds),
     send_to_index_queue(OrgName, OrgId, Index, SerializedObjects, NameIdDict).
 
@@ -265,9 +267,9 @@ log_failures(_OrgName, []) ->
 log_failures(OrgName, [Failure | Rest]) ->
     case Failure of
         {{TypeName, Id, _DbName}, Reason} ->
-            lager:error("reindexing[~s] item ~s[~s] failed to reindex: ~s", [OrgName, TypeName, Id, Reason]);
+            ?LOG_ERROR("reindexing[~s] item ~s[~s] failed to reindex: ~s", [OrgName, TypeName, Id, Reason]);
         Other ->
-            lager:error("reindexing[~s] unexpected reindexing failure: ~w", [OrgName, Other])
+            ?LOG_ERROR("reindexing[~s] unexpected reindexing failure: ~w", [OrgName, Other])
     end,
     log_failures(OrgName, Rest).
 
@@ -307,7 +309,7 @@ stub_records_for_indexing([SO | Rest], NameKey, NameIdDict, Index, OrgId, Existi
                                  StubRec = stub_record(Index, OrgId, ObjectId, ItemName, PreliminaryEJson),
                                  {[{StubRec, PreliminaryEJson} | ExistingAcc], MissingAcc};
                              error ->
-                                 lager:warning("skipping: no id found for name ~p", [ItemName]),
+                                 ?LOG_WARNING("skipping: no id found for name ~p", [ItemName]),
                                  {ExistingAcc, [{Index, ItemName} | MissingAcc]}
                          end,
     stub_records_for_indexing(Rest, NameKey, NameIdDict, Index, OrgId, NewEAcc, NewMAcc).

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_depsolver.erl
@@ -23,6 +23,8 @@
 
 -module(chef_wm_depsolver).
 
+-include_lib("kernel/include/logger.hrl").
+
 %% chef_wm behaviour callbacks
 -include("oc_chef_wm.hrl").
 -behaviour(chef_wm).
@@ -109,7 +111,7 @@ process_post(Req, #base_state{reqid = ReqId,
     EnvConstraints = chef_object_base:depsolver_constraints(Env),
     case chef_db:fetch_all_cookbook_version_dependencies(DbContext, OrgId) of
         {error, Error} ->
-            lager:error("Dependency retrieval failure for org ~p with environment ~p: ~p~n",
+            ?LOG_ERROR("Dependency retrieval failure for org ~p with environment ~p: ~p~n",
                                    [OrgName, EnvName, Error]),
             server_error(Req, State, <<"Dependency retrieval failed">>, dep_retrieval_failure);
         AllVersions ->
@@ -233,7 +235,7 @@ handle_depsolver_results(ok, {error, no_depsolver_workers}, Req, State) ->
             no_depsolver_workers);
 %% log the exception and return a 500
 handle_depsolver_results(ok, {error, exception, Message, Backtrace}, Req, State) ->
-    lager:error([{module, ?MODULE},
+    ?LOG_ERROR([{module, ?MODULE},
                                {error_type, depsolver_ruby_exception},
                                {message, Message},
                                {backtrace, Backtrace}]),
@@ -303,7 +305,7 @@ make_json_list(OrgId, CookbookVersions, URI, ApiVersion) ->
 
 make_json_list(_CookbookVersions, _URI, _ApiVersion, Key, ?CACHE_MAX_RETRIES) ->
     % Waiting is good, but let's not hang the client up forever.
-    lager:info("chef_wm_depsolver:make_json_list ~p - forcing retry after giving up on ~p", [self(), Key]),
+    ?LOG_INFO("chef_wm_depsolver:make_json_list ~p - forcing retry after giving up on ~p", [self(), Key]),
     {error, busy};
 make_json_list(CookbookVersions, URI, ApiVersion, Key, NumAttempts) ->
     case chef_cbv_cache:get(Key) of

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_search.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_search.erl
@@ -26,6 +26,8 @@
 
 -module(chef_wm_search).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 -include("chef_solr.hrl").
 
@@ -188,7 +190,7 @@ filter_permitted_results(ReqId, RequestorId, OrgId, DbContext, {data_bag, BagNam
                 false -> [];
                 true -> Ids;
                 Error ->
-                    lager:error("is_authorized_on_resource failed (~p, ~p, ~p): ~p~n",
+                    ?LOG_ERROR("is_authorized_on_resource failed (~p, ~p, ~p): ~p~n",
                                 [read, {data_bag, BagName}, RequestorId, Error]),
                     {{halt, 500}, ReqId}
             end
@@ -206,7 +208,7 @@ filter_permitted_results(ReqId, RequestorId, _OrgId, DbContext, IndexType, Ids) 
         {false, {_NoAuthzList, AuthzList}} ->
             AuthzList;
         {error, Why} ->
-            lager:error("failed to check permissions due to ~p on ~p~n", [Why, AuthzIds])
+            ?LOG_ERROR("failed to check permissions due to ~p on ~p~n", [Why, AuthzIds])
     end.
 
 %% Return current app config value for batch size, defaulting if absent.

--- a/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/chef_wm_status.erl
@@ -24,6 +24,8 @@
 
 -module(chef_wm_status).
 
+-include_lib("kernel/include/logger.hrl").
+
 -ifdef(TEST).
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -91,7 +93,7 @@ overall_status(Pings) ->
 -spec log_failure(fail | pong, [{binary(), <<_:32>>}]) -> ok.
 log_failure(fail, Pings) ->
     FailureData = {{status, fail}, {upstreams, {Pings}}},
-    lager:error("/_status~n~p~n", [FailureData]),
+    ?LOG_ERROR("/_status~n~p~n", [FailureData]),
     ok;
 log_failure(_, _) ->
     ok.
@@ -164,7 +166,7 @@ gather_health_workers([{{Pid, Ref}, Mod} | Rest] = List, Acc) ->
         %% crash. But to avoid the possibility of blocking with a bare receive, we set the
         %% timeout and return early.
         Timeout ->
-            lager:error({Mod, ping, hard_fail}),
+            ?LOG_ERROR({Mod, ping, hard_fail}),
             [ {?A2B(Mod), <<"fail">>} | Acc ]
     end;
 gather_health_workers([], Acc) ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_data_collector.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_data_collector.erl
@@ -1,5 +1,7 @@
 -module(oc_chef_data_collector).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 -export([notify/2]).
@@ -39,7 +41,7 @@ notify(Req, #base_state{reqid = ReqId, resource_state = ResourceState, resource_
                     ok ->
                         ok;
                     {error, Error} ->
-                        lager:debug("Data Collector notify failed: ~p", [Error])
+                        ?LOG_DEBUG("Data Collector notify failed: ~p", [Error])
                 end;
             %% If we're here then we've matched a resource that we want to report
             %% but the request has to have failed with a non-successful response
@@ -47,7 +49,7 @@ notify(Req, #base_state{reqid = ReqId, resource_state = ResourceState, resource_
             %% collector we'll skip the resource.
             {ReqMethod, _, _} ->
                 ResCode = wrq:response_code(Req),
-                lager:debug("Data Collector notify skipped for ~p ~p (~p)", [ReqMethod, ResourceState, ResCode]),
+                ?LOG_DEBUG("Data Collector notify skipped for ~p ~p (~p)", [ReqMethod, ResourceState, ResCode]),
                 ok
         end;
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm.app.src
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm.app.src
@@ -21,8 +21,6 @@
                   chef_objects,
                   compiler,
                   syntax_tools,
-                  goldrush,
-                  lager,
                   eldap,
                   data_collector,
                   chef_license

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authn_ldap.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_authn_ldap.erl
@@ -19,6 +19,8 @@
 %
 -module(oc_chef_wm_authn_ldap).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([auth_method/1, authenticate/2]).
 
 -include("chef_types.hrl").
@@ -125,7 +127,7 @@ find_and_authenticate_user(Session, User, Password, Config) ->
             case eldap:simple_bind(Session, CN, Password) of
                 ok -> {UserName, Data};
                 {error, Error} ->
-                    lager:info("ldap authentication failed for ~p: ~p", [User, Error]),
+                    ?LOG_INFO("ldap authentication failed for ~p: ~p", [User, Error]),
                     {error, unauthorized}
             end
     end.
@@ -136,36 +138,36 @@ search_result({error, Reason}) ->
     %% An error response means some kind of failure occurred - no
     %% matching results would not result in an error tuple, but rather
     %% an empty result set.
-    lager:error("LDAP search failed unexpectedly: ~p", [Reason]),
+    ?LOG_ERROR("LDAP search failed unexpectedly: ~p", [Reason]),
     error.
 
 bind(Session, BindDN, BindPassword) ->
     case eldap:simple_bind(Session, BindDN, BindPassword) of
         ok -> ok;
         {error, Error} ->
-            lager:error("Could not bind as ~p, please check chef-server.rb for correct bind_dn, bind_password, host, port and encrpytion values. Error: ~p", [BindDN, Error]),
+            ?LOG_ERROR("Could not bind as ~p, please check chef-server.rb for correct bind_dn, bind_password, host, port and encrpytion values. Error: ~p", [BindDN, Error]),
             {error, Error}
     end.
 
 maybe_encrypt_session(_Encryption, {error, Error}, _Timeout) ->
-    lager:error("Failed to connect to ldap host or an error occurred during connection setup. Please check chef-server.rb for correct host, port, and encryption values: ~p", [Error]),
+    ?LOG_ERROR("Failed to connect to ldap host or an error occurred during connection setup. Please check chef-server.rb for correct host, port, and encryption values: ~p", [Error]),
     error;
 maybe_encrypt_session(start_tls, {ok, Session}, Timeout) ->
     case eldap:start_tls(Session, [{verify, verify_none}], Timeout) of
         ok -> % secure upgrade completed
             {ok, Session};
         {error, tls_already_started} ->
-            lager:warning("start_tls on ldap session ignored request, tls already started"),
+            ?LOG_WARNING("start_tls on ldap session ignored request, tls already started"),
             {ok, Session}; % connection is already secure
         {error, {response, Reason}} ->  % Connection is still good, but is not made secure.
             % Because we're configured to require secure connection,  we'll fail here.
-            lager:error("start_tls on ldap session failed during request phase: ~p", [Reason]),
+            ?LOG_ERROR("start_tls on ldap session failed during request phase: ~p", [Reason]),
             error;
         {error, Other} ->
-            lager:error("start_tls on ldap session failed during upgrade phase: ~p", [Other]),
+            ?LOG_ERROR("start_tls on ldap session failed during upgrade phase: ~p", [Other]),
             error;
         Other ->
-            lager:error("start_tls on ldap session failed because ~p", [Other])
+            ?LOG_ERROR("start_tls on ldap session failed because ~p", [Other])
     end;
 maybe_encrypt_session(_, {ok, Session}, _) ->
     {ok, Session}.
@@ -179,7 +181,7 @@ canonical_username(Username) ->
                  [{return, list}, global])).
 
 result_to_user_ejson(_, UserName, []) ->
-    lager:info("User ~p not found in LDAP", [UserName]),
+    ?LOG_INFO("User ~p not found in LDAP", [UserName]),
     {error, unauthorized};
 result_to_user_ejson(LoginAttr, UserName, [{eldap_entry, CN, DataIn} | _]) ->
     % No guarantees on casing, so let's not make assumptions:

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_base.erl
@@ -21,6 +21,8 @@
 
 -module(oc_chef_wm_base).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
@@ -236,7 +238,7 @@ multi_auth_check_to_wm_response({false, {_AuthzObjectType, _AuthzId, Permission}
 multi_auth_check_to_wm_response({Error, {AuthzObjectType, AuthzId, Permission}, Req, State}) ->
     #base_state{requestor_id=RequestorId} = State,
     %% TODO: Extract this logging message, as it is used elsewhere, too
-    lager:error("is_authorized_on_resource failed (~p, ~p, ~p): ~p~n",
+    ?LOG_ERROR("is_authorized_on_resource failed (~p, ~p, ~p): ~p~n",
                            [Permission, {AuthzObjectType, AuthzId}, RequestorId, Error]),
     {{halt, 500}, Req, State#base_state{log_msg={error, is_authorized_on_resource}}}.
 
@@ -436,7 +438,7 @@ check_permission(Perm, AuthzObjectType, AuthzId, Req, #base_state{requestor_id=R
             {Req1, State1} = set_forbidden_msg(Req, State),
             {false, Req1, State1};
         Error ->
-            lager:error("is_authorized_on_resource failed (~p, ~p, ~p, ~p): ~p~n",
+            ?LOG_ERROR("is_authorized_on_resource failed (~p, ~p, ~p, ~p): ~p~n",
                                    [Perm, {AuthzObjectType, AuthzId}, RequestorId, Name, Error]),
             {{halt, 500}, Req, State#base_state{log_msg={error, is_authorized_on_resource}}}
     end.
@@ -553,7 +555,7 @@ spawn_stats_hero_worker(Req, #base_state{resource_mod = Mod,
         {ok, _} ->
             ok;
         {error, Reason} ->
-            lager:error("FAILED stats_hero_worker_sup:new_worker: ~p~n", [Reason]),
+            ?LOG_ERROR("FAILED stats_hero_worker_sup:new_worker: ~p~n", [Reason]),
             ok
     end.
 
@@ -650,7 +652,7 @@ check_cookbook_authz(Cookbooks, _Req, #base_state{reqid = ReqId,
         true -> ok;
         {error, Why} ->
             Report = {check_cookbook_authz, {Why, ReqId}},
-            lager:error("~p", [Report]),
+            ?LOG_ERROR("~p", [Report]),
             error(Report);
         {false, {NoAuthzList, _AuthzList}} ->
             {error, {[{<<"message">>, <<"Read permission is not granted for one or more cookbooks">>},
@@ -819,15 +821,15 @@ finish_request(Req, #base_state{reqid = ReqId,
         end
     catch
         X:Y:Stacktrace ->
-            lager:error("Error: ~p:~p. Stack trace follows.", [X, Y]),
-            lager:error("Stack Trace: ~p",  [Stacktrace]),
+            ?LOG_ERROR("Error: ~p:~p. Stack trace follows.", [X, Y]),
+            ?LOG_ERROR("Stack Trace: ~p",  [Stacktrace]),
             % If a failure occurs anywhere above, the request is completed (and changes
             % potentially made) but our bookkeeping has failed. Let's not crash the request
             % resulting in a 500 - which would indicate that the request should be retried.
             {true, Req, State}
     end;
 finish_request(_Req, Anything) ->
-    lager:error("chef_wm:finish_request/2 did not receive #base_state{}~nGot: ~p~n", [Anything]).
+    ?LOG_ERROR("chef_wm:finish_request/2 did not receive #base_state{}~nGot: ~p~n", [Anything]).
 
 log_action(Req, State) ->
     maybe_notify_data_collector(data_collector:is_enabled(), Req, State).
@@ -900,7 +902,7 @@ malformed_request(Req, #base_state{resource_mod=Mod,
             Req3 = wrq:set_resp_body(chef_json:encode(Msg1), Req),
             {{halt, 400}, Req3, State1#base_state{log_msg = bad_sign_desc}};
         throw:{too_big, Msg} ->
-            lager:info("json too large (~p)", [Msg]),
+            ?LOG_INFO("json too large (~p)", [Msg]),
             Req3 = wrq:set_resp_body(chef_json:encode({[{<<"error">>, Msg}]}), Req),
             {{halt, 413}, Req3, State1#base_state{log_msg = too_big}};
         throw:{acl_constraint_violation, Violation} ->
@@ -1109,7 +1111,7 @@ create_from_json(#wm_reqdata{} = Req,
             % 500 logging sanitizes responses to avoid exposing sensitive data -
             % TODO - parse sql error to get minimal meaningful message,
             % without exposing sensitive data
-            % lager:error("Error in object creation: ~p", [What]),
+            % ?LOG_ERROR("Error in object creation: ~p", [What]),
             {{halt, 500}, Req, State#base_state{log_msg = What}}
     end.
 
@@ -1181,7 +1183,7 @@ update_from_json(#wm_reqdata{} = Req, #base_state{reqid=ReqId,
                     State1 = State#base_state{log_msg = Why},
                     % TODO - parse sql error to get minimal meaningful message,
                     % without exposing sensitive data
-                    % lager:error("Error in object creation: ~p", [Why]),
+                    % ?LOG_ERROR("Error in object creation: ~p", [Why]),
                     {{halt, 500}, Req, State1}
             end
     end.
@@ -1274,7 +1276,7 @@ select_user_or_webui_key(Req, Requestors) ->
                             %% The proplist for webui_pub_key_list has been parsed, so the
                             %% key should exist as an atom
                             throw:badarg:Stacktrace ->
-                                lager:error({"unknown webkey tag", Tag,
+                                ?LOG_ERROR({"unknown webkey tag", Tag,
                                                            Stacktrace}),
                                 %% alternately, we could just use the default key instead of failing;
                                 %% but I prefer noisy errors
@@ -1289,7 +1291,7 @@ select_user_or_webui_key(Req, Requestors) ->
                     PublicKey;
                 {error, unknown_key} ->
                     Msg = io_lib:format("Failed finding key ~w", [WebKeyTag]),
-                    lager:error({no_such_key, Msg, [?MODULE, ?LINE]}),
+                    ?LOG_ERROR({no_such_key, Msg, [?MODULE, ?LINE]}),
                     throw({no_such_key, WebKeyTag})
             end,
             % The query in chef_sql:fetch_actors_by_name (whence we get Requestors) sorts

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_controls.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_controls.erl
@@ -5,6 +5,8 @@
 
 -module(oc_chef_wm_controls).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
@@ -71,7 +73,7 @@ validate_request('POST', Req, #base_state{resource_state = ControlState} = State
             {Req, State#base_state{resource_state =
                                      ControlState#control_state{control_data = Data}}};
         #ej_invalid{} = Error ->
-             lager:error(": ~p", [Error]),
+             ?LOG_ERROR(": ~p", [Error]),
              throw(Error)
     end.
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_organization.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_organization.erl
@@ -5,6 +5,8 @@
 
 -module(oc_chef_wm_named_organization).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
@@ -160,7 +162,7 @@ delete_read_access_group(DbContext, AuthzContext, OrgName, RequestorId) ->
         {not_found, authz_group} ->
             %% Ignoring this error lets us retry the whole deletion process if it fails part
             %% of the way through
-            lager:error("Could not find read access group when deleting org ~s", [OrgName]),
+            ?LOG_ERROR("Could not find read access group when deleting org ~s", [OrgName]),
             ok
     end.
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_group.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_group.erl
@@ -21,6 +21,8 @@
 
 -module(oc_chef_wm_named_policy_group).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
@@ -117,7 +119,7 @@ build_policy_revisions_json(Req, ReqId, DbContext, OrgId, PolicyGroupName) ->
     case chef_db:find_all_policy_revisions_associated_to_group(DbContext, OrgId, PolicyGroupName) of
         {error, Why} ->
             Report = {find_all_policy_revisions_by_group_and_name, {Why, ReqId}},
-            lager:error("~p", [Report]),
+            ?LOG_ERROR("~p", [Report]),
             error(Report);
 
         PolicyRevisionIDs ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_named_revision.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_named_policy_named_revision.erl
@@ -21,6 +21,8 @@
 %% /policies/:policy_name/revisions/:revision_id
 -module(oc_chef_wm_named_policy_named_revision).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
@@ -113,7 +115,7 @@ to_json(Req, #base_state{chef_db_context = DbContext,
         case chef_db:list_policy_groups_for_policy_revision(DbContext, RevisionID) of
             {error, Why} ->
                 Report = {list_policy_groups_for_policy_revision, {Why}},
-                lager:error("~p", [Report]),
+                ?LOG_ERROR("~p", [Report]),
                 error(Report);
 
             PolicyGroupNames ->

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_org_associations.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_org_associations.erl
@@ -18,6 +18,8 @@
 
 -module(oc_chef_wm_org_associations).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
@@ -216,11 +218,11 @@ deprovision_user(Req, #base_state{organization_name = OrgName,
             EJ = chef_user:assemble_user_ejson(User, OrgName),
             {true, chef_wm_util:set_json_body(Req, EJ), State#base_state{log_msg = {removed, UserName, from, OrgName}}};
         {warning, Warnings} ->
-            lager:error("Warnings in deprovision of ~p from ~p: ~p", [UserName, OrgName, Warnings]),
+            ?LOG_ERROR("Warnings in deprovision of ~p from ~p: ~p", [UserName, OrgName, Warnings]),
             EJ = chef_user:assemble_user_ejson(User, OrgName),
             {true, chef_wm_util:set_json_body(Req, EJ), State#base_state{log_msg = {warning_in_deprovision, Warnings}}};
         {error, Error} ->
-            lager:error("Error in deprovision of ~p from ~p: ~p", [UserName, OrgName, Error]),
+            ?LOG_ERROR("Error in deprovision of ~p from ~p: ~p", [UserName, OrgName, Error]),
             {{halt, 500}, Req, State#base_state{log_msg = {error_in_deprovision, Error}}}
      end.
 

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policies.erl
@@ -6,6 +6,8 @@
 
 -module(oc_chef_wm_policies).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
@@ -73,7 +75,7 @@ to_json(Req, #base_state{chef_db_context = DbContext,
     case chef_db:list_all_policy_revisions_by_orgid(DbContext, OrgId) of
         {error, Why} ->
             Report = {list_all_policy_revisions_by_orgid, {Why, ReqId}},
-            lager:error("~p", [Report]),
+            ?LOG_ERROR("~p", [Report]),
             error(Report);
         AllRevisions ->
             BaseEJSON = build_base_policy_list_ejson(Req, AllRevisions),

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_groups.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_policy_groups.erl
@@ -21,6 +21,8 @@
 
 -module(oc_chef_wm_policy_groups).
 
+-include_lib("kernel/include/logger.hrl").
+
 -include("oc_chef_wm.hrl").
 
 %% Webmachine resource callbacks
@@ -87,7 +89,7 @@ to_json(Req, #base_state{chef_db_context = DbContext, organization_guid = OrgId,
     case chef_db:find_all_policy_revisions_by_group_and_name(DbContext, OrgId) of
         {error, Why} ->
             Report = {find_all_policy_revisions_by_group_and_name, {Why, ReqId}},
-            lager:error("~p", [Report]),
+            ?LOG_ERROR("~p", [Report]),
             error(Report);
         PolicyGroupRevisionIDs ->
             EJSON = build_nested_list_data(PolicyGroupRevisionIDs, BaseEJSON),

--- a/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
+++ b/src/oc_erchef/apps/oc_chef_wm/src/oc_chef_wm_sup.erl
@@ -5,6 +5,8 @@
 
 -module(oc_chef_wm_sup).
 
+-include_lib("kernel/include/logger.hrl").
+
 -behaviour(supervisor).
 
 %% External exports
@@ -76,7 +78,7 @@ load_ibrowse_config() ->
     %% FIXME: location of the ibrowse.config should be itself configurable. Also need to
     %% revisit what's in that config to ensure it is as useful as possible.
     ConfigFile = filename:absname(filename:join(["etc", "ibrowse", "ibrowse.config"])),
-    lager:info("Loading ibrowse configuration from ~s~n", [ConfigFile]),
+    ?LOG_INFO("Loading ibrowse configuration from ~s~n", [ConfigFile]),
     ok = ibrowse:rescan_config(ConfigFile),
     ok.
 

--- a/src/oc_erchef/rebar.config
+++ b/src/oc_erchef/rebar.config
@@ -5,9 +5,6 @@
 {require_otp_vsn, "26.2.5.21"}.
 
 {deps, [
-    %% lager has to come first since we use its parse transform
-    {lager, ".*",
-        {git, "https://github.com/erlang-lager/lager",              {branch, "master"}}},
     {bcrypt, ".*",
         {git, "https://github.com/erlangpack/bcrypt",               {branch, "master"}}},
     {cf, "",
@@ -78,7 +75,6 @@
             {d, 'CHEF_WM_DARKLAUNCH', xdarklaunch_req},
             % Note: OC_LICENSE_PATH value is set dynamically in rebar.config.script
             % {d, OC_LICENSE_PATH, cli|"path/to/license/file"}
-            {parse_transform, lager_transform},
                 warnings_as_errors,
                 debug_info,
             {platform_define, "^[0-9]+", namespaced_types},

--- a/src/oc_erchef/src/oc_erchef.app.src
+++ b/src/oc_erchef/src/oc_erchef.app.src
@@ -35,8 +35,7 @@
                            chef_telemetry,
                            chef_license
                           ]},
-  {applications, [lager,
-                  chef_secrets,
+  {applications, [                  chef_secrets,
                   chef_index,
                   depsolver,
                   bear,


### PR DESCRIPTION
Replaces every `lager` call in `oc_erchef`, `oc_bifrost` and `bookshelf` with the OTP logger macros from `kernel/include/logger.hrl`, and drops the lager dependency, its parse transform and its application entries.

**86 call sites across 31 files**, plus 5 `rebar.config`s and 6 `.app.src` files.

## Why

`lager` is unmaintained and reaches inside OTP in four places rather than merely using it:

- `lager_stdlib.erl` is a verbatim copy of unexported OTP stdlib functions — *"Functions from Erlang OTP distribution that are really useful but aren't exported"*, **Copyright Ericsson AB 1996-2009** — and `lager_format.erl` is a fork of `io_lib_format` (1996-2011-2012).
- `lager_app` starts the deprecated `error_logger`, installs OTP's internal `error_logger` module as a logger handler **by hand** rather than through `error_logger:add_report_handler`, then calls `logger:remove_handler(default)` to delete OTP's own default handler. Its own comment calls this *"a band-aid"* for OTP 21.
- `error_logger_lager_h` pattern-matches OTP's internal `{error_report,_}` / `{info_report,_}` shapes.
- `lager_transform` rewrites the AST at compile time — hence *"lager has to come first"* in every `rebar.config`.

Upstream's last commit is `e6b3178` (2023-11-02), before OTP 27 existed, so none of that is being re-synced.

**To be precise about scope:** lager compiles fine on OTP 27 — I checked. This is not a compile-time blocker. The case is unmaintained code reaching into OTP internals, which is runtime fragility and accumulating risk, not a build break.

`?LOG_*` macros rather than `logger:Level/2` calls: the macros capture module, function and line, which is the job `lager_transform` did. Plain function calls silently lose that metadata.

## Per service

- **oc_erchef** — 74 sites across 25 files, all plain level calls (no `lager:md`, sinks or traces). `lager:start/0` goes from a test helper; logger is part of kernel and always running.
- **bookshelf** — 10 sites. `internal.hrl` already defined `?LOG_INFO`/`?LOG_ERROR`/`?LOG_DEBUG` at exactly the arities `logger.hrl` provides, so including it there migrates every existing `?LOG_*` call site **untouched** and retires the deprecated `error_logger:info_msg`/`error_msg` it used for two of them.
- **oc_bifrost** — 2 sites.

## Things only a build finds

These are not in the obvious places and are why this touches 31 files rather than 30:

- **`goldrush` in `oc_chef_wm.app.src`** — lager's own dependency. Leaving it behind breaks `rebar3 dialyzer` (*"Could not find application: goldrush"*) and `rebar3 release` (*"Application needed for release not found"*), **after** every unit test has already passed. Removed.
- **Sub-app `rebar.config`s** — `apps/data_collector` and `apps/chef_telemetry` each declare lager and the parse transform independently of the top-level config, on a rolling `master` branch.
- **Six `oc_chef_wm` itest suites** carrying `-compile([{parse_transform, lager_transform}])`, `setup_helper` setting lager's `error_logger_redirect` and starting lager/goldrush, and the bookshelf SUITE calling `lager_common_test_backend:bounce/1`. None are built by the default profile.
- **The relx release app list** in `oc_bifrost/rebar.config`.
- Every `-include_lib` was checked to be outside `-ifdef` blocks — an include placed inside `-ifdef(TEST)` silently vanishes from normal builds.

## Verified

`erlang:26` containers, clean `_build`:

- `oc_bifrost`, `bookshelf` and `oc_erchef` all compile with `warnings_as_errors` on.
- `oc_erchef` assembles: `Release successfully assembled: _build/default/rel/oc_erchef`.
- `oc_erchef` dialyzer is clean — 160 files analysed, exit 0. This matters specifically: `Resolving project files` is the step that fails on a stale `goldrush` entry, so a clean run here is what confirms the `.app.src` cleanup is complete.

## This does not remove lager from the build yet

Three libraries still declare lager and are pulled in transitively, so it remains in `_build` and in the assembled release until they land:

| Library | PR | Sites |
| --- | --- | --- |
| `chef_secrets` | chef/chef_secrets#88 | 7 + its `applications` entry, which is what *starts* lager |
| `folsom_graphite` | chef/folsom_graphite#16 | 14 |
| `opscoderl_httpc` | chef/opscoderl_httpc#21 | 1 |

**Merge those three first.** The lockfiles are deliberately left alone here — re-pinning them now would mean pointing at fork branches.

The `sys.config` templates that carry the `{lager, [...]}` blocks live in `chef-server-omnibus-config`, not this repo, so converting those to logger handlers (and moving lager's `$D0` midnight rotation to logrotate, since `logger_std_h` has no time trigger) is a separate change there.

## CI note

buildkite and the Grype scan fail on this PR. They fail identically on every open PR in this repo, including #4239, #4230 and #4209 — Grype reports `1 CRITICAL, 3 HIGH` from the existing dependency tree, gated by `grype-fail-on-high: true`. Neither is related to this change.
